### PR TITLE
Snapshots are not completely transferred by ClusterBackupAgent

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -841,7 +841,7 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
 
         boolean isDone()
         {
-            return isDone && endPosition <= recordingPosition;
+            return isDone && endPosition <= recordingPosition && image.isEndOfStream();
         }
 
         void pollRecordingPosition()


### PR DESCRIPTION
https://github.com/real-logic/aeron/blob/68fa2ea29f329e88acdc1d82039f2e09ef4246cc/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java#L844

This check returns true after the Aeron portion of the snapshot, which means the user portion may or may not be transferred.

I've submitted a quick fix to check EoS but wanted to discuss more complete solutions. 

Two options I can see are:
- Query remote recording stop position when transferring snapshot and use that as the threshold condition for 'done'.
- Use Archive replicate functionality.

Any thoughts?