### PR TITLE
Initialise variable (in case std::cin is closed or otherwise read from it fails)

### DIFF
--- a/aeron-client/src/main/cpp/util/StringUtil.h
+++ b/aeron-client/src/main/cpp/util/StringUtil.h
@@ -139,7 +139,7 @@ std::string strconcat (Ts... vs)
 inline bool continuationBarrier(const std::string& label)
 {
     bool result = false;
-    char response;
+    char response = '\0';
     std::cout << std::endl << label << " (y/n): ";
     std::cin >> response;
 


### PR DESCRIPTION
Fixes #562 (which addresses a `clang --analyze` static code check failure).