### PR TITLE
Use covarient return types for aeronDirectoryName in Contexts.

### DIFF
--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
@@ -454,6 +454,16 @@ public final class Aeron implements AutoCloseable
         }
 
         /**
+         * @see CommonContext#aeronDirectoryName(String)
+         */
+        @Override
+        public Context aeronDirectoryName(String dirName)
+        {
+            super.aeronDirectoryName(dirName);
+            return this;
+        }
+
+        /**
          * Clean up all resources that the client uses to communicate with the Media Driver.
          */
         public void close()

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
@@ -856,6 +856,16 @@ public final class MediaDriver implements AutoCloseable
             return this;
         }
 
+        /**
+         * @see CommonContext#aeronDirectoryName(String)
+         */
+        @Override
+        public Context aeronDirectoryName(String dirName)
+        {
+            super.aeronDirectoryName(dirName);
+            return this;
+        }
+
         public EpochClock epochClock()
         {
             return epochClock;


### PR DESCRIPTION
Just makes the config code a little bit nicer for the users.

At the moment you have to do:

```Java
final Aeron.Context ctx = new Aeron.Context()
    .errorHandler(aeronErrorHandler);

ctx.aeronDirectoryName(aeronDirectoryName);
```

Where this PR allows:

```Java
final Aeron.Context ctx = new Aeron.Context()
    .aeronDirectoryName(aeronDirectoryName)
    .errorHandler(aeronErrorHandler);
```