### PR TITLE
Ability to disable sending NAKs for testing

### DIFF
--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
@@ -337,7 +337,7 @@ public class Configuration
     public static final String THREADING_MODE_PROP_NAME = "aeron.threading.mode";
     public static final String THREADING_MODE_DEFAULT = DEDICATED.name();
 
-    /** Disable the NAKs from media driver (used for QA only)*/
+    /** Disable sending NAKs from the media driver. */
     public static final String DO_NOT_SEND_NAK_PROP_NAME = "aeron.driver.disable.naks";
 
     /**

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
@@ -15,24 +15,23 @@
  */
 package uk.co.real_logic.aeron.driver;
 
-import uk.co.real_logic.aeron.common.FeedbackDelayGenerator;
-import uk.co.real_logic.aeron.common.OptimalMulticastDelayGenerator;
-import uk.co.real_logic.aeron.common.StaticDelayGenerator;
-import uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy;
-import uk.co.real_logic.agrona.BitUtil;
-import uk.co.real_logic.agrona.concurrent.IdleStrategy;
-import uk.co.real_logic.agrona.TimerWheel;
-import uk.co.real_logic.agrona.LangUtil;
-import uk.co.real_logic.agrona.concurrent.broadcast.BroadcastBufferDescriptor;
-import uk.co.real_logic.agrona.concurrent.ringbuffer.RingBufferDescriptor;
-
-import java.util.concurrent.TimeUnit;
-
 import static java.lang.Integer.getInteger;
 import static java.lang.Long.getLong;
 import static java.lang.System.getProperty;
-
 import static uk.co.real_logic.aeron.driver.ThreadingMode.DEDICATED;
+
+import java.util.concurrent.TimeUnit;
+
+import uk.co.real_logic.aeron.common.FeedbackDelayGenerator;
+import uk.co.real_logic.aeron.common.OptimalMulticastDelayGenerator;
+import uk.co.real_logic.aeron.common.StaticDelayGenerator;
+import uk.co.real_logic.agrona.BitUtil;
+import uk.co.real_logic.agrona.LangUtil;
+import uk.co.real_logic.agrona.TimerWheel;
+import uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy;
+import uk.co.real_logic.agrona.concurrent.IdleStrategy;
+import uk.co.real_logic.agrona.concurrent.broadcast.BroadcastBufferDescriptor;
+import uk.co.real_logic.agrona.concurrent.ringbuffer.RingBufferDescriptor;
 
 /**
  * Configuration options for the media driver.
@@ -206,6 +205,12 @@ public class Configuration
         Configuration.NAK_UNICAST_DELAY_DEFAULT_NS, true);
 
     /**
+     * NAKs are effectively disabled.
+     */
+    public static final StaticDelayGenerator NO_NAK_DELAY_GENERATOR = new StaticDelayGenerator(
+            -1, false);
+
+    /**
      * Default delay for retransmission of data for unicast
      */
     public static final long RETRANS_UNICAST_DELAY_DEFAULT_NS = TimeUnit.NANOSECONDS.toNanos(0);
@@ -331,6 +336,9 @@ public class Configuration
 
     public static final String THREADING_MODE_PROP_NAME = "aeron.threading.mode";
     public static final String THREADING_MODE_DEFAULT = DEDICATED.name();
+
+    /** Disable the NAKs from media driver (used for QA only)*/
+    public static final String DO_NOT_SEND_NAK_PROP_NAME = "aeron.driver.disable.naks";
 
     /**
      * how often to check liveness & cleanup
@@ -504,5 +512,10 @@ public class Configuration
     public static ThreadingMode threadingMode()
     {
         return ThreadingMode.valueOf(getProperty(THREADING_MODE_PROP_NAME, THREADING_MODE_DEFAULT));
+    }
+
+    public static boolean doNotSendNaks()
+    {
+        return Boolean.parseBoolean(getProperty(DO_NOT_SEND_NAK_PROP_NAME, "false"));
     }
 }


### PR DESCRIPTION
Added a config property "aeron.driver.disable.naks", which, if set to true, will cause the media driver to effectively never send NAKs when it notices loss.  Useful for some types of automated testing.