### PR TITLE
[C++]: pass frag/block handler functions by reference in Subscription

### DIFF
--- a/aeron-client/src/main/cpp/Subscription.h
+++ b/aeron-client/src/main/cpp/Subscription.h
@@ -95,7 +95,7 @@ public:
      *
      * @see FragmentAssembler
      */
-    inline int poll(const fragment_handler_t fragmentHandler, int fragmentLimit)
+    inline int poll(const fragment_handler_t& fragmentHandler, int fragmentLimit)
     {
         int fragmentsRead = 0;
         const int length = std::atomic_load(&m_imagesLength);
@@ -133,7 +133,7 @@ public:
      * @param blockLengthLimit for each individual block.
      * @return the number of bytes consumed.
      */
-    inline long blockPoll(const block_handler_t blockHandler, int blockLengthLimit)
+    inline long blockPoll(const block_handler_t& blockHandler, int blockLengthLimit)
     {
         const int length = std::atomic_load(&m_imagesLength);
         Image *images = std::atomic_load(&m_images);


### PR DESCRIPTION
Changed passing these std::functions by reference, since with GCC 4.9.2 at least, passing by value resulted in a malloc/free, despite the fact that the closure was only capturing a 'this' pointer.