### PR TITLE
LossGenerator improvements

### DIFF
--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
@@ -495,7 +495,7 @@ public class Configuration
     {
         if (0 == lossRate)
         {
-            return (address, length) -> false;
+            return (address, length, buffer) -> false;
         }
 
         return new RandomLossGenerator(lossRate, lossSeed);

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
@@ -54,10 +54,6 @@ import static uk.co.real_logic.aeron.driver.MediaDriver.Context;
  */
 public class DriverConductor implements Agent
 {
-    private final long dataLossSeed;
-    private final long controlLossSeed;
-    private final double dataLossRate;
-    private final double controlLossRate;
     private final int mtuLength;
     private final int termBufferLength;
     private final int initialWindowLength;
@@ -95,6 +91,8 @@ public class DriverConductor implements Agent
     private final Consumer<DriverConductorCmd> onDriverConductorCmdFunc = this::onDriverConductorCmd;
     private final MessageHandler onClientCommandFunc = this::onClientCommand;
     private final MessageHandler onEventFunc;
+    private final LossGenerator dataLossGenerator;
+    private final LossGenerator controlLossGenerator;
 
     public DriverConductor(final Context ctx)
     {
@@ -116,12 +114,10 @@ public class DriverConductor implements Agent
         clientProxy = ctx.clientProxy();
         conductorProxy = ctx.driverConductorProxy();
         logger = ctx.eventLogger();
-        dataLossRate = ctx.dataLossRate();
-        dataLossSeed = ctx.dataLossSeed();
-        controlLossRate = ctx.controlLossRate();
-        controlLossSeed = ctx.controlLossSeed();
         systemCounters = ctx.systemCounters();
         checkTimeoutTimer = timerWheel.newTimeout(HEARTBEAT_TIMEOUT_MS, TimeUnit.MILLISECONDS, this::onHeartbeatCheckTimeouts);
+        dataLossGenerator = ctx.dataLossGenerator();
+        controlLossGenerator = ctx.controlLossGenerator();
 
         final Consumer<String> eventConsumer = ctx.eventConsumer();
         onEventFunc =
@@ -559,7 +555,7 @@ public class DriverConductor implements Agent
             channelEndpoint = new SendChannelEndpoint(
                 udpChannel,
                 logger,
-                Configuration.createLossGenerator(controlLossRate, controlLossSeed),
+                controlLossGenerator,
                 systemCounters);
 
             channelEndpoint.validateMtuLength(mtuLength);
@@ -636,9 +632,8 @@ public class DriverConductor implements Agent
         ReceiveChannelEndpoint channelEndpoint = receiveChannelEndpointByChannelMap.get(udpChannel.canonicalForm());
         if (null == channelEndpoint)
         {
-            final LossGenerator lossGenerator = Configuration.createLossGenerator(dataLossRate, dataLossSeed);
             channelEndpoint = new ReceiveChannelEndpoint(
-                udpChannel, conductorProxy, receiverProxy.receiver(), logger, systemCounters, lossGenerator);
+                udpChannel, conductorProxy, receiverProxy.receiver(), logger, systemCounters, dataLossGenerator);
 
             receiveChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
             receiverProxy.registerReceiveChannelEndpoint(channelEndpoint);

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/LossGenerator.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/LossGenerator.java
@@ -15,20 +15,22 @@
  */
 package uk.co.real_logic.aeron.driver;
 
+import uk.co.real_logic.agrona.concurrent.UnsafeBuffer;
 import java.net.InetSocketAddress;
 
 /**
- * Interface for loss generators
+ * Interface for loss generators.
  */
 @FunctionalInterface
 public interface LossGenerator
 {
     /**
-     * Should frame be dropped?
+     * Should the frame be dropped?
      *
-     * @param address of source of frame
-     * @param length of frame on wire
+     * @param address The source address of the frame.
+     * @param length The length of the frame.
+     * @param buffer The buffer containing the frame data.
      * @return true to drop, false to process
      */
-    boolean shouldDropFrame(InetSocketAddress address, int length);
+    boolean shouldDropFrame(final InetSocketAddress address, final int length, final UnsafeBuffer buffer);
 }

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
@@ -308,6 +308,9 @@ public final class MediaDriver implements AutoCloseable
         private ThreadingMode threadingMode;
         private boolean dirsDeleteOnExit;
 
+        private LossGenerator dataLossGenerator;
+        private LossGenerator controlLossGenerator;
+
         public Context()
         {
             termBufferLength(Configuration.termBufferLength());
@@ -395,6 +398,7 @@ public final class MediaDriver implements AutoCloseable
                     dirName(), publicationTermBufferLength, maxConnectionTermBufferLength, eventLogger));
 
                 concludeIdleStrategies();
+                concludeLossGenerators();
             }
             catch (final Exception ex)
             {
@@ -614,6 +618,18 @@ public final class MediaDriver implements AutoCloseable
             return this;
         }
 
+        public Context dataLossGenerator(final LossGenerator generator)
+        {
+            this.dataLossGenerator = generator;
+            return this;
+        }
+
+        public Context controlLossGenerator(final LossGenerator generator)
+        {
+            this.controlLossGenerator = generator;
+            return this;
+        }
+
         /**
          * Set whether or not this application will attempt to delete the Aeron directories when exiting.
          * @param dirsDeleteOnExit Attempt deletion.
@@ -785,6 +801,16 @@ public final class MediaDriver implements AutoCloseable
             return mtuLength;
         }
 
+        public LossGenerator dataLossGenerator()
+        {
+            return dataLossGenerator;
+        }
+
+        public LossGenerator controlLossGenerator()
+        {
+            return controlLossGenerator;
+        }
+
         public CommonContext mtuLength(final int mtuLength)
         {
             this.mtuLength = mtuLength;
@@ -880,6 +906,18 @@ public final class MediaDriver implements AutoCloseable
             if (null == sharedIdleStrategy)
             {
                 sharedIdleStrategy(Configuration.agentIdleStrategy());
+            }
+        }
+
+        private void concludeLossGenerators()
+        {
+            if (null == dataLossGenerator)
+            {
+                dataLossGenerator(Configuration.createLossGenerator(dataLossRate, dataLossSeed));
+            }
+            if (null == controlLossGenerator)
+            {
+                controlLossGenerator(Configuration.createLossGenerator(controlLossRate, controlLossSeed));
             }
         }
     }

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/RandomLossGenerator.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/RandomLossGenerator.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.aeron.driver;
 
+import uk.co.real_logic.agrona.concurrent.UnsafeBuffer;
+
 import java.net.InetSocketAddress;
 import java.util.Random;
 
@@ -49,7 +51,7 @@ public class RandomLossGenerator implements LossGenerator
     }
 
     /** {@inheritDoc} */
-    public boolean shouldDropFrame(final InetSocketAddress address, final int length)
+    public boolean shouldDropFrame(final InetSocketAddress address, final int length, final UnsafeBuffer buffer)
     {
         return random.nextDouble() <= lossRate;
     }

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/UdpChannelTransport.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/UdpChannelTransport.java
@@ -249,7 +249,7 @@ public abstract class UdpChannelTransport implements AutoCloseable
         if (null != srcAddress)
         {
             final int length = receiveByteBuffer.position();
-            if (lossGenerator.shouldDropFrame(srcAddress, length))
+            if (lossGenerator.shouldDropFrame(srcAddress, length, receiveBuffer))
             {
                 logger.logFrameInDropped(receiveByteBuffer, 0, length, srcAddress);
             }

--- a/aeron-driver/src/test/java/uk/co/real_logic/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/uk/co/real_logic/aeron/driver/ReceiverTest.java
@@ -147,7 +147,12 @@ public class ReceiverTest
             .toArray(TermReader[]::new);
 
         receiveChannelEndpoint = new ReceiveChannelEndpoint(
-            UdpChannel.parse(URI), driverConductorProxy, receiver, mockLogger, mockSystemCounters, (address, length) -> false);
+            UdpChannel.parse(URI),
+            driverConductorProxy,
+            receiver,
+            mockLogger,
+            mockSystemCounters,
+            (address, length, buffer) -> false);
     }
 
     @After

--- a/aeron-driver/src/test/java/uk/co/real_logic/aeron/driver/SelectorAndTransportTest.java
+++ b/aeron-driver/src/test/java/uk/co/real_logic/aeron/driver/SelectorAndTransportTest.java
@@ -45,7 +45,7 @@ public class SelectorAndTransportTest
     private static final UdpChannel SRC_DST = UdpChannel.parse("udp://localhost:" + SRC_PORT + "@localhost:" + RCV_PORT);
     private static final UdpChannel RCV_DST = UdpChannel.parse("udp://localhost:" + RCV_PORT);
 
-    private static final LossGenerator NO_LOSS = (address, length) -> false;
+    private static final LossGenerator NO_LOSS = (address, length, header) -> false;
 
     private final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(256);
     private final UnsafeBuffer buffer = new UnsafeBuffer(byteBuffer);

--- a/aeron-tools/src/main/java/uk/co/real_logic/aeron/tools/MediaDriverTool.java
+++ b/aeron-tools/src/main/java/uk/co/real_logic/aeron/tools/MediaDriverTool.java
@@ -16,9 +16,7 @@
 package uk.co.real_logic.aeron.tools;
 
 import java.util.logging.Logger;
-
 import org.apache.commons.cli.ParseException;
-
 import uk.co.real_logic.aeron.driver.MediaDriver;
 import uk.co.real_logic.agrona.concurrent.SigIntBarrier;
 
@@ -63,7 +61,9 @@ public class MediaDriverTool
             .senderIdleStrategy(opts.senderIdleStrategy())
             .receiverIdleStrategy(opts.receiverIdleStrategy())
             .sharedNetworkIdleStrategy(opts.sharedNetworkIdleStrategy())
-            .sharedIdleStrategy(opts.sharedIdleStrategy());
+            .sharedIdleStrategy(opts.sharedIdleStrategy())
+            .dataLossGenerator(opts.dataLossGenerator())
+            .controlLossGenerator(opts.controlLossGenerator());
 
         // Everything else can be changed by Aeron settings.
         try (final MediaDriver driver = MediaDriver.launch(context))
@@ -98,5 +98,9 @@ public class MediaDriverTool
         "aeron.tools.mediadriver.receiver" + NL +
         "aeron.tools.mediadriver.conductor" + NL +
         "aeron.tools.mediadriver.network" + NL +
-        "areon.tools.mediadriver.shared" + NL;
+        "areon.tools.mediadriver.shared" + NL +
+        NL +
+        "Set the loss generator classes for data and control using these properties:" + NL +
+        "aeron.tools.mediadriver.data.loss" + NL +
+        "aeron.tools.mediadriver.control.loss" + NL;
 }


### PR DESCRIPTION
Added the receive buffer to the parameters passed to shouldDropFrame in the LossGenerator interface. This gives a test application much more information when deciding what to drop.

In order to use custom loss generators, I added the ability to provide an implementation through the MediaDriver Context. If one is provided, it will take precedence over the configured rate & seed random loss generator. The RandomLossGenerator and default behavior (no loss) work the same as before. 

Updated MediaDriverTool to create and use a LossGenerator specified on the command line.