### PR TITLE
Modular build and copy paste fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(DOXYGEN_FOUND)
 
     # install the doc if it has been built
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc DESTINATION share OPTIONAL)
-endif(DOXYGEN_FOUND)
+endif()
 
 ##########################################################
 # package target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(COVERAGE_BUILD "Enable code coverage" OFF)
 option(AERON_TESTS "Enable tests" ${STANDALONE_BUILD})
 option(AERON_BUILD_SAMPLES "Enable building the sample projects" ${STANDALONE_BUILD})
 option(AERON_BUILD_DOCUMENTATION "Build Aeron documentation" ${STANDALONE_BUILD})
+option(AERON_INSTALL_TARGETS "Enable installation step" ${STANDALONE_BUILD})
 
 unset(STANDALONE_BUILD)
 
@@ -277,8 +278,10 @@ if(AERON_BUILD_DOCUMENTATION AND DOXYGEN_FOUND)
         COMMENT "Generating API documentation with Doxygen" VERBATIM
     )
 
-    # install the doc if it has been built
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc DESTINATION share OPTIONAL)
+   if(AERON_INSTALL_TARGETS)
+       # install the doc if it has been built
+       install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc DESTINATION share OPTIONAL)
+   endif()
 endif()
 
 ##########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,9 @@ if(AERON_BUILD_DOCUMENTATION)
    find_package(Doxygen)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 11)
+endif()
 
 # all UNIX-based platform compiler flags
 if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(SANITISE_BUILD "Enable sanitise options" OFF)
 option(COVERAGE_BUILD "Enable code coverage" OFF)
 option(AERON_TESTS "Enable tests" ${STANDALONE_BUILD})
 option(AERON_BUILD_SAMPLES "Enable building the sample projects" ${STANDALONE_BUILD})
+option(AERON_BUILD_DOCUMENTATION "Build Aeron documentation" ${STANDALONE_BUILD})
 
 unset(STANDALONE_BUILD)
 
@@ -137,7 +138,9 @@ find_package(Threads)
 ##########################################################
 # Doxygen for generating doc
 
-find_package(Doxygen)
+if(AERON_BUILD_DOCUMENTATION)
+   find_package(Doxygen)
+endif()
 
 set(CMAKE_CXX_STANDARD 11)
 
@@ -262,7 +265,7 @@ endif(BUILD_AERON_DRIVER)
 ##########################################################
 # doc target
 
-if(DOXYGEN_FOUND)
+if(AERON_BUILD_DOCUMENTATION AND DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cppbuild/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
     add_custom_target(

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -136,5 +136,7 @@ target_link_libraries(aeron_client
     INTERFACE ${CMAKE_THREAD_LIBS_INIT}
 )
 
-install(TARGETS aeron_client ARCHIVE DESTINATION lib)
-install(DIRECTORY . DESTINATION  include FILES_MATCHING PATTERN "*.h")
+if (AERON_INSTALL_TARGETS)
+    install(TARGETS aeron_client ARCHIVE DESTINATION lib)
+    install(DIRECTORY . DESTINATION  include FILES_MATCHING PATTERN "*.h")
+endif()

--- a/aeron-client/src/main/cpp/ExclusivePublication.h
+++ b/aeron-client/src/main/cpp/ExclusivePublication.h
@@ -119,7 +119,7 @@ public:
     }
 
     /**
-     * Registration Id returned by Aeron::addPublication when this Publication was added.
+     * Registration Id returned by Aeron::addExclusivePublication when this Publication was added.
      *
      * @return the registrationId of the publication.
      */

--- a/aeron-client/src/main/cpp/Subscription.h
+++ b/aeron-client/src/main/cpp/Subscription.h
@@ -472,7 +472,7 @@ public:
     /// @endcond
 
     /**
-     * Get the status for the channel of this {@link Publication}
+     * Get the status for the channel of this {@link Subscription}
      *
      * @return status code for this channel
      */

--- a/aeron-client/src/test/cpp/concurrent/OneToOneRingBufferTest.cpp
+++ b/aeron-client/src/test/cpp/concurrent/OneToOneRingBufferTest.cpp
@@ -426,7 +426,6 @@ TEST(OneToOneRingBufferConcurrentTest, shouldExchangeMessages)
     OneToOneRingBuffer ringBuffer(spscAb);
 
     std::atomic<int> countDown(1);
-    std::atomic<int> publisherId(0);
 
     std::vector<std::thread> threads;
 

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -281,9 +281,11 @@ target_link_libraries(
     ${AERON_LIB_M_LIBS}
     ${CMAKE_THREAD_LIBS_INIT})
 
-install(
-    TARGETS aeron_driver aeron_driver_agent
-    RUNTIME DESTINATION lib
-    LIBRARY DESTINATION lib)
-install(TARGETS aeronmd DESTINATION bin)
-install(DIRECTORY . DESTINATION  include/aeronmd FILES_MATCHING PATTERN "*.h")
+if (AERON_INSTALL_TARGETS)
+    install(
+        TARGETS aeron_driver aeron_driver_agent
+        RUNTIME DESTINATION lib
+        LIBRARY DESTINATION lib)
+    install(TARGETS aeronmd DESTINATION bin)
+    install(DIRECTORY . DESTINATION  include/aeronmd FILES_MATCHING PATTERN "*.h")
+endif()

--- a/aeron-driver/src/test/c/aeron_spsc_rb_test.cpp
+++ b/aeron-driver/src/test/c/aeron_spsc_rb_test.cpp
@@ -387,7 +387,6 @@ TEST(SpscRbConcurrentTest, shouldExchangeMessages)
     ASSERT_EQ(aeron_spsc_rb_init(&rb, spsc_buffer.data(), spsc_buffer.size()), 0);
 
     std::atomic<int> countDown(1);
-    std::atomic<int> publisherId(0);
 
     std::vector<std::thread> threads;
     size_t msgCount = 0;

--- a/aeron-samples/src/main/cpp/CMakeLists.txt
+++ b/aeron-samples/src/main/cpp/CMakeLists.txt
@@ -77,6 +77,8 @@ target_link_libraries(PingPong
 
 add_dependencies(PingPong hdr_histogram)
 
-install(
-    TARGETS AeronStat BasicPublisher TimeTests BasicSubscriber StreamingPublisher RateSubscriber Ping Pong Throughput ErrorStat ExclusiveThroughput PingPong
-    DESTINATION bin)
+if (AERON_INSTALL_TARGETS)
+    install(
+        TARGETS AeronStat BasicPublisher TimeTests BasicSubscriber StreamingPublisher RateSubscriber Ping Pong Throughput ErrorStat ExclusiveThroughput PingPong
+        DESTINATION bin)
+endif()


### PR DESCRIPTION
Continuation of the earlier work on making Aeron more modular when added as a subproject, making documentation and installation optional. Behaviour is not affected when Aeron is built as a standalone project.