### PR TITLE
add new verbose option in the CatalogTool

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/RecordingReader.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/RecordingReader.java
@@ -135,6 +135,11 @@ class RecordingReader implements AutoCloseable
         return recordingId;
     }
 
+    long replayPosition()
+    {
+        return replayPosition;
+    }
+
     boolean isDone()
     {
         return isDone;


### PR DESCRIPTION
hi! I really miss that feature to take a look on the data are stored by archive. 

the output looks like this
```
INFO: Mark file exists: /tmp/archive-test/archive-mark.dat
03:36:57 (start: 2019-05-17 03:36:48, activity: 2019-05-17 03:36:48)
[MarkFileHeader](sbeTemplateId=200|sbeSchemaId=100|sbeSchemaVersion=0|sbeBlockLength=128):version=257|activityTimestamp=1558053408638|startTimestamp=1558053408413|pid=5237|controlStreamId=10|localControlStreamId=11|eventsStreamId=30|controlChannel='aeron:udp?endpoint=localhost:8010'|localControlChannel='aeron:ipc'|eventsChannel='aeron:udp?control-mode=dynamic|control=localhost:8030'|aeronDirectory='/dev/shm/aeron-ivan'
Catalog Max Entries: 8192

Verbose mode is on. We will print 9223372036854775807 fragments at a time.


Recording 0 
  channel: aeron:ipc
  streamId: 2
  data length: 0
[RecordingDescriptorHeader](sbeTemplateId=21|sbeSchemaId=101|sbeSchemaVersion=2|sbeBlockLength=32):length=181|valid=1|reserved=0
[RecordingDescriptor](sbeTemplateId=22|sbeSchemaId=101|sbeSchemaVersion=2|sbeBlockLength=80):controlSessionId=0|correlationId=0|recordingId=0|startTimestamp=1558053362774|stopTimestamp=1558053362784|startPosition=0|stopPosition=0|initialTermId=-849535192|segmentFileLength=134217728|termBufferLength=33554432|mtuLength=16384|sessionId=530412009|streamId=2|strippedChannel='aeron:ipc'|originalChannel='aeron:ipc?mtu=16384|term-length=33554432'|sourceIdentity='aeron:ipc?mtu=16384|term-length=33554432'
Recording is empty


Recording 1 
  channel: aeron:ipc
  streamId: 2
  data length: 96
[RecordingDescriptorHeader](sbeTemplateId=21|sbeSchemaId=101|sbeSchemaVersion=2|sbeBlockLength=32):length=181|valid=1|reserved=0
[RecordingDescriptor](sbeTemplateId=22|sbeSchemaId=101|sbeSchemaVersion=2|sbeBlockLength=80):controlSessionId=0|correlationId=0|recordingId=1|startTimestamp=1558053396527|stopTimestamp=1558053396541|startPosition=0|stopPosition=96|initialTermId=-1834274981|segmentFileLength=134217728|termBufferLength=33554432|mtuLength=16384|sessionId=1039899594|streamId=2|strippedChannel='aeron:ipc'|originalChannel='aeron:ipc?mtu=16384|term-length=33554432'|sourceIdentity='aeron:ipc?mtu=16384|term-length=33554432'

Found a frame on the position [0] data on offset [32] with length = 45
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 00 00 00 00 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a |....zzzzzzzzzzzz|
|00000010| 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a |zzzzzzzzzzzzzzzz|
|00000020| 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a 7a          |zzzzzzzzzzzzz   |
+--------+-------------------------------------------------+----------------+
0 bytes (from 96) left in this recording 1

```

i hope that's ok... 