### PR TITLE
Add unit tests to validate contexts can't be reused when constructing…

### DIFF
--- a/aeron-driver/src/test/java/io/aeron/driver/DriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverContextTest.java
@@ -1,0 +1,27 @@
+package io.aeron.driver;
+
+import io.aeron.driver.exceptions.ActiveDriverException;
+import io.aeron.exceptions.ConcurrentConcludeException;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class DriverContextTest
+{
+    @Test
+    public void shouldPreventCreatingMultipleDriversWithTheSameContext()
+    {
+        final MediaDriver.Context ctx = new MediaDriver.Context();
+
+        try (
+            MediaDriver mediaDriver1 = MediaDriver.launchEmbedded(ctx);
+            MediaDriver mediaDriver2 = MediaDriver.launchEmbedded(ctx))
+        {
+            fail("Exception should be thrown for reuse of the MediaDriver.Context instance");
+        }
+        catch (final ActiveDriverException | ConcurrentConcludeException e)
+        {
+            // Expected
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ClientContextTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ClientContextTest.java
@@ -1,0 +1,25 @@
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.exceptions.ConcurrentConcludeException;
+import org.junit.Test;
+
+public class ClientContextTest
+{
+    @Test(expected = ConcurrentConcludeException.class)
+    public void shouldPreventCreatingMultipleClientsWithTheSameContext()
+    {
+        try (MediaDriver mediaDriver = MediaDriver.launchEmbedded())
+        {
+            final Aeron.Context ctx = new Aeron.Context()
+                .aeronDirectoryName(mediaDriver.aeronDirectoryName());
+
+            //noinspection EmptyTryBlock
+            try (
+                Aeron aeron1 = Aeron.connect(ctx);
+                Aeron aeron2 = Aeron.connect(ctx))
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
… clients and drivers.  Reinstates the unit tests from #666.