### PR TITLE
[Java] Fix NullPointerException when dynamic node joined and leader disappear

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2687,6 +2687,11 @@ class ConsensusModuleAgent implements Agent, MemberStatusListener
         highMemberId = Math.max(highMemberId, memberId);
 
         final ClusterMember eventMember = ClusterMember.findMember(newMembers, memberId);
+        if (eventMember != null && eventMember.publication() == null)
+        {
+            final ChannelUri memberStatusUri = ChannelUri.parse(ctx.memberStatusChannel());
+            ClusterMember.addMemberStatusPublication(eventMember, memberStatusUri, ctx.memberStatusStreamId(), aeron);
+        }
 
         clusterMembers = ClusterMember.addMember(clusterMembers, eventMember);
         clusterMemberByIdMap.put(memberId, eventMember);


### PR DESCRIPTION
There is an null pointer issue in next case:
1. Start 3 static nodes.
2. Join 1 dynamic node.
3. Stop LEADER.
Result: NullPointerException in other static nodes with next exception
```
E 2019-10-29T13:56:20,473 i.s.a.ClusteredServiceRunner Exception occurred at ConsensusModule:  [consensus-module]
java.lang.NullPointerException: null
	at io.aeron.cluster.MemberStatusPublisher.canvassPosition(MemberStatusPublisher.java:60) ~[aeron-cluster-1.23.1-SNAPSHOT.jar:1.23.1-SNAPSHOT]
	at io.aeron.cluster.Election.canvass(Election.java:508) ~[aeron-cluster-1.23.1-SNAPSHOT.jar:1.23.1-SNAPSHOT]
	at io.aeron.cluster.Election.doWork(Election.java:205) [aeron-cluster-1.23.1-SNAPSHOT.jar:1.23.1-SNAPSHOT]
	at io.aeron.cluster.ConsensusModuleAgent.doWork(ConsensusModuleAgent.java:295) [aeron-cluster-1.23.1-SNAPSHOT.jar:1.23.1-SNAPSHOT]
	at org.agrona.concurrent.AgentRunner.doDutyCycle(AgentRunner.java:283) [agrona-1.0.9.jar:1.0.9]
	at org.agrona.concurrent.AgentRunner.run(AgentRunner.java:164) [agrona-1.0.9.jar:1.0.9]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_222]

```

Currently publication for recently joined node is assigned only in LEADER node. In PR I assigned publication in followers and added test for this case.


