### PR TITLE
[C++] Change time to be long long and fix several warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,8 @@ include_directories(${AERON_CLIENT_TEST_PATH})
 
 ##########################################################
 
+add_definitions(-D_FILE_OFFSET_BITS=64)
+
 include_directories(${AERON_CLIENT_SOURCE_PATH})
 include_directories(${AERON_DRIVER_SOURCE_PATH})
 

--- a/aeron-client/src/main/cpp/Aeron.cpp
+++ b/aeron-client/src/main/cpp/Aeron.cpp
@@ -20,7 +20,7 @@ namespace aeron {
 
 static const std::chrono::duration<long, std::milli> IDLE_SLEEP_MS(4);
 
-static long currentTimeMillis()
+static long long currentTimeMillis()
 {
     using namespace std::chrono;
 
@@ -71,7 +71,7 @@ Aeron::~Aeron()
 
 inline MemoryMappedFile::ptr_t Aeron::mapCncFile(Context &context)
 {
-    const long startMs = currentTimeMillis();
+    const long long startMs = currentTimeMillis();
     while (MemoryMappedFile::getFileSize(context.cncFileName().c_str()) == -1)
     {
         if (currentTimeMillis() > (startMs + context.m_mediaDriverTimeout))

--- a/aeron-client/src/main/cpp/ClientConductor.cpp
+++ b/aeron-client/src/main/cpp/ClientConductor.cpp
@@ -372,7 +372,7 @@ void ClientConductor::onUnavailableImage(
     std::int32_t streamId,
     std::int64_t correlationId)
 {
-    const long now = m_epochClock();
+    const long long now = m_epochClock();
     std::lock_guard<std::recursive_mutex> lock(m_adminLock);
 
     std::for_each(m_subscriptions.begin(), m_subscriptions.end(),
@@ -399,7 +399,7 @@ void ClientConductor::onUnavailableImage(
         });
 }
 
-void ClientConductor::onInterServiceTimeout(long now)
+void ClientConductor::onInterServiceTimeout(long long now)
 {
     std::lock_guard<std::recursive_mutex> lock(m_adminLock);
 
@@ -434,7 +434,7 @@ void ClientConductor::onInterServiceTimeout(long now)
     m_subscriptions.clear();
 }
 
-void ClientConductor::onCheckManagedResources(long now)
+void ClientConductor::onCheckManagedResources(long long now)
 {
     std::lock_guard<std::recursive_mutex> lock(m_adminLock);
 
@@ -466,17 +466,17 @@ void ClientConductor::onCheckManagedResources(long now)
     m_lingeringImageArrays.erase(arrayIt, m_lingeringImageArrays.end());
 }
 
-void ClientConductor::lingerResource(long now, Image* array)
+void ClientConductor::lingerResource(long long now, Image* array)
 {
     m_lingeringImageArrays.emplace_back(now, array);
 }
 
-void ClientConductor::lingerResource(long now, std::shared_ptr<LogBuffers> logBuffers)
+void ClientConductor::lingerResource(long long now, std::shared_ptr<LogBuffers> logBuffers)
 {
     m_lingeringLogBuffers.emplace_back(now, logBuffers);
 }
 
-void ClientConductor::lingerResources(long now, Image* images, int imagesLength)
+void ClientConductor::lingerResources(long long now, Image* images, int imagesLength)
 {
     for (int i = 0; i < imagesLength; i++)
     {

--- a/aeron-client/src/main/cpp/CncFileDescriptor.h
+++ b/aeron-client/src/main/cpp/CncFileDescriptor.h
@@ -90,7 +90,7 @@ static const size_t VERSION_AND_META_DATA_LENGTH = BitUtil::align(sizeof(MetaDat
 
 inline static std::int32_t cncVersion(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
 
@@ -99,7 +99,7 @@ inline static std::int32_t cncVersion(MemoryMappedFile::ptr_t cncFile)
 
 inline static AtomicBuffer createToDriverBuffer(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
 
@@ -108,7 +108,7 @@ inline static AtomicBuffer createToDriverBuffer(MemoryMappedFile::ptr_t cncFile)
 
 inline static AtomicBuffer createToClientsBuffer(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
     std::uint8_t* basePtr = cncFile->getMemoryPtr() + VERSION_AND_META_DATA_LENGTH + metaData.toDriverBufferLength;
@@ -118,7 +118,7 @@ inline static AtomicBuffer createToClientsBuffer(MemoryMappedFile::ptr_t cncFile
 
 inline static AtomicBuffer createCounterMetadataBuffer(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
     std::uint8_t* basePtr =
@@ -132,7 +132,7 @@ inline static AtomicBuffer createCounterMetadataBuffer(MemoryMappedFile::ptr_t c
 
 inline static AtomicBuffer createCounterValuesBuffer(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
     std::uint8_t* basePtr =
@@ -147,7 +147,7 @@ inline static AtomicBuffer createCounterValuesBuffer(MemoryMappedFile::ptr_t cnc
 
 inline static AtomicBuffer createErrorLogBuffer(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
     std::uint8_t* basePtr =
@@ -163,7 +163,7 @@ inline static AtomicBuffer createErrorLogBuffer(MemoryMappedFile::ptr_t cncFile)
 
 inline static std::int64_t clientLivenessTimeout(MemoryMappedFile::ptr_t cncFile)
 {
-    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), cncFile->getMemorySize());
+    AtomicBuffer metaDataBuffer(cncFile->getMemoryPtr(), convertSizeToIndex(cncFile->getMemorySize()));
 
     const MetaDataDefn& metaData = metaDataBuffer.overlayStruct<MetaDataDefn>(0);
 

--- a/aeron-client/src/main/cpp/DriverProxy.h
+++ b/aeron-client/src/main/cpp/DriverProxy.h
@@ -196,8 +196,8 @@ private:
     inline void writeCommandToDriver(const std::function<util::index_t(AtomicBuffer&, util::index_t &)>& filler)
     {
         AERON_DECL_ALIGNED(driver_proxy_command_buffer_t messageBuffer, 16);
-        AtomicBuffer buffer(&messageBuffer[0], messageBuffer.size());
-        util::index_t length = messageBuffer.size();
+        AtomicBuffer buffer(messageBuffer);
+        util::index_t length = buffer.capacity();
 
         util::index_t msgTypeId = filler(buffer, length);
 

--- a/aeron-client/src/main/cpp/LogBuffers.cpp
+++ b/aeron-client/src/main/cpp/LogBuffers.cpp
@@ -36,7 +36,7 @@ LogBuffers::LogBuffers(const char *filename)
 
         for (int i = 0; i < LogBufferDescriptor::PARTITION_COUNT; i++)
         {
-            m_buffers[i].wrap(basePtr + (i * termLength), termLength);
+            m_buffers[i].wrap(basePtr + (i * termLength), util::convertSizeToIndex(termLength));
         }
 
         m_buffers[LogBufferDescriptor::PARTITION_COUNT]
@@ -45,7 +45,7 @@ LogBuffers::LogBuffers(const char *filename)
     }
     else
     {
-        const std::int64_t metaDataSectionOffset = (index_t) (termLength * LogBufferDescriptor::PARTITION_COUNT);
+        const index_t metaDataSectionOffset = (index_t) (termLength * LogBufferDescriptor::PARTITION_COUNT);
         const std::int64_t metaDataSectionLength = (index_t) (logLength - metaDataSectionOffset);
 
         m_memoryMappedFiles.push_back(
@@ -60,7 +60,7 @@ LogBuffers::LogBuffers(const char *filename)
 
             std::uint8_t *basePtr = m_memoryMappedFiles[i + 1]->getMemoryPtr();
 
-            m_buffers[i].wrap(basePtr, termLength);
+            m_buffers[i].wrap(basePtr, util::convertSizeToIndex(termLength));
         }
 
         m_buffers[LogBufferDescriptor::PARTITION_COUNT].wrap(metaDataBasePtr, LogBufferDescriptor::LOG_META_DATA_LENGTH);

--- a/aeron-client/src/main/cpp/concurrent/broadcast/CopyBroadcastReceiver.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/CopyBroadcastReceiver.h
@@ -37,7 +37,7 @@ class CopyBroadcastReceiver
 public:
     CopyBroadcastReceiver(BroadcastReceiver& receiver) :
         m_receiver(receiver),
-        m_scratchBuffer(&m_scratch[0], m_scratch.size())
+        m_scratchBuffer(m_scratch)
     {
         while (m_receiver.receiveNext())
         {

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/DataFrameHeader.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/DataFrameHeader.h
@@ -29,8 +29,8 @@ namespace DataFrameHeader {
 struct DataFrameHeaderDefn
 {
     std::int32_t frameLength;
-    std::int8_t version;
-    std::int8_t flags;
+    std::uint8_t version;
+    std::uint8_t flags;
     std::uint16_t type;
     std::int32_t termOffset;
     std::int32_t sessionId;

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/LogBufferDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/LogBufferDescriptor.h
@@ -122,15 +122,15 @@ struct LogMetaDataDefn
 };
 #pragma pack(pop)
 
-static const util::index_t TERM_TAIL_COUNTER_OFFSET = offsetof(LogMetaDataDefn, termTailCounters[0]);
+static const util::index_t TERM_TAIL_COUNTER_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, termTailCounters[0]);
 
-static const util::index_t LOG_ACTIVE_PARTITION_INDEX_OFFSET = offsetof(LogMetaDataDefn, activePartitionIndex);
-static const util::index_t LOG_TIME_OF_LAST_STATUS_MESSAGE_OFFSET = offsetof(LogMetaDataDefn, timeOfLastStatusMessage);
-static const util::index_t LOG_INITIAL_TERM_ID_OFFSET = offsetof(LogMetaDataDefn, initialTermId);
-static const util::index_t LOG_DEFAULT_FRAME_HEADER_LENGTH_OFFSET = offsetof(LogMetaDataDefn, defaultFrameHeaderLength);
-static const util::index_t LOG_MTU_LENGTH_OFFSET = offsetof(LogMetaDataDefn, mtuLength);
-static const util::index_t LOG_DEFAULT_FRAME_HEADER_OFFSET = sizeof(LogMetaDataDefn);
-static const util::index_t LOG_META_DATA_LENGTH = sizeof(LogMetaDataDefn) + LOG_DEFAULT_FRAME_HEADER_MAX_LENGTH;
+static const util::index_t LOG_ACTIVE_PARTITION_INDEX_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, activePartitionIndex);
+static const util::index_t LOG_TIME_OF_LAST_STATUS_MESSAGE_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, timeOfLastStatusMessage);
+static const util::index_t LOG_INITIAL_TERM_ID_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, initialTermId);
+static const util::index_t LOG_DEFAULT_FRAME_HEADER_LENGTH_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, defaultFrameHeaderLength);
+static const util::index_t LOG_MTU_LENGTH_OFFSET = (util::index_t)offsetof(LogMetaDataDefn, mtuLength);
+static const util::index_t LOG_DEFAULT_FRAME_HEADER_OFFSET = (util::index_t)sizeof(LogMetaDataDefn);
+static const util::index_t LOG_META_DATA_LENGTH = (util::index_t)sizeof(LogMetaDataDefn) + LOG_DEFAULT_FRAME_HEADER_MAX_LENGTH;
 
 inline static void checkTermLength(std::int64_t termLength)
 {

--- a/aeron-client/src/main/cpp/util/Index.h
+++ b/aeron-client/src/main/cpp/util/Index.h
@@ -17,13 +17,23 @@
 #ifndef INCLUDED_AERON_UTIL_INDEX_FILE__
 #define INCLUDED_AERON_UTIL_INDEX_FILE__
 
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace aeron { namespace util {
 
 // a 32bit signed int that is to be used for sizes and offsets to be compatible with
 // java's signed 32 bit int.
 typedef std::int32_t index_t;
+
+inline static index_t convertSizeToIndex(size_t size)
+{
+    if (size > std::numeric_limits<index_t>::max())
+        return std::numeric_limits<index_t>::max();
+
+    return static_cast<index_t>(size);
+}
 
 }}
 


### PR DESCRIPTION
This commit changes the internal time type to long long to be more compatible with 32-bit platforms and Windows 64-bit. It also brings it more in-line with Java, which uses the Java long type (equivalent to int64_t in C++).

This commit also fixes several warnings with type conversions from size_t to index_t (int32_t). There are also changes to handle certain cases where the size_t is out-of-range for the int32_t type.