### PR TITLE
Add thread names to c++

### DIFF
--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -22,6 +22,8 @@
 #include <thread>
 #include <atomic>
 #include <concurrent/logbuffer/TermReader.h>
+#include <pthread.h>
+
 
 namespace aeron {
 
@@ -48,6 +50,13 @@ public:
     {
         m_thread = std::thread([&]()
         {
+          std::string name("Aeron Agent");
+#ifdef  __APPLE__
+          pthread_setname_np(name.c_str());
+#else
+          pthread_setname_np(pthread_self(), name.c_str());
+#endif
+
             run();
         });
     }


### PR DESCRIPTION
Hi, this is where I needed the thread name. Not sure if there are other places that need it, I only see this thread in my debugging.

Also I have a mac which uses a slightly different function to Linux. Not sure if there are other versions you want to support.