### PR TITLE
[Java] Add ClusterTool#addMember

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
@@ -720,6 +720,7 @@ public class ClusterTool
         out.println(
             "  tombstone-latest-snapshot: Mark the latest snapshot as a tombstone so previous is loaded.");
         out.println(
-            "                 add-member: [memberId] [memberEndpoints] requests adding a member by its memberId and endpoints.");
+            "                 add-member: [memberId] [memberEndpoints] requests adding a member by its memberId and " +
+            "endpoints.");
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAdapter.java
@@ -37,6 +37,7 @@ final class ConsensusModuleAdapter implements AutoCloseable
     private final CloseSessionDecoder closeSessionDecoder = new CloseSessionDecoder();
     private final ClusterMembersQueryDecoder clusterMembersQueryDecoder = new ClusterMembersQueryDecoder();
     private final RemoveMemberDecoder removeMemberDecoder = new RemoveMemberDecoder();
+    private final AddMemberDecoder addMemberDecoder = new AddMemberDecoder();
     private final FragmentAssembler fragmentAssembler = new FragmentAssembler(this::onFragment);
 
     ConsensusModuleAdapter(final Subscription subscription, final ConsensusModuleAgent consensusModuleAgent)
@@ -153,6 +154,19 @@ final class ConsensusModuleAdapter implements AutoCloseable
                     removeMemberDecoder.correlationId(),
                     removeMemberDecoder.memberId(),
                     BooleanType.TRUE == removeMemberDecoder.isPassive());
+                break;
+
+            case AddMemberDecoder.TEMPLATE_ID:
+                addMemberDecoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    messageHeaderDecoder.blockLength(),
+                    messageHeaderDecoder.version());
+
+                consensusModuleAgent.onAddMember(
+                    addMemberDecoder.correlationId(),
+                    addMemberDecoder.memberId(),
+                    addMemberDecoder.memberEndpoints());
                 break;
         }
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -777,7 +777,8 @@ class ConsensusModuleAgent implements Agent, MemberStatusListener
     @SuppressWarnings("unused")
     public void onAddMember(final long correlationId, final int memberId, final String memberEndpoints)
     {
-        if (null == election && Cluster.Role.LEADER == role && ClusterMember.isNotDuplicateEndpoint(clusterMembers, memberEndpoints))
+        if (null == election && Cluster.Role.LEADER == role &&
+            ClusterMember.isNotDuplicateEndpoint(clusterMembers, memberEndpoints))
         {
             final ClusterMember member = ClusterMember.parseEndpoints(memberId, memberEndpoints);
             final ClusterMember[] newMembers = ClusterMember.addMember(clusterMembers, member);

--- a/aeron-cluster/src/main/resources/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/aeron-cluster-codecs.xml
@@ -307,6 +307,14 @@
         <field name="isPassive"                id="3" type="BooleanType"/>
     </sbe:message>
 
+    <sbe:message name="AddMember"
+                 id="36"
+                 description="Add a cluster member as normal member.">
+        <field name="correlationId"            id="1" type="int64"/>
+        <field name="memberId"                 id="2" type="int32"/>
+        <data  name="memberEndpoints"          id="3" type="varAsciiEncoding"/>
+    </sbe:message>
+
     <sbe:message name="JoinLog"
                  id="40"
                  description="Consensus Module instructing a service to join a log">


### PR DESCRIPTION
I have a use case when some static nodes drop down and it never will start again on the same IP address, at that time its data volume is still accessible so I’d like to use the kept volume to launch a node on another IP address. And I need to launch the node in static mode due to the node publishes outcome into archive recordings, it's kinda stateful service. The issue is how to notice other cluster members about it and successfully join them. 
I looked at the `ClusterTool` and it has already the ability to remove a normal static member and its IP address from the cluster members, so I tried to add an opportunity to add a new cluster member as a static member. It seems working well. And after that, I can remove the old member, which will never come back, and then add a static member with a new IP address, and finally start node with the old volume on added member IP address.

So could it be an acceptable solution?