### PR TITLE
Share egress publication between CM & CSC

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -16,7 +16,6 @@
 package io.aeron.cluster;
 
 import io.aeron.Aeron;
-import io.aeron.ChannelUri;
 import io.aeron.Publication;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.CloseReason;
@@ -125,11 +124,9 @@ class ClusterSession
             throw new ClusterException("response publication already added");
         }
 
-        final ChannelUri channelUri = ChannelUri.parse(responseChannel);
-
         try
         {
-            responsePublication = aeron.addPublication(channelUri.toString(), responseStreamId);
+            responsePublication = aeron.addPublication(responseChannel, responseStreamId);
         }
         catch (final InvalidChannelException ignore)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -17,7 +17,6 @@ package io.aeron.cluster;
 
 import io.aeron.Aeron;
 import io.aeron.ChannelUri;
-import io.aeron.CommonContext;
 import io.aeron.Publication;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.CloseReason;
@@ -127,12 +126,10 @@ class ClusterSession
         }
 
         final ChannelUri channelUri = ChannelUri.parse(responseChannel);
-        channelUri.put(CommonContext.TERM_LENGTH_PARAM_NAME, "64k");
-        channelUri.put(CommonContext.SPARSE_PARAM_NAME, "true");
 
         try
         {
-            responsePublication = aeron.addExclusivePublication(channelUri.toString(), responseStreamId);
+            responsePublication = aeron.addPublication(channelUri.toString(), responseStreamId);
         }
         catch (final InvalidChannelException ignore)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClientSession.java
@@ -152,7 +152,7 @@ public class ClientSession
         {
             try
             {
-                responsePublication = aeron.addExclusivePublication(responseChannel, responseStreamId);
+                responsePublication = aeron.addPublication(responseChannel, responseStreamId);
             }
             catch (final RegistrationException ignore)
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -52,7 +52,7 @@ public class ConsensusModuleAgentTest
     private final EgressPublisher mockEgressPublisher = mock(EgressPublisher.class);
     private final LogPublisher mockLogPublisher = mock(LogPublisher.class);
     private final Aeron mockAeron = mock(Aeron.class);
-    private final ExclusivePublication mockResponsePublication = mock(ExclusivePublication.class);
+    private final ConcurrentPublication mockResponsePublication = mock(ConcurrentPublication.class);
     private final Counter mockTimedOutClientCounter = mock(Counter.class);
 
     private final ConsensusModule.Context ctx = new ConsensusModule.Context()
@@ -83,7 +83,7 @@ public class ConsensusModuleAgentTest
         when(mockLogPublisher.appendSessionOpen(any(), anyLong(), anyLong())).thenReturn(128L);
         when(mockLogPublisher.appendClusterAction(anyLong(), anyLong(), anyLong(), any(ClusterAction.class)))
             .thenReturn(TRUE);
-        when(mockAeron.addExclusivePublication(anyString(), anyInt())).thenReturn(mockResponsePublication);
+        when(mockAeron.addPublication(anyString(), anyInt())).thenReturn(mockResponsePublication);
         when(mockAeron.addSubscription(anyString(), anyInt())).thenReturn(mock(Subscription.class));
         when(mockAeron.addSubscription(anyString(), anyInt(), eq(null), any(UnavailableImageHandler.class)))
             .thenReturn(mock(Subscription.class));


### PR DESCRIPTION
Use shared egress publication in ClusteredService. CM already ensures the Publication is connected as part of the session processing logic.

Sharing this publication reduces the likelyhood of having to block the service thread. 
e.g. if a message needs to be sent as a result of onSessionOpen.