### PR TITLE
squid:S1611 - Parentheses should be removed from a single lambda input parameter when its type is inferred

### DIFF
--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/ActivePublications.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/ActivePublications.java
@@ -43,7 +43,7 @@ public class ActivePublications
     public Publication put(final String channel, final int streamId, final Publication publication)
     {
         final Int2ObjectHashMap<Publication> publicationByStreamIdMap =
-            getOrDefault(publicationsByChannelMap, channel, (ignore) -> new Int2ObjectHashMap<>());
+            getOrDefault(publicationsByChannelMap, channel, ignore -> new Int2ObjectHashMap<>());
 
         return publicationByStreamIdMap.put(streamId, publication);
     }
@@ -70,7 +70,7 @@ public class ActivePublications
         publicationsByChannelMap
             .values()
             .stream()
-            .flatMap((publicationByStreamIdMap) -> publicationByStreamIdMap.values().stream())
+            .flatMap(publicationByStreamIdMap -> publicationByStreamIdMap.values().stream())
             .collect(toList())
             .forEach(Publication::release);
     }

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/ActiveSubscriptions.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/ActiveSubscriptions.java
@@ -40,7 +40,7 @@ class ActiveSubscriptions
     public void add(final Subscription subscription)
     {
         final List<Subscription> subscriptions = subscriptionsByStreamIdMap.computeIfAbsent(
-            subscription.streamId(), (ignore) -> new ArrayList<>());
+            subscription.streamId(), ignore -> new ArrayList<>());
 
         subscriptions.add(subscription);
     }

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/Aeron.java
@@ -47,7 +47,7 @@ public final class Aeron implements AutoCloseable
      * @see Aeron.Context#errorHandler(ErrorHandler)
      */
     public static final ErrorHandler DEFAULT_ERROR_HANDLER =
-        (throwable) ->
+        throwable ->
         {
             throwable.printStackTrace();
             if (throwable instanceof DriverTimeoutException)
@@ -255,12 +255,12 @@ public final class Aeron implements AutoCloseable
 
                 if (null == availableImageHandler)
                 {
-                    availableImageHandler = (image) -> { };
+                    availableImageHandler = image -> { };
                 }
 
                 if (null == unavailableImageHandler)
                 {
-                    unavailableImageHandler = (image) -> { };
+                    unavailableImageHandler = image -> { };
                 }
             }
             catch (final Exception ex)

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/ClientConductor.java
@@ -206,7 +206,7 @@ class ClientConductor implements Agent, DriverListener
     {
         activeSubscriptions.forEach(
             streamId,
-            (subscription) ->
+            subscription ->
             {
                 if (!subscription.hasImage(sessionId))
                 {
@@ -241,7 +241,7 @@ class ClientConductor implements Agent, DriverListener
     {
         activeSubscriptions.forEach(
             streamId,
-            (subscription) ->
+            subscription ->
             {
                 final Image image = subscription.removeImage(correlationId);
                 if (null != image)

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/ControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/ControlledFragmentAssembler.java
@@ -61,7 +61,7 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
     public ControlledFragmentAssembler(final ControlledFragmentHandler delegate, final int initialBufferLength)
     {
         this.delegate = delegate;
-        builderFunc = (ignore) -> new BufferBuilder(initialBufferLength);
+        builderFunc = ignore -> new BufferBuilder(initialBufferLength);
     }
 
     /**

--- a/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssembler.java
+++ b/aeron-client/src/main/java/uk/co/real_logic/aeron/FragmentAssembler.java
@@ -61,7 +61,7 @@ public class FragmentAssembler implements FragmentHandler
     public FragmentAssembler(final FragmentHandler delegate, final int initialBufferLength)
     {
         this.delegate = delegate;
-        builderFunc = (ignore) -> new BufferBuilder(initialBufferLength);
+        builderFunc = ignore -> new BufferBuilder(initialBufferLength);
     }
 
     /**

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/DriverConductor.java
@@ -266,7 +266,7 @@ public class DriverConductor implements Agent
                 sourceAddress);
 
             subscriberPositions.forEach(
-                (subscriberPosition) -> subscriberPosition.subscription().addImage(image, subscriberPosition.position()));
+                subscriberPosition -> subscriberPosition.subscription().addImage(image, subscriberPosition.position()));
 
             publicationImages.add(image);
             receiverProxy.newPublicationImage(channelEndpoint, image);
@@ -349,8 +349,8 @@ public class DriverConductor implements Agent
 
         subscriptionLinks
             .stream()
-            .filter((link) -> image.matches(link.channelEndpoint(), link.streamId()))
-            .forEach((subscriptionLink) -> subscriptionLink.removeImage(image));
+            .filter(link -> image.matches(link.channelEndpoint(), link.streamId()))
+            .forEach(subscriptionLink -> subscriptionLink.removeImage(image));
     }
 
     private List<SubscriberPosition> listSubscriberPositions(
@@ -362,9 +362,9 @@ public class DriverConductor implements Agent
     {
         return subscriptionLinks
             .stream()
-            .filter((subscription) -> subscription.matches(channelEndpoint, streamId))
+            .filter(subscription -> subscription.matches(channelEndpoint, streamId))
             .map(
-                (subscription) ->
+                subscription ->
                 {
                     final Position position = newPosition(
                         "subscriber pos", channel, sessionId, streamId, subscription.registrationId());
@@ -749,9 +749,9 @@ public class DriverConductor implements Agent
 
         publicationImages
             .stream()
-            .filter((image) -> image.matches(channelEndpoint, streamId) && (image.subscriberCount() > 0))
+            .filter(image -> image.matches(channelEndpoint, streamId) && (image.subscriberCount() > 0))
             .forEach(
-                (image) ->
+                image ->
                 {
                     final int sessionId = image.sessionId();
                     final Position position = newPosition("subscriber pos", channel, sessionId, streamId, registrationId);

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/MediaDriver.java
@@ -290,7 +290,7 @@ public final class MediaDriver implements AutoCloseable
     private MediaDriver start()
     {
         runners.forEach(
-            (runner) ->
+            runner ->
             {
                 final Thread thread = new Thread(runner);
                 thread.setName(runner.agent().roleName());
@@ -362,7 +362,7 @@ public final class MediaDriver implements AutoCloseable
             }
             else
             {
-                logProgress = (message) -> { };
+                logProgress = message -> { };
             }
 
             if (ctx.dirsDeleteOnStart())

--- a/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/NetworkUtil.java
+++ b/aeron-driver/src/main/java/uk/co/real_logic/aeron/driver/NetworkUtil.java
@@ -72,7 +72,7 @@ public class NetworkUtil
         sort(filterResults);
 
         final List<NetworkInterface> results = new ArrayList<>();
-        filterResults.forEach((filterResult) -> results.add(filterResult.ifc));
+        filterResults.forEach(filterResult -> results.add(filterResult.ifc));
 
         return results;
     }

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/SamplesUtil.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/SamplesUtil.java
@@ -61,7 +61,7 @@ public class SamplesUtil
         final FragmentHandler fragmentHandler, final int limit, final AtomicBoolean running, final IdleStrategy idleStrategy)
     {
         return
-            (subscription) ->
+            subscription ->
             {
                 try
                 {

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/HackSelectReceiveSendUdpPong.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/HackSelectReceiveSendUdpPong.java
@@ -59,7 +59,7 @@ public class HackSelectReceiveSendUdpPong
         final NioSelectedKeySet keySet = Common.keySet(selector);
 
         final ToIntFunction<SelectionKey> handler =
-            (key) ->
+            key ->
             {
                 try
                 {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1611 - Parentheses should be removed from a single lambda input parameter when its type is inferred.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1611
Please let me know if you have any questions.
George Kankava