### PR TITLE
Add CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,118 @@
+language: java
+
+os:
+- linux
+
+before_script:
+- export CXX=$COMPILER
+# Add an IPv6 config - see the corresponding Travis issue
+# https://github.com/travis-ci/travis-ci/issues/8361
+- if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+  sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+  fi
+
+# don't run gradle during C++ builds
+install: skip
+
+matrix:
+  include:
+  - name: "Oracle Java 8"
+    language: java
+    jdk: oraclejdk8
+    os: linux
+    script:
+    - ./gradlew
+
+  - name: "Oracle Java 11"
+    language: java
+    jdk: oraclejdk11
+    os: linux
+    script:
+    - ./gradlew
+
+  # clang-4
+  - env: COMPILER=clang++-4.0
+    compiler: clang
+    addons:
+      apt:
+        packages:
+        - clang-4.0
+        - libstdc++-6-dev
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-4.0
+    script:
+    - cppbuild/cppbuild -b
+
+  # clang-5
+  - env: COMPILER=clang++-5.0
+    compiler: clang
+    addons:
+      apt:
+        packages:
+        - clang-5.0
+        - libstdc++-7-dev
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-5.0
+    script:
+    - cppbuild/cppbuild -b
+
+  # clang-6
+  - env: COMPILER=clang++-6.0
+    compiler: clang
+    addons:
+      apt:
+        packages:
+        - clang-6.0
+        - libstdc++-7-dev
+        sources:
+        - ubuntu-toolchain-r-test
+        - llvm-toolchain-trusty-6.0
+    script:
+    - cppbuild/cppbuild -b
+
+  # gcc-6
+  - env: COMPILER=g++-6
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - g++-6
+        sources:
+        - ubuntu-toolchain-r-test
+    script:
+    - cppbuild/cppbuild -b
+
+  # gcc-7
+  - env: COMPILER=g++-7
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - g++-7
+        sources:
+        - ubuntu-toolchain-r-test
+    script:
+    - cppbuild/cppbuild -b
+
+  # gcc-8
+  - env: COMPILER=g++-8
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - g++-8
+        sources:
+        - ubuntu-toolchain-r-test
+    script:
+    - cppbuild/cppbuild -b
+
+before_cache:
+- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aeron
 [![Code Quality: Java](https://img.shields.io/lgtm/grade/java/g/real-logic/Aeron.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/real-logic/Aeron/context:java)
 [![Code Quality: C/C++](https://img.shields.io/lgtm/grade/cpp/g/real-logic/Aeron.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/real-logic/Aeron/context:cpp)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/real-logic/Aeron.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/real-logic/Aeron/alerts)
+[![Build Status](https://travis-ci.org/real-logic/aeron.svg?branch=master)](https://travis-ci.org/real-logic/aeron)
 
 Efficient reliable UDP unicast, UDP multicast, and IPC message transport. Java and C++ clients are available in this
 repository, and a [.NET client](https://github.com/AdaptiveConsulting/Aeron.NET) is available from a 3rd party. All


### PR DESCRIPTION
I've added configuration for travis builds covering linux and OSX.
If accepted, the maintainers have to press a button at https://travis-ci.org to activate.

This change is motivated because in #560 I apparently created a build issue that I can't reproduce.

Incidentally, I find that OSX builds currently fail on io.aeron.MemoryOrderingTest. I've marked OSX as allowed to fail in the submission for now.