### PR TITLE
Simplify local function call with compile time polymorphic semantics

### DIFF
--- a/aeron-client/src/main/cpp/DriverProxy.h
+++ b/aeron-client/src/main/cpp/DriverProxy.h
@@ -276,7 +276,8 @@ private:
     ManyToOneRingBuffer& m_toDriverCommandBuffer;
     std::int64_t m_clientId;
 
-    inline void writeCommandToDriver(const std::function<util::index_t(AtomicBuffer&, util::index_t &)>& filler)
+    template <typename Filler>
+    inline void writeCommandToDriver(Filler&& filler)
     {
         AERON_DECL_ALIGNED(driver_proxy_command_buffer_t messageBuffer, 16);
         AtomicBuffer buffer(messageBuffer);


### PR DESCRIPTION
Semantically, there is no necessity for `std::function` as the call is not
stored nor type erasure is needed.
Furthermore, while compilers can optimize and inline the call, too complex
functions usually end up going through the `std::function` construction
and polymorphic call.