### PR TITLE
Hide the min/max macros defined in Windef.h

### DIFF
--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.h
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
The macros interfere with the std::min used in other parts of the code.
Compiler - VS 2013