### PR TITLE
Configure build-scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,14 @@ buildscript {
 
 plugins {
     id 'java'
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'com.github.johnrengelman.shadow' version '5.0.0' apply false
     id "io.freefair.javadoc-links" version "3.2.0" apply false
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    apply from: 'gradle/build-scans.gradle'
 }
 
 defaultTasks 'clean', 'build', 'shadowJar', 'install'

--- a/gradle/build-scans.gradle
+++ b/gradle/build-scans.gradle
@@ -1,0 +1,33 @@
+def acceptFile = new File(gradle.gradleUserHomeDir, "build-scans/aeron/gradle-scans-license-agree.txt")
+def env = System.getenv()
+boolean isCI = env.CI || env.TRAVIS
+boolean hasAccepted = isCI || env.AERON_GRADLE_SCANS_ACCEPT=='yes' || acceptFile.exists() && acceptFile.text.trim() == 'yes'
+boolean hasRefused = env.AERON_GRADLE_SCANS_ACCEPT=='no' || acceptFile.exists() && acceptFile.text.trim() == 'no'
+
+buildScan {
+    if (hasAccepted) {
+        termsOfServiceAgree = 'yes'
+    } else if (!hasRefused) {
+        gradle.buildFinished {
+            println """
+This build uses Gradle Build Scans to gather statistics, share information about 
+failures, environmental issues, dependencies resolved during the build and more.
+Build scans will be published after each build, if you accept the terms of 
+service, and in particular the privacy policy.
+
+Please read 
+   
+    https://gradle.com/terms-of-service 
+    https://gradle.com/legal/privacy
+
+and then:
+
+  - set the `AERON_GRADLE_SCANS_ACCEPT` to `yes`/`no` if you agree with/refuse the TOS
+  - or create the ${acceptFile} file with `yes`/`no` in it if you agree with/refuse
+
+And we'll not bother you again. Note that build scans are only made public if 
+you share the URL at the end of the build.
+"""
+        }
+    }
+}


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.

Here's an example scan https://scans.gradle.com/s/jkf57dj4qsrrq