### PR TITLE
[Java] Fix issue where multiple archive clients are trying to connect.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/ControlResponsePoller.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ControlResponsePoller.java
@@ -28,7 +28,7 @@ import org.agrona.DirectBuffer;
  */
 public class ControlResponsePoller implements ControlledFragmentHandler
 {
-    private static final int FRAGMENT_LIMIT = 10;
+    private static final int FRAGMENT_LIMIT = 1;
 
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     private final ControlResponseDecoder controlResponseDecoder = new ControlResponseDecoder();

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -15,7 +15,14 @@
  */
 package io.aeron.archive;
 
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.driver.MediaDriver;
 import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -32,5 +39,37 @@ public class ArchiveTest
         final String actual = Archive.segmentFileName(recordingId, segmentIndex);
 
         assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void shouldAllowMultipleConnectionsInParallel() throws InterruptedException
+    {
+        final int numberOfArchiveClients = 5;
+        final CountDownLatch latch = new CountDownLatch(numberOfArchiveClients);
+        final ExecutorService executorService = Executors.newFixedThreadPool(numberOfArchiveClients);
+
+        final MediaDriver.Context driverCtx = new MediaDriver.Context();
+        final Archive.Context archiveCtx = new Archive.Context();
+
+        try (ArchivingMediaDriver driver = ArchivingMediaDriver.launch(driverCtx, archiveCtx))
+        {
+            for (int i = 0; i < numberOfArchiveClients; i++)
+            {
+                executorService.execute(() ->
+                {
+                    AeronArchive.connect();
+                    latch.countDown();
+                });
+            }
+
+            latch.await(10, TimeUnit.SECONDS);
+
+            assertThat(latch.getCount(), is(0L));
+        }
+        finally
+        {
+            archiveCtx.deleteArchiveDirectory();
+            driverCtx.deleteAeronDirectory();
+        }
     }
 }


### PR DESCRIPTION
When spawning clients simultaneously the following exception is thrown in some of the clients:
```
io.aeron.exceptions.TimeoutException: awaiting response - correlationId=24
	at io.aeron.archive.client.AeronArchive.checkDeadline(AeronArchive.java:1008)
	at io.aeron.archive.client.AeronArchive.pollNextResponse(AeronArchive.java:1122)
	at io.aeron.archive.client.AeronArchive.awaitSessionOpened(AeronArchive.java:1021)
	at io.aeron.archive.client.AeronArchive.<init>(AeronArchive.java:109)
	at io.aeron.archive.client.AeronArchive.connect(AeronArchive.java:183)
	at io.aeron.archive.ArchiveTest.lambda$shouldAllowMultipleConnectionsInParallel$0(ArchiveTest.java:56)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The `ControlResponsePoller` expects that calling BREAK will stop the polling operation but when there are multiple Images, subsequent Images will be polled and messages are lost.
Reducing the fragmentLimit is the simplest way I can see to fix this for the time being. 
It might be worth adjusting the contract for `Subscription.controlledPoll` so that anything other than a CONTINUE would stop the current polling operation.