### PR TITLE
Added socket buffer check during media driver startup

### DIFF
--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/media/UdpChannelTransport.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/media/UdpChannelTransport.java
@@ -78,25 +78,11 @@ public abstract class UdpChannelTransport implements AutoCloseable
             if (0 != Configuration.SOCKET_SNDBUF_LENGTH)
             {
                 datagramChannel.setOption(StandardSocketOptions.SO_SNDBUF, Configuration.SOCKET_SNDBUF_LENGTH);
-                final int soSndbuf = datagramChannel.getOption(StandardSocketOptions.SO_SNDBUF);
-
-                if (soSndbuf != Configuration.SOCKET_SNDBUF_LENGTH)
-                {
-                    throw new IllegalStateException(String.format(
-                        "Failed to set SO_SNDBUF: attempted=%d, actual=%d", Configuration.SOCKET_SNDBUF_LENGTH, soSndbuf));
-                }
             }
 
             if (0 != Configuration.SOCKET_RCVBUF_LENGTH)
             {
                 datagramChannel.setOption(StandardSocketOptions.SO_RCVBUF, Configuration.SOCKET_RCVBUF_LENGTH);
-                final int soRcvbuf = datagramChannel.getOption(StandardSocketOptions.SO_RCVBUF);
-
-                if (soRcvbuf != Configuration.SOCKET_RCVBUF_LENGTH)
-                {
-                    throw new IllegalStateException(String.format(
-                        "Failed to set SO_RCVBUF: attempted=%d, actual=%d", Configuration.SOCKET_RCVBUF_LENGTH, soRcvbuf));
-                }
             }
 
             datagramChannel.configureBlocking(false);


### PR DESCRIPTION
Added some up-front checks for socket buffer sizes during MediaDriver startup rather than doing a per-socket check while creating new UdpChannelTransports.

Rather than throwing an exception when we're unable to set the desired size, we just accept the maximum the OS will give us.

Fixes #29 