### PR TITLE
Moved include of <sys/types.h> from cpp to header

### DIFF
--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
@@ -16,7 +16,6 @@
 
 #ifndef _WIN32
     #include <sys/mman.h>
-    #include <sys/types.h>
     #include <sys/stat.h>
     #include <fcntl.h>
     #include <unistd.h>

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.h
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.h
@@ -20,11 +20,12 @@
 #include <memory>
 
 #ifdef _WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif // !NOMINMAX
-
-#include <windows.h>
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif // !NOMINMAX
+    #include <windows.h>
+#else
+    #include <sys/types.h>
 #endif
 
 


### PR DESCRIPTION
Makes sure 'off_t' is included before usage.

Fixes #544