### PR TITLE
[Java] Makes tail initialisation atomic

### DIFF
--- a/aeron-client/src/main/java/io/aeron/logbuffer/LogBufferDescriptor.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/LogBufferDescriptor.java
@@ -552,7 +552,7 @@ public class LogBufferDescriptor
     public static void initialiseTailWithTermId(
         final UnsafeBuffer logMetaData, final int partitionIndex, final int termId)
     {
-        logMetaData.putLong(TERM_TAIL_COUNTERS_OFFSET + (partitionIndex * SIZE_OF_LONG), packTail(termId, 0));
+        logMetaData.putLongOrdered(TERM_TAIL_COUNTERS_OFFSET + (partitionIndex * SIZE_OF_LONG), packTail(termId, 0));
     }
 
     /**


### PR DESCRIPTION
A TermAppender fallen behind (ie in a past active partition), but that has already passed the backpressure check, could perform the claim when the tail is going to be reinitialised (ie the partition reactivated), hence the initialisation is needed to be atomic (a memory relaxed operation).
It is more likely to happen with a lot of producer threads (ie much more than the core count)and very small term capacity.