### PR TITLE
aeron-agent: improve logging detachment; allow to enable/disable logging at runtime via MX bean

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogControl.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogControl.java
@@ -1,0 +1,22 @@
+package io.aeron.agent;
+
+public class EventLogControl implements EventLogControlMXBean
+{
+    @Override
+    public boolean enableLogging()
+    {
+        return EventLogAgent.enableLogging();
+    }
+
+    @Override
+    public boolean disableLogging()
+    {
+        return EventLogAgent.disableLogging();
+    }
+
+    @Override
+    public boolean isLogging()
+    {
+        return EventLogAgent.isLogging();
+    }
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogControlMXBean.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogControlMXBean.java
@@ -1,0 +1,13 @@
+package io.aeron.agent;
+
+import javax.management.MXBean;
+
+@MXBean
+public interface EventLogControlMXBean
+{
+    boolean enableLogging();
+
+    boolean disableLogging();
+
+    boolean isLogging();
+}

--- a/build.gradle
+++ b/build.gradle
@@ -371,7 +371,7 @@ project(':aeron-agent') {
 
     dependencies {
         compile project(':aeron-client'), project(':aeron-driver')
-        compile "net.bytebuddy:byte-buddy:1.4.23"
+        compile "net.bytebuddy:byte-buddy:1.4.24"
     }
 
     jar {
@@ -379,7 +379,6 @@ project(':aeron-agent') {
             attributes(
                 "Premain-Class" : "io.aeron.agent.EventLogAgent",
                 "Agent-Class" : "io.aeron.agent.EventLogAgent",
-                "Can-Redefine-Classes" : "true",
                 "Can-Retransform-Classes" : "true")
         }
     }


### PR DESCRIPTION
The Aeron agent now reads its argument and registers an MX bean to the running platform's MBean server if `mbean` is contained in the agent arguments. Using this exposed MX bean, it is now possible to enable or disable logging during runtime and to check the current logging state of a running application.