### PR TITLE
Don't raise exception on cluster egress

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
@@ -56,8 +56,6 @@ class EgressPublisher
 
                 return true;
             }
-
-            checkResult(result);
         }
         while (--attempts > 0);
 
@@ -88,21 +86,9 @@ class EgressPublisher
 
                 return true;
             }
-
-            checkResult(result);
         }
         while (--attempts > 0);
 
         return false;
-    }
-
-    private static void checkResult(final long result)
-    {
-        if (result == Publication.NOT_CONNECTED ||
-            result == Publication.CLOSED ||
-            result == Publication.MAX_POSITION_EXCEEDED)
-        {
-            throw new IllegalStateException("Unexpected publication state: " + result);
-        }
     }
 }


### PR DESCRIPTION
Sequencer gets stuck trying to inform clients that their session expired.

```
78454 observations from 2018-02-15 23:34:50.209+0000 to 2018-02-15 23:37:32.217+0000 for:
 java.lang.IllegalStateException: Unexpected publication state: -1
        at io.aeron.cluster.EgressPublisher.checkResult(EgressPublisher.java:105)
        at io.aeron.cluster.EgressPublisher.sendEvent(EgressPublisher.java:60)
        at io.aeron.cluster.SequencerAgent.checkSessions(SequencerAgent.java:845)
        at io.aeron.cluster.SequencerAgent.slowTickCycle(SequencerAgent.java:662)
        at io.aeron.cluster.SequencerAgent.doWork(SequencerAgent.java:261)
        at org.agrona.concurrent.AgentRunner.doDutyCycle(AgentRunner.java:233)
        at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:159)
        at java.lang.Thread.run(Unknown Source)
```