### PR TITLE
[Java] Prevent resource leak in case of failed launch.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchivingMediaDriver.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchivingMediaDriver.java
@@ -78,14 +78,24 @@ public class ArchivingMediaDriver implements AutoCloseable
      */
     public static ArchivingMediaDriver launch(final MediaDriver.Context driverCtx, final Archive.Context archiveCtx)
     {
-        final MediaDriver driver = MediaDriver.launch(driverCtx);
+        MediaDriver driver = null;
+        Archive archive = null;
+        try
+        {
+            driver = MediaDriver.launch(driverCtx);
 
-        final Archive archive = Archive.launch(archiveCtx
-            .mediaDriverAgentInvoker(driver.sharedAgentInvoker())
-            .errorHandler(driverCtx.errorHandler())
-            .errorCounter(driverCtx.systemCounters().get(SystemCounterDescriptor.ERRORS)));
+            archive = Archive.launch(archiveCtx
+                .mediaDriverAgentInvoker(driver.sharedAgentInvoker())
+                .errorHandler(driverCtx.errorHandler())
+                .errorCounter(driverCtx.systemCounters().get(SystemCounterDescriptor.ERRORS)));
 
-        return new ArchivingMediaDriver(driver, archive);
+            return new ArchivingMediaDriver(driver, archive);
+        }
+        catch (final Exception ex)
+        {
+            CloseHelper.quietCloseAll(archive, driver);
+            throw ex;
+        }
     }
 
     /**


### PR DESCRIPTION
Avoid resource leaks in situations like:

```
    java.nio.file.FileSystemException: aeron-archive\23-0.rec: The process cannot access the file because it is being used by another process.
        at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
        at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
        at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:270)
        at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:105)
        at java.base/java.nio.file.Files.delete(Files.java:1141)
        at org.agrona.IoUtil.delete(IoUtil.java:156)
        at org.agrona.IoUtil.delete(IoUtil.java:147)
        at io.aeron.archive.Archive$Context.conclude(Archive.java:489)
        at io.aeron.archive.Archive.<init>(Archive.java:61)
        at io.aeron.archive.Archive.launch(Archive.java:156)
        at io.aeron.archive.ArchivingMediaDriver.launch(ArchivingMediaDriver.java:83)
        at uk.co.real_logic.artio.TestFixtures.launchMediaDriver(TestFixtures.java:68)
        at uk.co.real_logic.artio.TestFixtures.launchMediaDriver(TestFixtures.java:62)
        at uk.co.real_logic.artio.TestFixtures.launchMediaDriver(TestFixtures.java:52)
        at uk.co.real_logic.artio.system_tests.MessageBasedAcceptorSystemTest.setup(MessageBasedAcceptorSystemTest.java:97)
        at uk.co.real_logic.artio.system_tests.MessageBasedAcceptorSystemTest.shouldNotNotifyLibraryOfSessionUntilLoggedOn(MessageBasedAcceptorSystemTest.java:76)
```