### PR TITLE
enable Aeron to run on 32-bit machines (tested w/ Raspberry Pi)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,11 @@ find_package(Doxygen)
 
 # all UNIX-based platform compiler flags
 if(UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -fexceptions -g -m64")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -fexceptions -g -m64")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++11 -fexceptions -g")
+    endif()
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Ofast")
 endif()

--- a/aeron-client/src/main/cpp/ClientConductor.h
+++ b/aeron-client/src/main/cpp/ClientConductor.h
@@ -57,7 +57,7 @@ public:
         const exception_handler_t& errorHandler,
         long driverTimeoutMs,
         long resourceLingerTimeoutMs,
-        long interServiceTimeoutNs,
+        long long interServiceTimeoutNs,
         long publicationConnectionTimeoutMs) :
         m_driverProxy(driverProxy),
         m_driverListenerAdapter(broadcastReceiver, *this),

--- a/aeron-client/src/main/cpp/util/Platform.h
+++ b/aeron-client/src/main/cpp/util/Platform.h
@@ -40,9 +40,6 @@
 
     #if defined(__x86_64__)
         #define AERON_CPU_X64 1
-
-    #else
-        #error Unsupported CPU!
     #endif
 
 #else

--- a/aeron-client/src/test/cpp/ClientConductorFixture.h
+++ b/aeron-client/src/test/cpp/ClientConductorFixture.h
@@ -43,7 +43,7 @@ using namespace std::placeholders;
 
 static const long DRIVER_TIMEOUT_MS = 10 * 1000;
 static const long RESOURCE_LINGER_TIMEOUT_MS = 5 * 1000;
-static const long INTER_SERVICE_TIMEOUT_NS = 5 * 1000 * 1000 * 1000L;
+static const long long INTER_SERVICE_TIMEOUT_NS = 5 * 1000 * 1000 * 1000LL;
 static const long INTER_SERVICE_TIMEOUT_MS = INTER_SERVICE_TIMEOUT_NS / 1000000L;
 static const long PUBLICATION_CONNECTION_TIMEOUT_MS = 5 * 1000L;
 

--- a/aeron-samples/src/main/cpp/Ping.cpp
+++ b/aeron-samples/src/main/cpp/Ping.cpp
@@ -84,10 +84,10 @@ Settings parseCmdLine(CommandOptionParser& cp, int argc, char** argv)
     s.pongChannel = cp.getOption(optPongChannel).getParam(0, s.pongChannel);
     s.pingStreamId = cp.getOption(optPingStreamId).getParamAsInt(0, 1, INT32_MAX, s.pingStreamId);
     s.pongStreamId = cp.getOption(optPongStreamId).getParamAsInt(0, 1, INT32_MAX, s.pongStreamId);
-    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, INT64_MAX, s.numberOfMessages);
+    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, LONG_MAX, s.numberOfMessages);
     s.messageLength = cp.getOption(optLength).getParamAsInt(0, sizeof(std::int64_t), INT32_MAX, s.messageLength);
     s.fragmentCountLimit = cp.getOption(optFrags).getParamAsInt(0, 1, INT32_MAX, s.fragmentCountLimit);
-    s.numberOfWarmupMessages = cp.getOption(optWarmupMessages).getParamAsLong(0, 0, INT64_MAX, s.numberOfWarmupMessages);
+    s.numberOfWarmupMessages = cp.getOption(optWarmupMessages).getParamAsLong(0, 0, LONG_MAX, s.numberOfWarmupMessages);
     return s;
 }
 
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
         }
 
         hdr_histogram* histogram;
-        hdr_init(1, 10 * 1000 * 1000 * 1000L, 3, &histogram);
+        hdr_init(1, 10 * 1000 * 1000 * 1000LL, 3, &histogram);
 
         do
         {

--- a/aeron-samples/src/main/cpp/StreamingPublisher.cpp
+++ b/aeron-samples/src/main/cpp/StreamingPublisher.cpp
@@ -74,7 +74,7 @@ Settings parseCmdLine(CommandOptionParser& cp, int argc, char** argv)
     s.dirPrefix = cp.getOption(optPrefix).getParam(0, s.dirPrefix);
     s.channel = cp.getOption(optChannel).getParam(0, s.channel);
     s.streamId = cp.getOption(optStreamId).getParamAsInt(0, 1, INT32_MAX, s.streamId);
-    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, INT64_MAX, s.numberOfMessages);
+    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, LONG_MAX, s.numberOfMessages);
     s.messageLength = cp.getOption(optLength).getParamAsInt(0, sizeof(std::int64_t), INT32_MAX, s.messageLength);
     s.lingerTimeoutMs = cp.getOption(optLinger).getParamAsInt(0, 0, 60 * 60 * 1000, s.lingerTimeoutMs);
     s.randomMessageLength = cp.getOption(optRandLen).isPresent();

--- a/aeron-samples/src/main/cpp/Throughput.cpp
+++ b/aeron-samples/src/main/cpp/Throughput.cpp
@@ -77,7 +77,7 @@ Settings parseCmdLine(CommandOptionParser& cp, int argc, char** argv)
     s.dirPrefix = cp.getOption(optPrefix).getParam(0, s.dirPrefix);
     s.channel = cp.getOption(optChannel).getParam(0, s.channel);
     s.streamId = cp.getOption(optStreamId).getParamAsInt(0, 1, INT32_MAX, s.streamId);
-    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, INT64_MAX, s.numberOfMessages);
+    s.numberOfMessages = cp.getOption(optMessages).getParamAsLong(0, 0, LONG_MAX, s.numberOfMessages);
     s.messageLength = cp.getOption(optLength).getParamAsInt(0, sizeof(std::int64_t), INT32_MAX, s.messageLength);
     s.lingerTimeoutMs = cp.getOption(optLinger).getParamAsInt(0, 0, 60 * 60 * 1000, s.lingerTimeoutMs);
     s.fragmentCountLimit = cp.getOption(optFrags).getParamAsInt(0, 1, INT32_MAX, s.fragmentCountLimit);


### PR DESCRIPTION
I have run `ctest` successfully on the Raspberry Pi (32-bit kernel/userland) without errors.

I do get intermittent test failures with the Java code when running `./gradelw`, which I believe is due to out-of-memory situations and an inability to consistently allocate memory-mapped buffers. I don't believe there's any underlying issue with the Java code.