### PR TITLE
Allows Catalog to be constructed over a directory where old recordings have been deleted

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -638,8 +638,8 @@ class Catalog implements AutoCloseable
         if (headerDecoder.valid() == VALID && decoder.stopTimestamp() == NULL_TIMESTAMP)
         {
             final String prefix = recordingId + "-";
-            String[] segmentFiles =
-                archiveDir.list((dir, name) -> name.endsWith(RECORDING_SEGMENT_POSTFIX));
+            String[] segmentFiles = // Only the segments for recordingId
+                archiveDir.list((dir, name) -> name.startsWith(prefix) && name.endsWith(RECORDING_SEGMENT_POSTFIX));
             int maxSegmentIndex = -1;
 
             if (null == segmentFiles)

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -22,7 +22,6 @@ import org.agrona.concurrent.EpochClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -308,7 +307,6 @@ public class CatalogTest
     }
 
     @Test
-    @Ignore
     public void shouldNotThrowWhenOldRecordingLogsAreDeleted() throws IOException
     {
         // Simulate the scenario where old recordings have been deleted. Here those are the
@@ -320,8 +318,7 @@ public class CatalogTest
         final boolean segmentFileExists = Files.exists(archiveDir.toPath().resolve(segmentFilePath));
         assumeThat(segmentFileExists, is(true));
 
-        // This should pass but it throws
-        // java.nio.file.NoSuchFileException: /tmp/archive-test/0-0.rec
+        // Check creating a Catalog does not throw
         try (Catalog ignored = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
         {
         }


### PR DESCRIPTION
# Background

Previously, we were able to start a consensus module over a directory where old recordings had been deleted; however, upon upgrading to v1.9.0 this was no longer possible.

This change adds back the aforementioned behaviour. 

# Changes

Inside `Catalog.refreshAndFixDescriptor(...)` it determines the maximum "segment index" for a given `recordingId` by looking at the file segments inside the archive directory. Previously it looked at all segment files. Now it just looks at the segment files that are for the `recordingId`.