### PR TITLE
squid:S1215 - Execution of the Garbage Collector should be triggered only by the JVM.

### DIFF
--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendHackSelectReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendHackSelectReceiveUdpPing.java
@@ -74,7 +74,6 @@ public class SendHackSelectReceiveUdpPing implements ToIntFunction<SelectionKey>
             measureRoundTrip(HISTOGRAM, SEND_ADDRESS, buffer, sendChannel, selector, keySet, running);
 
             HISTOGRAM.reset();
-            System.gc();
             LockSupport.parkNanos(1000 * 1000 * 1000);
         }
     }

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendReceiveUdpPing.java
@@ -69,7 +69,6 @@ public class SendReceiveUdpPing
             measureRoundTrip(histogram, sendAddress, buffer, receiveChannels, sendChannel, running);
 
             histogram.reset();
-            System.gc();
             LockSupport.parkNanos(1000_000_000);
         }
     }

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendSelectReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/SendSelectReceiveUdpPing.java
@@ -102,7 +102,6 @@ public class SendSelectReceiveUdpPing
             measureRoundTrip(histogram, SEND_ADDRESS, buffer, sendChannel, selector, running);
 
             histogram.reset();
-            System.gc();
             LockSupport.parkNanos(1000 * 1000 * 1000);
         }
     }

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/TransferToPing.java
@@ -67,7 +67,6 @@ public class TransferToPing
                 running);
 
             histogram.reset();
-            System.gc();
             LockSupport.parkNanos(1000 * 1000 * 1000);
         }
     }

--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/WriteReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/raw/WriteReceiveUdpPing.java
@@ -68,7 +68,6 @@ public class WriteReceiveUdpPing
             measureRoundTrip(histogram, buffer, receiveChannels, writeChannel, running);
 
             histogram.reset();
-            System.gc();
             LockSupport.parkNanos(1000_000_000);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1215 - Execution of the Garbage Collector should be triggered only by the JVM.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1215
Please let me know if you have any questions.
George Kankava