### PR TITLE
[Java] use correct field in `toString` method of `RecordingLog`

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -897,7 +897,7 @@ public class RecordingLog implements AutoCloseable
     {
         return "RecordingLog{" +
             "entries=" + entriesCache +
-            ", cacheIndex=" + entriesCache +
+            ", cacheIndex=" + cacheIndexByLeadershipTermIdMap +
             '}';
     }
 


### PR DESCRIPTION
`entriesCache` was written out twice in the `toString` method. Inferring the correct field to be `cacheIndexByLeadershipTermIdMap`...