### PR TITLE
Media driver agnostic system tests

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
@@ -17,19 +17,20 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.BufferClaim;
+import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableBoolean;
 import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import io.aeron.logbuffer.BufferClaim;
-import io.aeron.logbuffer.FragmentHandler;
-import org.agrona.concurrent.UnsafeBuffer;
 
 import java.nio.ByteBuffer;
 
@@ -49,7 +50,7 @@ public class BufferClaimMessageTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
     private static final int MESSAGE_LENGTH = 200;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
@@ -22,24 +22,30 @@ import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.status.ChannelEndpointStatus;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.IoUtil;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 public class ChannelEndpointStatusTest
 {
@@ -61,8 +67,8 @@ public class ChannelEndpointStatusTest
     private Aeron clientA;
     private Aeron clientB;
     private Aeron clientC;
-    private MediaDriver driverA;
-    private MediaDriver driverB;
+    private TestMediaDriver driverA;
+    private TestMediaDriver driverB;
 
     private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[MESSAGE_LENGTH]);
 
@@ -76,6 +82,9 @@ public class ChannelEndpointStatusTest
     @Before
     public void before()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet(
+            "Need an alternative way of getting the error counters for the C media driver");
+
         final String baseDirA = ROOT_DIR + "A";
         final String baseDirB = ROOT_DIR + "B";
 
@@ -93,8 +102,8 @@ public class ChannelEndpointStatusTest
             .errorHandler(countingErrorHandler)
             .threadingMode(THREADING_MODE);
 
-        driverA = MediaDriver.launch(driverAContext);
-        driverB = MediaDriver.launch(driverBContext);
+        driverA = TestMediaDriver.launch(driverAContext);
+        driverB = TestMediaDriver.launch(driverBContext);
 
         clientA = Aeron.connect(
             new Aeron.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
@@ -124,14 +124,8 @@ public class ChannelEndpointStatusTest
     @After
     public void after()
     {
-        CloseHelper.quietClose(clientC);
-        CloseHelper.quietClose(clientB);
-        CloseHelper.quietClose(clientA);
-
-        driverB.close();
-        driverA.close();
-
-        IoUtil.delete(new File(ROOT_DIR), false);
+        CloseHelper.quietCloseAll(clientC, clientB, clientA, driverB, driverA);
+        IoUtil.delete(new File(ROOT_DIR), true);
     }
 
     @Test(timeout = 5000, expected = RegistrationException.class)

--- a/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
@@ -15,16 +15,17 @@
  */
 package io.aeron;
 
-import io.aeron.logbuffer.LogBufferDescriptor;
-import org.agrona.CloseHelper;
-import org.junit.After;
-import org.junit.Test;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.logbuffer.Header;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.After;
+import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -36,7 +37,7 @@ public class ControlledMessageTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
     private static final int PAYLOAD_LENGTH = 10;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)

--- a/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
@@ -18,14 +18,15 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.status.ReadableCounter;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
@@ -38,7 +39,7 @@ public class CounterTest
 
     private Aeron clientA;
     private Aeron clientB;
-    private MediaDriver driver;
+    private TestMediaDriver driver;
 
     private final AvailableCounterHandler availableCounterHandlerClientA = mock(AvailableCounterHandler.class);
     private final UnavailableCounterHandler unavailableCounterHandlerClientA = mock(UnavailableCounterHandler.class);
@@ -51,7 +52,7 @@ public class CounterTest
     {
         labelBuffer.putStringWithoutLengthAscii(0, COUNTER_LABEL);
 
-        driver = MediaDriver.launch(
+        driver = TestMediaDriver.launch(
             new MediaDriver.Context()
                 .dirDeleteOnShutdown(true)
                 .errorHandler(Throwable::printStackTrace)

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -17,6 +17,7 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -50,7 +51,7 @@ public class ExclusivePublicationTest
 
     private final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(MESSAGE_LENGTH));
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .threadingMode(ThreadingMode.SHARED));

--- a/aeron-system-tests/src/test/java/io/aeron/FlowControlStrategiesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FlowControlStrategiesTest.java
@@ -20,6 +20,8 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
+import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
 import org.agrona.SystemUtil;
@@ -53,8 +55,8 @@ public class FlowControlStrategiesTest
 
     private Aeron clientA;
     private Aeron clientB;
-    private MediaDriver driverA;
-    private MediaDriver driverB;
+    private TestMediaDriver driverA;
+    private TestMediaDriver driverB;
     private Publication publication;
     private Subscription subscriptionA;
     private Subscription subscriptionB;
@@ -82,8 +84,8 @@ public class FlowControlStrategiesTest
             .errorHandler(Throwable::printStackTrace)
             .threadingMode(ThreadingMode.SHARED);
 
-        driverA = MediaDriver.launch(driverAContext);
-        driverB = MediaDriver.launch(driverBContext);
+        driverA = TestMediaDriver.launch(driverAContext);
+        driverB = TestMediaDriver.launch(driverBContext);
         clientA = Aeron.connect(
             new Aeron.Context()
                 .errorHandler(Throwable::printStackTrace)
@@ -100,8 +102,7 @@ public class FlowControlStrategiesTest
     {
         clientB.close();
         clientA.close();
-        driverB.close();
-        driverA.close();
+        CloseHelper.quietCloseAll(driverB, driverA);
 
         IoUtil.delete(new File(ROOT_DIR), true);
     }

--- a/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
@@ -15,9 +15,15 @@
  */
 package io.aeron;
 
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
@@ -25,11 +31,6 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.agrona.concurrent.UnsafeBuffer;
-import io.aeron.driver.MediaDriver;
-import io.aeron.driver.ThreadingMode;
-import io.aeron.logbuffer.FragmentHandler;
-import io.aeron.logbuffer.Header;
 
 import static io.aeron.logbuffer.FrameDescriptor.END_FRAG_FLAG;
 import static org.hamcrest.Matchers.is;
@@ -53,7 +54,7 @@ public class FragmentedMessageTest
 
     private final FragmentHandler mockFragmentHandler = mock(FragmentHandler.class);
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)

--- a/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
@@ -17,6 +17,7 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.junit.After;
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class ImageAvailabilityTest
 
     private static final int STREAM_ID = 1;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .dirDeleteOnStart(true)

--- a/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
@@ -18,6 +18,7 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
@@ -35,7 +36,7 @@ public class MaxPositionPublicationTest
 
     private final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnStart(true)
         .dirDeleteOnShutdown(true)

--- a/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
@@ -19,9 +19,12 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.After;
 import org.junit.Test;
 
@@ -42,7 +45,7 @@ public class MemoryOrderingTest
 
     private static volatile String failedMessage = null;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .threadingMode(ThreadingMode.SHARED)

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -37,7 +37,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class MultiDestinationCastTest
 {
@@ -78,6 +83,8 @@ public class MultiDestinationCastTest
 
     private void launch()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet("Multi-destination-cast not available");
+
         final String baseDirA = ROOT_DIR + "A";
         final String baseDirB = ROOT_DIR + "B";
 
@@ -98,8 +105,6 @@ public class MultiDestinationCastTest
         driverB = TestMediaDriver.launch(driverBContext);
         clientA = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverAContext.aeronDirectoryName()));
         clientB = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverBContext.aeronDirectoryName()));
-
-        driverA.notSupportedOnCMediaDriverYet();
     }
 
     @After

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -21,6 +21,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -63,8 +64,8 @@ public class MultiDestinationCastTest
 
     private Aeron clientA;
     private Aeron clientB;
-    private MediaDriver driverA;
-    private MediaDriver driverB;
+    private TestMediaDriver driverA;
+    private TestMediaDriver driverB;
     private Publication publication;
     private Subscription subscriptionA;
     private Subscription subscriptionB;
@@ -93,10 +94,12 @@ public class MultiDestinationCastTest
             .aeronDirectoryName(baseDirB)
             .threadingMode(ThreadingMode.SHARED);
 
-        driverA = MediaDriver.launch(driverAContext);
-        driverB = MediaDriver.launch(driverBContext);
+        driverA = TestMediaDriver.launch(driverAContext);
+        driverB = TestMediaDriver.launch(driverBContext);
         clientA = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverAContext.aeronDirectoryName()));
         clientB = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverBContext.aeronDirectoryName()));
+
+        driverA.notSupportedOnCMediaDriverYet();
     }
 
     @After

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -38,7 +38,12 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class MultiDestinationSubscriptionTest
 {
@@ -79,6 +84,8 @@ public class MultiDestinationSubscriptionTest
 
     private void launch()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet("Multi-destination-cast not available");
+
         final String baseDirA = ROOT_DIR + "A";
 
         buffer.putInt(0, 1);
@@ -91,8 +98,6 @@ public class MultiDestinationSubscriptionTest
 
         driverA = TestMediaDriver.launch(driverContextA);
         clientA = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverContextA.aeronDirectoryName()));
-
-        driverA.notSupportedOnCMediaDriverYet();
     }
 
     private void launchSecond()
@@ -107,8 +112,6 @@ public class MultiDestinationSubscriptionTest
 
         driverB = TestMediaDriver.launch(driverContextB);
         clientB = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverContextB.aeronDirectoryName()));
-
-        driverB.notSupportedOnCMediaDriverYet();
     }
 
     @After

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -21,6 +21,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -65,8 +66,8 @@ public class MultiDestinationSubscriptionTest
 
     private Aeron clientA;
     private Aeron clientB;
-    private MediaDriver driverA;
-    private MediaDriver driverB;
+    private TestMediaDriver driverA;
+    private TestMediaDriver driverB;
     private Publication publicationA;
     private Publication publicationB;
     private Subscription subscription;
@@ -88,8 +89,10 @@ public class MultiDestinationSubscriptionTest
             .aeronDirectoryName(baseDirA)
             .threadingMode(ThreadingMode.SHARED);
 
-        driverA = MediaDriver.launch(driverContextA);
+        driverA = TestMediaDriver.launch(driverContextA);
         clientA = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverContextA.aeronDirectoryName()));
+
+        driverA.notSupportedOnCMediaDriverYet();
     }
 
     private void launchSecond()
@@ -102,8 +105,10 @@ public class MultiDestinationSubscriptionTest
             .aeronDirectoryName(baseDirB)
             .threadingMode(ThreadingMode.SHARED);
 
-        driverB = MediaDriver.launch(driverContextB);
+        driverB = TestMediaDriver.launch(driverContextB);
         clientB = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverContextB.aeronDirectoryName()));
+
+        driverB.notSupportedOnCMediaDriverYet();
     }
 
     @After

--- a/aeron-system-tests/src/test/java/io/aeron/PongTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PongTest.java
@@ -16,20 +16,21 @@
 package io.aeron;
 
 import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
+import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import io.aeron.driver.ThreadingMode;
-import io.aeron.logbuffer.FragmentHandler;
-import io.aeron.logbuffer.Header;
-import io.aeron.protocol.DataHeaderFlyweight;
-import org.agrona.BitUtil;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 import java.util.concurrent.TimeUnit;
 
@@ -49,7 +50,7 @@ public class PongTest
 
     private Aeron pingClient;
     private Aeron pongClient;
-    private MediaDriver driver;
+    private TestMediaDriver driver;
     private Subscription pingSubscription;
     private Subscription pongSubscription;
     private Publication pingPublication;
@@ -61,7 +62,7 @@ public class PongTest
     @Before
     public void before()
     {
-        driver = MediaDriver.launch(
+        driver = TestMediaDriver.launch(
             new MediaDriver.Context()
                 .errorHandler(Throwable::printStackTrace)
                 .dirDeleteOnShutdown(true)

--- a/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
@@ -17,18 +17,19 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.BufferClaim;
+import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import io.aeron.logbuffer.BufferClaim;
-import io.aeron.logbuffer.FragmentHandler;
-import org.agrona.concurrent.UnsafeBuffer;
 
 import java.util.concurrent.TimeUnit;
 
@@ -47,7 +48,7 @@ public class PublicationUnblockTest
     private static final int STREAM_ID = 1;
     private static final int FRAGMENT_COUNT_LIMIT = 10;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .threadingMode(ThreadingMode.SHARED)
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)

--- a/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
@@ -20,6 +20,7 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -33,7 +34,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class PublishFromArbitraryPositionTest
 {
@@ -54,7 +55,7 @@ public class PublishFromArbitraryPositionTest
     private final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(MAX_MESSAGE_LENGTH));
     private long seed;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .threadingMode(ThreadingMode.SHARED));

--- a/aeron-system-tests/src/test/java/io/aeron/ReentrantClientTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ReentrantClientTest.java
@@ -17,6 +17,7 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.exceptions.AeronException;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.collections.MutableReference;
@@ -25,11 +26,15 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 public class ReentrantClientTest
 {
-    final MediaDriver mediaDriver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver mediaDriver = TestMediaDriver.launch(new MediaDriver.Context()
         .dirDeleteOnShutdown(true)
         .dirDeleteOnStart(true));
 

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -108,10 +108,6 @@ public class SessionSpecificPublicationTest
             {
                 fail("Exception should have been thrown due to duplicate session id");
             }
-            finally
-            {
-                verify(mockErrorHandler).onError(any(IllegalStateException.class));
-            }
         }
     }
 
@@ -124,10 +120,6 @@ public class SessionSpecificPublicationTest
             Publication ignored2 = aeron.addPublication(channelBuilder.mtu(MTU_2).build(), STREAM_ID))
         {
             fail("Exception should have been thrown due to non-matching mtu");
-        }
-        finally
-        {
-            verify(mockErrorHandler).onError(any(IllegalStateException.class));
         }
     }
 
@@ -144,10 +136,6 @@ public class SessionSpecificPublicationTest
         {
             fail("Exception should have been thrown due to non-matching term length");
         }
-        finally
-        {
-            verify(mockErrorHandler).onError(any(IllegalStateException.class));
-        }
     }
 
     @Test(expected = RegistrationException.class)
@@ -162,10 +150,6 @@ public class SessionSpecificPublicationTest
             Publication ignored2 = aeron.addPublication(channelTwo, STREAM_ID))
         {
             fail("Exception should have been thrown due using different session ids");
-        }
-        finally
-        {
-            verify(mockErrorHandler).onError(any(IllegalStateException.class));
         }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -19,8 +19,6 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.support.JavaTestMediaDriver;
-import io.aeron.support.NativeTestMediaDriver;
 import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
@@ -31,15 +29,11 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static io.aeron.CommonContext.IPC_MEDIA;
 import static io.aeron.CommonContext.UDP_MEDIA;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @RunWith(value = Parameterized.class)
 public class SessionSpecificPublicationTest

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -19,6 +19,9 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.JavaTestMediaDriver;
+import io.aeron.support.NativeTestMediaDriver;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.junit.After;
@@ -28,6 +31,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static io.aeron.CommonContext.IPC_MEDIA;
 import static io.aeron.CommonContext.UDP_MEDIA;
@@ -67,19 +72,20 @@ public class SessionSpecificPublicationTest
     }
 
     private final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final MediaDriver.Context mediaDriverContext = new MediaDriver.Context()
         .errorHandler(mockErrorHandler)
         .dirDeleteOnShutdown(true)
         .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)
-        .threadingMode(ThreadingMode.SHARED));
+        .threadingMode(ThreadingMode.SHARED);
 
+    private final TestMediaDriver testMediaDriver = TestMediaDriver.launch(mediaDriverContext);
     private final Aeron aeron = Aeron.connect();
 
     @After
     public void after()
     {
         CloseHelper.close(aeron);
-        CloseHelper.close(driver);
+        CloseHelper.close(testMediaDriver);
     }
 
     @Test(expected = RegistrationException.class)

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -20,6 +20,7 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -57,7 +58,7 @@ public class SpySimulatedConnectionTest
     private final MediaDriver.Context driverContext = new MediaDriver.Context();
 
     private Aeron client;
-    private MediaDriver driver;
+    private TestMediaDriver driver;
     private Publication publication;
     private Subscription subscription;
     private Subscription spy;
@@ -77,7 +78,7 @@ public class SpySimulatedConnectionTest
             .dirDeleteOnShutdown(true)
             .threadingMode(ThreadingMode.SHARED);
 
-        driver = MediaDriver.launch(driverContext);
+        driver = TestMediaDriver.launch(driverContext);
         client = Aeron.connect();
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -20,11 +20,13 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.MediaDriverTestWatcher;
 import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
@@ -71,6 +73,9 @@ public class SpySimulatedConnectionTest
     private final MutableInteger fragmentCountSub = new MutableInteger();
     private final FragmentHandler fragmentHandlerSub = (buffer1, offset, length, header) -> fragmentCountSub.value++;
 
+    @Rule
+    public MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+
     private void launch()
     {
         driverContext.publicationTermBufferLength(TERM_BUFFER_LENGTH)
@@ -78,7 +83,7 @@ public class SpySimulatedConnectionTest
             .dirDeleteOnShutdown(true)
             .threadingMode(ThreadingMode.SHARED);
 
-        driver = TestMediaDriver.launch(driverContext);
+        driver = TestMediaDriver.launch(driverContext, watcher);
         client = Aeron.connect();
     }
 
@@ -233,6 +238,7 @@ public class SpySimulatedConnectionTest
 
         while (fragmentsReadFromSpy < messagesToSend)
         {
+//            System.out.printf("Messages - toSend: %d, toRead: %d%n", messagesLeftToSend, fragmentsReadFromSpy);
             if (messagesLeftToSend > 0)
             {
                 if (publication.offer(buffer, 0, buffer.capacity()) >= 0L)

--- a/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
@@ -19,6 +19,7 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -52,7 +53,7 @@ public class SpySubscriptionTest
     private final MutableInteger fragmentCountSub = new MutableInteger();
     private final FragmentHandler fragmentHandlerSub = (buffer1, offset, length, header) -> fragmentCountSub.value++;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)

--- a/aeron-system-tests/src/test/java/io/aeron/TermBufferLengthTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TermBufferLengthTest.java
@@ -17,6 +17,7 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.support.TestMediaDriver;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
@@ -51,7 +52,8 @@ public class TermBufferLengthTest
             .publicationTermBufferLength(TEST_TERM_LENGTH * 2)
             .ipcTermBufferLength(TEST_TERM_LENGTH * 2);
 
-        try (MediaDriver ignore = MediaDriver.launch(ctx);
+        try (
+            TestMediaDriver ignore = TestMediaDriver.launch(ctx);
             Aeron aeron = Aeron.connect();
             Publication publication = aeron.addPublication(channel, STREAM_ID))
         {

--- a/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
@@ -18,6 +18,7 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -33,7 +34,7 @@ public class TwoBufferOfferMessageTest
     private static final int STREAM_ID = 1;
     private static final int FRAGMENT_COUNT_LIMIT = 10;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .dirDeleteOnShutdown(true)
         .threadingMode(ThreadingMode.SHARED));

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -19,6 +19,7 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.support.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.After;
@@ -33,7 +34,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Theories.class)
 public class UntetheredSubscriptionTest
@@ -51,7 +53,7 @@ public class UntetheredSubscriptionTest
     private static final int FRAGMENT_COUNT_LIMIT = 10;
     private static final int MESSAGE_LENGTH = 512 - DataHeaderFlyweight.HEADER_LENGTH;
 
-    private final MediaDriver driver = MediaDriver.launch(new MediaDriver.Context()
+    private final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context()
         .errorHandler(Throwable::printStackTrace)
         .spiesSimulateConnection(true)
         .dirDeleteOnShutdown(true)

--- a/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
@@ -162,10 +162,10 @@ public final class CTestMediaDriver implements TestMediaDriver
         }
     }
 
-    private static String getFlowControlStrategyName(FlowControlSupplier multicastFlowControlSupplier)
+    private static String getFlowControlStrategyName(final FlowControlSupplier flowControlSupplier)
     {
-        return null == multicastFlowControlSupplier ?
-            null : C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.get(multicastFlowControlSupplier.getClass());
+        return null == flowControlSupplier ?
+            null : C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.get(flowControlSupplier.getClass());
     }
 
     @Override

--- a/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
@@ -1,32 +1,65 @@
 package io.aeron.support;
 
 import io.aeron.CommonContext;
+import io.aeron.driver.DefaultMulticastFlowControlSupplier;
+import io.aeron.driver.DefaultUnicastFlowControlSupplier;
+import io.aeron.driver.FlowControlSupplier;
+import io.aeron.driver.MaxMulticastFlowControlSupplier;
 import io.aeron.driver.MediaDriver;
+import io.aeron.driver.MinMulticastFlowControlSupplier;
 import org.agrona.IoUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-public class CTestMediaDriver implements TestMediaDriver
+public final class CTestMediaDriver implements TestMediaDriver
 {
+    private static final File NULL_FILE = System.getProperty("os.name").startsWith("Windows") ?
+        new File("NUL") : new File("/dev/null");
+    private static final Map<Class, String> C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE =
+        new IdentityHashMap<>();
+
+    static
+    {
+        C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.put(
+            DefaultMulticastFlowControlSupplier.class, "aeron_max_multicast_flow_control_strategy_supplier");
+        C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.put(
+            MaxMulticastFlowControlSupplier.class, "aeron_max_multicast_flow_control_strategy_supplier");
+        C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.put(
+            MinMulticastFlowControlSupplier.class, "aeron_min_flow_control_strategy_supplier");
+        C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.put(
+            DefaultUnicastFlowControlSupplier.class, "aeron_unicast_flow_control_strategy_supplier");
+    }
+
     private final Process aeronmdProcess;
     private final MediaDriver.Context context;
 
-    private CTestMediaDriver(Process aeronmdProcess, MediaDriver.Context context)
+    private CTestMediaDriver(
+        final Process aeronmdProcess,
+        final MediaDriver.Context context)
     {
         this.aeronmdProcess = aeronmdProcess;
         this.context = context;
     }
 
     @Override
-    public void close() throws Exception
+    public void close()
     {
         terminateDriver();
-        if (!aeronmdProcess.waitFor(10, TimeUnit.SECONDS))
+        try
         {
-            aeronmdProcess.destroyForcibly();
-            throw new Exception("Failed to shutdown cleaning, forcing close");
+            if (!aeronmdProcess.waitFor(10, TimeUnit.SECONDS))
+            {
+                aeronmdProcess.destroyForcibly();
+                throw new RuntimeException("Failed to shutdown cleaning, forcing close");
+            }
+        }
+        catch (final InterruptedException e)
+        {
+            throw new RuntimeException("Interrupted while waiting for shutdown", e);
         }
 
         if (context.dirDeleteOnShutdown())
@@ -41,7 +74,9 @@ public class CTestMediaDriver implements TestMediaDriver
         CommonContext.requestDriverTermination(new File(context.aeronDirectoryName()), null, 0, 0);
     }
 
-    public static CTestMediaDriver launch(MediaDriver.Context context)
+    public static CTestMediaDriver launch(
+        final MediaDriver.Context context,
+        final DriverOutputConsumer driverOutputConsumer)
     {
         final String aeronmdPath = System.getProperty(TestMediaDriver.AERON_TEST_SYSTEM_AERONMD_PATH);
         final File f = new File(aeronmdPath);
@@ -54,30 +89,94 @@ public class CTestMediaDriver implements TestMediaDriver
         IoUtil.ensureDirectoryExists(
             new File(context.aeronDirectoryName()).getParentFile(), "Aeron C Media Driver directory");
 
-        final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
-            .redirectOutput(new File("/tmp/out.txt"))
-            .redirectError(new File("/tmp/err.txt"));
+        final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath());
 
-        pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
-        pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
+        pb.environment().put("AERON_CLIENT_LIVENESS_TIMEOUT", String.valueOf(context.clientLivenessTimeoutNs()));
         pb.environment().put("AERON_DIR", context.aeronDirectoryName());
-        pb.environment().put("AERON_TIMER_INTERVAL", String.valueOf(context.timerIntervalNs()));
         pb.environment().put("AERON_DRIVER_TERMINATION_VALIDATOR", "allow");
+        pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
+        pb.environment().put(
+            "AERON_PUBLICATION_UNBLOCK_TIMEOUT", String.valueOf(context.publicationUnblockTimeoutNs()));
+        pb.environment().put("AERON_SPIES_SIMULATE_CONNECTION", String.valueOf(context.spiesSimulateConnection()));
+        if (null != context.threadingMode())
+        {
+            pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
+        }
+        pb.environment().put("AERON_TIMER_INTERVAL", String.valueOf(context.timerIntervalNs()));
+        pb.environment().put("AERON_UNTETHERED_RESTING_TIMEOUT", String.valueOf(context.untetheredRestingTimeoutNs()));
+        pb.environment().put(
+            "AERON_UNTETHERED_WINDOW_LIMIT_TIMEOUT", String.valueOf(context.untetheredWindowLimitTimeoutNs()));
+        setFlowControlStrategy(pb.environment(), context);
 
         try
         {
-            System.out.println("Launching C driver: " + f.getAbsolutePath());
+            final File stdoutFile;
+            final File stderrFile;
+
+            if (null == driverOutputConsumer)
+            {
+                stdoutFile = NULL_FILE;
+                stderrFile = NULL_FILE;
+            }
+            else
+            {
+                stdoutFile = File.createTempFile("CTestMediaDriver-", ".out");
+                stderrFile = File.createTempFile("CTestMediaDriver-", ".err");
+                driverOutputConsumer.outputFiles(context.aeronDirectoryName(), stdoutFile, stderrFile);
+            }
+
+            pb.redirectOutput(stdoutFile).redirectError(stderrFile);
+
             return new CTestMediaDriver(pb.start(), context);
         }
-        catch (IOException e)
+        catch (final IOException e)
         {
             throw new RuntimeException(e);
         }
+    }
+
+    private static void setFlowControlStrategy(final Map<String, String> environment, final MediaDriver.Context context)
+    {
+        final FlowControlSupplier multicastFlowControlSupplier = context.multicastFlowControlSupplier();
+        final String multicastFlowControlStrategyName = getFlowControlStrategyName(multicastFlowControlSupplier);
+        if (null != multicastFlowControlStrategyName)
+        {
+            environment.put("AERON_MULTICAST_FLOWCONTROL_SUPPLIER", multicastFlowControlStrategyName);
+        }
+        else if (null != multicastFlowControlSupplier)
+        {
+            throw new RuntimeException("No equivalent C multicast flow control strategy for: " +
+                multicastFlowControlSupplier.getClass().getSimpleName());
+        }
+
+        final FlowControlSupplier unicastFlowControlSupplier = context.unicastFlowControlSupplier();
+        final String unicastFlowControlStrategyName = getFlowControlStrategyName(unicastFlowControlSupplier);
+        if (null != unicastFlowControlStrategyName)
+        {
+            environment.put("AERON_UNICAST_FLOWCONTROL_SUPPLIER", unicastFlowControlStrategyName);
+        }
+        else if (null != unicastFlowControlSupplier)
+        {
+            throw new RuntimeException("No equivalent C unicast flow control strategy for: " +
+                multicastFlowControlSupplier.getClass().getSimpleName());
+        }
+    }
+
+    private static String getFlowControlStrategyName(FlowControlSupplier multicastFlowControlSupplier)
+    {
+        return null == multicastFlowControlSupplier ?
+            null : C_DRIVER_FLOW_CONTROL_STRATEGY_NAME_BY_SUPPLIER_TYPE.get(multicastFlowControlSupplier.getClass());
     }
 
     @Override
     public MediaDriver.Context context()
     {
         return context;
+    }
+
+    @Override
+    public String aeronDirectoryName()
+    {
+        return context.aeronDirectoryName();
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
@@ -97,6 +97,8 @@ public final class CTestMediaDriver implements TestMediaDriver
         pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
         pb.environment().put(
             "AERON_PUBLICATION_UNBLOCK_TIMEOUT", String.valueOf(context.publicationUnblockTimeoutNs()));
+        pb.environment().put(
+            "AERON_PUBLICATION_CONNECTION_TIMEOUT", String.valueOf(context.publicationConnectionTimeoutNs()));
         pb.environment().put("AERON_SPIES_SIMULATE_CONNECTION", String.valueOf(context.spiesSimulateConnection()));
         if (null != context.threadingMode())
         {

--- a/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/CTestMediaDriver.java
@@ -8,12 +8,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-public class NativeTestMediaDriver implements TestMediaDriver
+public class CTestMediaDriver implements TestMediaDriver
 {
     private final Process aeronmdProcess;
     private final MediaDriver.Context context;
 
-    private NativeTestMediaDriver(Process aeronmdProcess, MediaDriver.Context context)
+    private CTestMediaDriver(Process aeronmdProcess, MediaDriver.Context context)
     {
         this.aeronmdProcess = aeronmdProcess;
         this.context = context;
@@ -41,7 +41,7 @@ public class NativeTestMediaDriver implements TestMediaDriver
         CommonContext.requestDriverTermination(new File(context.aeronDirectoryName()), null, 0, 0);
     }
 
-    public static NativeTestMediaDriver launch(MediaDriver.Context context)
+    public static CTestMediaDriver launch(MediaDriver.Context context)
     {
         final String aeronmdPath = System.getProperty(TestMediaDriver.AERON_TEST_SYSTEM_AERONMD_PATH);
         final File f = new File(aeronmdPath);
@@ -67,7 +67,7 @@ public class NativeTestMediaDriver implements TestMediaDriver
         try
         {
             System.out.println("Launching C driver: " + f.getAbsolutePath());
-            return new NativeTestMediaDriver(pb.start(), context);
+            return new CTestMediaDriver(pb.start(), context);
         }
         catch (IOException e)
         {

--- a/aeron-system-tests/src/test/java/io/aeron/support/DriverOutputConsumer.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/DriverOutputConsumer.java
@@ -1,0 +1,8 @@
+package io.aeron.support;
+
+import java.io.File;
+
+public interface DriverOutputConsumer
+{
+    void outputFiles(String aeronDirectoryName, File stdoutFile, File stderrFile);
+}

--- a/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
@@ -2,11 +2,11 @@ package io.aeron.support;
 
 import io.aeron.driver.MediaDriver;
 
-public class JavaTestMediaDriver implements TestMediaDriver
+public final class JavaTestMediaDriver implements TestMediaDriver
 {
     private MediaDriver mediaDriver;
 
-    private JavaTestMediaDriver(MediaDriver mediaDriver)
+    private JavaTestMediaDriver(final MediaDriver mediaDriver)
     {
         this.mediaDriver = mediaDriver;
     }
@@ -17,9 +17,9 @@ public class JavaTestMediaDriver implements TestMediaDriver
         mediaDriver.close();
     }
 
-    public static JavaTestMediaDriver launch(MediaDriver.Context context)
+    public static JavaTestMediaDriver launch(final MediaDriver.Context context)
     {
-        MediaDriver mediaDriver = MediaDriver.launch(context);
+        final MediaDriver mediaDriver = MediaDriver.launch(context);
         return new JavaTestMediaDriver(mediaDriver);
     }
 
@@ -27,5 +27,11 @@ public class JavaTestMediaDriver implements TestMediaDriver
     public MediaDriver.Context context()
     {
         return mediaDriver.context();
+    }
+
+    @Override
+    public String aeronDirectoryName()
+    {
+        return mediaDriver.aeronDirectoryName();
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
@@ -1,0 +1,25 @@
+package io.aeron.support;
+
+import io.aeron.driver.MediaDriver;
+
+public class JavaTestMediaDriver implements TestMediaDriver
+{
+    private MediaDriver mediaDriver;
+
+    private JavaTestMediaDriver(MediaDriver mediaDriver)
+    {
+        this.mediaDriver = mediaDriver;
+    }
+
+    @Override
+    public void close()
+    {
+        mediaDriver.close();
+    }
+
+    public static JavaTestMediaDriver launch(MediaDriver.Context context)
+    {
+        MediaDriver mediaDriver = MediaDriver.launch(context);
+        return new JavaTestMediaDriver(mediaDriver);
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/JavaTestMediaDriver.java
@@ -22,4 +22,10 @@ public class JavaTestMediaDriver implements TestMediaDriver
         MediaDriver mediaDriver = MediaDriver.launch(context);
         return new JavaTestMediaDriver(mediaDriver);
     }
+
+    @Override
+    public MediaDriver.Context context()
+    {
+        return mediaDriver.context();
+    }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/MediaDriverTestWatcher.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/MediaDriverTestWatcher.java
@@ -18,7 +18,7 @@ public class MediaDriverTestWatcher extends TestWatcher implements DriverOutputC
         hasFailed = true;
     }
 
-    protected void finished(Description description)
+    protected void finished(final Description description)
     {
         if (hasFailed && !outputFilesByAeronDirectoryName.isEmpty())
         {
@@ -45,12 +45,12 @@ public class MediaDriverTestWatcher extends TestWatcher implements DriverOutputC
         outputFilesByAeronDirectoryName.put(aeronDirectoryName, new StdOutputFiles(stdoutFile, stderrFile));
     }
 
-    private static class StdOutputFiles
+    private static final class StdOutputFiles
     {
         private final File stderr;
         private final File stdout;
 
-        private StdOutputFiles(File stderr, File stdout)
+        private StdOutputFiles(final File stderr, final File stdout)
         {
             this.stderr = stderr;
             this.stdout = stdout;

--- a/aeron-system-tests/src/test/java/io/aeron/support/MediaDriverTestWatcher.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/MediaDriverTestWatcher.java
@@ -1,0 +1,59 @@
+package io.aeron.support;
+
+import org.agrona.IoUtil;
+import org.agrona.collections.Object2ObjectHashMap;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.io.File;
+import java.util.Map;
+
+public class MediaDriverTestWatcher extends TestWatcher implements DriverOutputConsumer
+{
+    private boolean hasFailed = false;
+    private final Map<String, StdOutputFiles> outputFilesByAeronDirectoryName = new Object2ObjectHashMap<>();
+
+    protected void failed(final Throwable e, final Description description)
+    {
+        hasFailed = true;
+    }
+
+    protected void finished(Description description)
+    {
+        if (hasFailed && !outputFilesByAeronDirectoryName.isEmpty())
+        {
+            System.out.println("C Media Driver tests failed");
+            outputFilesByAeronDirectoryName.forEach((aeronDirectoryName, files) ->
+            {
+                System.out.println("Media Driver: " + aeronDirectoryName);
+                System.out.println("  stdout: " + files.stdout + ", stderr: " + files.stderr);
+            });
+        }
+        else
+        {
+            outputFilesByAeronDirectoryName.forEach(
+                (aeronDirectoryName, files) ->
+                {
+                    IoUtil.delete(files.stdout, false);
+                    IoUtil.delete(files.stderr, false);
+                });
+        }
+    }
+
+    public void outputFiles(final String aeronDirectoryName, final File stdoutFile, final File stderrFile)
+    {
+        outputFilesByAeronDirectoryName.put(aeronDirectoryName, new StdOutputFiles(stdoutFile, stderrFile));
+    }
+
+    private static class StdOutputFiles
+    {
+        private final File stderr;
+        private final File stdout;
+
+        private StdOutputFiles(File stderr, File stdout)
+        {
+            this.stderr = stderr;
+            this.stdout = stdout;
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -1,0 +1,74 @@
+package io.aeron.support;
+
+import io.aeron.driver.MediaDriver;
+import org.agrona.IoUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class NativeTestMediaDriver implements TestMediaDriver
+{
+    private static final String DEFAULT_AERONMD_LOCATION =
+        System.getProperty("user.dir") + "/../cppbuild/Release/binaries/aeronmd";
+    private final Process aeronmdProcess;
+    private final MediaDriver.Context context;
+
+    private NativeTestMediaDriver(Process aeronmdProcess, MediaDriver.Context context)
+    {
+        this.aeronmdProcess = aeronmdProcess;
+        this.context = context;
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        aeronmdProcess.destroy();
+        if (!aeronmdProcess.waitFor(10, TimeUnit.SECONDS))
+        {
+            aeronmdProcess.destroyForcibly();
+            throw new Exception("Failed to shutdown cleaning, forcing close");
+        }
+
+        if (context.dirDeleteOnShutdown())
+        {
+            final File aeronDirectory = new File(context.aeronDirectoryName());
+            IoUtil.delete(aeronDirectory, false);
+        }
+    }
+
+    public static NativeTestMediaDriver launch(MediaDriver.Context context)
+    {
+        final String aeronmdPath = System.getProperty("aeron.test.system.aeronmd.path", DEFAULT_AERONMD_LOCATION);
+        File f = new File(aeronmdPath);
+
+        if (!f.exists())
+        {
+            throw new RuntimeException("Unable to find native media driver binary: " + f.getAbsolutePath());
+        }
+
+        final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
+//            .inheritIO();
+            .redirectOutput(new File("/dev/null"))
+            .redirectError(new File("/dev/null"));
+
+//        final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
+//            .inheritIO();
+//            .redirectOutput(new File("out.txt"))
+//            .redirectError(new File("err.txt"));
+
+        pb.environment().put("AERON_DIR_DELETE_ON_START", String.valueOf(context.dirDeleteOnShutdown()));
+        pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
+        pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
+        pb.environment().put("AERON_DIR", context.aeronDirectoryName());
+
+        try
+        {
+            return new NativeTestMediaDriver(pb.start(), context);
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -45,9 +45,12 @@ public class NativeTestMediaDriver implements TestMediaDriver
             throw new RuntimeException("Unable to find native media driver binary: " + f.getAbsolutePath());
         }
 
+        IoUtil.ensureDirectoryExists(
+            new File(context.aeronDirectoryName()).getParentFile(), "Aeron C Media Driver directory");
+
         final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
-            .redirectOutput(new File("/dev/null"))
-            .redirectError(new File("/dev/null"));
+            .redirectOutput(new File("/tmp/out.txt"))
+            .redirectError(new File("/tmp/err.txt"));
 
         pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
         pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -1,5 +1,6 @@
 package io.aeron.support;
 
+import io.aeron.CommonContext;
 import io.aeron.driver.MediaDriver;
 import org.agrona.IoUtil;
 
@@ -21,7 +22,7 @@ public class NativeTestMediaDriver implements TestMediaDriver
     @Override
     public void close() throws Exception
     {
-        aeronmdProcess.destroy();
+        terminateDriver();
         if (!aeronmdProcess.waitFor(10, TimeUnit.SECONDS))
         {
             aeronmdProcess.destroyForcibly();
@@ -33,6 +34,11 @@ public class NativeTestMediaDriver implements TestMediaDriver
             final File aeronDirectory = new File(context.aeronDirectoryName());
             IoUtil.delete(aeronDirectory, false);
         }
+    }
+
+    private void terminateDriver()
+    {
+        CommonContext.requestDriverTermination(new File(context.aeronDirectoryName()), null, 0, 0);
     }
 
     public static NativeTestMediaDriver launch(MediaDriver.Context context)
@@ -56,6 +62,7 @@ public class NativeTestMediaDriver implements TestMediaDriver
         pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
         pb.environment().put("AERON_DIR", context.aeronDirectoryName());
         pb.environment().put("AERON_TIMER_INTERVAL", String.valueOf(context.timerIntervalNs()));
+        pb.environment().put("AERON_DRIVER_TERMINATION_VALIDATOR", "allow");
 
         try
         {

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -52,9 +52,11 @@ public class NativeTestMediaDriver implements TestMediaDriver
         pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
         pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
         pb.environment().put("AERON_DIR", context.aeronDirectoryName());
+        pb.environment().put("AERON_TIMER_INTERVAL", String.valueOf(context.timerIntervalNs()));
 
         try
         {
+            System.out.println("Launching C driver: " + f.getAbsolutePath());
             return new NativeTestMediaDriver(pb.start(), context);
         }
         catch (IOException e)

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -67,4 +67,10 @@ public class NativeTestMediaDriver implements TestMediaDriver
             throw new RuntimeException(e);
         }
     }
+
+    @Override
+    public MediaDriver.Context context()
+    {
+        return context;
+    }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -9,8 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 public class NativeTestMediaDriver implements TestMediaDriver
 {
-    private static final String DEFAULT_AERONMD_LOCATION =
-        System.getProperty("user.dir") + "/../cppbuild/Release/binaries/aeronmd";
     private final Process aeronmdProcess;
     private final MediaDriver.Context context;
 
@@ -39,8 +37,8 @@ public class NativeTestMediaDriver implements TestMediaDriver
 
     public static NativeTestMediaDriver launch(MediaDriver.Context context)
     {
-        final String aeronmdPath = System.getProperty("aeron.test.system.aeronmd.path", DEFAULT_AERONMD_LOCATION);
-        File f = new File(aeronmdPath);
+        final String aeronmdPath = System.getProperty("aeron.test.system.aeronmd.path");
+        final File f = new File(aeronmdPath);
 
         if (!f.exists())
         {
@@ -48,16 +46,9 @@ public class NativeTestMediaDriver implements TestMediaDriver
         }
 
         final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
-//            .inheritIO();
             .redirectOutput(new File("/dev/null"))
             .redirectError(new File("/dev/null"));
 
-//        final ProcessBuilder pb = new ProcessBuilder(f.getAbsolutePath())
-//            .inheritIO();
-//            .redirectOutput(new File("out.txt"))
-//            .redirectError(new File("err.txt"));
-
-        pb.environment().put("AERON_DIR_DELETE_ON_START", String.valueOf(context.dirDeleteOnShutdown()));
         pb.environment().put("AERON_TERM_BUFFER_LENGTH", String.valueOf(context.publicationTermBufferLength()));
         pb.environment().put("AERON_THREADING_MODE", context.threadingMode().name());
         pb.environment().put("AERON_DIR", context.aeronDirectoryName());

--- a/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/NativeTestMediaDriver.java
@@ -37,7 +37,7 @@ public class NativeTestMediaDriver implements TestMediaDriver
 
     public static NativeTestMediaDriver launch(MediaDriver.Context context)
     {
-        final String aeronmdPath = System.getProperty("aeron.test.system.aeronmd.path");
+        final String aeronmdPath = System.getProperty(TestMediaDriver.AERON_TEST_SYSTEM_AERONMD_PATH);
         final File f = new File(aeronmdPath);
 
         if (!f.exists())

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -2,14 +2,16 @@ package io.aeron.support;
 
 import io.aeron.driver.MediaDriver;
 
+import static org.agrona.Strings.isEmpty;
+
 public interface TestMediaDriver extends AutoCloseable
 {
     String AERON_TEST_SYSTEM_AERONMD_PATH = "aeron.test.system.aeronmd.path";
 
     static TestMediaDriver launch(MediaDriver.Context context)
     {
-        return (null != System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH)) ?
-            NativeTestMediaDriver.launch(context) :
-            JavaTestMediaDriver.launch(context);
+        return (isEmpty(System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH))) ?
+            JavaTestMediaDriver.launch(context) :
+            NativeTestMediaDriver.launch(context);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -9,17 +9,32 @@ public interface TestMediaDriver extends AutoCloseable
 {
     String AERON_TEST_SYSTEM_AERONMD_PATH = "aeron.test.system.aeronmd.path";
 
+    static boolean shouldRunCMediaDriver()
+    {
+        return !isEmpty(System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH));
+    }
+
+    static void notSupportedOnCMediaDriverYet(String reason)
+    {
+        Assume.assumeFalse("Functionality not support by C Media Driver: " + reason, shouldRunCMediaDriver());
+    }
+
     static TestMediaDriver launch(MediaDriver.Context context)
     {
-        return (isEmpty(System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH))) ?
-            JavaTestMediaDriver.launch(context) :
-            CTestMediaDriver.launch(context);
+        return shouldRunCMediaDriver() ?
+            CTestMediaDriver.launch(context, null) : JavaTestMediaDriver.launch(context);
+    }
+
+    static TestMediaDriver launch(MediaDriver.Context context, DriverOutputConsumer driverOutputConsumer)
+    {
+        return shouldRunCMediaDriver() ?
+            CTestMediaDriver.launch(context, driverOutputConsumer) : JavaTestMediaDriver.launch(context);
     }
 
     MediaDriver.Context context();
 
-    default void notSupportedOnCMediaDriverYet()
-    {
-        Assume.assumeFalse(this instanceof CTestMediaDriver);
-    }
+    String aeronDirectoryName();
+
+    @Override
+    void close();
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -14,4 +14,6 @@ public interface TestMediaDriver extends AutoCloseable
             JavaTestMediaDriver.launch(context) :
             NativeTestMediaDriver.launch(context);
     }
+
+    MediaDriver.Context context();
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -13,13 +13,13 @@ public interface TestMediaDriver extends AutoCloseable
     {
         return (isEmpty(System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH))) ?
             JavaTestMediaDriver.launch(context) :
-            NativeTestMediaDriver.launch(context);
+            CTestMediaDriver.launch(context);
     }
 
     MediaDriver.Context context();
 
     default void notSupportedOnCMediaDriverYet()
     {
-        Assume.assumeFalse(this instanceof NativeTestMediaDriver);
+        Assume.assumeFalse(this instanceof CTestMediaDriver);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -1,0 +1,15 @@
+package io.aeron.support;
+
+import io.aeron.driver.MediaDriver;
+
+public interface TestMediaDriver extends AutoCloseable
+{
+    String AERON_TEST_SYSTEM_AERONMD_PATH = "aeron.test.system.aeronmd.path";
+
+    static TestMediaDriver launch(MediaDriver.Context context)
+    {
+        return (null != System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH)) ?
+            NativeTestMediaDriver.launch(context) :
+            JavaTestMediaDriver.launch(context);
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/support/TestMediaDriver.java
@@ -1,6 +1,7 @@
 package io.aeron.support;
 
 import io.aeron.driver.MediaDriver;
+import org.junit.Assume;
 
 import static org.agrona.Strings.isEmpty;
 
@@ -16,4 +17,9 @@ public interface TestMediaDriver extends AutoCloseable
     }
 
     MediaDriver.Context context();
+
+    default void notSupportedOnCMediaDriverYet()
+    {
+        Assume.assumeFalse(this instanceof NativeTestMediaDriver);
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -736,6 +736,7 @@ project(':aeron-system-tests') {
 
     test {
         systemProperties('java.net.preferIPv4Stack': 'true')
+        systemProperties('aeron.test.system.aeronmd.path': System.getProperty('aeron.test.system.aeronmd.path'))
     }
 
     uploadArchives {


### PR DESCRIPTION
This allows for the system tests to be run against a C Media Driver.  This is achieved by setting the `aeron.test.system.aeronmd.path` system property to be the location of a C Media Driver binary.

To make a new test work against the C Media Driver, use the `TestMediaDriver::launch` method.  It will default to the Java one and automatically flip to the C version when the property is set.

If the test fails and you need to get at the stdout/stderr information from the C Media Driver process, Add `@Rule public MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();` to the test and pass the `watcher` into the `TestMediaDriver::launch` method as the second argument.  The `FlowControlStrategiesTest` shows this in use.

If a test uses a feature that is not supported, use `TestMediaDriver::notSupportedOnCMediaDriverYet` passing in the reason why it can not run against the C Media Driver (reason provided as in code documentation).