### PR TITLE
Missing Heartbeat Counter

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -964,11 +964,6 @@ public class ConsensusModule implements AutoCloseable
                 moduleState = aeron.addCounter(CONSENSUS_MODULE_STATE_TYPE_ID, "Consensus module state");
             }
 
-            if (null == clusterNodeRole)
-            {
-                clusterNodeRole = aeron.addCounter(Configuration.CLUSTER_NODE_ROLE_TYPE_ID, "Cluster node role");
-            }
-
             if (null == controlToggle)
             {
                 controlToggle = aeron.addCounter(CONTROL_TOGGLE_TYPE_ID, "Cluster control toggle");
@@ -991,6 +986,11 @@ public class ConsensusModule implements AutoCloseable
                 {
                     serviceHeartbeatCounters[i] = ServiceHeartbeat.allocate(aeron, tempBuffer, i);
                 }
+            }
+
+            if (null == clusterNodeRole)
+            {
+                clusterNodeRole = aeron.addCounter(Configuration.CLUSTER_NODE_ROLE_TYPE_ID, "Cluster node role");
             }
 
             if (null == threadFactory)


### PR DESCRIPTION
Fix case where heartbeat counter doesn't necessarily exist when node role counter does.
1. Await service heartbeat counter.
2. Adjust ordering of counter creation so node role counter is created last.

Related to: https://github.com/real-logic/aeron/commit/1ebeaa9e2b41c512fead5288b143c434951492cd

```
1 observations from 2018-05-10 11:11:47.098+0100 to 2018-05-10 11:11:47.098+0100 for:
 java.lang.IllegalStateException: failed to find heartbeat counter
        at io.aeron.cluster.service.ClusteredServiceAgent.findHeartbeatCounter(ClusteredServiceAgent.java:670)
        at io.aeron.cluster.service.ClusteredServiceAgent.onStart(ClusteredServiceAgent.java:92)
        at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:151)
        at java.lang.Thread.run(Thread.java:748)
```