### PR TITLE
[Java] Fix overflow issue when requesting large buffer size.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -33,15 +33,6 @@ import java.util.Arrays;
  */
 public class BufferBuilder
 {
-    /**
-     * Maximum capacity to which the buffer can grow.
-     */
-    public static final int MAX_CAPACITY = Integer.MAX_VALUE - 8;
-
-    /**
-     * Initial minimum capacity for the internal buffer when used, zero if not used.
-     */
-    public static final int MIN_ALLOCATED_CAPACITY = 4096;
 
     private final boolean isDirect;
     private int limit = 0;
@@ -150,7 +141,7 @@ public class BufferBuilder
      */
     public BufferBuilder compact()
     {
-        resize(Math.max(MIN_ALLOCATED_CAPACITY, limit));
+        resize(Math.max(BufferBuilderUtil.MIN_ALLOCATED_CAPACITY, limit));
 
         return this;
     }
@@ -177,7 +168,7 @@ public class BufferBuilder
     {
         final long requiredCapacity = (long)limit + additionalCapacity;
 
-        if (requiredCapacity > MAX_CAPACITY)
+        if (requiredCapacity > BufferBuilderUtil.MAX_CAPACITY)
         {
             throw new IllegalStateException(
                 "Max capacity exceeded: limit=" + limit + " required=" + requiredCapacity);
@@ -186,7 +177,7 @@ public class BufferBuilder
         final int capacity = buffer.capacity();
         if (requiredCapacity > capacity)
         {
-            resize(findSuitableCapacity(capacity, (int)requiredCapacity));
+            resize(BufferBuilderUtil.findSuitableCapacity(capacity, (int)requiredCapacity));
         }
     }
 
@@ -205,30 +196,4 @@ public class BufferBuilder
         }
     }
 
-    private static int findSuitableCapacity(final int currentCapacity, final int requiredCapacity)
-    {
-        int capacity = currentCapacity;
-
-        do
-        {
-            final int newCapacity = Math.max(capacity + (capacity >> 1), MIN_ALLOCATED_CAPACITY);
-
-            if (newCapacity < 0 || newCapacity > MAX_CAPACITY)
-            {
-                if (capacity == MAX_CAPACITY)
-                {
-                    throw new IllegalStateException("Max capacity reached: " + MAX_CAPACITY);
-                }
-
-                capacity = MAX_CAPACITY;
-            }
-            else
-            {
-                capacity = newCapacity;
-            }
-        }
-        while (capacity < requiredCapacity);
-
-        return capacity;
-    }
 }

--- a/aeron-client/src/main/java/io/aeron/BufferBuilderUtil.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilderUtil.java
@@ -1,0 +1,45 @@
+package io.aeron;
+
+final class BufferBuilderUtil
+{
+    /**
+     * Maximum capacity to which the buffer can grow.
+     */
+    static final int MAX_CAPACITY = Integer.MAX_VALUE - 8;
+    /**
+     * Initial minimum capacity for the internal buffer when used, zero if not used.
+     */
+    static final int MIN_ALLOCATED_CAPACITY = 4096;
+
+    private BufferBuilderUtil()
+    {
+    }
+
+    static int findSuitableCapacity(final int currentCapacity, final int requiredCapacity)
+    {
+        int capacity = currentCapacity;
+
+        do
+        {
+            final int candidateCapacity = capacity + (capacity >> 1);
+            final int newCapacity = Math.max(candidateCapacity, MIN_ALLOCATED_CAPACITY);
+
+            if (candidateCapacity < 0 || newCapacity > MAX_CAPACITY)
+            {
+                if (capacity == MAX_CAPACITY)
+                {
+                    throw new IllegalStateException("Max capacity reached: " + MAX_CAPACITY);
+                }
+
+                capacity = MAX_CAPACITY;
+            }
+            else
+            {
+                capacity = newCapacity;
+            }
+        }
+        while (capacity < requiredCapacity);
+
+        return capacity;
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -21,13 +21,13 @@ import org.agrona.concurrent.UnsafeBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import static io.aeron.BufferBuilderUtil.MIN_ALLOCATED_CAPACITY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
-import static io.aeron.BufferBuilder.MIN_ALLOCATED_CAPACITY;
 
 public class BufferBuilderTest
 {

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderUtilTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderUtilTest.java
@@ -1,0 +1,16 @@
+package io.aeron;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public final class BufferBuilderUtilTest
+{
+    @Test
+    public void shouldFindMaxCapacityWhenRequested()
+    {
+        assertThat(BufferBuilderUtil.findSuitableCapacity(0, BufferBuilderUtil.MAX_CAPACITY),
+            is(BufferBuilderUtil.MAX_CAPACITY));
+    }
+}


### PR DESCRIPTION
Fixes an infinite loop when calculated `newCapacity` overflows:

```
final int newCapacity = Math.max(capacity + (capacity >> 1), MIN_ALLOCATED_CAPACITY);
// newCapacity is never negative, as Math.max returns MIN_ALLOCATED_CAPACITY
// when capacity + (capacity >> 1) overflows
if (newCapacity < 0 || newCapacity > MAX_CAPACITY)
```

Extracted utility method out to separate class to facilitate testing.