### PR TITLE
Treat Egress Channel as NOT_CONNECTED on InvalidChannelException

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.Publication;
 import io.aeron.cluster.codecs.*;
 import io.aeron.logbuffer.BufferClaim;
 import org.agrona.ExpandableArrayBuffer;
@@ -40,7 +39,6 @@ class EgressPublisher
         final EventCode code,
         final String detail)
     {
-        final Publication publication = session.responsePublication();
         final int length = MessageHeaderEncoder.ENCODED_LENGTH +
             SessionEventEncoder.BLOCK_LENGTH +
             SessionEventEncoder.detailHeaderLength() +
@@ -49,7 +47,7 @@ class EgressPublisher
         int attempts = SEND_ATTEMPTS;
         do
         {
-            final long result = publication.tryClaim(length, bufferClaim);
+            final long result = session.tryClaim(length, bufferClaim);
             if (result > 0)
             {
                 sessionEventEncoder
@@ -73,8 +71,7 @@ class EgressPublisher
 
     boolean sendChallenge(final ClusterSession session, final byte[] encodedChallenge)
     {
-        final Publication publication = session.responsePublication();
-        if (!publication.isConnected())
+        if (!session.isResponsePublicationConnected())
         {
             return false;
         }
@@ -90,7 +87,7 @@ class EgressPublisher
         int attempts = SEND_ATTEMPTS;
         do
         {
-            final long result = publication.offer(buffer, 0, length, null);
+            final long result = session.offer(buffer, 0, length);
             if (result > 0)
             {
                 return true;
@@ -107,7 +104,6 @@ class EgressPublisher
         final int leaderMemberId,
         final String memberEndpoints)
     {
-        final Publication publication = session.responsePublication();
         final int length = MessageHeaderEncoder.ENCODED_LENGTH +
             NewLeaderEventEncoder.BLOCK_LENGTH +
             NewLeaderEventEncoder.memberEndpointsHeaderLength() +
@@ -116,7 +112,7 @@ class EgressPublisher
         int attempts = SEND_ATTEMPTS;
         do
         {
-            final long result = publication.tryClaim(length, bufferClaim);
+            final long result = session.tryClaim(length, bufferClaim);
             if (result > 0)
             {
                 newLeaderEventEncoder

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
@@ -17,6 +17,7 @@ package io.aeron.cluster.service;
 
 import io.aeron.Aeron;
 import io.aeron.Publication;
+import io.aeron.driver.exceptions.InvalidChannelException;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 
@@ -134,7 +135,14 @@ public class ClientSession
     {
         if (null == responsePublication)
         {
-            responsePublication = aeron.addExclusivePublication(responseChannel, responseStreamId);
+            try
+            {
+                responsePublication = aeron.addExclusivePublication(responseChannel, responseStreamId);
+            }
+            catch (final InvalidChannelException ex)
+            {
+                // responsePublication stays null
+            }
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -243,6 +243,11 @@ class ClusteredServiceAgent implements Agent, Cluster
             return ClientSession.MOCKED_OFFER;
         }
 
+        if (null == publication)
+        {
+            return Publication.NOT_CONNECTED;
+        }
+
         egressMessageHeaderEncoder
             .clusterSessionId(clusterSessionId)
             .timestamp(clusterTimeMs);


### PR DESCRIPTION
A channel that was resolvable at connection time can subsequently become unresolvable which causes a cascade of errors when a node becomes leader or the cluster is coming up after shutdown.

```
 io.aeron.exceptions.RegistrationException: errorCodeValue=1 java.net.UnknownHostException: could not resolve endpoint address: xxx.host:9020
    at io.aeron.ClientConductor.onError(ClientConductor.java:169)
    at io.aeron.DriverEventsAdapter.onMessage(DriverEventsAdapter.java:85)
    at org.agrona.concurrent.broadcast.CopyBroadcastReceiver.receive(CopyBroadcastReceiver.java:120)
    at io.aeron.DriverEventsAdapter.receive(DriverEventsAdapter.java:56)
    at io.aeron.ClientConductor.service(ClientConductor.java:718)
    at io.aeron.ClientConductor.awaitResponse(ClientConductor.java:762)
    at io.aeron.ClientConductor.addExclusivePublication(ClientConductor.java:407)
    at io.aeron.Aeron.addExclusivePublication(Aeron.java:253)
    at io.aeron.cluster.ClusterSession.connect(ClusterSession.java:130)
    at io.aeron.cluster.ConsensusModuleAgent.becomeLeader(ConsensusModuleAgent.java:1113)
    at io.aeron.cluster.Election.leaderTransition(Election.java:653)
    at io.aeron.cluster.Election.doWork(Election.java:209)
    at io.aeron.cluster.ConsensusModuleAgent.doWork(ConsensusModuleAgent.java:272)
    at org.agrona.concurrent.AgentRunner.doDutyCycle(AgentRunner.java:268)
    at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:161)
    at java.base/java.lang.Thread.run(Thread.java:844)
```