### PR TITLE
Refactored the Function<T,Integer> to ToIntFunction<T>

### DIFF
--- a/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
+++ b/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
@@ -35,7 +35,7 @@ import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import static java.lang.Boolean.TRUE;
 import static java.nio.ByteBuffer.allocateDirect;
@@ -548,12 +548,12 @@ public class ClientConductorTest
     }
 
     private void whenReceiveBroadcastOnMessage(
-        final int msgTypeId, final MutableDirectBuffer buffer, final Function<MutableDirectBuffer, Integer> filler)
+        final int msgTypeId, final MutableDirectBuffer buffer, final ToIntFunction<MutableDirectBuffer> filler)
     {
         doAnswer(
             (invocation) ->
             {
-                final int length = filler.apply(buffer);
+                final int length = filler.applyAsInt(buffer);
                 conductor.driverListenerAdapter().onMessage(msgTypeId, buffer, 0, length);
 
                 return 1;


### PR DESCRIPTION
Hello,

I am a graduate student at Oregon State University and as a part of my research and subject CS562 Applied Software Engineering project (Study and Refactoring of Functional Interface in Java), 
I have done refactoring of the Function<T,Integer> to ToIntFunction<T>.  
My project deals with the boxing and unboxing of Wrapper class and the primitive data-types. 
I want to know that whether the open source community is ready to accept these micro-optimizing refactorings or not. 

In the file ClientConductorTest, the Function<MutableDirectBuffer,Integer> is consumed as primitive int in the line **final int length = filler.apply(buffer)**.  So, Java Compiler has to autobox the Integer to int and because of that, the performance reduces. So, instead of using Function<T,Integer>, Java 8 has provided a specialized primitive functional interface to ToIntFunction.

Thank you,
Harsh Thakor