### PR TITLE
[Java] Explicitly stop live log backup

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -146,7 +146,10 @@ public class ClusterBackupAgent implements Agent, FragmentHandler, UnavailableCo
             CloseHelper.close(memberStatusSubscription);
             CloseHelper.close(memberStatusPublication);
         }
-
+        if (NULL_VALUE != liveLogReplaySubscriptionId)
+        {
+            backupArchive.stopRecording(liveLogReplaySubscriptionId);
+        }
         CloseHelper.close(backupArchive);
         CloseHelper.close(clusterArchive);
         CloseHelper.close(recordingLog);


### PR DESCRIPTION
This change explicitly stops a live log recording when the ClusterBackupAgent is closed