### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/Configuration.java
@@ -35,7 +35,9 @@ import static uk.co.real_logic.aeron.driver.ThreadingMode.DEDICATED;
  */
 public class Configuration
 {
-    /**
+    private static final String UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY = "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy";
+
+	/**
      * Byte buffer length (in bytes) for reads
      */
     public static final String RECEIVE_BUFFER_LENGTH_PROP_NAME = "aeron.rcv.buffer.length";
@@ -312,7 +314,7 @@ public class Configuration
      */
     public static final String SENDER_IDLE_STRATEGY_PROP_NAME = "aeron.sender.idle.strategy";
     public static final String SENDER_IDLE_STRATEGY = getProperty(
-        SENDER_IDLE_STRATEGY_PROP_NAME, "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy");
+        SENDER_IDLE_STRATEGY_PROP_NAME, UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY);
 
     /**
      * {@link IdleStrategy} to be employed by {@link DriverConductor} for {@link ThreadingMode#DEDICATED}
@@ -320,14 +322,14 @@ public class Configuration
      */
     public static final String CONDUCTOR_IDLE_STRATEGY_PROP_NAME = "aeron.conductor.idle.strategy";
     public static final String CONDUCTOR_IDLE_STRATEGY = getProperty(
-        CONDUCTOR_IDLE_STRATEGY_PROP_NAME, "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy");
+        CONDUCTOR_IDLE_STRATEGY_PROP_NAME, UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY);
 
     /**
      * {@link IdleStrategy} to be employed by {@link Receiver} for {@link ThreadingMode#DEDICATED}.
      */
     public static final String RECEIVER_IDLE_STRATEGY_PROP_NAME = "aeron.receiver.idle.strategy";
     public static final String RECEIVER_IDLE_STRATEGY = getProperty(
-        RECEIVER_IDLE_STRATEGY_PROP_NAME, "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy");
+        RECEIVER_IDLE_STRATEGY_PROP_NAME, UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY);
 
     /**
      * {@link IdleStrategy} to be employed by {@link Sender} and {@link Receiver} for
@@ -335,7 +337,7 @@ public class Configuration
      */
     public static final String SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME = "aeron.sharednetwork.idle.strategy";
     public static final String SHARED_NETWORK_IDLE_STRATEGY = getProperty(
-        SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME, "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy");
+        SHARED_NETWORK_IDLE_STRATEGY_PROP_NAME, UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY);
 
     /**
      * {@link IdleStrategy} to be employed by {@link Sender}, {@link Receiver}, and {@link DriverConductor}
@@ -343,7 +345,7 @@ public class Configuration
      */
     public static final String SHARED_IDLE_STRATEGY_PROP_NAME = "aeron.shared.idle.strategy";
     public static final String SHARED_IDLE_STRATEGY = getProperty(
-        SHARED_IDLE_STRATEGY_PROP_NAME, "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy");
+        SHARED_IDLE_STRATEGY_PROP_NAME, UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY);
 
     /** Capacity for the command queues used between driver agents. */
     public static final int CMD_QUEUE_CAPACITY = 1024;
@@ -449,7 +451,7 @@ public class Configuration
         IdleStrategy idleStrategy = null;
         switch (name)
         {
-            case "uk.co.real_logic.agrona.concurrent.BackoffIdleStrategy":
+            case UK_CO_REAL_LOGIC_AGRONA_CONCURRENT_BACKOFF_IDLE_STRATEGY:
                 idleStrategy = new BackoffIdleStrategy(
                     AGENT_IDLE_MAX_SPINS, AGENT_IDLE_MAX_YIELDS, AGENT_IDLE_MIN_PARK_NS, AGENT_IDLE_MAX_PARK_NS);
                 break;

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
@@ -59,7 +59,8 @@ import static uk.co.real_logic.aeron.driver.event.EventConfiguration.EVENT_READE
  */
 public class DriverConductor implements Agent
 {
-    private final long imageLivenessTimeoutNs;
+    private static final String SUBSCRIBER_POS = "subscriber pos";
+	private final long imageLivenessTimeoutNs;
     private final long clientLivenessTimeoutNs;
     private final long publicationUnblockTimeoutNs;
     private final int mtuLength;
@@ -367,7 +368,7 @@ public class DriverConductor implements Agent
                 (subscription) ->
                 {
                     final Position position = newPosition(
-                        "subscriber pos", channel, sessionId, streamId, subscription.registrationId());
+                        SUBSCRIBER_POS, channel, sessionId, streamId, subscription.registrationId());
 
                     position.setOrdered(joiningPosition);
 
@@ -754,7 +755,7 @@ public class DriverConductor implements Agent
                 (image) ->
                 {
                     final int sessionId = image.sessionId();
-                    final Position position = newPosition("subscriber pos", channel, sessionId, streamId, registrationId);
+                    final Position position = newPosition(SUBSCRIBER_POS, channel, sessionId, streamId, registrationId);
                     position.setOrdered(image.rebuildPosition());
 
                     image.addSubscriber(position);
@@ -776,7 +777,7 @@ public class DriverConductor implements Agent
         final AeronClient client = getOrAddClient(clientId);
 
         final int sessionId = publication.sessionId();
-        final Position position = newPosition("subscriber pos", CommonContext.IPC_CHANNEL, sessionId, streamId, registrationId);
+        final Position position = newPosition(SUBSCRIBER_POS, CommonContext.IPC_CHANNEL, sessionId, streamId, registrationId);
         position.setOrdered(publication.joiningPosition());
 
         final SubscriptionLink subscriptionLink = new SubscriptionLink(registrationId, streamId, publication, position, client);

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/EmbeddedPingPong.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/EmbeddedPingPong.java
@@ -41,7 +41,8 @@ import uk.co.real_logic.agrona.console.ContinueBarrier;
 
 public class EmbeddedPingPong
 {
-    private static final int PING_STREAM_ID = SampleConfiguration.PING_STREAM_ID;
+    private static final String ON_STREAM_ID = " on stream Id ";
+	private static final int PING_STREAM_ID = SampleConfiguration.PING_STREAM_ID;
     private static final int PONG_STREAM_ID = SampleConfiguration.PONG_STREAM_ID;
     private static final String PING_CHANNEL = SampleConfiguration.PING_CHANNEL;
     private static final String PONG_CHANNEL = SampleConfiguration.PONG_CHANNEL;
@@ -90,8 +91,8 @@ public class EmbeddedPingPong
             .availableImageHandler(EmbeddedPingPong::availablePongImageHandler)
             .aeronDirectoryName(embeddedDirName);
 
-        System.out.println("Publishing Ping at " + PING_CHANNEL + " on stream Id " + PING_STREAM_ID);
-        System.out.println("Subscribing Pong at " + PONG_CHANNEL + " on stream Id " + PONG_STREAM_ID);
+        System.out.println("Publishing Ping at " + PING_CHANNEL + ON_STREAM_ID + PING_STREAM_ID);
+        System.out.println("Subscribing Pong at " + PONG_CHANNEL + ON_STREAM_ID + PONG_STREAM_ID);
         System.out.println("Message size of " + MESSAGE_LENGTH + " bytes");
 
         final FragmentAssembler dataHandler = new FragmentAssembler(EmbeddedPingPong::pongHandler);
@@ -135,8 +136,8 @@ public class EmbeddedPingPong
         {
             public void run()
             {
-                System.out.println("Subscribing Ping at " + PING_CHANNEL + " on stream Id " + PING_STREAM_ID);
-                System.out.println("Publishing Pong at " + PONG_CHANNEL + " on stream Id " + PONG_STREAM_ID);
+                System.out.println("Subscribing Ping at " + PING_CHANNEL + ON_STREAM_ID + PING_STREAM_ID);
+                System.out.println("Publishing Pong at " + PONG_CHANNEL + ON_STREAM_ID + PONG_STREAM_ID);
 
                 final Aeron.Context ctx = new Aeron.Context().aeronDirectoryName(embeddedDirName);
 

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPing.java
@@ -16,6 +16,7 @@
 package uk.co.real_logic.aeron.samples.raw;
 
 import org.HdrHistogram.Histogram;
+
 import uk.co.real_logic.agrona.concurrent.SigInt;
 
 import java.io.IOException;
@@ -33,7 +34,9 @@ import static uk.co.real_logic.agrona.BitUtil.SIZE_OF_LONG;
 
 public class TransferToPing
 {
-    public static void main(final String[] args) throws IOException
+    private static final String LOCALHOST = "localhost";
+
+	public static void main(final String[] args) throws IOException
     {
         final Histogram histogram = new Histogram(TimeUnit.SECONDS.toNanos(10), 3);
 
@@ -41,15 +44,15 @@ public class TransferToPing
         final ByteBuffer sendByteBuffer = sendFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, MTU_LENGTH_DEFAULT);
         final DatagramChannel sendDatagramChannel = DatagramChannel.open();
         init(sendDatagramChannel);
-        sendDatagramChannel.bind(new InetSocketAddress("localhost", 40123));
-        sendDatagramChannel.connect(new InetSocketAddress("localhost", 40124));
+        sendDatagramChannel.bind(new InetSocketAddress(LOCALHOST, 40123));
+        sendDatagramChannel.connect(new InetSocketAddress(LOCALHOST, 40124));
 
         final FileChannel receiveFileChannel = Common.createTmpFileChannel();
         final ByteBuffer receiveByteBuffer = receiveFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, MTU_LENGTH_DEFAULT);
         final DatagramChannel receiveDatagramChannel = DatagramChannel.open();
         init(receiveDatagramChannel);
-        receiveDatagramChannel.bind(new InetSocketAddress("localhost", 40126));
-        receiveDatagramChannel.connect(new InetSocketAddress("localhost", 40125));
+        receiveDatagramChannel.bind(new InetSocketAddress(LOCALHOST, 40126));
+        receiveDatagramChannel.connect(new InetSocketAddress(LOCALHOST, 40125));
 
         final AtomicBoolean running = new AtomicBoolean(true);
         SigInt.register(() -> running.set(false));

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPong.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPong.java
@@ -30,21 +30,23 @@ import static uk.co.real_logic.agrona.BitUtil.SIZE_OF_LONG;
 
 public class TransferToPong
 {
-    public static void main(final String[] args) throws IOException
+    private static final String LOCALHOST = "localhost";
+
+	public static void main(final String[] args) throws IOException
     {
         final FileChannel receiveFileChannel = Common.createTmpFileChannel();
         final ByteBuffer receiveByteBuffer = receiveFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, MTU_LENGTH_DEFAULT);
         final DatagramChannel receiveDatagramChannel = DatagramChannel.open();
         init(receiveDatagramChannel);
-        receiveDatagramChannel.bind(new InetSocketAddress("localhost", 40124));
-        receiveDatagramChannel.connect(new InetSocketAddress("localhost", 40123));
+        receiveDatagramChannel.bind(new InetSocketAddress(LOCALHOST, 40124));
+        receiveDatagramChannel.connect(new InetSocketAddress(LOCALHOST, 40123));
 
         final FileChannel sendFileChannel = Common.createTmpFileChannel();
         final ByteBuffer sendByteBuffer = sendFileChannel.map(FileChannel.MapMode.READ_WRITE, 0, MTU_LENGTH_DEFAULT);
         final DatagramChannel sendDatagramChannel = DatagramChannel.open();
         init(sendDatagramChannel);
-        sendDatagramChannel.bind(new InetSocketAddress("localhost", 40125));
-        sendDatagramChannel.connect(new InetSocketAddress("localhost", 40126));
+        sendDatagramChannel.bind(new InetSocketAddress(LOCALHOST, 40125));
+        sendDatagramChannel.connect(new InetSocketAddress(LOCALHOST, 40126));
 
         final AtomicBoolean running = new AtomicBoolean(true);
         SigInt.register(() -> running.set(false));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava