### PR TITLE
A trimmed down version of Javadoc

### DIFF
--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
@@ -41,9 +41,21 @@ import static uk.co.real_logic.agrona.IoUtil.mapExistingFile;
 
 /**
  * Aeron entry point for communicating to the Media Driver for creating {@link Publication}s and {@link Subscription}s.
+ * Use an {@link Aeron.Context} to configure the Aeron object.
+ * <p>
+ * A client application requires only one Aeron object per Media Driver.
  */
 public final class Aeron implements AutoCloseable
 {
+    /**
+     * The Default handler for Aeron runtime exceptions.
+     * When a {@link uk.co.real_logic.aeron.exceptions.DriverTimeoutException} is encountered, this handler will
+     * exit the program.
+     * <p>
+     * The error handler can be overridden by supplying an {@link Aeron.Context} with a custom handler.
+     *
+     * @see Aeron.Context#errorHandler(Consumer)
+     */
     public static final Consumer<Throwable> DEFAULT_ERROR_HANDLER =
         (throwable) ->
         {
@@ -147,7 +159,7 @@ public final class Aeron implements AutoCloseable
      *
      * @param channel   for receiving the messages known to the media layer.
      * @param streamId  within the channel scope.
-     * @param sessionId to scope the source of the Publication.
+     * @param sessionId To identify the Publication instance within a channel and streamId pair.
      * @return the new Publication.
      */
     public Publication addPublication(final String channel, final int streamId, final int sessionId)
@@ -191,6 +203,12 @@ public final class Aeron implements AutoCloseable
         return this;
     }
 
+    /**
+     * This class provides configuration for the {@link Aeron} class via the {@link Aeron#connect(Aeron.Context)}
+     * method and its overloads. It gives applications some control over the interactions with the Aeron Media Driver.
+     * It can also set up error handling as well as application callbacks for connection information from the
+     * Media Driver.
+     */
     public static class Context extends CommonContext
     {
         private IdleStrategy idleStrategy;
@@ -206,6 +224,12 @@ public final class Aeron implements AutoCloseable
         private InactiveConnectionHandler inactiveConnectionHandler;
         private long mediaDriverTimeoutMs = NULL_TIMEOUT;
 
+        /**
+         * This is called automatically by {@link Aeron#connect(Aeron.Context)} and its overloads.
+         * There is no need to call it from a client application. It is responsible for providing default
+         * values for options that are not individually changed through field setters.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context conclude()
         {
             super.conclude();
@@ -278,59 +302,113 @@ public final class Aeron implements AutoCloseable
             return this;
         }
 
+        /**
+         * Provides an IdleStrategy for the thread responsible for communicating with the Aeron Media Driver.
+         * @param idleStrategy Thread idle strategy for communication with the Media Driver.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context idleStrategy(final IdleStrategy idleStrategy)
         {
             this.idleStrategy = idleStrategy;
             return this;
         }
 
+        /**
+         * This method is used for testing and debugging.
+         * @param toClientBuffer Injected CopyBroadcastReceiver
+         * @return this Aeron.Context for method chaining.
+         */
         public Context toClientBuffer(final CopyBroadcastReceiver toClientBuffer)
         {
             this.toClientBuffer = toClientBuffer;
             return this;
         }
 
+        /**
+         * This method is used for testing and debugging.
+         * @param toDriverBuffer Injected RingBuffer.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context toDriverBuffer(final RingBuffer toDriverBuffer)
         {
             this.toDriverBuffer = toDriverBuffer;
             return this;
         }
 
+        /**
+         * This method is used for testing and debugging.
+         * @param logBuffersFactory Injected LogBuffersFactory
+         * @return this Aeron.Context for method chaining.
+         */
         public Context bufferManager(final LogBuffersFactory logBuffersFactory)
         {
             this.logBuffersFactory = logBuffersFactory;
             return this;
         }
 
+        /**
+         * Handle Aeron exceptions in a callback method. The default behavior is defined by
+         * {@link Aeron#DEFAULT_ERROR_HANDLER}.
+         * @see uk.co.real_logic.aeron.exceptions.DriverTimeoutException
+         * @see uk.co.real_logic.aeron.exceptions.RegistrationException
+         * @param handler Method to handle objects of type Throwable.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context errorHandler(final Consumer<Throwable> handler)
         {
             this.errorHandler = handler;
             return this;
         }
 
+        /**
+         * Set up a callback for when a new connection is created.
+         * @param handler Callback method for handling new connection notifications.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context newConnectionHandler(final NewConnectionHandler handler)
         {
             this.newConnectionHandler = handler;
             return this;
         }
 
+        /**
+         * Set up a callback for when a connection determined to be inactive.
+         * @param handler Callback method for handling inactive connection notifications.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context inactiveConnectionHandler(final InactiveConnectionHandler handler)
         {
             this.inactiveConnectionHandler = handler;
             return this;
         }
 
+        /**
+         * Set the amount of time, in milliseconds, that this client will wait until it determines the
+         * Media Driver is unavailable. When this happens a
+         * {@link uk.co.real_logic.aeron.exceptions.DriverTimeoutException} will be generated for the error handler.
+         * @see #errorHandler(Consumer)
+         * @param value Number of milliseconds.
+         * @return this Aeron.Context for method chaining.
+         */
         public Context mediaDriverTimeout(final long value)
         {
             this.mediaDriverTimeoutMs = value;
             return this;
         }
 
+        /**
+         * Get the amount of time, in milliseconds, that this client will wait until it determines the
+         * Media Driver is unavailable.
+         * @return Number of milliseconds.
+         */
         public long mediaDriverTimeout()
         {
             return mediaDriverTimeoutMs;
         }
 
+        /**
+         * Clean up all resources that the client uses to communicate with the Media Driver.
+         */
         public void close()
         {
             IoUtil.unmap(cncByteBuffer);

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
@@ -26,14 +26,13 @@ import java.util.function.Supplier;
 import static uk.co.real_logic.aeron.common.concurrent.logbuffer.FrameDescriptor.*;
 
 /**
- * {@link DataHandler} that sits in a chain-of-responsibilities pattern that re-assembles fragmented messages
- * so that next handler in the chain only sees unfragmented messages.
- *
+ * A {@link DataHandler} that sits in a chain-of-responsibility pattern that reassembles fragmented messages
+ * so that the next handler in the chain only sees whole messages.
+ * <p>
  * Unfragmented messages are delegated without copy. Fragmented messages are copied to a temporary
  * buffer for reassembly before delegation.
- *
+ * <p>
  * Session based buffers will be allocated and grown as necessary based on the length of messages to be assembled.
- *
  * When sessions go inactive see {@link InactiveConnectionHandler}, it is possible to free the buffer by calling
  * {@link #freeSessionBuffer(int)}.
  */
@@ -45,7 +44,7 @@ public class FragmentAssemblyAdapter implements DataHandler
     private final Supplier<BufferBuilder> builderSupplier;
 
     /**
-     * Construct an adapter to reassembly message fragments and delegate on only whole messages.
+     * Construct an adapter to reassemble message fragments and delegate on only whole messages.
      *
      * @param delegate onto which whole messages are forwarded.
      */
@@ -66,6 +65,13 @@ public class FragmentAssemblyAdapter implements DataHandler
         builderSupplier = () -> new BufferBuilder(initialBufferLength);
     }
 
+    /**
+     * The implementation of {@link DataHandler} that reassembles and forwards whole messages.
+     * @param buffer containing the data.
+     * @param offset at which the data begins.
+     * @param length of the data in bytes.
+     * @param header representing the meta data for the data.
+     */
     public void onData(final DirectBuffer buffer, final int offset, final int length, final Header header)
     {
         final byte flags = header.flags();

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
@@ -34,7 +34,7 @@ import static uk.co.real_logic.aeron.common.concurrent.logbuffer.FrameDescriptor
  *
  * Session based buffers will be allocated and grown as necessary based on the length of messages to be assembled.
  *
- * When sessions go inactive {@see InactiveConnectionHandler}, it is possible to free the buffer by calling
+ * When sessions go inactive {@link InactiveConnectionHandler}, it is possible to free the buffer by calling
  * {@link #freeSessionBuffer(int)}.
  */
 public class FragmentAssemblyAdapter implements DataHandler

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssemblyAdapter.java
@@ -34,7 +34,7 @@ import static uk.co.real_logic.aeron.common.concurrent.logbuffer.FrameDescriptor
  *
  * Session based buffers will be allocated and grown as necessary based on the length of messages to be assembled.
  *
- * When sessions go inactive {@link InactiveConnectionHandler}, it is possible to free the buffer by calling
+ * When sessions go inactive see {@link InactiveConnectionHandler}, it is possible to free the buffer by calling
  * {@link #freeSessionBuffer(int)}.
  */
 public class FragmentAssemblyAdapter implements DataHandler

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/InactiveConnectionHandler.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/InactiveConnectionHandler.java
@@ -16,17 +16,17 @@
 package uk.co.real_logic.aeron;
 
 /**
- * Interface for delivery of inactive connection events to a {@link uk.co.real_logic.aeron.Subscription}
+ * Interface for delivery of inactive connection events to a {@link uk.co.real_logic.aeron.Subscription}.
  */
 @FunctionalInterface
 public interface InactiveConnectionHandler
 {
     /**
-     * Method called by Aeron to deliver notification that a source has gone inactive.
+     * Method called by Aeron to deliver notification that a Publisher has gone inactive.
      *
-     * @param channel of the inactive source
-     * @param streamId of the inactive stream
-     * @param sessionId of the inactive source
+     * @param channel The channel of the inactive Publisher.
+     * @param streamId The scope within the channel of the inactive Publisher.
+     * @param sessionId The instance identifier of the inactive Publisher.
      */
     void onInactiveConnection(String channel, int streamId, int sessionId);
 }

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/NewConnectionHandler.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/NewConnectionHandler.java
@@ -24,10 +24,10 @@ public interface NewConnectionHandler
     /**
      * Method called by Aeron to deliver notification of a new connected session.
      *
-     * @param channel           for the source
-     * @param streamId          for the source
-     * @param sessionId         for the source
-     * @param sourceInformation that is transport specific
+     * @param channel           The channel for the new session.
+     * @param streamId          The scope within the channel for the new session.
+     * @param sessionId         The publisher instance identifier for the new session.
+     * @param sourceInformation A transport specific string with additional information about the publisher.
      */
     void onNewConnection(String channel, int streamId, int sessionId, String sourceInformation);
 }

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/Publication.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/Publication.java
@@ -27,9 +27,15 @@ import static uk.co.real_logic.aeron.common.concurrent.logbuffer.LogBufferDescri
 import static uk.co.real_logic.aeron.common.protocol.DataHeaderFlyweight.TERM_ID_FIELD_OFFSET;
 
 /**
- * Publication end of a channel and stream for publishing messages to subscribers.
+ * Aeron Publisher API for sending messages to subscribers of a given channel and streamId pair. Publishers
+ * are created via an {@link Aeron} object, and messages are sent via an offer method or a claim and commit
+ * method combination.
+ * <p>
+ * The APIs used to send are all non-blocking.
  * <p>
  * Note: Publication instances are threadsafe and can be shared between publisher threads.
+ * @see Aeron#addPublication(String, int)
+ * @see Aeron#addPublication(String, int, int)
  */
 public class Publication implements AutoCloseable
 {
@@ -92,7 +98,7 @@ public class Publication implements AutoCloseable
     }
 
     /**
-     * Session under which messages are published.
+     * Session under which messages are published. Identifies this Publication instance.
      *
      * @return the session id for this publication.
      */
@@ -111,6 +117,9 @@ public class Publication implements AutoCloseable
         return logAppenders[0].maxMessageLength();
     }
 
+    /**
+     * Release resources used by this Publication.
+     */
     public void close()
     {
         synchronized (clientConductor)
@@ -174,10 +183,10 @@ public class Publication implements AutoCloseable
     /**
      * Try to claim a range in the publication log into which a message can be written with zero copy semantics.
      * Once the message has been written then {@link BufferClaim#commit()} should be called thus making it available.
-     *
+     * <p>
      * <b>Note:</b> This method can only be used for message lengths less than MTU length minus header.
      *
-     * <code>
+     * <pre>{@code
      *     final BufferClaim bufferClaim = new BufferClaim(); // Can be stored and reused to avoid allocation
      *
      *     if (publication.tryClaim(messageLength, bufferClaim))
@@ -194,9 +203,9 @@ public class Publication implements AutoCloseable
      *             bufferClaim.commit();
      *         }
      *     }
-     * </code>
+     * }</pre>
      *
-     * @param length      of the range to claim.
+     * @param length      of the range to claim, in bytes..
      * @param bufferClaim to be populate if the claim succeeds.
      * @return true if the claim was successful otherwise false.
      * @throws IllegalArgumentException if the length is greater than max payload length within an MTU.

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/Subscription.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/Subscription.java
@@ -22,8 +22,18 @@ import uk.co.real_logic.agrona.status.PositionReporter;
 
 /**
  * Aeron Subscriber API for receiving messages from publishers on a given channel and streamId pair.
+ * Subscribers are created via an {@link Aeron} object, and received messages are delivered
+ * to the {@link DataHandler} provided at creation time.
+ * <p>
+ * By default fragmented messages are not reassembled before delivery. If an application must
+ * receive whole messages, whether or not they were fragmented, then the Subscriber
+ * should be created with a {@link FragmentAssemblyAdapter} or a custom implementation.
+ * <p>
+ * It is an applications responsibility to {@link #poll} the Subscriber for new messages.
  * <p>
  * Subscriptions are not threadsafe and should not be shared between subscribers.
+ * @see Aeron#addSubscription(String, int, DataHandler)
+ * @see FragmentAssemblyAdapter
  */
 public class Subscription implements AutoCloseable
 {

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
@@ -24,22 +24,22 @@ import static java.lang.Boolean.getBoolean;
 import static java.lang.System.getProperty;
 
 /**
- * Location of context that is common between the client and the media driver.
- *
+ * This class provides the Media Driver and client with common configuration for the Aeron directory.
+ * <p>
  * Properties
  * <ul>
- * <li><code>aeron.dir</code>: Use value as directory name for aeron buffers and stats.</li>
+ * <li><code>aeron.dir</code>: Use value as directory name for Aeron buffers and stats.</li>
+ * <li><code>aeron.dir.delete.on.exit</code>: Attempt to delete Aeron directories on exit.</li>
  * </ul>
  */
 public class CommonContext implements AutoCloseable
 {
-    /** Top level Aeron directory */
+    /** The top level Aeron directory used for communication between a Media Driver and client.  */
     public static final String AERON_DIR_PROP_NAME = "aeron.dir";
+    /** The value of the top level Aeron directory unless overridden by {@link #dirName(String)} */
     public static final String AERON_DIR_PROP_DEFAULT;
-
     /** Name of the default multicast interface */
     public static final String MULTICAST_DEFAULT_INTERFACE_PROP_NAME = "aeron.multicast.default.interface";
-
     /** Attempt to delete directories on exit */
     public static final String DIRS_DELETE_ON_EXIT_PROP_NAME = "aeron.dir.delete.on.exit";
 
@@ -70,6 +70,9 @@ public class CommonContext implements AutoCloseable
         AERON_DIR_PROP_DEFAULT = aeronDirName;
     }
 
+    /**
+     * Create a new context with Aeron directory and delete on exit values based on the current system properties.
+     */
     public CommonContext()
     {
         dirName = getProperty(AERON_DIR_PROP_NAME, AERON_DIR_PROP_DEFAULT);
@@ -77,33 +80,60 @@ public class CommonContext implements AutoCloseable
         dirsDeleteOnExit(getBoolean(DIRS_DELETE_ON_EXIT_PROP_NAME));
     }
 
+    /**
+     * This completes initialization of the CommonContext object. It is automatically called by subclasses.
+     * @return this Object for method chaining.
+     */
     public CommonContext conclude()
     {
         cncFile = new File(adminDirName(), CncFileDescriptor.CNC_FILE);
         return this;
     }
 
+    /**
+     * Get the top level Aeron directory used for communication between the client and Media Driver, and
+     * the location of the data buffers.
+     * @return The top level Aeron directory.
+     */
     public String dirName()
     {
         return dirName;
     }
 
+    /**
+     * Set the top level Aeron directory used for communication between the client and Media Driver, and the location
+     * of the data buffers.
+     * @param dirName New top level Aeron directory.
+     * @return this Object for method chaining.
+     */
     public CommonContext dirName(final String dirName)
     {
         this.dirName = dirName;
         return this;
     }
 
+    /**
+     * Get the directory used by the Media Driver and client to transfer channel data.
+     * @return The data directory.
+     */
     public String dataDirName()
     {
         return dirName + File.separator + DATA_DIR_NAME;
     }
 
+    /**
+     * Get the directory used by the Media Driver and client to communicate administrative messages.
+     * @return The administration directory.
+     */
     public String adminDirName()
     {
         return dirName + File.separator + CONDUCTOR_DIR_NAME;
     }
 
+    /**
+     * Create a new command and control file in the administration directory.
+     * @return The newly created File.
+     */
     public static File newDefaultCncFile()
     {
         return new File(
@@ -111,44 +141,78 @@ public class CommonContext implements AutoCloseable
             CncFileDescriptor.CNC_FILE);
     }
 
+    /**
+     * Get whether or not this application will attempt to delete the Aeron directories when exiting.
+     * @return true when directories will be deleted, otherwise false.
+     */
     public boolean dirsDeleteOnExit()
     {
         return dirsDeleteOnExit;
     }
 
+    /**
+     * Set whether or not this application will attempt to delete the Aeron directories when exiting.
+     * @param dirsDeleteOnExit Attempt deletion.
+     * @return this Object for method chaining.
+     */
     public CommonContext dirsDeleteOnExit(final boolean dirsDeleteOnExit)
     {
         this.dirsDeleteOnExit = dirsDeleteOnExit;
         return this;
     }
 
+    /**
+     * Get the buffer containing the counter labels.
+     * @return The buffer storing the counter labels.
+     */
     public UnsafeBuffer counterLabelsBuffer()
     {
         return counterLabelsBuffer;
     }
 
+    /**
+     * Set the buffer containing the counter labels.
+     * @param counterLabelsBuffer The new counter labels buffer.
+     * @return this Object for method chaining.
+     */
     public CommonContext counterLabelsBuffer(final UnsafeBuffer counterLabelsBuffer)
     {
         this.counterLabelsBuffer = counterLabelsBuffer;
         return this;
     }
 
+    /**
+     * Get the buffer containing the counters.
+     * @return The buffer storing the counters.
+     */
     public UnsafeBuffer countersBuffer()
     {
         return countersBuffer;
     }
 
+    /**
+     * Set the buffer containing the counters
+     * @param countersBuffer The new counters buffer.
+     * @return this Object for method chaining.
+     */
     public CommonContext countersBuffer(final UnsafeBuffer countersBuffer)
     {
         this.countersBuffer = countersBuffer;
         return this;
     }
 
+    /**
+     * Get the command and control file.
+     * @return The command and control file.
+     */
     public File cncFile()
     {
         return cncFile;
     }
 
+    /**
+     * Release resources used by the CommonContext.
+     */
     public void close()
     {
     }

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/ErrorCode.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/ErrorCode.java
@@ -16,15 +16,21 @@
 package uk.co.real_logic.aeron.common;
 
 /**
- * Error codes between media driver and library and the on-wire protocol.
+ * Error codes between media driver and client and the on-wire protocol.
  */
 public enum ErrorCode
 {
+    /** Aeron encountered an error condition. */
     GENERIC_ERROR(0),
+    /** A failure occurred creating a new channel or parsing the channel string. */
     INVALID_CHANNEL(1),
+    /** Attempted to remove a subscription, but it was not found */
     UNKNOWN_SUBSCRIPTION(2),
+    /** Reserved for future use. */
     GENERIC_ERROR_MESSAGE(3),
+    /** Reserved for future use. */
     GENERIC_ERROR_SUBSCRIPTION_MESSAGE(4),
+    /** Attempted to remove a publication, but it was not found. */
     UNKNOWN_PUBLICATION(5);
 
     private final short value;
@@ -34,11 +40,20 @@ public enum ErrorCode
         this.value = (short) value;
     }
 
+    /**
+     * Get the value of this ErrorCode.
+     * @return The value.
+     */
     public short value()
     {
         return value;
     }
 
+    /**
+     * Get the ErrorCode that corresponds to the given value.
+     * @param value Of the ErrorCode
+     * @return ErrorCode
+     */
     public static ErrorCode get(final short value)
     {
         if (value > Singleton.VALUES.length)

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/concurrent/logbuffer/BufferClaim.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/concurrent/logbuffer/BufferClaim.java
@@ -20,6 +20,9 @@ import uk.co.real_logic.agrona.concurrent.AtomicBuffer;
 
 /**
  * Represents a claimed range in a buffer to be used for recording a message without copy semantics for later commit.
+ * <p>
+ * The claimed space is in #buffer() between #offset() and #offset() + #length(). When the buffer is filled
+ * with message data, use #commit() to make it available to subscribers.
  */
 public class BufferClaim
 {
@@ -52,7 +55,7 @@ public class BufferClaim
     }
 
     /**
-     * The offset in the buffer at which the range begins.
+     * The offset in the buffer at which the claimed range begins.
      *
      * @return offset in the buffer at which the range begins.
      */
@@ -74,12 +77,12 @@ public class BufferClaim
     }
 
     /**
-     * The length of the range in the buffer.
+     * The length of the claimed range in the buffer.
      *
      * @return length of the range in the buffer.
      */
     public int length()
-    {
+     {
         return length;
     }
 
@@ -120,7 +123,7 @@ public class BufferClaim
     }
 
     /**
-     * Commit the message to the log buffer so that is it available to consumers.
+     * Commit the message to the log buffer so that is it available to subscribers.
      */
     public void commit()
     {

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/concurrent/logbuffer/Header.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/concurrent/logbuffer/Header.java
@@ -154,7 +154,9 @@ public class Header
     }
 
     /**
-     * The flags for this frame.
+     * The flags for this frame. Valid flags are {@link DataHeaderFlyweight#BEGIN_FLAG}
+     * and {@link DataHeaderFlyweight#END_FLAG}. A convenience flag {@link DataHeaderFlyweight#BEGIN_AND_END_FLAGS}
+     * can be used for both flags.
      *
      * @return the flags for this frame.
      */

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/uri/AeronUri.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/uri/AeronUri.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * value     = *( "[^|]" )
  * </pre>
  *
- * <li>Multiple params with the same key are allowed, the last value specified 'wins'.</li>
+ * Multiple params with the same key are allowed, the last value specified 'wins'.
  */
 public class AeronUri
 {

--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/uri/AeronUri.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/uri/AeronUri.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * value     = *( "[^|]" )
  * </pre>
  *
+ * <p>
  * Multiple params with the same key are allowed, the last value specified 'wins'.
  */
 public class AeronUri

--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,6 @@ buildscript {
     }
 }
 
-configurations {
-  javadoc
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
@@ -296,5 +292,9 @@ task docs(type: Javadoc) {
 task docsJar (type: Jar, dependsOn: docs) {
         classifier = 'docs'
         from docs.destinationDir
+}
+
+artifacts {
+       archives docsJar
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ buildscript {
     }
 }
 
+configurations {
+  javadoc
+}
+
 subprojects {
     apply plugin: 'java'
     apply plugin: 'maven'
@@ -101,11 +105,22 @@ subprojects {
     }
 
     javadoc {
-        title = '<h1>Aeron Transport Protocol</h1>'
+        title = '<h1>Aeron Transport Protocol  </h1>'
 
         options.bottom = '<i>Copyright &#169; 2014 - 2015 Real Logic Ltd. All Rights Reserved.</i>'
         options.addStringOption('XDignore.symbol.file', '-quiet')
     }
+    afterEvaluate {
+		if(plugins.hasPlugin(JavaPlugin)) {
+			
+			// configuration here
+			rootProject.tasks.docs {
+				source += files(sourceSets.collect { srcSet -> srcSet.allJava })
+				classpath += files(sourceSets*.compileClasspath)
+			}
+
+		}
+	}
 
     task sourcesJar(type: Jar) {
         classifier = 'sources'
@@ -117,7 +132,7 @@ subprojects {
         from sourceSets.test.output
     }
 
-    task javadocJar(type: Jar) {
+    task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
     }
@@ -255,4 +270,25 @@ uploadArchives {
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.1'
+}
+
+task docs(type: Javadoc) {
+	title = '<h1>Aeron Transport Protocol </h1>'
+
+        options.bottom = '<i>Copyright &#169; 2014 - 2015 Real Logic Ltd. All Rights Reserved.</i>'
+        options.addStringOption('XDignore.symbol.file', '-quiet')
+        include '**/Aeron.java'
+        include '**/FragmentAssemblyAdapter.java'
+        include '**/InactiveConnectionHandler.java'
+        include '**/NewConnectionHandler.java'
+        include '**/Publication.java'
+        include '**/Subscription.java'
+        include '**/CommonContext.java'
+        include '**/ErrorCode.java'
+        include '**/Header.java'
+        include '**/DataHandler.java'
+        include '**/BufferClaim.java'
+        include '**/RegistrationException.java'
+        include '**/DriverTimeoutException.java'
+	destinationDir = file("$buildDir/docs/all")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ subprojects {
         from sourceSets.test.output
     }
 
-    task javadocJar(type: Jar, dependsOn: javadoc) {
+    task javadocJar(type: Jar) {
         classifier = 'javadoc'
         from javadoc.destinationDir
     }

--- a/build.gradle
+++ b/build.gradle
@@ -292,3 +292,9 @@ task docs(type: Javadoc) {
         include '**/DriverTimeoutException.java'
 	destinationDir = file("$buildDir/docs/all")
 }
+
+task docsJar (type: Jar, dependsOn: docs) {
+        classifier = 'docs'
+        from docs.destinationDir
+}
+


### PR DESCRIPTION
A trimmed down version of Javadoc for Aeron APIs. Two new tasks 'docs' and 'docsJar' have been added to the 'build.gradle'. In addition, more clarifications have been added to client APIs.