### PR TITLE
[C++] Fix narrowing conversion in client

### DIFF
--- a/aeron-client/src/main/cpp/ClientConductor.cpp
+++ b/aeron-client/src/main/cpp/ClientConductor.cpp
@@ -878,9 +878,9 @@ void ClientConductor::onUnavailableImage(std::int64_t correlationId, std::int64_
 
         if (nullptr != subscription)
         {
-            std::pair<Image::array_t, int> result = subscription->removeImage(correlationId);
+            std::pair<Image::array_t, std::size_t> result = subscription->removeImage(correlationId);
             Image::array_t oldImageArray = result.first;
-            const int index = result.second;
+            const std::size_t index = result.second;
 
             if (nullptr != oldImageArray)
             {

--- a/aeron-client/src/main/cpp/Subscription.h
+++ b/aeron-client/src/main/cpp/Subscription.h
@@ -433,7 +433,7 @@ public:
         return m_imageArray.addElement(std::move(image)).first;
     }
 
-    std::pair<Image::array_t, int> removeImage(std::int64_t correlationId)
+    std::pair<Image::array_t, std::size_t> removeImage(std::int64_t correlationId)
     {
         auto result = m_imageArray.removeElement([&](const std::shared_ptr<Image>& image)
         {

--- a/aeron-client/src/main/cpp/concurrent/AtomicArrayUpdater.h
+++ b/aeron-client/src/main/cpp/concurrent/AtomicArrayUpdater.h
@@ -116,7 +116,7 @@ public:
     }
 
     template<typename F>
-    std::pair<E*, int> removeElement(F&& func)
+    std::pair<E*, std::size_t> removeElement(F&& func)
     {
         std::pair<E*, std::size_t> oldArray = load();
         const std::size_t length = oldArray.second;
@@ -133,7 +133,7 @@ public:
             }
         }
 
-        return {nullptr, -1};
+        return {nullptr, 0};
     }
 
 private:


### PR DESCRIPTION
MSCV is correctly complaining about the narrowing conversion from
`std::size_t` to `int` in `AtomicArrayUpdater::removeElement`.

This patch makes us return a `std::size_t` instead. Using `-1` to
signify an invalid length is not needed as the length value is not used
anyway if the pointer is null. Hence we use `0` as the invalid value and
avoid the narrowing conversion.