### PR TITLE
[C++] Remove original registration ID from ExclusivePublication.

### DIFF
--- a/aeron-client/src/main/cpp/ClientConductor.cpp
+++ b/aeron-client/src/main/cpp/ClientConductor.cpp
@@ -16,6 +16,8 @@
 
 #include "ClientConductor.h"
 
+#include <cassert>
+
 namespace aeron {
 
 template<typename T, typename... U>
@@ -204,7 +206,6 @@ std::shared_ptr<ExclusivePublication> ClientConductor::findExclusivePublication(
                     *this,
                     state.m_channel,
                     state.m_registrationId,
-                    state.m_originalRegistrationId,
                     state.m_streamId,
                     state.m_sessionId,
                     publicationLimit,
@@ -624,6 +625,8 @@ void ClientConductor::onNewExclusivePublication(
     std::int32_t channelStatusIndicatorId,
     const std::string &logFileName)
 {
+    assert(registrationId == originalRegistrationId);
+
     std::lock_guard<std::recursive_mutex> lock(m_adminLock);
 
     auto it = m_exclusivePublicationByRegistrationId.find(registrationId);
@@ -636,7 +639,6 @@ void ClientConductor::onNewExclusivePublication(
         state.m_publicationLimitCounterId = publicationLimitCounterId;
         state.m_channelStatusId = channelStatusIndicatorId;
         state.m_buffers = getLogBuffers(originalRegistrationId, logFileName, state.m_channel);
-        state.m_originalRegistrationId = originalRegistrationId;
 
         CallbackGuard callbackGuard(m_isInCallback);
         m_onNewExclusivePublicationHandler(state.m_channel, streamId, sessionId, registrationId);

--- a/aeron-client/src/main/cpp/ClientConductor.h
+++ b/aeron-client/src/main/cpp/ClientConductor.h
@@ -287,7 +287,6 @@ private:
         std::weak_ptr<ExclusivePublication> m_publication;
         const std::string m_channel;
         const std::int64_t m_registrationId;
-        std::int64_t m_originalRegistrationId = -1;
         const long long m_timeOfRegistrationMs;
         const std::int32_t m_streamId;
         std::int32_t m_sessionId = -1;

--- a/aeron-client/src/main/cpp/ExclusivePublication.cpp
+++ b/aeron-client/src/main/cpp/ExclusivePublication.cpp
@@ -23,7 +23,6 @@ ExclusivePublication::ExclusivePublication(
     ClientConductor &conductor,
     const std::string &channel,
     std::int64_t registrationId,
-    std::int64_t originalRegistrationId,
     std::int32_t streamId,
     std::int32_t sessionId,
     UnsafeBufferPosition& publicationLimit,
@@ -33,7 +32,6 @@ ExclusivePublication::ExclusivePublication(
     m_logMetaDataBuffer(logBuffers->atomicBuffer(LogBufferDescriptor::LOG_META_DATA_SECTION_INDEX)),
     m_channel(channel),
     m_registrationId(registrationId),
-    m_originalRegistrationId(originalRegistrationId),
     m_maxPossiblePosition(static_cast<int64_t>(logBuffers->atomicBuffer(0).capacity()) << 31),
     m_streamId(streamId),
     m_sessionId(sessionId),
@@ -79,7 +77,7 @@ void ExclusivePublication::addDestination(const std::string& endpointChannel)
         throw util::IllegalStateException(std::string("Publication is closed"), SOURCEINFO);
     }
 
-    m_conductor.addDestination(m_originalRegistrationId, endpointChannel);
+    m_conductor.addDestination(m_registrationId, endpointChannel);
 }
 
 void ExclusivePublication::removeDestination(const std::string& endpointChannel)
@@ -89,7 +87,7 @@ void ExclusivePublication::removeDestination(const std::string& endpointChannel)
         throw util::IllegalStateException(std::string("Publication is closed"), SOURCEINFO);
     }
 
-    m_conductor.removeDestination(m_originalRegistrationId, endpointChannel);
+    m_conductor.removeDestination(m_registrationId, endpointChannel);
 }
 
 std::int64_t ExclusivePublication::channelStatus()

--- a/aeron-client/src/main/cpp/ExclusivePublication.h
+++ b/aeron-client/src/main/cpp/ExclusivePublication.h
@@ -57,7 +57,6 @@ public:
         ClientConductor& conductor,
         const std::string& channel,
         std::int64_t registrationId,
-        std::int64_t originalRegistrationId,
         std::int32_t streamId,
         std::int32_t sessionId,
         UnsafeBufferPosition& publicationLimit,
@@ -115,7 +114,7 @@ public:
      */
     inline std::int64_t originalRegistrationId() const
     {
-        return m_originalRegistrationId;
+        return m_registrationId;
     }
 
     /**
@@ -129,14 +128,13 @@ public:
     }
 
     /**
-     * Is this Publication the original instance added to the driver? If not then it was added after another client
-     * has already added the publication.
+     * ExclusivePublication instances are always original.
      *
-     * @return true if this instance is the first added otherwise false.
+     * @return true.
      */
-    inline bool isOriginal() const
+    static constexpr bool isOriginal()
     {
-        return m_originalRegistrationId == m_registrationId;
+        return true;
     }
 
     /**
@@ -561,7 +559,6 @@ private:
 
     const std::string m_channel;
     std::int64_t m_registrationId;
-    std::int64_t m_originalRegistrationId;
     std::int64_t m_maxPossiblePosition;
     std::int32_t m_streamId;
     std::int32_t m_sessionId;

--- a/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp
+++ b/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp
@@ -82,7 +82,7 @@ public:
     void createPub()
     {
         m_publication = std::unique_ptr<ExclusivePublication>(new ExclusivePublication(
-            m_conductor, CHANNEL, CORRELATION_ID, CORRELATION_ID, STREAM_ID, SESSION_ID,
+            m_conductor, CHANNEL, CORRELATION_ID, STREAM_ID, SESSION_ID,
             m_publicationLimit, ChannelEndpointStatus::NO_ID_ALLOCATED, m_logBuffers));
     }
 


### PR DESCRIPTION
As exclusive publications are guaranteed to be original.