### PR TITLE
Use relative source path in exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
+# relative file paths for use in exceptions
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__CMAKE_SOURCE_DIR__='\"${CMAKE_SOURCE_DIR}\"'")
+
 set(AERON_THIRDPARTY_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/thirdparty")
 
 ##########################################################

--- a/aeron-client/src/test/cpp/util/TestUtils.h
+++ b/aeron-client/src/test/cpp/util/TestUtils.h
@@ -52,7 +52,7 @@ std::string makeTempFileName()
 #endif
 }
 
-void throwIllegalArgumentException()
+inline void throwIllegalArgumentException()
 {
     throw util::IllegalArgumentException("Intentional IllegalArgumentException", SOURCEINFO);
 }

--- a/aeron-client/src/test/cpp/util/UtilTest.cpp
+++ b/aeron-client/src/test/cpp/util/UtilTest.cpp
@@ -19,9 +19,10 @@
 #include <util/ScopeUtils.h>
 #include <util/StringUtil.h>
 #include <util/BitUtil.h>
+#include "TestUtils.h"
 
 #include <gtest/gtest.h>
-
+#include <gmock/gmock.h>
 
 using namespace aeron::util;
 
@@ -103,4 +104,27 @@ TEST(utilTests, numberOfTrailingZeroes)
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0x0000FFFF), 0);
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0xFFFF0000), 16);
     EXPECT_EQ(BitUtil::numberOfTrailingZeroes<std::uint32_t>(0x00000001), 0);
+}
+
+void throwIllegalArgumentException()
+{
+    aeron::test::throwIllegalArgumentException();
+}
+
+TEST(utilTests, sourcedException)
+{
+    EXPECT_THROW({
+        try
+        {
+            aeron::test::throwIllegalArgumentException();
+        }
+        catch(const SourcedException& e)
+        {
+            // Path must be relative and not have a prefix
+            EXPECT_THAT(e.where(), ::testing::HasSubstr(" aeron-client/"));
+            // The exception should point to the code before it was inlined
+            EXPECT_THAT(e.where(), ::testing::HasSubstr("TestUtils.h"));
+            throw;
+        }
+    }, SourcedException);
 }


### PR DESCRIPTION
Have sourced exceptions contain text that looks like aeron-client/.../filename instead of /home/luke/aeron/aeron-client....

Note that #555 was a previous attempt at this.