### PR TITLE
[Tom/Michael/Andrey] Close NetworkPublication::senderBpe

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1034,8 +1034,6 @@ public class DriverConductor implements Agent
             tempBuffer, countersManager, registrationId, sessionId, streamId, channel);
         final UnsafeBufferPosition senderLimit = SenderLimit.allocate(
             tempBuffer, countersManager, registrationId, sessionId, streamId, channel);
-        final AtomicCounter senderBpe = SenderBpe.allocate(
-            tempBuffer, countersManager, registrationId, sessionId, streamId, channel);
 
         if (params.isReplay)
         {
@@ -1068,7 +1066,7 @@ public class DriverConductor implements Agent
             publisherLimit,
             senderPosition,
             senderLimit,
-            senderBpe,
+            SenderBpe.allocate(tempBuffer, countersManager, registrationId, sessionId, streamId, channel),
             sessionId,
             streamId,
             initialTermId,

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -246,6 +246,7 @@ public class NetworkPublication
         publisherLimit.close();
         senderPosition.close();
         senderLimit.close();
+        senderBpe.close();
         for (final ReadablePosition position : spyPositions)
         {
             position.close();


### PR DESCRIPTION
The senderBpe AtomicCounter is not being closed when
NetworkPublication::close is being invoked. This is causing a small
resource leak in the MediaDriver