### PR TITLE
Fix for IPv6 interface specification handling.

### DIFF
--- a/aeron-common/src/main/java/uk/co/real_logic/aeron/common/NetworkUtil.java
+++ b/aeron-common/src/main/java/uk/co/real_logic/aeron/common/NetworkUtil.java
@@ -133,7 +133,7 @@ public class NetworkUtil
 
             return
                 (upperMask & toLong(a, 0)) == (upperMask & toLong(b, 0)) &&
-                (lowerMask & toLong(b, 8)) == (lowerMask & toLong(b, 8));
+                (lowerMask & toLong(a, 8)) == (lowerMask & toLong(b, 8));
         }
 
         throw new IllegalArgumentException("How many bytes does an IP address have again?");

--- a/aeron-common/src/test/java/uk/co/real_logic/aeron/common/NetworkUtilTest.java
+++ b/aeron-common/src/test/java/uk/co/real_logic/aeron/common/NetworkUtilTest.java
@@ -141,7 +141,7 @@ public class NetworkUtilTest
     }
 
     @Test
-    public void shouldFilerBySubnetAndFindOneIpV6Result() throws Exception
+    public void shouldFilterBySubnetAndFindOneIpV6Result() throws Exception
     {
         final NetworkInterfaceStub stub = new NetworkInterfaceStub();
 
@@ -149,7 +149,7 @@ public class NetworkUtilTest
         stub.add("fe80:0:0:0002:0003:0:0:1/80");
 
         final Collection<NetworkInterface> filteredBySubnet =
-            filterBySubnet(stub, getByName("fe80:0:0:0001:0:0:0:0"), 80);
+            filterBySubnet(stub, getByName("fe80:0:0:0001:0002:0:0:0"), 80);
 
         assertThat(filteredBySubnet.size(), is(1));
         assertThat(first(filteredBySubnet), is(ifc1));


### PR DESCRIPTION
Corrected isMatchWithPrefix() to properly compare IPv6 addresses. Also corrected the corresponding unit test.