### PR TITLE
Treat back-pressure as a successful keep-alive signal

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -403,7 +403,7 @@ public final class AeronCluster implements AutoCloseable
         while (true)
         {
             final long result = publication.offer(keepaliveMsgBuffer, 0, keepaliveMsgBuffer.capacity(), null);
-            if (result > 0)
+            if (result > 0 || result == Publication.BACK_PRESSURED)
             {
                 return true;
             }


### PR DESCRIPTION
We shouldn't disconnect from the cluster while we're actively sending it data.