### PR TITLE
aeron-agent: rather inline logging into methods than use delegation

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
@@ -17,6 +17,7 @@ package io.aeron.agent;
 
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.SendChannelEndpoint;
+import net.bytebuddy.asm.Advice;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import java.net.InetSocketAddress;
@@ -26,59 +27,93 @@ public class ChannelEndpointInterceptor
 {
     public static class SenderProxyInterceptor
     {
-        public static void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
-        {
-            EventLogger.LOGGER.logChannelCreated(
-                EventCode.SEND_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+
+        public static class RegisterSendChannelEndpoint {
+
+            @Advice.OnMethodEnter
+            public static void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
+            {
+                EventLogger.LOGGER.logChannelCreated(
+                   EventCode.SEND_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+            }
         }
 
-        public static void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
-        {
-            EventLogger.LOGGER.logChannelCreated(
-                EventCode.SEND_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+        public static class CloseSendChannelEndpoint {
+
+            @Advice.OnMethodEnter
+            public static void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
+            {
+                EventLogger.LOGGER.logChannelCreated(
+                    EventCode.SEND_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+            }
         }
     }
 
     public static class ReceiverProxyInterceptor
     {
-        public static void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
-        {
-            EventLogger.LOGGER.logChannelCreated(
-                EventCode.RECEIVE_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+
+        public static class RegisterReceiveChannelEndpoint {
+
+            @Advice.OnMethodEnter
+            public static void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
+            {
+                EventLogger.LOGGER.logChannelCreated(
+                    EventCode.RECEIVE_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+            }
         }
 
-        public static void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
-        {
-            EventLogger.LOGGER.logChannelCreated(
-                EventCode.RECEIVE_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+        public static class CloseReceiveChannelEndpoint {
+
+            @Advice.OnMethodEnter
+            public static void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
+            {
+                EventLogger.LOGGER.logChannelCreated(
+                    EventCode.RECEIVE_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+            }
         }
     }
 
     public static class SendChannelEndpointInterceptor
     {
-        public static void presend(final ByteBuffer buffer, final InetSocketAddress address)
-        {
-            EventLogger.LOGGER.logFrameOut(buffer, address);
+
+        public static class Presend {
+
+            @Advice.OnMethodEnter
+            public static void presend(final ByteBuffer buffer, final InetSocketAddress address)
+            {
+                EventLogger.LOGGER.logFrameOut(buffer, address);
+            }
         }
 
-        public static void dispatch(final UnsafeBuffer buffer, final int length, final InetSocketAddress srcAddress)
-        {
-            EventLogger.LOGGER.logFrameIn(buffer, 0, length, srcAddress);
+        public static class Dispatch {
+
+            @Advice.OnMethodEnter
+            public static void dispatch(final UnsafeBuffer buffer, final int length, final InetSocketAddress srcAddress)
+            {
+                EventLogger.LOGGER.logFrameIn(buffer, 0, length, srcAddress);
+            }
         }
     }
 
     public static class ReceiveChannelEndpointInterceptor
     {
-        public static void sendTo(
-            final ByteBuffer buffer,
-            final InetSocketAddress address)
-        {
-            EventLogger.LOGGER.logFrameOut(buffer, address);
+
+        public static class SendTo {
+
+            @Advice.OnMethodEnter
+            public static void sendTo(final ByteBuffer buffer, final InetSocketAddress address)
+            {
+                EventLogger.LOGGER.logFrameOut(buffer, address);
+            }
         }
 
-        public static void dispatch(final UnsafeBuffer buffer, final int length, final InetSocketAddress srcAddress)
-        {
-            EventLogger.LOGGER.logFrameIn(buffer, 0, length, srcAddress);
+        public static class Dispatch {
+
+            @Advice.OnMethodEnter
+            public static void dispatch(final UnsafeBuffer buffer, final int length, final InetSocketAddress srcAddress)
+            {
+                EventLogger.LOGGER.logFrameIn(buffer, 0, length, srcAddress);
+            }
         }
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/CleanupInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CleanupInterceptor.java
@@ -19,33 +19,47 @@ import io.aeron.driver.SubscriptionLink;
 import io.aeron.driver.NetworkPublication;
 import io.aeron.driver.PublicationImage;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
+import net.bytebuddy.asm.Advice;
 
 public class CleanupInterceptor
 {
     public static class DriverConductorInterceptor
     {
-        public static void cleanupImageInterceptor(final PublicationImage image)
-        {
-            EventLogger.LOGGER.logImageRemoval(
-                image.channelUriString(), image.sessionId(), image.streamId(), image.correlationId());
-        }
 
-        public static void cleanupPublication(final NetworkPublication publication)
-        {
-            EventLogger.LOGGER.logPublicationRemoval(
-                publication.sendChannelEndpoint().originalUriString(), publication.sessionId(), publication.streamId());
-        }
+        public static class CleanupImage {
 
-        public static void cleanupSubscriptionLink(final SubscriptionLink subscriptionLink)
-        {
-            final ReceiveChannelEndpoint channelEndpoint = subscriptionLink.channelEndpoint();
-
-            if (null != channelEndpoint)
+            @Advice.OnMethodEnter
+            public static void cleanupImageInterceptor(final PublicationImage image)
             {
-                final int streamId = subscriptionLink.streamId();
+                EventLogger.LOGGER.logImageRemoval(
+                    image.channelUriString(), image.sessionId(), image.streamId(), image.correlationId());
+            }
+        }
 
-                EventLogger.LOGGER.logSubscriptionRemoval(
-                    channelEndpoint.originalUriString(), subscriptionLink.streamId(), subscriptionLink.registrationId());
+        public static class CleanupPublication {
+
+            @Advice.OnMethodEnter
+            public static void cleanupPublication(final NetworkPublication publication)
+            {
+                EventLogger.LOGGER.logPublicationRemoval(
+                        publication.sendChannelEndpoint().originalUriString(), publication.sessionId(), publication.streamId());
+            }
+        }
+
+        public static class CleanupSubscriptionLink {
+
+            @Advice.OnMethodEnter
+            public static void cleanupSubscriptionLink(final SubscriptionLink subscriptionLink)
+            {
+                final ReceiveChannelEndpoint channelEndpoint = subscriptionLink.channelEndpoint();
+
+                if (null != channelEndpoint)
+                {
+                    final int streamId = subscriptionLink.streamId();
+
+                    EventLogger.LOGGER.logSubscriptionRemoval(
+                        channelEndpoint.originalUriString(), subscriptionLink.streamId(), subscriptionLink.registrationId());
+                }
             }
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.agent;
 
+import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
 
 import static io.aeron.agent.EventCode.*;
@@ -23,6 +24,7 @@ import static io.aeron.command.ControlProtocolEvents.*;
 
 public class CmdInterceptor
 {
+    @Advice.OnMethodEnter
     public static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
     {
         switch (msgTypeId)


### PR DESCRIPTION
Using Byte Buddy's Advice component, it is possible to inline code rather than adding additional methods that instrument via interceptor classes. This reduces the call stack depth, avoids allocations and ultimatively improves performance. 