### PR TITLE
[Java] Remove source of garbage when cancelling missed timers

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2473,7 +2473,15 @@ class ConsensusModuleAgent implements Agent, MemberStatusListener
 
     private void cancelMissedTimers()
     {
-        missedTimersSet.removeIf(timerService::cancelTimer);
+        final LongHashSet.LongIterator timerIdIterator = missedTimersSet.iterator();
+        while (timerIdIterator.hasNext())
+        {
+            final long missedTimerId = timerIdIterator.nextValue();
+            if (timerService.cancelTimer(missedTimerId))
+            {
+                timerIdIterator.remove();
+            }
+        }
     }
 
     private void onUnavailableIngressImage(final Image image)


### PR DESCRIPTION
Use of the `Predicate` was causing the `long` values to be auto-boxed to `Long`.