### PR TITLE
[C] Fix bug where active_term_count gets reset to 0 incorrectly when …

### DIFF
--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -116,7 +116,6 @@ int aeron_ipc_publication_create(
         _pub->log_meta_data->active_term_count = 0;
     }
 
-    _pub->log_meta_data->active_term_count = 0;
     _pub->log_meta_data->initial_term_id = initial_term_id;
     _pub->log_meta_data->mtu_length = (int32_t)params->mtu_length;
     _pub->log_meta_data->term_length = (int32_t)params->term_length;


### PR DESCRIPTION
…the channel specifies a custom term_id, for IPC publications.