### PR TITLE
[C++] Added setting clientId on remove messages to the driver

### DIFF
--- a/aeron-client/src/main/cpp/DriverProxy.h
+++ b/aeron-client/src/main/cpp/DriverProxy.h
@@ -76,6 +76,7 @@ public:
         {
             RemoveMessageFlyweight removeMessage(buffer, 0);
 
+            removeMessage.clientId(m_clientId);
             removeMessage.correlationId(correlationId);
             removeMessage.registrationId(registrationId);
 
@@ -117,6 +118,7 @@ public:
         {
             RemoveMessageFlyweight removeMessage(buffer, 0);
 
+            removeMessage.clientId(m_clientId);
             removeMessage.correlationId(correlationId);
             removeMessage.registrationId(registrationId);
 


### PR DESCRIPTION
It appears that clientId is not set on the flyweights for removeSubscription and removePublication sent to the driver. Doesn't seem to impact the functionality, however.