### PR TITLE
Use relative path in SourcedException

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 set(AERON_THIRDPARTY_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/thirdparty")
 
+# relative file paths for use in exceptions
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__FILENAME__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
+
 ##########################################################
 # gmock usage
 

--- a/aeron-client/src/main/cpp/util/Exceptions.h
+++ b/aeron-client/src/main/cpp/util/Exceptions.h
@@ -29,14 +29,14 @@
 namespace aeron { namespace util {
 
 #ifdef _MSC_VER
-    #define SOURCEINFO __FUNCTION__,  " : "  __FILE__  " : " TOSTRING(__LINE__)
+    #define SOURCEINFO __FUNCTION__,  " : "  __FILENAME__  " : " TOSTRING(__LINE__)
     #if _MSC_VER >= 1900
         #define AERON_NOEXCEPT noexcept
     #else
         #define AERON_NOEXCEPT throw()
     #endif
 #else
-    #define SOURCEINFO  __PRETTY_FUNCTION__,  " : "  __FILE__  " : " TOSTRING(__LINE__)
+    #define SOURCEINFO  __PRETTY_FUNCTION__,  " : "  __FILENAME__  " : " TOSTRING(__LINE__)
     #define AERON_NOEXCEPT noexcept
 #endif
 

--- a/aeron-client/src/test/cpp/util/TestUtils.h
+++ b/aeron-client/src/test/cpp/util/TestUtils.h
@@ -52,6 +52,11 @@ std::string makeTempFileName()
 #endif
 }
 
+void throwIllegalArgumentException()
+{
+    throw util::IllegalArgumentException("Intentional IllegalArgumentException", SOURCEINFO);
+}
+
 }}
 
 #endif //AERON_TESTUTILS_H

--- a/aeron-client/src/test/cpp/util/UtilTest.cpp
+++ b/aeron-client/src/test/cpp/util/UtilTest.cpp
@@ -19,10 +19,14 @@
 #include <util/ScopeUtils.h>
 #include <util/StringUtil.h>
 #include <util/BitUtil.h>
+#include "TestUtils.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 
 using namespace aeron::util;
+using namespace aeron::test;
 
 TEST(utilTests, scopeTest)
 {
@@ -102,4 +106,19 @@ TEST(utilTests, numberOfTrailingZeroes)
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0x0000FFFF), 0);
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0xFFFF0000), 16);
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0x00000001), 0);
+}
+
+TEST(utilTests, sourcedExceptionContainsRelativePath)
+{
+    EXPECT_THROW({
+        try
+        {
+            throwIllegalArgumentException();
+        }
+        catch(const SourcedException& e)
+        {
+            EXPECT_THAT(e.where(), ::testing::HasSubstr(" aeron-client/"));
+            throw;
+        }
+    }, SourcedException);
 }

--- a/aeron-driver/src/main/c/aeron_agent.c
+++ b/aeron-driver/src/main/c/aeron_agent.c
@@ -191,7 +191,7 @@ int aeron_agent_init(
     {
         int err_code = errno;
 
-        aeron_set_err(err_code, "%s:%d: %s", __FILE__, __LINE__, strerror(err_code));
+        aeron_set_err(err_code, "%s:%d: %s", __FILENAME__, __LINE__, strerror(err_code));
         return -1;
     }
     memcpy((char *)runner->role_name, role_name, role_name_length);

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -170,7 +170,7 @@ int aeron_report_existing_errors(aeron_mapped_file_t *cnc_map, const char *aeron
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             result = -1;
         }
     }
@@ -324,7 +324,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "socket %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "socket %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         goto cleanup;
     }
 
@@ -334,7 +334,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         goto cleanup;
     }
 
@@ -344,7 +344,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         goto cleanup;
     }
 
@@ -359,7 +359,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "setsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "setsockopt(SO_SNDBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             goto cleanup;
         }
 
@@ -368,7 +368,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             goto cleanup;
         }
 
@@ -393,7 +393,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "setsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "setsockopt(SO_RCVBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             goto cleanup;
         }
 
@@ -402,7 +402,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             goto cleanup;
         }
 
@@ -536,7 +536,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         goto error;
     }
 

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -56,7 +56,7 @@ int aeron_driver_receiver_init(
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             return -1;
         }
 

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -57,7 +57,7 @@ int aeron_driver_sender_init(
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             return -1;
         }
 

--- a/aeron-driver/src/main/c/aeron_system_counters.c
+++ b/aeron-driver/src/main/c/aeron_system_counters.c
@@ -54,7 +54,7 @@ int aeron_system_counters_init(aeron_system_counters_t *counters, aeron_counters
 {
     if (NULL == counters || NULL == manager)
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
         return -1;
     }
 
@@ -63,7 +63,7 @@ int aeron_system_counters_init(aeron_system_counters_t *counters, aeron_counters
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 

--- a/aeron-driver/src/main/c/collections/aeron_str_to_ptr_hash_map.h
+++ b/aeron-driver/src/main/c/collections/aeron_str_to_ptr_hash_map.h
@@ -76,7 +76,7 @@ inline int aeron_str_to_ptr_hash_map_init(
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 
@@ -84,7 +84,7 @@ inline int aeron_str_to_ptr_hash_map_init(
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 
@@ -116,7 +116,7 @@ inline int aeron_str_to_ptr_hash_map_rehash(aeron_str_to_ptr_hash_map_t *map, si
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 
@@ -124,7 +124,7 @@ inline int aeron_str_to_ptr_hash_map_rehash(aeron_str_to_ptr_hash_map_t *map, si
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 

--- a/aeron-driver/src/main/c/concurrent/aeron_broadcast_transmitter.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_broadcast_transmitter.c
@@ -35,7 +35,7 @@ int aeron_broadcast_transmitter_init(volatile aeron_broadcast_transmitter_t *tra
     }
     else
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
     }
 
     return result;

--- a/aeron-driver/src/main/c/concurrent/aeron_counters_manager.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_counters_manager.c
@@ -48,7 +48,7 @@ int aeron_counters_manager_init(
     }
     else
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
     }
 
     return result;
@@ -71,13 +71,13 @@ int32_t aeron_counters_manager_allocate(
 
     if ((counter_id * AERON_COUNTERS_MANAGER_VALUE_LENGTH) + AERON_COUNTERS_MANAGER_VALUE_LENGTH > manager->values_length)
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
         return -1;
     }
 
     if ((counter_id * AERON_COUNTERS_MANAGER_METADATA_LENGTH) + AERON_COUNTERS_MANAGER_METADATA_LENGTH > manager->metadata_length)
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
         return -1;
     }
 

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
@@ -39,7 +39,7 @@ int aeron_distinct_error_log_init(
 {
     if (NULL == log || NULL == clock || NULL == linger)
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
         return -1;
     }
 
@@ -47,7 +47,7 @@ int aeron_distinct_error_log_init(
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 

--- a/aeron-driver/src/main/c/concurrent/aeron_mpsc_rb.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_mpsc_rb.c
@@ -34,7 +34,7 @@ int aeron_mpsc_rb_init(volatile aeron_mpsc_rb_t *ring_buffer, void *buffer, size
     }
     else
     {
-        aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
+        aeron_set_err(EINVAL, "%s:%d: %s", __FILENAME__, __LINE__, strerror(EINVAL));
     }
 
     return result;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -391,7 +391,7 @@ int aeron_udp_channel_transport_get_so_rcvbuf(aeron_udp_channel_transport_t *tra
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 

--- a/aeron-driver/src/main/c/util/aeron_fileutil.c
+++ b/aeron-driver/src/main/c/util/aeron_fileutil.c
@@ -73,7 +73,7 @@ int aeron_fallocate(int fd, off_t length, bool fill_with_zeroes)
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 #else
@@ -81,7 +81,7 @@ int aeron_fallocate(int fd, off_t length, bool fill_with_zeroes)
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         return -1;
     }
 #endif
@@ -118,21 +118,21 @@ int aeron_map_new_file(aeron_mapped_file_t *mapped_file, const char *path, bool 
             {
                 int errcode = errno;
 
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             }
         }
         else
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         }
     }
     else
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
     }
 
     return result;
@@ -160,14 +160,14 @@ int aeron_map_existing_file(aeron_mapped_file_t *mapped_file, const char *path)
             {
                 int errcode = errno;
 
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             }
         }
         else
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
         }
 
         close(fd);
@@ -176,7 +176,7 @@ int aeron_map_existing_file(aeron_mapped_file_t *mapped_file, const char *path)
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
     }
 
     return result;
@@ -272,7 +272,7 @@ int aeron_map_raw_log(
             {
                 int errcode = errno;
 
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
                 return -1;
             }
 
@@ -301,7 +301,7 @@ int aeron_map_raw_log(
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             close(fd);
         }
     }
@@ -309,7 +309,7 @@ int aeron_map_raw_log(
     {
         int errcode = errno;
 
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
     }
 
     return result;
@@ -330,7 +330,7 @@ int aeron_map_raw_log_close(aeron_mapped_raw_log_t *mapped_raw_log, const char *
         {
             int errcode = errno;
 
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err(errcode, "%s:%d: %s", __FILENAME__, __LINE__, strerror(errcode));
             return -1;
         }
 


### PR DESCRIPTION
Today, SourcedException uses the absolute path of wherever aeron was built. I'd instead like it to refer to the relative path within the source tree.

It's probably misleading for a potential production exception to refer to /home/luke/aeron... or something to that effect.