### PR TITLE
[Java] Test showing recovery issue with timers.

### DIFF
--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -307,15 +307,20 @@ public class TestCluster implements AutoCloseable
         for (int i = 0; i < messageCount; i++)
         {
             msgBuffer.putInt(0, i);
-            while (client.offer(msgBuffer, 0, BitUtil.SIZE_OF_INT) < 0)
-            {
-                TestUtil.checkInterruptedStatus();
-                client.pollEgress();
-                Thread.yield();
-            }
-
-            client.pollEgress();
+            sendMessage(BitUtil.SIZE_OF_INT);
         }
+    }
+
+    void sendMessage(final int messageLength)
+    {
+        while (client.offer(msgBuffer, 0, messageLength) < 0)
+        {
+            TestUtil.checkInterruptedStatus();
+            client.pollEgress();
+            Thread.yield();
+        }
+
+        client.pollEgress();
     }
 
     void awaitResponses(final int messageCount)

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestMessages.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestMessages.java
@@ -1,0 +1,7 @@
+package io.aeron.cluster;
+
+class TestMessages
+{
+    static final String NO_OP = "No op!           ";
+    static final String REGISTER_TIMER = "Register a timer!";
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
@@ -41,6 +41,7 @@ import static org.agrona.BitUtil.SIZE_OF_INT;
 
 class TestNode implements AutoCloseable
 {
+
     private final ClusteredMediaDriver clusteredMediaDriver;
     private final ClusteredServiceContainer container;
     private final TestService service;
@@ -240,6 +241,12 @@ class TestNode implements AutoCloseable
             final int length,
             final Header header)
         {
+            final String message = buffer.getStringWithoutLengthAscii(offset, length);
+            if (message.equals(TestMessages.REGISTER_TIMER))
+            {
+                cluster.scheduleTimer(1, cluster.timeMs() + 1_000);
+            }
+
             while (session.offer(buffer, offset, length) < 0)
             {
                 cluster.idle();


### PR DESCRIPTION
This test captures some behaviour we've seen at a client. 

Please let me know if you'd like me to clean it up at all. I considered injecting a different `ClusteredService` implementation rather than adding the switching in the existing one. I'm not sure what your preference is.

We see follower nodes stuck whilst catching up after performing the following steps:
1. Starting a 3 node cluster
2. Stopping a follower node
3. Sending a message to the cluster that triggers a timer to be
registered
4. Starting the follower node (again)

I've added two tests:
- `shouldCatchUpAfterFollowerMissesAMessage()` passes; but
- `shouldCatchUpAfterFollowerMissesTimerRegistration()` fails

The only difference between them is that the failing one registers a timer in the `onSessionMessage(...)` handler of `ClusteredService`.

The failure I see is:
```
Expected :is null
Actual   :<FOLLOWER_CATCHUP>
```

I'm running on JDK 1.8 (202 AMZN).