### PR TITLE
Improve exception message when ClientSession is used after disconnected

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
@@ -148,6 +148,11 @@ public class ClientSession
         sessionHeaderEncoder.timestamp(cluster.timeMs());
         messageBuffer.reset(buffer, offset, length);
 
+        if (null == responsePublication)
+        {
+            throw new IllegalStateException("ClientSession not connected");
+        }
+
         return responsePublication.offer(vectors, null);
     }
 


### PR DESCRIPTION
After disconnect(), if offer() was called on ClientSession, then dereferencing the responsePublication would cause a NullPointerException. This change adds a null-check in offer(), and will throw an IllegalStateException (with a descriptive message) instead.