### PR TITLE
AeronStat

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -135,13 +135,24 @@ public class ConsensusModule implements AutoCloseable
         public static State get(final AtomicCounter counter)
         {
             final long code = counter.get();
+            return get((int)code);
+        }
 
-            if (code < 0 || code > (STATES.length - 1))
+        /**
+         * Get the {@link State} corresponding to a particular value.
+         *
+         * @param value of the State.
+         * @return the {@link State} corresponding to the provided value.
+         * @throws ClusterException if the value does not correspond to a valid State.
+         */
+        public static State get(final int value)
+        {
+            if (value < 0 || value > (STATES.length - 1))
             {
-                throw new ClusterException("invalid state counter code: " + code);
+                throw new ClusterException("invalid state counter code: " + value);
             }
 
-            return STATES[(int)code];
+            return STATES[value];
         }
     }
 

--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -20,7 +20,6 @@ import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.DirectBuffer;
 import org.agrona.SemanticVersion;
 import org.agrona.SystemUtil;
-import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.SigInt;
 import org.agrona.concurrent.status.CountersReader;
 
@@ -193,9 +192,10 @@ public class AeronStat
             }
         }
 
-        final MutableInteger cncFileVersion = new MutableInteger();
+        final CncFileReader cncFileReader = CncFileReader.map();
+
         final AeronStat aeronStat = new AeronStat(
-            SamplesUtil.mapCounters(cncFileVersion),
+            cncFileReader.countersReader(),
             typeFilter,
             identityFilter,
             sessionFilter,
@@ -205,8 +205,6 @@ public class AeronStat
         final AtomicBoolean running = new AtomicBoolean(watch);
         SigInt.register(() -> running.set(false));
 
-        final String header =
-            " - Aeron Stat (CnC v" + SemanticVersion.toString(cncFileVersion.get()) + "), pid " + SystemUtil.getPid();
         final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
 
         do
@@ -217,7 +215,10 @@ public class AeronStat
             }
 
             System.out.print(dateFormat.format(new Date()));
-            System.out.println(header);
+            System.out.println(
+                " - Aeron Stat (CnC v" + cncFileReader.semanticVersion() + ")" +
+                    ", pid " + SystemUtil.getPid() +
+                    ", heartbeat " + cncFileReader.driverHeartbeatAge() + "ms");
             System.out.println("======================================================================");
 
             aeronStat.print(System.out);

--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -18,12 +18,10 @@ package io.aeron.samples;
 import io.aeron.CncFileDescriptor;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.DirectBuffer;
-import org.agrona.SemanticVersion;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.SigInt;
 import org.agrona.concurrent.status.CountersReader;
 
-import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -96,39 +94,6 @@ public class AeronStat
      */
     private static final String COUNTER_CHANNEL = "channel";
 
-    private final CountersReader counters;
-    private final Pattern typeFilter;
-    private final Pattern identityFilter;
-    private final Pattern sessionFilter;
-    private final Pattern streamFilter;
-    private final Pattern channelFilter;
-
-    public AeronStat(
-        final CountersReader counters,
-        final Pattern typeFilter,
-        final Pattern identityFilter,
-        final Pattern sessionFilter,
-        final Pattern streamFilter,
-        final Pattern channelFilter)
-    {
-        this.counters = counters;
-        this.typeFilter = typeFilter;
-        this.identityFilter = identityFilter;
-        this.sessionFilter = sessionFilter;
-        this.streamFilter = streamFilter;
-        this.channelFilter = channelFilter;
-    }
-
-    public AeronStat(final CountersReader counters)
-    {
-        this.counters = counters;
-        this.typeFilter = null;
-        this.identityFilter = null;
-        this.sessionFilter = null;
-        this.streamFilter = null;
-        this.channelFilter = null;
-    }
-
     public static void main(final String[] args) throws Exception
     {
         long delayMs = 1000L;
@@ -194,56 +159,64 @@ public class AeronStat
 
         final CncFileReader cncFileReader = CncFileReader.map();
 
-        final AeronStat aeronStat = new AeronStat(
-            cncFileReader.countersReader(),
+        final CounterFilter counterFilter = new CounterFilter(
             typeFilter,
             identityFilter,
             sessionFilter,
             streamFilter,
             channelFilter);
 
-        final AtomicBoolean running = new AtomicBoolean(watch);
-        SigInt.register(() -> running.set(false));
+        if (watch)
+        {
+            workLoop(delayMs, () -> printOutput(cncFileReader, counterFilter));
+        }
+        else
+        {
+            printOutput(cncFileReader, counterFilter);
+        }
+    }
 
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+    private static void workLoop(final long delayMs, final Runnable printOutput) throws Exception
+    {
+        final AtomicBoolean running = new AtomicBoolean(true);
+        SigInt.register(() -> running.set(false));
 
         do
         {
-            if (watch)
-            {
-                clearScreen();
-            }
+            clearScreen();
 
-            System.out.print(dateFormat.format(new Date()));
-            System.out.println(
-                " - Aeron Stat (CnC v" + cncFileReader.semanticVersion() + ")" +
-                    ", pid " + SystemUtil.getPid() +
-                    ", heartbeat " + cncFileReader.driverHeartbeatAge() + "ms");
-            System.out.println("======================================================================");
+            printOutput.run();
 
-            aeronStat.print(System.out);
-            System.out.println("--");
-
-            if (watch)
-            {
-                Thread.sleep(delayMs);
-            }
-
+            Thread.sleep(delayMs);
         }
         while (running.get());
     }
 
-    public void print(final PrintStream out)
+    private static void printOutput(final CncFileReader cncFileReader, final CounterFilter counterFilter)
     {
+        final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+
+        System.out.print(dateFormat.format(new Date()));
+        System.out.println(
+            " - Aeron Stat (CnC v" + cncFileReader.semanticVersion() + ")" +
+            ", pid " + SystemUtil.getPid() +
+            ", heartbeat " + cncFileReader.driverHeartbeatAge() + "ms");
+        System.out.println("======================================================================");
+
+        final CountersReader counters = cncFileReader.countersReader();
+
         counters.forEach(
             (counterId, typeId, keyBuffer, label) ->
             {
-                if (filter(typeId, keyBuffer))
+                if (counterFilter.filter(typeId, keyBuffer))
                 {
                     final long value = counters.getCounterValue(counterId);
-                    out.format("%3d: %,20d - %s%n", counterId, value, label);
+                    System.out.format("%3d: %,20d - %s%n", counterId, value, label);
                 }
-            });
+            }
+        );
+
+        System.out.println("--");
     }
 
     private static void checkForHelp(final String[] args)
@@ -268,39 +241,6 @@ public class AeronStat
         }
     }
 
-    private boolean filter(final int typeId, final DirectBuffer keyBuffer)
-    {
-        if (!match(typeFilter, () -> Integer.toString(typeId)))
-        {
-            return false;
-        }
-
-        if (SYSTEM_COUNTER_TYPE_ID == typeId && !match(identityFilter, () -> Integer.toString(keyBuffer.getInt(0))))
-        {
-            return false;
-        }
-        else if ((typeId >= PUBLISHER_LIMIT_TYPE_ID && typeId <= RECEIVER_POS_TYPE_ID) ||
-            typeId == SENDER_LIMIT_TYPE_ID || typeId == PER_IMAGE_TYPE_ID || typeId == PUBLISHER_POS_TYPE_ID)
-        {
-            return
-                match(identityFilter, () -> Long.toString(keyBuffer.getLong(REGISTRATION_ID_OFFSET))) &&
-                match(sessionFilter, () -> Integer.toString(keyBuffer.getInt(SESSION_ID_OFFSET))) &&
-                match(streamFilter, () -> Integer.toString(keyBuffer.getInt(STREAM_ID_OFFSET))) &&
-                match(channelFilter, () -> keyBuffer.getStringAscii(CHANNEL_OFFSET));
-        }
-        else if (typeId >= SEND_CHANNEL_STATUS_TYPE_ID && typeId <= RECEIVE_CHANNEL_STATUS_TYPE_ID)
-        {
-            return match(channelFilter, () -> keyBuffer.getStringAscii(ChannelEndpointStatus.CHANNEL_OFFSET));
-        }
-
-        return true;
-    }
-
-    private static boolean match(final Pattern pattern, final Supplier<String> supplier)
-    {
-        return null == pattern || pattern.matcher(supplier.get()).find();
-    }
-
     private static void clearScreen() throws Exception
     {
         if (SystemUtil.osName().contains("win"))
@@ -310,6 +250,62 @@ public class AeronStat
         else
         {
             System.out.print(ANSI_CLS + ANSI_HOME);
+        }
+    }
+
+    static class CounterFilter
+    {
+        private final Pattern typeFilter;
+        private final Pattern identityFilter;
+        private final Pattern sessionFilter;
+        private final Pattern streamFilter;
+        private final Pattern channelFilter;
+
+        CounterFilter(
+            final Pattern typeFilter,
+            final Pattern identityFilter,
+            final Pattern sessionFilter,
+            final Pattern streamFilter,
+            final Pattern channelFilter)
+        {
+            this.typeFilter = typeFilter;
+            this.identityFilter = identityFilter;
+            this.sessionFilter = sessionFilter;
+            this.streamFilter = streamFilter;
+            this.channelFilter = channelFilter;
+        }
+
+        private static boolean match(final Pattern pattern, final Supplier<String> supplier)
+        {
+            return null == pattern || pattern.matcher(supplier.get()).find();
+        }
+
+        boolean filter(final int typeId, final DirectBuffer keyBuffer)
+        {
+            if (!match(typeFilter, () -> Integer.toString(typeId)))
+            {
+                return false;
+            }
+
+            if (SYSTEM_COUNTER_TYPE_ID == typeId && !match(identityFilter, () -> Integer.toString(keyBuffer.getInt(0))))
+            {
+                return false;
+            }
+            else if ((typeId >= PUBLISHER_LIMIT_TYPE_ID && typeId <= RECEIVER_POS_TYPE_ID) ||
+                typeId == SENDER_LIMIT_TYPE_ID || typeId == PER_IMAGE_TYPE_ID || typeId == PUBLISHER_POS_TYPE_ID)
+            {
+                return
+                    match(identityFilter, () -> Long.toString(keyBuffer.getLong(REGISTRATION_ID_OFFSET))) &&
+                        match(sessionFilter, () -> Integer.toString(keyBuffer.getInt(SESSION_ID_OFFSET))) &&
+                        match(streamFilter, () -> Integer.toString(keyBuffer.getInt(STREAM_ID_OFFSET))) &&
+                        match(channelFilter, () -> keyBuffer.getStringAscii(CHANNEL_OFFSET));
+            }
+            else if (typeId >= SEND_CHANNEL_STATUS_TYPE_ID && typeId <= RECEIVE_CHANNEL_STATUS_TYPE_ID)
+            {
+                return match(channelFilter, () -> keyBuffer.getStringAscii(ChannelEndpointStatus.CHANNEL_OFFSET));
+            }
+
+            return true;
         }
     }
 }

--- a/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
@@ -1,0 +1,125 @@
+package io.aeron.samples;
+
+import io.aeron.CncFileDescriptor;
+import io.aeron.CommonContext;
+import io.aeron.exceptions.AeronException;
+import org.agrona.DirectBuffer;
+import org.agrona.IoUtil;
+import org.agrona.SemanticVersion;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.agrona.concurrent.status.CountersReader;
+
+import java.io.File;
+import java.nio.MappedByteBuffer;
+
+import static io.aeron.CncFileDescriptor.*;
+import static io.aeron.samples.SamplesUtil.mapExistingFileReadOnly;
+
+/**
+ * A utility class for interpreting the cnc file.
+ */
+public final class CncFileReader implements AutoCloseable
+{
+    private final MappedByteBuffer cncByteBuffer;
+    private final int cncVersion;
+    private final CountersReader countersReader;
+    private final ManyToOneRingBuffer toDriverBuffer;
+    private final String cncSemanticVersion;
+
+    private CncFileReader(final MappedByteBuffer cncByteBuffer)
+    {
+        this.cncByteBuffer = cncByteBuffer;
+
+        final DirectBuffer cncMetaDataBuffer = createMetaDataBuffer(cncByteBuffer);
+        final int cncVersion = cncMetaDataBuffer.getInt(cncVersionOffset(0));
+
+        try
+        {
+            checkVersion(cncVersion);
+        }
+        catch (final AeronException e)
+        {
+            IoUtil.unmap(cncByteBuffer);
+            throw e;
+        }
+
+        this.cncVersion = cncVersion;
+        this.cncSemanticVersion = SemanticVersion.toString(cncVersion);
+
+        this.toDriverBuffer = new ManyToOneRingBuffer(
+            CncFileDescriptor.createToDriverBuffer(cncByteBuffer, cncMetaDataBuffer));
+
+        this.countersReader = new CountersReader(
+            createCountersMetaDataBuffer(cncByteBuffer, cncMetaDataBuffer),
+            createCountersValuesBuffer(cncByteBuffer, cncMetaDataBuffer));
+    }
+
+    /**
+     * Map an existing CnC file.
+     *
+     * @throws AeronException if the cnc version major version is not compatible.
+     * @return the {@link CncFileReader} wrapper for reading useful data from the cnc file.
+     */
+    public static CncFileReader map()
+    {
+        final File cncFile = CommonContext.newDefaultCncFile();
+        final MappedByteBuffer cncByteBuffer = mapExistingFileReadOnly(cncFile);
+        return new CncFileReader(cncByteBuffer);
+    }
+
+    /**
+     * Get the cnc version.
+     *
+     * @return the cnc version.
+     */
+    public int cncVersion()
+    {
+        return cncVersion;
+    }
+
+    /**
+     * Get the cnc semantic version.
+     *
+     * @return the cnc semantic version.
+     */
+    public String semanticVersion()
+    {
+        return cncSemanticVersion;
+    }
+
+    /**
+     * Get the counters reader for querying counter values.
+     *
+     * @return the counters reader.
+     */
+    public CountersReader countersReader()
+    {
+        return countersReader;
+    }
+
+    /**
+     * Get the timestamp (ms) of the last driver heartbeat.
+     *
+     * @return the timestamp (ms) of the last driver heartbeat.
+     */
+    public long driverHeartbeat()
+    {
+        return toDriverBuffer.consumerHeartbeatTime();
+    }
+
+    /**
+     * Get the number of milliseconds since the last driver heartbeat.
+     *
+     * @return the number of milliseconds since the last driver heartbeat.
+     */
+    public long driverHeartbeatAge()
+    {
+        return System.currentTimeMillis() - driverHeartbeat();
+    }
+
+    @Override
+    public void close()
+    {
+        IoUtil.unmap(cncByteBuffer);
+    }
+}


### PR DESCRIPTION
- Add an option to AeronStat (`watch=false`) to do only one dump of the counters.
- Add driver heartbeat to AeronStat output
- Add `CncFileReader` that brings together some helpers for interpreting the cnc file.
- A minor refactor to AeronStat (to stop CheckStyle complaining about method length)
- Add overload to get ConsensusModule.State without an AtomicCounter

```
10:15:38 - Aeron Stat (CnC v0.0.15), pid 20620, heartbeat 12ms
======================================================================
  0:                    0 - Bytes sent
  1:                    0 - Bytes received
...
```