### PR TITLE
Make artifacts valid OSGi bundles.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,8 @@ subprojects {
 }
 
 project(':aeron-client') {
+    apply plugin: 'osgi'
+
     dependencies {
         compile 'org.agrona:Agrona:0.5.6'
     }
@@ -212,6 +214,7 @@ project(':aeron-client') {
 
 project(':aeron-driver') {
     apply plugin: 'application'
+    apply plugin: 'osgi'
 
     mainClassName = 'io.aeron.driver.MediaDriver'
 
@@ -367,6 +370,7 @@ project(':aeron-system-tests') {
 
 project(':aeron-agent') {
     apply plugin: 'com.github.johnrengelman.shadow'
+    apply plugin: 'osgi'
 
     dependencies {
         compile project(':aeron-client'), project(':aeron-driver')


### PR DESCRIPTION
I would like to use the artifacts of this project in an OSGi environment. (Actually, they come in as transitive dependencies of the most recent akka-remote version.) So far, the produced jars do not contain any OSGi meta data.

This patch is pretty trivial. It just adds the Gradle OSGi plugin to the relevant projects. This produces standard OSGi meta data which is sufficient to use the jars as bundles in an OSGi container; I could verify that they could be deployed and used successfully in a local project.