### PR TITLE
[Java] Use AeronArchive error handler in `conclude` if any

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -1673,7 +1673,10 @@ public class AeronArchive implements AutoCloseable
 
             if (null == aeron)
             {
-                aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(aeronDirectoryName));
+                aeron = Aeron.connect(
+                    new Aeron.Context()
+                        .aeronDirectoryName(aeronDirectoryName)
+                        .errorHandler(errorHandler));
                 ownsAeronClient = true;
             }
 


### PR DESCRIPTION
It's the last place where no setting the given error handler in a context `conclude`. And by default Aeron has a little dangerous handler with `System.exit` in the timeout case.