### PR TITLE
Fix Visual Studio compile issue

### DIFF
--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -22,8 +22,10 @@
 #include <thread>
 #include <atomic>
 #include <concurrent/logbuffer/TermReader.h>
-#include <pthread.h>
 
+#if !defined(AERON_COMPILER_MSVC)
+#include <pthread.h>
+#endif
 
 namespace aeron {
 
@@ -71,7 +73,8 @@ public:
     {
         m_thread = std::thread([&]()
         {
-#if defined(Darwin)
+#if defined(AERON_COMPILER_MSVC)
+#elif defined(Darwin)
             pthread_setname_np(m_name.c_str());
 #else
             pthread_setname_np(pthread_self(), m_name.c_str());


### PR DESCRIPTION
This is a minor fix for compiling in Visual Studio. Native Windows threads have no concept of a thread name (at least that I can tell, although there are some hackish ways to get it to show up in a debug window), so I just changed the code to conditionally compile.