### PR TITLE
aeronmd: Change aeron_uri_parse to accept len.

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -1726,7 +1726,7 @@ int aeron_driver_conductor_on_add_ipc_publication(
     aeron_uri_t aeron_uri_params;
     aeron_uri_publication_params_t params;
 
-    if (aeron_uri_parse(uri, &aeron_uri_params) < 0 ||
+    if (aeron_uri_parse(uri, (size_t)uri_length, &aeron_uri_params) < 0 ||
         aeron_uri_publication_params(&aeron_uri_params, &params, conductor->context, is_exclusive) < 0)
     {
         goto error_cleanup;
@@ -1925,8 +1925,9 @@ int aeron_driver_conductor_on_add_ipc_subscription(
     const char *uri = (const char *)command + sizeof(aeron_subscription_command_t);
     aeron_uri_t aeron_uri_params;
     aeron_uri_subscription_params_t params;
+    int32_t uri_length = command->channel_length;
 
-    if (aeron_uri_parse(uri, &aeron_uri_params) < 0 ||
+    if (aeron_uri_parse(uri, (size_t)uri_length, &aeron_uri_params) < 0 ||
         aeron_uri_subscription_params(&aeron_uri_params, &params, conductor->context) < 0)
     {
         goto error_cleanup;
@@ -2303,7 +2304,7 @@ int aeron_driver_conductor_on_add_destination(
         }
 
         strncpy(buffer, command_uri, (size_t)command->channel_length);
-        if (aeron_uri_parse(buffer, &uri_params) < 0)
+        if (aeron_uri_parse(buffer, (size_t)command->channel_length, &uri_params) < 0)
         {
             return -1;
         }
@@ -2370,7 +2371,7 @@ int aeron_driver_conductor_on_remove_destination(
         }
 
         strncpy(buffer, command_uri, (size_t)command->channel_length);
-        if (aeron_uri_parse(buffer, &uri_params) < 0)
+        if (aeron_uri_parse(buffer, (size_t)command->channel_length, &uri_params) < 0)
         {
             return -1;
         }

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -195,7 +195,7 @@ int aeron_udp_channel_parse(const char *uri, size_t uri_length, aeron_udp_channe
         return -1;
     }
 
-    if (aeron_uri_parse(uri, &_channel->uri) < 0)
+    if (aeron_uri_parse(uri, uri_length, &_channel->uri) < 0)
     {
         goto error_cleanup;
     }

--- a/aeron-driver/src/main/c/uri/aeron_uri.c
+++ b/aeron-driver/src/main/c/uri/aeron_uri.c
@@ -202,11 +202,18 @@ int aeron_ipc_uri_parse(char *uri, aeron_ipc_channel_params_t *params)
 #define AERON_URI_UDP_TRANSPORT "udp"
 #define AERON_URI_IPC_TRANSPORT "ipc"
 
-int aeron_uri_parse(const char *uri, aeron_uri_t *params)
+int aeron_uri_parse(const char *uri, size_t uri_len, aeron_uri_t *params)
 {
     char *ptr = params->mutable_uri;
 
-    strncpy(params->mutable_uri, uri, sizeof(params->mutable_uri));
+    if (uri_len > sizeof(params->mutable_uri) - 1)
+    {
+        aeron_set_err(EINVAL, "URI scheme or transport too long: %.*s", uri_len, uri);
+        return -1;
+    }
+    memset(params->mutable_uri, 0, sizeof(params->mutable_uri));
+    memcpy(params->mutable_uri, uri, uri_len);
+//    strncpy(params->mutable_uri, uri, sizeof(params->mutable_uri));
     params->type = AERON_URI_UNKNOWN;
 
     if (strncmp(ptr, AERON_URI_SCHEME, strlen(AERON_URI_SCHEME)) == 0)

--- a/aeron-driver/src/main/c/uri/aeron_uri.h
+++ b/aeron-driver/src/main/c/uri/aeron_uri.h
@@ -116,7 +116,7 @@ int aeron_uri_parse_params(char *uri, aeron_uri_parse_callback_t param_func, voi
 int aeron_udp_uri_parse(char *uri, aeron_udp_channel_params_t *params);
 int aeron_ipc_uri_parse(char *uri, aeron_ipc_channel_params_t *params);
 
-int aeron_uri_parse(const char *uri, aeron_uri_t *params);
+int aeron_uri_parse(const char *uri, size_t uri_len, aeron_uri_t *params);
 
 void aeron_uri_close(aeron_uri_t *params);
 

--- a/aeron-driver/src/test/c/aeron_uri_test.cpp
+++ b/aeron-driver/src/test/c/aeron_uri_test.cpp
@@ -51,44 +51,46 @@ protected:
     aeron_driver_context_t *m_context = NULL;
 };
 
+#define AERON_URI_PARSE_WITH_STRLEN(ss, params) aeron_uri_parse(ss, strlen(ss), params)
+
 TEST_F(UriTest, shouldNotParseInvalidUriScheme)
 {
-    EXPECT_EQ(aeron_uri_parse("aaron", &m_uri), -1);
-    EXPECT_EQ(aeron_uri_parse("aeron:", &m_uri), -1);
-    EXPECT_EQ(aeron_uri_parse("aron:", &m_uri), -1);
-    EXPECT_EQ(aeron_uri_parse(":aeron", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aaron", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aron:", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN(":aeron", &m_uri), -1);
 }
 
 TEST_F(UriTest, shouldNotParseUnknownUriTransport)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:tcp", &m_uri), -1);
-    EXPECT_EQ(aeron_uri_parse("aeron:sctp", &m_uri), -1);
-    EXPECT_EQ(aeron_uri_parse("aeron:udp", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:tcp", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:sctp", &m_uri), -1);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp", &m_uri), -1);
 }
 
 TEST_F(UriTest, shouldParseKnownUriTransportWithoutParamsIpcNoSeparator)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc", &m_uri), 0);
     ASSERT_EQ(m_uri.type, AERON_URI_IPC);
     EXPECT_EQ(m_uri.params.ipc.additional_params.length, 0u);
 }
 
 TEST_F(UriTest, shouldParseKnownUriTransportWithoutParamsUdpWithSeparator)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?", &m_uri), 0);
     EXPECT_EQ(m_uri.type, AERON_URI_UDP);
 }
 
 TEST_F(UriTest, shouldParseKnownUriTransportWithoutParamsIpcWithSeparator)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?", &m_uri), 0);
     EXPECT_EQ(m_uri.type, AERON_URI_IPC);
     EXPECT_EQ(m_uri.params.ipc.additional_params.length, 0u);
 }
 
 TEST_F(UriTest, shouldParseWithSingleParamUdpEndpoint)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
     ASSERT_EQ(m_uri.type, AERON_URI_UDP);
     EXPECT_EQ(std::string(m_uri.params.udp.endpoint_key), "224.10.9.8");
     EXPECT_EQ(m_uri.params.udp.additional_params.length, 0u);
@@ -96,7 +98,7 @@ TEST_F(UriTest, shouldParseWithSingleParamUdpEndpoint)
 
 TEST_F(UriTest, shouldParseWithSingleParamUdpVariableWithEmbeddedPipe)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?add|ress=224.10.9.8", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?add|ress=224.10.9.8", &m_uri), 0);
     ASSERT_EQ(m_uri.type, AERON_URI_UDP);
     ASSERT_EQ(m_uri.params.udp.additional_params.length, 1u);
     EXPECT_EQ(std::string(m_uri.params.udp.additional_params.array[0].key), "add|ress");
@@ -105,7 +107,7 @@ TEST_F(UriTest, shouldParseWithSingleParamUdpVariableWithEmbeddedPipe)
 
 TEST_F(UriTest, shouldParseWithSingleParamUdpValueWithEmbeddedEquals)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.1=0.9.8", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.1=0.9.8", &m_uri), 0);
     ASSERT_EQ(m_uri.type, AERON_URI_UDP);
     EXPECT_EQ(std::string(m_uri.params.udp.endpoint_key), "224.1=0.9.8");
     EXPECT_EQ(m_uri.params.udp.additional_params.length, 0u);
@@ -113,7 +115,7 @@ TEST_F(UriTest, shouldParseWithSingleParamUdpValueWithEmbeddedEquals)
 
 TEST_F(UriTest, shouldParseWithMultipleParams)
 {
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|port=4567|interface=192.168.0.3|ttl=16", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|port=4567|interface=192.168.0.3|ttl=16", &m_uri), 0);
     ASSERT_EQ(m_uri.type, AERON_URI_UDP);
     EXPECT_EQ(std::string(m_uri.params.udp.endpoint_key), "224.10.9.8");
     EXPECT_EQ(std::string(m_uri.params.udp.interface_key), "192.168.0.3");
@@ -127,10 +129,10 @@ TEST_F(UriTest, shouldParseNoPublicationParams)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
 }
 
@@ -138,7 +140,7 @@ TEST_F(UriTest, shouldParsePublicationParamLingerTimeout)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|linger=7777", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|linger=7777", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.linger_timeout_ns, 7777u);
 }
@@ -147,7 +149,7 @@ TEST_F(UriTest, shouldParsePublicationParamUdpTermLength)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|term-length=131072", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|term-length=131072", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.term_length, 131072u);
 }
@@ -156,7 +158,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcTermLength)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?term-length=262144", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?term-length=262144", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.term_length, 262144u);
 }
@@ -165,7 +167,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcTermLengthOddValue)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?term-length=262143", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?term-length=262143", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -173,7 +175,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcTermLength32K)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?term-length=32768", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?term-length=32768", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -181,7 +183,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcTermLength2T)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?term-length=2147483648", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?term-length=2147483648", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -189,7 +191,7 @@ TEST_F(UriTest, shouldParsePublicationParamUdpEndpointAndMtuLength)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|mtu=18432", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|mtu=18432", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.mtu_length, 18432u);
 }
@@ -198,7 +200,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcMtuLength32K)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?mtu=32768", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?mtu=32768", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.mtu_length, 32768u);
 }
@@ -207,7 +209,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcMtuLengthNonPowerOf2)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?mtu=66560", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?mtu=66560", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -215,7 +217,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcMtuLengthLessThanHeaderLength)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?mtu=10", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?mtu=10", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -223,7 +225,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcMtuLengthNotMultipleOfFrameAlignme
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?mtu=255", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?mtu=255", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), -1);
 }
 
@@ -231,7 +233,7 @@ TEST_F(UriTest, shouldParsePublicationParamIpcSparse)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?sparse=true", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?sparse=true", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, false), 0);
     EXPECT_EQ(params.is_sparse, true);
 }
@@ -240,7 +242,7 @@ TEST_F(UriTest, shouldParsePublicationParamsForReplayUdp)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|init-term-id=120|term-id=127|term-offset=64", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|init-term-id=120|term-id=127|term-offset=64", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, true), 0) << aeron_errmsg();
     EXPECT_EQ(params.is_replay, true);
     EXPECT_EQ(params.initial_term_id, 120l);
@@ -252,7 +254,7 @@ TEST_F(UriTest, shouldParsePublicationParamsForReplayIpc)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?init-term-id=250|term-id=257|term-offset=128", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?init-term-id=250|term-id=257|term-offset=128", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, true), 0) << aeron_errmsg();
     EXPECT_EQ(params.is_replay, true);
     EXPECT_EQ(params.initial_term_id, 250l);
@@ -264,7 +266,7 @@ TEST_F(UriTest, shouldParsePublicationParamsForReplayIpcNegativeTermIds)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?init-term-id=-257|term-id=-250|term-offset=128", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?init-term-id=-257|term-id=-250|term-offset=128", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, true), 0) << aeron_errmsg();
     EXPECT_EQ(params.initial_term_id, -257l);
     EXPECT_EQ(params.term_id, -250l);
@@ -274,7 +276,7 @@ TEST_F(UriTest, shouldParsePublicationParamsForReplayIpcOddTermOffset)
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:ipc?init-term-id=-257|term-id=-250|term-offset=127", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:ipc?init-term-id=-257|term-id=-250|term-offset=127", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, true), -1);
 }
 
@@ -282,7 +284,7 @@ TEST_F(UriTest, shouldParsePublicationParamsForReplayIpcTermOffsetBeyondTermLeng
 {
     aeron_uri_publication_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse(
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN(
         "aeron:ipc?term-length=65536|init-term-id=-257|term-id=-250|term-offset=65537", &m_uri), 0);
     EXPECT_EQ(aeron_uri_publication_params(&m_uri, &params, m_context, true), -1);
 }
@@ -291,7 +293,7 @@ TEST_F(UriTest, shouldParseSubscriptionParamReliable)
 {
     aeron_uri_subscription_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8|reliable=false", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8|reliable=false", &m_uri), 0);
     EXPECT_EQ(aeron_uri_subscription_params(&m_uri, &params, m_context), 0);
     EXPECT_EQ(params.is_reliable, false);
 }
@@ -300,7 +302,7 @@ TEST_F(UriTest, shouldParseSubscriptionParamReliableDefault)
 {
     aeron_uri_subscription_params_t params;
 
-    EXPECT_EQ(aeron_uri_parse("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE_WITH_STRLEN("aeron:udp?endpoint=224.10.9.8", &m_uri), 0);
     EXPECT_EQ(aeron_uri_subscription_params(&m_uri, &params, m_context), 0);
     EXPECT_EQ(params.is_reliable, true);
 }


### PR DESCRIPTION
When the URI is received in a command over UDP it does not have a trailing null. 
The size of the URI is known in the command buffer and does not need to be null terminated.
In some cases aeron_uri_parse is called without a null terminated string so it fails to parse the address, even though the URI is correctly received.