### PR TITLE
Use configured aeron directory for Archiver & Cluster clients

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -16,7 +16,6 @@
 package io.aeron.archive;
 
 import io.aeron.Aeron;
-import io.aeron.CommonContext;
 import io.aeron.Image;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.driver.exceptions.ConfigurationException;
@@ -287,7 +286,7 @@ public class Archive implements AutoCloseable
     {
         private boolean deleteArchiveOnStart = false;
         private boolean ownsAeronClient = false;
-        private String aeronDirectoryName = CommonContext.AERON_DIR_PROP_DEFAULT;
+        private String aeronDirectoryName;
         private Aeron aeron;
         private File archiveDir;
 
@@ -341,14 +340,19 @@ public class Archive implements AutoCloseable
             {
                 ownsAeronClient = true;
 
-                aeron = Aeron.connect(
-                    new Aeron.Context()
-                        .aeronDirectoryName(aeronDirectoryName)
-                        .errorHandler(errorHandler)
-                        .epochClock(epochClock)
-                        .driverAgentInvoker(mediaDriverAgentInvoker)
-                        .useConductorAgentInvoker(true)
-                        .clientLock(new NoOpLock()));
+                final Aeron.Context ctx = new Aeron.Context()
+                    .errorHandler(errorHandler)
+                    .epochClock(epochClock)
+                    .driverAgentInvoker(mediaDriverAgentInvoker)
+                    .useConductorAgentInvoker(true)
+                    .clientLock(new NoOpLock());
+
+                if (null != aeronDirectoryName)
+                {
+                    ctx.aeronDirectoryName(aeronDirectoryName);
+                }
+
+                aeron = Aeron.connect(ctx);
 
                 if (null == errorCounter)
                 {

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -1111,7 +1111,7 @@ public class AeronArchive implements AutoCloseable
         private int controlMtuLength = Configuration.controlMtuLength();
         private IdleStrategy idleStrategy;
         private Lock lock;
-        private String aeronDirectoryName = CommonContext.AERON_DIR_PROP_DEFAULT;
+        private String aeronDirectoryName;
         private Aeron aeron;
         private boolean ownsAeronClient = false;
 
@@ -1122,8 +1122,14 @@ public class AeronArchive implements AutoCloseable
         {
             if (null == aeron)
             {
-                aeron = Aeron.connect(new Aeron.Context()
-                    .aeronDirectoryName(aeronDirectoryName));
+                final Aeron.Context ctx = new Aeron.Context();
+
+                if (null != aeronDirectoryName)
+                {
+                    ctx.aeronDirectoryName(aeronDirectoryName);
+                }
+
+                aeron = Aeron.connect(ctx);
 
                 ownsAeronClient = true;
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -657,7 +657,7 @@ public final class AeronCluster implements AutoCloseable
         private int egressStreamId = Configuration.egressStreamId();
         private IdleStrategy idleStrategy;
         private Lock lock;
-        private String aeronDirectoryName = CommonContext.AERON_DIR_PROP_DEFAULT;
+        private String aeronDirectoryName;
         private Aeron aeron;
         private CredentialsSupplier credentialsSupplier;
         private boolean ownsAeronClient = true;
@@ -667,8 +667,14 @@ public final class AeronCluster implements AutoCloseable
         {
             if (null == aeron)
             {
-                aeron = Aeron.connect(new Aeron.Context()
-                    .aeronDirectoryName(aeronDirectoryName));
+                final Aeron.Context ctx = new Aeron.Context();
+
+                if (null != aeronDirectoryName)
+                {
+                    ctx.aeronDirectoryName(aeronDirectoryName);
+                }
+
+                aeron = Aeron.connect(ctx);
             }
 
             if (null == idleStrategy)


### PR DESCRIPTION
Issue: ClustedMediaDriver/ArchivingMediaDriver fail if you specify and alternative aeron directory because the spawned aeron clients continue to use the default directory.

Not currently an issue in the ConsensusModule because it doesn't allow explicit override of the aeronDirectoryName.