### PR TITLE
[C++]: Fixed segfault due to null ifa_addr from getifaddrs

### DIFF
--- a/aeron-driver/src/main/cpp/media/InterfaceLookup.cpp
+++ b/aeron-driver/src/main/cpp/media/InterfaceLookup.cpp
@@ -66,7 +66,7 @@ void BsdInterfaceLookup::lookupIPv4(IPv4LookupCallback func) const
 
     while (cursor)
     {
-        if (cursor->ifa_addr->sa_family == AF_INET)
+        if (cursor->ifa_addr != nullptr && cursor->ifa_addr->sa_family == AF_INET)
         {
             sockaddr_in* sockaddrIn = (sockaddr_in*) cursor->ifa_addr;
             Inet4Address inet4Address{sockaddrIn->sin_addr, 0};
@@ -108,7 +108,7 @@ void BsdInterfaceLookup::lookupIPv6(IPv6LookupCallback func) const
 
     while (cursor)
     {
-        if (cursor->ifa_addr->sa_family == AF_INET6)
+        if (cursor->ifa_addr != nullptr && cursor->ifa_addr->sa_family == AF_INET6)
         {
             sockaddr_in6* sockaddrIn = (sockaddr_in6*) cursor->ifa_addr;
             Inet6Address inet6Address{sockaddrIn->sin6_addr, 0};


### PR DESCRIPTION
`BsdInterfaceLookup::lookupIPv4` and `BsdInterfaceLookup::lookupIPv6` can segfault on a machine with interfaces that have `NULL` `ifa_addr` (e.g. OpenVPN `tun` interface).

From the documentation of `getifaddrs`:

> `ifa_addr` and other fields can actually be `NULL` if the interface has no address, and no link-level address is returned if the interface has an IP address assigned.