### PR TITLE
Change the round-robin mechanism of Subscription's poll methods

### DIFF
--- a/aeron-client/src/main/cpp/Subscription.h
+++ b/aeron-client/src/main/cpp/Subscription.h
@@ -144,20 +144,24 @@ public:
         Image *images = imageList->m_images;
         int fragmentsRead = 0;
 
-        std::size_t startingIndex = m_roundRobinIndex++;
-        if (startingIndex >= length)
-        {
-            m_roundRobinIndex = startingIndex = 0;
-        }
-
-        for (std::size_t i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
+        for (std::size_t i = m_roundRobinIndex; i < length; i++)
         {
             fragmentsRead += images[i].poll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                m_roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
-        for (std::size_t i = 0; i < startingIndex && fragmentsRead < fragmentLimit; i++)
+        for (std::size_t i = 0; i < m_roundRobinIndex; i++)
         {
             fragmentsRead += images[i].poll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                m_roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
         return fragmentsRead;
@@ -186,20 +190,24 @@ public:
         Image *images = imageList->m_images;
         int fragmentsRead = 0;
 
-        std::size_t startingIndex = m_roundRobinIndex++;
-        if (startingIndex >= length)
-        {
-            m_roundRobinIndex = startingIndex = 0;
-        }
-
-        for (std::size_t i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
+        for (std::size_t i = m_roundRobinIndex; i < length; i++)
         {
             fragmentsRead += images[i].controlledPoll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                m_roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
-        for (std::size_t i = 0; i < startingIndex && fragmentsRead < fragmentLimit; i++)
+        for (std::size_t i = 0; i < m_roundRobinIndex; i++)
         {
             fragmentsRead += images[i].controlledPoll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                m_roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
         return fragmentsRead;

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -196,20 +196,24 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
         final int length = images.length;
         int fragmentsRead = 0;
 
-        int startingIndex = roundRobinIndex++;
-        if (startingIndex >= length)
-        {
-            roundRobinIndex = startingIndex = 0;
-        }
-
-        for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
+        for (int i = roundRobinIndex; i < length; i++)
         {
             fragmentsRead += images[i].poll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
-        for (int i = 0; i < startingIndex && fragmentsRead < fragmentLimit; i++)
+        for (int i = 0; i < roundRobinIndex; i++)
         {
             fragmentsRead += images[i].poll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
         return fragmentsRead;
@@ -236,20 +240,24 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
         final int length = images.length;
         int fragmentsRead = 0;
 
-        int startingIndex = roundRobinIndex++;
-        if (startingIndex >= length)
-        {
-            roundRobinIndex = startingIndex = 0;
-        }
-
-        for (int i = startingIndex; i < length && fragmentsRead < fragmentLimit; i++)
+        for (int i = roundRobinIndex; i < length; i++)
         {
             fragmentsRead += images[i].controlledPoll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
-        for (int i = 0; i < startingIndex && fragmentsRead < fragmentLimit; i++)
+        for (int i = 0; i < roundRobinIndex; i++)
         {
             fragmentsRead += images[i].controlledPoll(fragmentHandler, fragmentLimit - fragmentsRead);
+            if (fragmentsRead == fragmentLimit)
+            {
+                roundRobinIndex = i + 1;
+                return fragmentsRead;
+            }
         }
 
         return fragmentsRead;


### PR DESCRIPTION
To be able to continue from the next `Image` in subsequent calls.