### PR TITLE
Add ThreadFactories for each thread in MediaDriver to support program…

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -106,7 +106,7 @@ public final class Aeron implements AutoCloseable
             ctx.interServiceTimeout(),
             ctx.publicationConnectionTimeout());
 
-        conductorRunner = new AgentRunner(ctx.idleStrategy, ctx.errorHandler, null, conductor, ctx.threadFactory);
+        conductorRunner = new AgentRunner(ctx.idleStrategy, ctx.errorHandler, null, conductor);
     }
 
     /**
@@ -169,7 +169,7 @@ public final class Aeron implements AutoCloseable
 
     private Aeron start()
     {
-        AgentRunner.startOnThread(conductorRunner);
+        AgentRunner.startOnThread(conductorRunner, ctx.threadFactory);
 
         return this;
     }

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -106,7 +106,7 @@ public final class Aeron implements AutoCloseable
             ctx.interServiceTimeout(),
             ctx.publicationConnectionTimeout());
 
-        conductorRunner = new AgentRunner(ctx.idleStrategy, ctx.errorHandler, null, conductor);
+        conductorRunner = new AgentRunner(ctx.idleStrategy, ctx.errorHandler, null, conductor, ctx.threadFactory);
     }
 
     /**
@@ -169,7 +169,7 @@ public final class Aeron implements AutoCloseable
 
     private Aeron start()
     {
-        AgentRunner.startOnThread(conductorRunner, ctx.threadFactory);
+        AgentRunner.startOnThread(conductorRunner);
 
         return this;
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -73,7 +73,11 @@ public final class MediaDriver implements AutoCloseable
      */
     public static final String DIRS_DELETE_ON_START_PROP_NAME = "aeron.dir.delete.on.start";
 
-    private final List<AgentRunner> runners;
+    private final AgentRunner sharedRunner;
+    private final AgentRunner sharedNetworkRunner;
+    private final AgentRunner conductorRunner;
+    private final AgentRunner receiverRunner;
+    private final AgentRunner senderRunner;
     private final Context ctx;
 
     /**
@@ -182,49 +186,36 @@ public final class MediaDriver implements AutoCloseable
         switch (context.threadingMode)
         {
             case SHARED:
-                runners = Collections.singletonList(
-                    new AgentRunner(
+                this.sharedRunner = new AgentRunner(
                         context.sharedIdleStrategy,
                         errorHandler,
                         errorCounter,
-                        new CompositeAgent(sender, receiver, conductor), context.sharedThreadFactory)
-                );
+                        new CompositeAgent(sender, receiver, conductor));
+                this.sharedNetworkRunner = null;
+                this.conductorRunner = null;
+                this.receiverRunner = null;
+                this.senderRunner = null;
                 break;
 
             case SHARED_NETWORK:
-                runners = Arrays.asList(
-                    new AgentRunner(
+                this.sharedNetworkRunner = new AgentRunner(
                         context.sharedNetworkIdleStrategy,
                         errorHandler,
                         errorCounter,
-                        new CompositeAgent(sender, receiver), context.sharedNetworkThreadFactory),
-                    new AgentRunner(context.conductorIdleStrategy,
-                        errorHandler,
-                        errorCounter,
-                        conductor,
-                        context.conductorThreadFactory)
-                );
+                        new CompositeAgent(sender, receiver));
+                this.conductorRunner = new AgentRunner(context.conductorIdleStrategy, errorHandler, errorCounter, conductor);
+                this.sharedRunner = null;
+                this.receiverRunner = null;
+                this.senderRunner = null;
                 break;
 
             default:
             case DEDICATED:
-                runners = Arrays.asList(
-                    new AgentRunner(context.senderIdleStrategy,
-                        errorHandler,
-                        errorCounter,
-                        sender,
-                        context.senderThreadFactory),
-                    new AgentRunner(context.receiverIdleStrategy,
-                        errorHandler,
-                        errorCounter,
-                        receiver,
-                        context.receiverThreadFactory),
-                    new AgentRunner(context.conductorIdleStrategy,
-                        errorHandler,
-                        errorCounter,
-                        conductor,
-                        context.conductorThreadFactory)
-                );
+                this.senderRunner = new AgentRunner(context.senderIdleStrategy, errorHandler, errorCounter, sender);
+                this.receiverRunner = new AgentRunner(context.receiverIdleStrategy, errorHandler, errorCounter, receiver);
+                this.conductorRunner = new AgentRunner(context.conductorIdleStrategy, errorHandler, errorCounter, conductor);
+                this.sharedNetworkRunner = null;
+                this.sharedRunner = null;
         }
     }
 
@@ -287,7 +278,26 @@ public final class MediaDriver implements AutoCloseable
     {
         try
         {
-            runners.forEach(AgentRunner::close);
+            if (null != this.sharedRunner)
+            {
+                this.sharedRunner.close();
+            }
+            if (null != this.sharedNetworkRunner)
+            {
+                this.sharedNetworkRunner.close();
+            }
+            if (null != this.receiverRunner)
+            {
+                this.receiverRunner.close();
+            }
+            if (null != this.senderRunner)
+            {
+                this.senderRunner.close();
+            }
+            if (null != this.conductorRunner)
+            {
+                this.conductorRunner.close();
+            }
             ctx.close();
         }
         catch (final Exception ex)
@@ -309,7 +319,26 @@ public final class MediaDriver implements AutoCloseable
 
     private MediaDriver start()
     {
-        runners.forEach(AgentRunner::startOnThread);
+        if (null != this.sharedRunner)
+        {
+            AgentRunner.startOnThread(this.sharedRunner, ctx.sharedThreadFactory);
+        }
+        if (null != this.sharedNetworkRunner)
+        {
+            AgentRunner.startOnThread(this.sharedNetworkRunner, ctx.sharedNetworkThreadFactory);
+        }
+        if (null != this.receiverRunner)
+        {
+            AgentRunner.startOnThread(this.receiverRunner, ctx.receiverThreadFactory);
+        }
+        if (null != this.senderRunner)
+        {
+            AgentRunner.startOnThread(this.senderRunner, ctx.senderThreadFactory);
+        }
+        if (null != this.conductorRunner)
+        {
+            AgentRunner.startOnThread(this.conductorRunner, ctx.conductorThreadFactory);
+        }
 
         return this;
     }


### PR DESCRIPTION
Adds configurations to MediaDriver Context to pass in ThreadFactories for each of the threads spun up by the MediaDriver.  Will allow users to easily create ThreadFactories that pin indivudal MediaDriver threads to cores.  (Dependent on Agrona PR https://github.com/real-logic/Agrona/pull/69)