### PR TITLE
Segv in #612 is still an issue

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/StartStopSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/StartStopSystemTest.java
@@ -16,6 +16,8 @@
 package io.aeron;
 
 import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class StartStopSystemTest
@@ -41,5 +43,24 @@ public class StartStopSystemTest
         {
             driverCtx.deleteAeronDirectory();
         }
+    }
+
+
+    @Ignore
+    @Test
+    public void shouldNotSegvIfContextIsClosed()
+    {
+        final MediaDriver mediaDriver;
+
+        try (MediaDriver.Context driverCtx = new MediaDriver.Context()
+                .errorHandler(Throwable::printStackTrace)
+                .threadingMode(ThreadingMode.INVOKER))
+        {
+            mediaDriver = MediaDriver.launchEmbedded(driverCtx);
+        }
+
+        mediaDriver.sharedAgentInvoker().invoke();
+
+        mediaDriver.close();
     }
 }


### PR DESCRIPTION
that's because io.aeron.driver.MediaDriver.Context#close unmaps cnc and lossReoprt buffers.
But the media driver tries to write some counter value to the cnc. 