### PR TITLE
Catch std::bad_cast by reference

### DIFF
--- a/aeron-client/src/main/cpp/Context.h
+++ b/aeron-client/src/main/cpp/Context.h
@@ -125,7 +125,7 @@ inline void defaultErrorHandler(const std::exception& exception)
         const SourcedException& sourcedException = dynamic_cast<const SourcedException&>(exception);
         std::cerr << " : " << sourcedException.where();
     }
-    catch (std::bad_cast)
+    catch (const std::bad_cast&)
     {
         // ignore
     }


### PR DESCRIPTION
gcc 8 introduced a new warning category `-Wcatch-value` enabled in `-Wall` that warns about catching a polymorphic class by value.