### PR TITLE
[Java] Ensure that clusterMembersStatusEndpointsCursor is reset

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -210,6 +210,7 @@ public class ClusterBackupAgent implements Agent, FragmentHandler, UnavailableCo
         snapshotsRetrieved.clear();
         leaderLogEntry = null;
         leaderLastTermEntry = null;
+        clusterMembersStatusEndpointsCursor = NULL_VALUE;
 
         if (null != recordingLog)
         {


### PR DESCRIPTION
The cursor to select the next member status endpoint currently gets stuck at the last array position. This change causes the cursor to be reset along with other state in the ClusterBackupAgent.