### PR TITLE
[Java] Set a default error handler in Archive context when it is not supplied.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -348,6 +348,19 @@ public class Archive implements AutoCloseable
         public static final int ARCHIVE_ERROR_COUNT_TYPE_ID = 101;
 
         /**
+         * The Default handler for Aeron runtime exceptions.
+         * <p>
+         * The error handler can be overridden by supplying an {@link Context} with a custom handler.
+         *
+         * @see Context#errorHandler(ErrorHandler)
+         */
+        public static final ErrorHandler DEFAULT_ERROR_HANDLER =
+            (throwable) ->
+            {
+                throwable.printStackTrace();
+            };
+
+        /**
          * Get the directory name to be used for storing the archive.
          *
          * @return the directory name to be used for storing the archive.
@@ -592,7 +605,7 @@ public class Archive implements AutoCloseable
         private Supplier<IdleStrategy> recorderIdleStrategySupplier;
         private EpochClock epochClock;
 
-        private ErrorHandler errorHandler;
+        private ErrorHandler errorHandler = Configuration.DEFAULT_ERROR_HANDLER;
         private AtomicCounter errorCounter;
         private CountedErrorHandler countedErrorHandler;
 
@@ -627,8 +640,6 @@ public class Archive implements AutoCloseable
             {
                 throw new ConcurrentConcludeException();
             }
-
-            Objects.requireNonNull(errorHandler, "Error handler must be supplied");
 
             if (null == epochClock)
             {


### PR DESCRIPTION
While it is intended to run the Archive module independently of the MediaDriver, in its current implementation, it fails due to no default error handler being supplied.

I tried to come up with a simple default here which just prints the stack trace based on the one in the client minus the special handling of timeout exceptions. I think it is possible to pipe stdout from Archive module to a file to provide simple logging.