### PR TITLE
[Java] Fix bug when truncating sessions before election.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -754,7 +754,7 @@ class ConsensusModuleAgent implements Agent, MemberStatusListener
         for (final Iterator<ClusterSession> i = sessionByIdMap.values().iterator(); i.hasNext(); )
         {
             final ClusterSession session = i.next();
-            if (session.openedLogPosition() >= logPosition)
+            if (session.openedLogPosition() > logPosition)
             {
                 i.remove();
                 session.close();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -61,6 +61,21 @@ public class ClusterTest
     }
 
     @Test(timeout = 30_000)
+    public void clientShouldBeSentNewLeaderEventOnLeaderChange() throws Exception
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+
+            cluster.connectClient();
+
+            cluster.stopNode(leader);
+
+            cluster.awaitLeadershipEvent(1);
+        }
+    }
+
+    @Test(timeout = 30_000)
     public void shouldStopLeaderAndFollowersAndRestartAllWithSnapshot() throws Exception
     {
         try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))


### PR DESCRIPTION
Fix bug which dropped a session if its opening was the last event to be appended to the log before an election.