### PR TITLE
Additional getters and setters

### DIFF
--- a/aeron-common/src/main/cpp/concurrent/AtomicBuffer.h
+++ b/aeron-common/src/main/cpp/concurrent/AtomicBuffer.h
@@ -286,12 +286,25 @@ public:
         return length;
     }
 
-
     inline util::index_t getCapacity() const
     {
         return m_length;
     }
-
+    
+    inline void setCapacity(util::index_t length)
+    {
+        m_length = length;
+    }
+    
+    inline std::uint8_t * getBuffer() const
+    {
+        return m_buffer;
+    }
+        
+    inline void setBuffer(std::uint8_t *buffer)
+    {
+        m_buffer = buffer;
+    }
 private:
     std::uint8_t *m_buffer;
     util::index_t m_length;


### PR DESCRIPTION
To avoid memory allocation when using this class as a wrapper over an underlying buffer it would be convenient to be able reposition the buffer which would be enabled with additional setters. 
Further, the getCapacity() is named after the Java implementation. Would it not be more correct to say getLength() or length() instead?

Thanks