### PR TITLE
[C++] Add definition for __PROJECT_SOURCE_DIR__ to aeron_client's public interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-# relative file paths for use in exceptions
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__PROJECT_SOURCE_DIR__='\"${PROJECT_SOURCE_DIR}\"'")
-
 set(AERON_THIRDPARTY_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/thirdparty")
 
 ##########################################################

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -127,6 +127,11 @@ target_include_directories(aeron_client
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# relative file paths for use in exceptions
+target_compile_definitions(aeron_client
+    PUBLIC "__PROJECT_SOURCE_DIR__=\"${PROJECT_SOURCE_DIR}\""
+)
+
 if (NOT WIN32)
 	set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 	set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -14,13 +14,12 @@
 # limitations under the License.
 
 include_directories(${AERON_DRIVER_SOURCE_PATH})
-include_directories(${AERON_CLIENT_SOURCE_PATH})
 
 set(TEST_HEADERS aeron_driver_conductor_test.h)
 
 function(aeron_driver_test name file)
     add_executable(${name} ${file} ${TEST_HEADERS})
-    target_link_libraries(${name} aeron_driver ${GMOCK_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(${name} aeron_client aeron_driver ${GMOCK_LIBS} ${CMAKE_THREAD_LIBS_INIT})
     add_dependencies(${name} gmock)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()


### PR DESCRIPTION
This is required in case there is an upper level directory that includes
Aeron. In that case the added definitions do not reach the source files
that may include Aeron headers and __PROJECT_SOURCE_DIR__ will be
undefined to them.