### PR TITLE
Notify ClusteredService that recovery has ended.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredService.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredService.java
@@ -107,10 +107,7 @@ public interface ClusteredService
     void onReplayBegin();
 
     /**
-     * Notify the service that a replay of existing logs has ended so that it can check external state is consistent.
-     * <p>
-     * If the service is in an invalid state and wished to terminate operation it can throw a
-     * {@link org.agrona.concurrent.AgentTerminationException}.
+     * Notify the service that a replay of existing logs has ended.
      */
     void onReplayEnd();
 
@@ -120,4 +117,13 @@ public interface ClusteredService
      * @param newRole that the node has assumed.
      */
     void onRoleChange(Cluster.Role newRole);
+
+
+    /**
+     * Notify the service that recovery has finished so that it can check external state is consistent.
+     * <p>
+     * If the service is in an invalid state and wished to terminate operation it can throw a
+     * {@link org.agrona.concurrent.AgentTerminationException}.
+     */
+    void onReady();
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -96,6 +96,8 @@ final class ClusteredServiceAgent implements Agent, Cluster, ServiceControlListe
         checkForReplay(counters, recoveryCounterId);
         isRecovering = false;
 
+        service.onReady();
+
         joinActiveLog(counters);
 
         roleCounter = awaitClusterRoleCounter(counters);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StubClusteredService.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StubClusteredService.java
@@ -75,4 +75,8 @@ public class StubClusteredService implements ClusteredService
     public void onRoleChange(final Cluster.Role newRole)
     {
     }
+
+    public void onReady()
+    {
+    }
 }


### PR DESCRIPTION
onReplayEnd is not called when starting from clean state or recovering snapshot only.