### PR TITLE
Reset logAdapter when recovering

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/SequencerAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/SequencerAgent.java
@@ -1286,6 +1286,8 @@ class SequencerAgent implements Agent, ServiceControlListener, MemberStatusListe
             try (Counter counter = CommitPos.allocate(aeron, tempBuffer, leadershipTermId, termBaseLogPosition, length))
             {
                 serviceAckCount = 0;
+                logAdapter = null;
+
                 if (length > 0)
                 {
                     try (Subscription subscription = aeron.addSubscription(channel, streamId))


### PR DESCRIPTION
When recovering multiple terms, validateServiceAck fails because currentTermPosition() returns the position from the previous term when it should return 0.