### PR TITLE
[Java] Fixed dynamic node joins single static node

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -480,7 +480,7 @@ public class Election implements AutoCloseable
 
         candidateTermId = Math.max(ctx.clusterMarkFile().candidateTermId(), leadershipTermId);
 
-        if (clusterMembers.length == 1)
+        if (clusterMembers.length == 1 && thisMember == clusterMembers[0])
         {
             candidateTermId = Math.max(leadershipTermId + 1, candidateTermId + 1);
             leaderMember = thisMember;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -254,6 +254,20 @@ public class DynamicMembershipTest
         }
     }
 
+    @Test(timeout = 10_000)
+    public void shouldJoinDynamicNodeToSingleStaticLeader() throws Exception
+    {
+        try (TestCluster cluster = TestCluster.startCluster(1, 1))
+        {
+            final TestNode initialLeader = cluster.awaitLeader();
+            cluster.startDynamicNode(1, true);
+
+            Thread.sleep(1000);
+
+            assertThat(numberOfMembers(initialLeader.clusterMembership()), is(2));
+        }
+    }
+
     private int numberOfMembers(final ClusterTool.ClusterMembership clusterMembership)
     {
         return clusterMembership.activeMembers.size();


### PR DESCRIPTION
**Given:**
Start single static node `S`. Start dynamic node `D`, and point it to `S`. See discontinued exceptions in the attached logs. Looks like dynamic node decided that it is LEADER. **NOTE: this is not reproduced when there're more than 1 static node when dynamic node is joining a cluster.

**Version**
`1.23.1`

**Attached Logs**

[Static_Node_Output.txt](https://github.com/real-logic/aeron/files/3859616/Static_Node_Output.txt)
[Dynamic_Node_Output.txt](https://github.com/real-logic/aeron/files/3859617/Dynamic_Node_Output.txt)
