### PR TITLE
Error Counter Type IDs

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -17,6 +17,7 @@ package io.aeron.archive;
 
 import io.aeron.Aeron;
 import io.aeron.CommonContext;
+import io.aeron.Counter;
 import io.aeron.Image;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ArchiveException;
@@ -40,7 +41,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
 
 import static io.aeron.archive.ArchiveThreadingMode.DEDICATED;
-import static io.aeron.driver.status.SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MAX_LENGTH;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
 import static java.lang.System.getProperty;
@@ -340,6 +340,12 @@ public class Archive implements AutoCloseable
          * Maximum block length of data read from disk in a single operation during a replay.
          */
         static final int MAX_BLOCK_LENGTH = 2 * 1024 * 1024;
+
+
+        /**
+         * The type id of the {@link Counter} used for keeping track of the number of errors that have occurred.
+         */
+        public static final int ARCHIVE_ERROR_COUNT_TYPE_ID = 101;
 
         /**
          * Get the directory name to be used for storing the archive.
@@ -645,7 +651,7 @@ public class Archive implements AutoCloseable
 
                 if (null == errorCounter)
                 {
-                    errorCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "Archive errors");
+                    errorCounter = aeron.addCounter(Configuration.ARCHIVE_ERROR_COUNT_TYPE_ID, "Archive errors");
                 }
             }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -43,7 +43,6 @@ import java.util.function.Supplier;
 
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static io.aeron.cluster.ConsensusModule.Configuration.SERVICE_ID;
-import static io.aeron.driver.status.SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 import static org.agrona.SystemUtil.getDurationInNanos;
 
@@ -55,17 +54,22 @@ public final class ClusterBackup implements AutoCloseable
     /**
      * The type id of the {@link Counter} used for the backup state.
      */
-    static final int BACKUP_STATE_TYPE_ID = 208;
+    public static final int BACKUP_STATE_TYPE_ID = 208;
 
     /**
      * The type id of the {@link Counter} used for the live log position counter.
      */
-    static final int LIVE_LOG_POSITION_TYPE_ID = 209;
+    public static final int LIVE_LOG_POSITION_TYPE_ID = 209;
 
     /**
      * The type id of the {@link Counter} used for the next query deadline counter.
      */
-    static final int QUERY_DEADLINE_TYPE_ID = 210;
+    public static final int QUERY_DEADLINE_TYPE_ID = 210;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the number of errors that have occurred.
+     */
+    public static final int CLUSTER_BACKUP_ERROR_COUNT_TYPE_ID = 211;
 
     enum State
     {
@@ -430,7 +434,7 @@ public final class ClusterBackup implements AutoCloseable
 
                 if (null == errorCounter)
                 {
-                    errorCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "ClusterBackup errors");
+                    errorCounter = aeron.addCounter(CLUSTER_BACKUP_ERROR_COUNT_TYPE_ID, "ClusterBackup errors");
                 }
             }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -44,7 +44,6 @@ import java.util.function.Supplier;
 import static io.aeron.cluster.ConsensusModule.Configuration.*;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SNAPSHOT_CHANNEL_PROP_NAME;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SNAPSHOT_STREAM_ID_PROP_NAME;
-import static io.aeron.driver.status.SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 import static org.agrona.SystemUtil.*;
 import static org.agrona.concurrent.status.CountersReader.METADATA_LENGTH;
@@ -428,6 +427,21 @@ public class ConsensusModule implements AutoCloseable
          * Counter type id for the consensus module state.
          */
         public static final int CONSENSUS_MODULE_STATE_TYPE_ID = 200;
+
+        /**
+         * Counter type id for the consensus module error count.
+         */
+        public static final int CONSENSUS_MODULE_ERROR_COUNT_TYPE_ID = 212;
+
+        /**
+         * Counter type id for the number of cluster clients which have been timed out.
+         */
+        public static final int CLUSTER_CLIENT_TIMEOUT_COUNT_TYPE_ID = 213;
+
+        /**
+         * Counter type id for the number of invalid requests which the cluster has received.
+         */
+        public static final int CLUSTER_INVALID_REQUEST_COUNT_TYPE_ID = 214;
 
         /**
          * Counter type id for the cluster node role.
@@ -1147,7 +1161,7 @@ public class ConsensusModule implements AutoCloseable
 
                 if (null == errorCounter)
                 {
-                    errorCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "Cluster errors");
+                    errorCounter = aeron.addCounter(CONSENSUS_MODULE_ERROR_COUNT_TYPE_ID, "Cluster errors");
                 }
             }
 
@@ -1192,12 +1206,14 @@ public class ConsensusModule implements AutoCloseable
 
             if (null == invalidRequestCounter)
             {
-                invalidRequestCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "Invalid cluster request count");
+                invalidRequestCounter =
+                    aeron.addCounter(CLUSTER_INVALID_REQUEST_COUNT_TYPE_ID, "Invalid cluster request count");
             }
 
             if (null == timedOutClientCounter)
             {
-                timedOutClientCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "Timed out cluster client count");
+                timedOutClientCounter =
+                    aeron.addCounter(CLUSTER_CLIENT_TIMEOUT_COUNT_TYPE_ID, "Timed out cluster client count");
             }
 
             if (null == clusterNodeRole)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
 
-import static io.aeron.driver.status.SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.*;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 import static org.agrona.SystemUtil.getSizeAsInt;
 import static org.agrona.SystemUtil.loadPropertiesFiles;
@@ -282,6 +282,11 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public static final String DELEGATING_ERROR_HANDLER_PROP_NAME =
             "aeron.cluster.service.delegating.error.handler";
+
+        /**
+         * Counter type id for the clustered service error count.
+         */
+        public static final int CLUSTERED_SERVICE_ERROR_COUNT_TYPE_ID = 215;
 
         /**
          * The value {@link #SERVICE_ID_DEFAULT} or system property {@link #SERVICE_ID_PROP_NAME} if set.
@@ -642,7 +647,8 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             if (null == errorCounter)
             {
-                errorCounter = aeron.addCounter(SYSTEM_COUNTER_TYPE_ID, "Cluster errors - service " + serviceId);
+                errorCounter =
+                    aeron.addCounter(CLUSTERED_SERVICE_ERROR_COUNT_TYPE_ID, "Cluster errors - service " + serviceId);
             }
 
             if (null == countedErrorHandler)


### PR DESCRIPTION
Because the 'id' field is not set for these, they clash with "Bytes Sent" when read (id=0).
Simplest strategy seemed to be to give them their own types.