### PR TITLE
Allow configuration of the loss generating transport binding for the C media driver.

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -48,7 +48,7 @@ public class GapFillLossTest
     @Rule
     public MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
 
-    @Test//(timeout = 10_000)
+    @Test(timeout = 10_000)
     public void shouldGapFillWhenLossOccurs() throws Exception
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(MSG_LENGTH));

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -17,12 +17,14 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.MediaDriverTestWatcher;
 import io.aeron.test.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableLong;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
@@ -64,6 +66,9 @@ public class PubAndSubTest
     @DataPoint
     public static final String IPC_URI = "aeron:ipc";
 
+    @Rule
+    public MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+
     private static final int STREAM_ID = 1;
     private static final ThreadingMode THREADING_MODE = ThreadingMode.SHARED;
 
@@ -88,7 +93,7 @@ public class PubAndSubTest
             .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500))
             .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100));
 
-        driver = TestMediaDriver.launch(context);
+        driver = TestMediaDriver.launch(context, watcher);
         subscribingClient = Aeron.connect();
         publishingClient = Aeron.connect();
         subscription = subscribingClient.addSubscription(channel, STREAM_ID);
@@ -802,12 +807,6 @@ public class PubAndSubTest
     @Test(timeout = 20_000)
     public void shouldNoticeDroppedSubscriber(final String channel) throws Exception
     {
-        if (TestMediaDriver.shouldRunCMediaDriver())
-        {
-            // Not sure why this is not being picked up, need to investigate...
-            return;
-        }
-
         launch(channel);
 
         while (!publication.isConnected())

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -97,7 +97,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         final MediaDriver.Context context,
         final DriverOutputConsumer driverOutputConsumer)
     {
-        final String aeronDirPath = System.getProperty(TestMediaDriver.AERON_TEST_SYSTEM_AERONMD_PATH);
+        final String aeronDirPath = System.getProperty(TestMediaDriver.AERONMD_PATH);
         final File f = new File(aeronDirPath);
 
         if (!f.exists())
@@ -129,8 +129,8 @@ public final class CTestMediaDriver implements TestMediaDriver
             "AERON_UNTETHERED_WINDOW_LIMIT_TIMEOUT", String.valueOf(context.untetheredWindowLimitTimeoutNs()));
 
         setFlowControlStrategy(pb.environment(), context);
-
         TRANSPORT_BINDINGS_CONFIGURATION.get().getOrDefault(context, emptyMap()).forEach(pb.environment()::put);
+        setLogging(pb.environment());
 
         try
         {
@@ -157,6 +157,25 @@ public final class CTestMediaDriver implements TestMediaDriver
         {
             throw new RuntimeException(e);
         }
+    }
+
+    private static void setLogging(final Map<String, String> environment)
+    {
+        final String driverAgentPath = System.getProperty(DRIVER_AGENT_PATH);
+        if (null == driverAgentPath)
+        {
+            return;
+        }
+
+        final File driverAgent = new File(driverAgentPath);
+        if (!driverAgent.exists())
+        {
+            throw new RuntimeException(
+                "Unable to find driver agent file at: " + DRIVER_AGENT_PATH + "=" + driverAgentPath);
+        }
+
+        environment.put("AERON_EVENT_LOG", "0xFFFF");
+        environment.put("LD_PRELOAD", driverAgent.getAbsolutePath());
     }
 
     private static void setFlowControlStrategy(final Map<String, String> environment, final MediaDriver.Context context)

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -28,7 +28,6 @@ import org.agrona.collections.Object2ObjectHashMap;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -151,8 +150,6 @@ public final class CTestMediaDriver implements TestMediaDriver
             }
 
             pb.redirectOutput(stdoutFile).redirectError(stderrFile);
-
-            pb.environment().forEach((k,v) -> System.out.printf("%s -> %s%n", k, v));
 
             return new CTestMediaDriver(pb.start(), context);
         }

--- a/aeron-system-tests/src/test/java/io/aeron/test/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/TestMediaDriver.java
@@ -22,11 +22,12 @@ import static org.agrona.Strings.isEmpty;
 
 public interface TestMediaDriver extends AutoCloseable
 {
-    String AERON_TEST_SYSTEM_AERONMD_PATH = "aeron.test.system.aeronmd.path";
+    String AERONMD_PATH = "aeron.test.system.aeronmd.path";
+    String DRIVER_AGENT_PATH = "aeron.test.system.driver.agent.path";
 
     static boolean shouldRunCMediaDriver()
     {
-        return !isEmpty(System.getProperty(AERON_TEST_SYSTEM_AERONMD_PATH));
+        return !isEmpty(System.getProperty(AERONMD_PATH));
     }
 
     static void notSupportedOnCMediaDriverYet(String reason)

--- a/aeron-system-tests/src/test/java/io/aeron/test/TestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/TestMediaDriver.java
@@ -46,6 +46,24 @@ public interface TestMediaDriver extends AutoCloseable
             CTestMediaDriver.launch(context, driverOutputConsumer) : JavaTestMediaDriver.launch(context);
     }
 
+    static void enableLossGenerationOnReceive(
+        final MediaDriver.Context context,
+        final double rate,
+        final long seed,
+        final boolean loseDataMessages,
+        final boolean loseControlMessages)
+    {
+        if (shouldRunCMediaDriver())
+        {
+            CTestMediaDriver.enableLossGenerationOnReceive(context, rate, seed, loseDataMessages, loseControlMessages);
+        }
+        else
+        {
+            JavaTestMediaDriver.enableLossGenerationOnReceive(
+                context, rate, seed, loseDataMessages, loseControlMessages);
+        }
+    }
+
     MediaDriver.Context context();
 
     String aeronDirectoryName();


### PR DESCRIPTION
When running the system tests.  Still requires the setting of the system properties to enable the C driver to run, so can be committed at any point.  To actually run the loss based system tests against the C driver requires PR #760.

I've used a slightly hacky approach to track the configuration for the loss generation on the C driver side, mainly because the loss generation information on the MediaDriver.Context is not declarative.  I've gone for the approach requiring the smallest amount of work.  There may be scope for something DSL to set up the media drivers instead of using the Context.