### PR TITLE
Remove commented out println statement

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/ReplayMerge.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ReplayMerge.java
@@ -487,7 +487,6 @@ public class ReplayMerge implements AutoCloseable
 
     private void state(final ReplayMerge.State newState)
     {
-        //System.out.println(state + " -> " + newState);
         state = newState;
         activeCorrelationId = Aeron.NULL_VALUE;
     }


### PR DESCRIPTION
Small change removing commented out println from `ReplayMerge`