### PR TITLE
Remove uses of mocked LossReport to test loss in system tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ cppbuild/Win32
 
 # JVM crash reports
 hs_err_pid*
+
+# Archive and Cluster data from system tests
+/aeron-archive/*.rec
+/aeron-archive/*.catalog
+/aeron-archive/*.dat
+/aeron-cluster/*.dat
+/aeron-cluster/recording.log

--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -17,20 +17,17 @@ package io.aeron;
 
 import io.aeron.driver.*;
 import io.aeron.driver.ext.*;
-import io.aeron.driver.reports.LossReport;
 import io.aeron.logbuffer.*;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.aeron.test.LossReportTestUtil.verifyLossOccuredForStream;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 public class GapFillLossTest
 {
@@ -57,9 +54,6 @@ public class GapFillLossTest
             .dirDeleteOnStart(true)
             .dirDeleteOnShutdown(true)
             .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH);
-
-        final LossReport lossReport = mock(LossReport.class);
-        ctx.lossReport(lossReport);
 
         final LossGenerator dataLossGenerator =
             DebugChannelEndpointConfiguration.lossGeneratorSupplier(0.20, 0xcafebabeL);
@@ -99,7 +93,7 @@ public class GapFillLossTest
             subscriberThread.join();
 
             assertThat(subscriber.messageCount, lessThan(NUM_MESSAGES));
-            verify(lossReport).createEntry(anyLong(), anyLong(), anyInt(), eq(STREAM_ID), anyString(), anyString());
+            verifyLossOccuredForStream(ctx.aeronDirectoryName(), STREAM_ID);
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static io.aeron.test.LossReportTestUtil.verifyLossOccuredForStream;
+import static io.aeron.test.LossReportTestUtil.verifyLossOccurredForStream;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
@@ -93,7 +93,7 @@ public class GapFillLossTest
             subscriberThread.join();
 
             assertThat(subscriber.messageCount, lessThan(NUM_MESSAGES));
-            verifyLossOccuredForStream(ctx.aeronDirectoryName(), STREAM_ID);
+            verifyLossOccurredForStream(ctx.aeronDirectoryName(), STREAM_ID);
         }
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -44,7 +44,7 @@ import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 
 
-import static io.aeron.test.LossReportTestUtil.verifyLossOccuredForStream;
+import static io.aeron.test.LossReportTestUtil.verifyLossOccurredForStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -346,7 +346,7 @@ public class PubAndSubTest
             eq(messageLength),
             any(Header.class));
 
-        verifyLossOccuredForStream(context.aeronDirectoryName(), STREAM_ID);
+        verifyLossOccurredForStream(context.aeronDirectoryName(), STREAM_ID);
     }
 
     @Theory
@@ -415,7 +415,7 @@ public class PubAndSubTest
             eq(messageLength),
             any(Header.class));
 
-        verifyLossOccuredForStream(context.aeronDirectoryName(), STREAM_ID);
+        verifyLossOccurredForStream(context.aeronDirectoryName(), STREAM_ID);
     }
 
     @Theory

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -17,7 +17,6 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
-import io.aeron.driver.reports.LossReport;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
@@ -40,10 +39,12 @@ import io.aeron.logbuffer.Header;
 import org.agrona.BitUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 
+import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 
 
+import static io.aeron.test.LossReportTestUtil.verifyLossOccuredForStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
@@ -287,7 +288,7 @@ public class PubAndSubTest
 
     @Theory
     @Test(timeout = 20_000)
-    public void shouldReceivePublishedMessageOneForOneWithDataLoss(final String channel)
+    public void shouldReceivePublishedMessageOneForOneWithDataLoss(final String channel) throws IOException
     {
         if (IPC_URI.equals(channel))
         {
@@ -298,9 +299,6 @@ public class PubAndSubTest
         final int numMessagesInTermBuffer = 64;
         final int messageLength = (termBufferLength / numMessagesInTermBuffer) - HEADER_LENGTH;
         final int numMessagesToSend = 2 * numMessagesInTermBuffer;
-
-        final LossReport lossReport = mock(LossReport.class);
-        context.lossReport(lossReport);
 
         final LossGenerator dataLossGenerator =
             DebugChannelEndpointConfiguration.lossGeneratorSupplier(0.10, 0xcafebabeL);
@@ -348,12 +346,12 @@ public class PubAndSubTest
             eq(messageLength),
             any(Header.class));
 
-        verify(lossReport).createEntry(anyLong(), anyLong(), anyInt(), eq(STREAM_ID), anyString(), anyString());
+        verifyLossOccuredForStream(context.aeronDirectoryName(), STREAM_ID);
     }
 
     @Theory
     @Test(timeout = 20_000)
-    public void shouldReceivePublishedMessageBatchedWithDataLoss(final String channel)
+    public void shouldReceivePublishedMessageBatchedWithDataLoss(final String channel) throws IOException
     {
         if (IPC_URI.equals(channel))
         {
@@ -366,9 +364,6 @@ public class PubAndSubTest
         final int numMessagesToSend = 2 * numMessagesInTermBuffer;
         final int numBatches = 4;
         final int numMessagesPerBatch = numMessagesToSend / numBatches;
-
-        final LossReport lossReport = mock(LossReport.class);
-        context.lossReport(lossReport);
 
         final LossGenerator dataLossGenerator =
             DebugChannelEndpointConfiguration.lossGeneratorSupplier(0.10, 0xcafebabeL);
@@ -420,7 +415,7 @@ public class PubAndSubTest
             eq(messageLength),
             any(Header.class));
 
-        verify(lossReport).createEntry(anyLong(), anyLong(), anyInt(), eq(STREAM_ID), anyString(), anyString());
+        verifyLossOccuredForStream(context.aeronDirectoryName(), STREAM_ID);
     }
 
     @Theory

--- a/aeron-system-tests/src/test/java/io/aeron/test/LossReportTestUtil.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/LossReportTestUtil.java
@@ -19,7 +19,9 @@ import static org.mockito.Mockito.verify;
 
 public class LossReportTestUtil
 {
-    public static void verifyLossOccuredForStream(String aeronDirectoryName, int streamId) throws IOException
+    public static void verifyLossOccurredForStream(
+        final String aeronDirectoryName,
+        final int streamId) throws IOException
     {
         final File lossReportFile = LossReportUtil.file(aeronDirectoryName);
         assertTrue(lossReportFile.exists());

--- a/aeron-system-tests/src/test/java/io/aeron/test/LossReportTestUtil.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/LossReportTestUtil.java
@@ -1,0 +1,41 @@
+package io.aeron.test;
+
+import io.aeron.driver.reports.LossReportReader;
+import io.aeron.driver.reports.LossReportUtil;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class LossReportTestUtil
+{
+    public static void verifyLossOccuredForStream(String aeronDirectoryName, int streamId) throws IOException
+    {
+        final File lossReportFile = LossReportUtil.file(aeronDirectoryName);
+        assertTrue(lossReportFile.exists());
+
+        try (
+            RandomAccessFile file = new RandomAccessFile(lossReportFile, "r");
+            FileChannel channel = file.getChannel())
+        {
+            final MappedByteBuffer mappedByteBuffer = channel.map(READ_ONLY, 0, channel.size());
+            final AtomicBuffer buffer = new UnsafeBuffer(mappedByteBuffer);
+
+            final LossReportReader.EntryConsumer lossEntryConsumer = mock(LossReportReader.EntryConsumer.class);
+            LossReportReader.read(buffer, lossEntryConsumer);
+
+            verify(lossEntryConsumer).accept(
+                longThat(l -> l > 0), longThat(l -> l > 0), anyLong(), anyLong(), anyInt(), eq(streamId), any(), any());
+        }
+    }
+}


### PR DESCRIPTION
Move over to using the LossReportReader instead.  Will be necessary for testing the C media driver.