### PR TITLE
fix formatting of bytes to ascii in LogInspector. Negative bytes to be formatted to zero

### DIFF
--- a/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/LogInspector.java
+++ b/aeron-samples/src/main/java/uk/co/real_logic/aeron/samples/LogInspector.java
@@ -144,14 +144,14 @@ public class LogInspector
 
         for (int i = 0; i < length; i++)
         {
-            int b = buffer.getByte(offset + i) & 0xFF;
+            byte b = buffer.getByte(offset + i);
 
             if (b < 0)
             {
                 b = 0;
             }
 
-            chars[i] = (char)b;
+            chars[i] = (char) (b & 0xFF);
         }
 
         return chars;

--- a/aeron-samples/src/test/java/uk/co/real_logic/aeron/samples/LogInspectorAsciiFormatBytesTest.java
+++ b/aeron-samples/src/test/java/uk/co/real_logic/aeron/samples/LogInspectorAsciiFormatBytesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 - 2016 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.aeron.samples;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import uk.co.real_logic.agrona.concurrent.UnsafeBuffer;
+
+import java.util.Arrays;
+
+@RunWith(Parameterized.class)
+public class LogInspectorAsciiFormatBytesTest
+{
+    private static final String FORMAT_KEY = "aeron.log.inspector.data.format";
+    private String originalDataFormatProperty;
+
+    private byte buffer;
+    private char expected;
+
+    public LogInspectorAsciiFormatBytesTest(final int buffer, final int expected)
+    {
+        this.buffer = (byte) buffer;
+        this.expected = (char) expected;
+    }
+
+    @Parameters(name = "{index}: ascii format[{0}]={1}")
+    public static Iterable<Object[]> data()
+    {
+        return Arrays.asList(
+            new Object[][]
+            {
+                { 0x17,  0x17                     },
+                { 0,     0                        },
+                { -1,    0                        },
+                { Byte.MAX_VALUE,  Byte.MAX_VALUE },
+                { Byte.MIN_VALUE,  0              },
+            });
+    }
+
+    @Test
+    public void shouldFormatBytesToAscii()
+    {
+        System.setProperty(FORMAT_KEY, "ascii");
+        final char[] formattedBytes = LogInspector.formatBytes(new UnsafeBuffer(new byte[] { buffer }), 0, 1);
+
+        Assert.assertEquals(expected, formattedBytes[0]);
+    }
+
+    @Before
+    public void setUp()
+    {
+        originalDataFormatProperty = System.getProperty(FORMAT_KEY);
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (originalDataFormatProperty == null)
+        {
+            System.clearProperty(FORMAT_KEY);
+        }
+        else
+        {
+            System.setProperty(FORMAT_KEY, originalDataFormatProperty);
+        }
+    }
+}


### PR DESCRIPTION
That seemed to me to be the intention in the previous code, however, the widening of the byte to an integer made sure that 'b' would never be negative and therefore the condition was redundant.




