### PR TITLE
[Java] Send `leadershipTermId` in `SessionCloseRequest`

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -692,6 +692,7 @@ public final class AeronCluster implements AutoCloseable
             {
                 sessionCloseRequestEncoder
                     .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
+                    .leadershipTermId(leadershipTermId)
                     .clusterSessionId(clusterSessionId);
 
                 bufferClaim.commit();


### PR DESCRIPTION
Send `leadershipTermId` along with `SessionCloseRequest` since it is used in `onSessionClose` method of `ConsensusModuleAgent` to check if session has to be closed on the cluster side:
https://github.com/real-logic/aeron/blob/17fc41b01ef292e61640ff57ad1275a7ae271e36/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java#L349-L361