### PR TITLE
Narrow Aeron constructor to private visibility

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -78,7 +78,7 @@ public class Aeron implements AutoCloseable
     private final AgentRunner conductorRunner;
     private final Context ctx;
 
-    Aeron(final Context ctx)
+    private Aeron(final Context ctx)
     {
         ctx.conclude();
 


### PR DESCRIPTION
We don't use it outside the file and generally speaking we use static factory methods for instancing Aeron object.

Correct me if there is any concern we intend to make it package-private.