### PR TITLE
Change the embedded driver directories to work better on multi-user systems. 

### DIFF
--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/CommonContext.java
@@ -69,7 +69,7 @@ public class CommonContext implements AutoCloseable
     public static String generateEmbeddedDirName()
     {
         final String randomDirName = UUID.randomUUID().toString();
-        String aeronDirName = IoUtil.tmpDirName() + "aeron" + File.separator + randomDirName;
+        String aeronDirName = IoUtil.tmpDirName() + "aeron-" + randomDirName;
 
         // Use shared memory on Linux to avoid contention on the page cache.
         if ("Linux".equalsIgnoreCase(System.getProperty("os.name")))
@@ -78,7 +78,7 @@ public class CommonContext implements AutoCloseable
 
             if (devShmDir.exists())
             {
-                aeronDirName = "/dev/shm/aeron/" + randomDirName;
+                aeronDirName = "/dev/shm/aeron-" + randomDirName;
             }
         }
 

--- a/aeron-system-tests/src/test/java/uk/co/real_logic/aeron/MultiDriverTest.java
+++ b/aeron-system-tests/src/test/java/uk/co/real_logic/aeron/MultiDriverTest.java
@@ -27,6 +27,7 @@ import uk.co.real_logic.aeron.driver.MediaDriver;
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -47,6 +48,8 @@ public class MultiDriverTest
     private static final int NUM_MESSAGES_PER_TERM = 64;
     private static final int MESSAGE_LENGTH =
         (TERM_BUFFER_SIZE / NUM_MESSAGES_PER_TERM) - DataHeaderFlyweight.HEADER_LENGTH;
+    private static final String ROOT_DIR =
+        IoUtil.tmpDirName() + "aeron-system-tests-" + UUID.randomUUID().toString() + File.separator;
 
     private final MediaDriver.Context driverAContext = new MediaDriver.Context();
     private final MediaDriver.Context driverBContext = new MediaDriver.Context();
@@ -67,8 +70,8 @@ public class MultiDriverTest
 
     private void launch()
     {
-        final String baseDirA = IoUtil.tmpDirName() + "aeron-system-tests" + File.separator + "A";
-        final String baseDirB = IoUtil.tmpDirName() + "aeron-system-tests" + File.separator + "B";
+        final String baseDirA = ROOT_DIR + "A";
+        final String baseDirB = ROOT_DIR + "B";
 
         buffer.putInt(0, 1);
 
@@ -112,6 +115,8 @@ public class MultiDriverTest
         clientA.close();
         driverB.close();
         driverA.close();
+
+        IoUtil.delete(new File(ROOT_DIR), true);
     }
 
     @Test(timeout = 10000)


### PR DESCRIPTION
Now appends a UUID to the base directory, and deletes the base directory on exit.

Avoids issues due to concurrent builds by different users on a shared system.