### PR TITLE
Fix bug with multi-destination subscription where destinations are setup in advance.

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
@@ -798,6 +798,7 @@ public class PublicationImage
 
     private void trackConnection(final int transportIndex, final InetSocketAddress srcAddress, final long nowNs)
     {
+        imageConnections = ArrayUtil.ensureCapacity(imageConnections, transportIndex + 1);
         ImageConnection imageConnection = imageConnections[transportIndex];
 
         if (null == imageConnection)


### PR DESCRIPTION
Driver was throwing the following exception:
```
java.lang.ArrayIndexOutOfBoundsException: 1
	at io.aeron.driver.PublicationImage.trackConnection(PublicationImage.java:802)
	at io.aeron.driver.PublicationImage.addDestinationConnectionIfUnknown(PublicationImage.java:416)
	at io.aeron.driver.DataPacketDispatcher.onSetupMessage(DataPacketDispatcher.java:325)
	at io.aeron.driver.media.ReceiveChannelEndpoint.onSetupMessage(ReceiveChannelEndpoint.java:369)
	at io.aeron.driver.media.DataTransportPoller.poll(DataTransportPoller.java:175)
	at io.aeron.driver.media.DataTransportPoller.pollTransports(DataTransportPoller.java:78)
	at io.aeron.driver.Receiver.doWork(Receiver.java:72)
	at org.agrona.concurrent.CompositeAgent.doWork(CompositeAgent.java:114)
	at org.agrona.concurrent.AgentRunner.doDutyCycle(AgentRunner.java:286)
	at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:164)
	at java.lang.Thread.run(Thread.java:748)

```