### PR TITLE
Recovery from snapshot

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/SequencerAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/SequencerAgent.java
@@ -1186,7 +1186,7 @@ class SequencerAgent implements Agent, ServiceControlListener
         final RecordingLog.Entry snapshot = snapshotStep.entry;
 
         cachedEpochClock.update(snapshot.timestamp);
-        baseLogPosition = snapshot.logPosition;
+        baseLogPosition = snapshot.logPosition + snapshot.termPosition;
         leadershipTermId = snapshot.leadershipTermId;
 
         final long recordingId = snapshot.recordingId;
@@ -1259,7 +1259,7 @@ class SequencerAgent implements Agent, ServiceControlListener
             }
 
             final long length = stopPosition - startPosition;
-            final long logPosition = entry.logPosition;
+            final long logPosition = entry.logPosition + (entry.termPosition - length);
 
             if (logPosition != baseLogPosition)
             {
@@ -1300,7 +1300,7 @@ class SequencerAgent implements Agent, ServiceControlListener
                     ctx.recordingLog().commitLeadershipTermPosition(leadershipTermId, termPosition);
                 }
 
-                baseLogPosition += termPosition;
+                baseLogPosition = entry.logPosition + termPosition;
             }
         }
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -324,7 +324,7 @@ final class ClusteredServiceAgent implements Agent, Cluster, ServiceControlListe
                 throw new IllegalStateException("No snapshot available for term position: " + termPosition);
             }
 
-            baseLogPosition = snapshotEntry.logPosition;
+            baseLogPosition = snapshotEntry.logPosition + snapshotEntry.termPosition;
             loadSnapshot(snapshotEntry.recordingId);
         }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -354,12 +354,13 @@ final class ClusteredServiceAgent implements Agent, Cluster, ServiceControlListe
                 serviceControlPublisher.ackAction(baseLogPosition, leadershipTermId, serviceId, ClusterAction.READY);
 
                 final Image image = awaitImage(activeLog.sessionId, subscription);
+                final long initialPosition = image.position();
                 final ReadableCounter limit = new ReadableCounter(counters, counterId);
                 final BoundedLogAdapter adapter = new BoundedLogAdapter(image, limit, this);
 
                 consumeImage(image, adapter);
 
-                final long logPosition = baseLogPosition + image.position();
+                final long logPosition = baseLogPosition + image.position() - initialPosition;
                 serviceControlPublisher.ackAction(logPosition, leadershipTermId, serviceId, ClusterAction.REPLAY);
             }
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/RecordingLog.java
@@ -96,7 +96,7 @@ public class RecordingLog
          *
          * @param recordingId      of the entry in an archive.
          * @param leadershipTermId of this entry.
-         * @param logPosition      accumulated position of the log over leadership terms for the beginning of the term.
+         * @param logPosition      accumulated position of the log over leadership terms at the beginning of the term.
          * @param termPosition     position reached within the current leadership term, same at leadership term length.
          * @param timestamp        of this entry.
          * @param memberIdVote     which member this node voted for in the election.
@@ -572,7 +572,7 @@ public class RecordingLog
                     final Entry entry = entries.get(i);
                     if (ENTRY_TYPE_TERM == entry.type)
                     {
-                        getRecordingExtent(archive, recordingExtent, snapshot);
+                        getRecordingExtent(archive, recordingExtent, entry);
                         final long snapshotPosition = snapshot.logPosition + snapshot.termPosition;
 
                         if (recordingExtent.stopPosition == NULL_POSITION ||


### PR DESCRIPTION
1. Fix bug in the RecoveryPlan where the wrong recording was fetched.
2. Adjust snapshot recovery so that if no log entry follows it, the correct logPosition is used for the new leadership term.