### PR TITLE
Fix faults in incremental and parallel builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,15 +386,21 @@ project(':aeron-archive') {
     }
 
     task generateCodecs(type: JavaExec) {
+        def codecsFile = 'src/main/resources/aeron-archive-codecs.xml'
+        def markCodecsFile = 'src/main/resources/aeron-archive-mark-codecs.xml'
+        def sbeFile = 'src/main/resources/fpl/sbe.xsd'
+
+        inputs.files(codecsFile, markCodecsFile, sbeFile)
+        outputs.dir generatedDir
+
         main = 'uk.co.real_logic.sbe.SbeTool'
         classpath = configurations.codecGeneration
         systemProperties(
             'sbe.output.dir': generatedDir,
             'sbe.target.language': 'Java',
-            'sbe.validation.xsd': 'src/main/resources/fpl/sbe.xsd',
+            'sbe.validation.xsd': sbeFile,
             'sbe.validation.stop.on.error': 'true')
-        args = ['src/main/resources/aeron-archive-codecs.xml',
-                'src/main/resources/aeron-archive-mark-codecs.xml']
+        args = [codecsFile, markCodecsFile]
     }
 
     def generatedCppDir = file(System.properties['codec.target.dir'] ?: "${rootDir}/cppbuild/Release/generated")
@@ -454,6 +460,8 @@ project(':aeron-archive') {
     }
 
     task sourcesJar(type: Jar) {
+        dependsOn generateCodecs
+
         archiveClassifier = 'sources'
         from sourceSets.main.allSource
         from sourceSets.generated.allSource
@@ -502,15 +510,21 @@ project(':aeron-cluster') {
     }
 
     task generateCodecs(type: JavaExec) {
+        def codecsFile = 'src/main/resources/aeron-cluster-codecs.xml'
+        def markCodecsFile = 'src/main/resources/aeron-cluster-mark-codecs.xml'
+        def sbeFile = 'src/main/resources/fpl/sbe.xsd'
+
+        inputs.files(codecsFile, markCodecsFile, sbeFile)
+        outputs.dir generatedDir
+
         main = 'uk.co.real_logic.sbe.SbeTool'
         classpath = configurations.codecGeneration
         systemProperties(
             'sbe.output.dir': generatedDir,
             'sbe.target.language': 'Java',
-            'sbe.validation.xsd': 'src/main/resources/fpl/sbe.xsd',
+            'sbe.validation.xsd': sbeFile,
             'sbe.validation.stop.on.error': 'true')
-        args = ['src/main/resources/aeron-cluster-codecs.xml',
-                'src/main/resources/aeron-cluster-mark-codecs.xml']
+        args = [codecsFile, markCodecsFile]
     }
 
     apply plugin: 'biz.aQute.bnd.builder'
@@ -557,6 +571,8 @@ project(':aeron-cluster') {
     }
 
     task sourcesJar(type: Jar) {
+        dependsOn generateCodecs
+
         archiveClassifier = 'sources'
         from sourceSets.main.allSource
         from sourceSets.generated.allSource
@@ -863,6 +879,8 @@ project(':aeron-all') {
     }
 
     shadowJar {
+        mustRunAfter jar
+
         archiveClassifier = ''
         relocate 'org.HdrHistogram', 'io.aeron.shadow.org.HdrHistogram'
     }


### PR DESCRIPTION
Hello

This commit fixes a couple of faults in the incremental and parallel builds of this project.

First, it makes the time-consuming task `generateCodecs` incremental.

Second, it fixes a race condition related to the creation of the sources Jar. In particular, `sourcesJar` must be executed after the task `generateCodecs`. Otherwise, the created jar does not include the files generated by this task.

These are the files that are missing when `sourcesJar` runs before `generateCodecs`:

```
< io/aeron/cluster/codecs/
< io/aeron/cluster/codecs/SessionCloseRequestDecoder.java
< io/aeron/cluster/codecs/ClientSessionEncoder.java
< io/aeron/cluster/codecs/ChallengeResponseEncoder.java
< io/aeron/cluster/codecs/ElectionStartEventDecoder.java
< io/aeron/cluster/codecs/ClusterAction.java
< io/aeron/cluster/codecs/VarDataEncodingDecoder.java
< io/aeron/cluster/codecs/NewLeaderEventEncoder.java
< io/aeron/cluster/codecs/AddPassiveMemberEncoder.java
< io/aeron/cluster/codecs/ClusterMembersExtendedResponseDecoder.java
< io/aeron/cluster/codecs/ClusterTimeUnit.java
< io/aeron/cluster/codecs/SnapshotRecordingsDecoder.java
< io/aeron/cluster/codecs/CanvassPositionEncoder.java
< io/aeron/cluster/codecs/SessionCloseEventDecoder.java
< io/aeron/cluster/codecs/SnapshotRecordingsEncoder.java
< io/aeron/cluster/codecs/SessionKeepAliveEncoder.java
< io/aeron/cluster/codecs/VarDataEncodingEncoder.java
< io/aeron/cluster/codecs/MessageHeaderEncoder.java
< io/aeron/cluster/codecs/CatchupPositionEncoder.java
< io/aeron/cluster/codecs/NewLeaderEventDecoder.java
< io/aeron/cluster/codecs/SnapshotRecordingQueryDecoder.java
< io/aeron/cluster/codecs/TimerDecoder.java
< io/aeron/cluster/codecs/ClientSessionDecoder.java
< io/aeron/cluster/codecs/CommitPositionDecoder.java
< io/aeron/cluster/codecs/BackupQueryEncoder.java
< io/aeron/cluster/codecs/ClusterMembersChangeEncoder.java
< io/aeron/cluster/codecs/ServiceTerminationPositionEncoder.java
< io/aeron/cluster/codecs/JoinClusterDecoder.java
< io/aeron/cluster/codecs/AddPassiveMemberDecoder.java
< io/aeron/cluster/codecs/CloseSessionDecoder.java
< io/aeron/cluster/codecs/RemoveMemberEncoder.java
< io/aeron/cluster/codecs/BackupResponseDecoder.java
< io/aeron/cluster/codecs/ChallengeEncoder.java
< io/aeron/cluster/codecs/ClusterMembersExtendedResponseEncoder.java
< io/aeron/cluster/codecs/StopCatchupEncoder.java
< io/aeron/cluster/codecs/ClusterMembersResponseDecoder.java
< io/aeron/cluster/codecs/ClusterSessionEncoder.java
< io/aeron/cluster/codecs/SessionConnectRequestEncoder.java
< io/aeron/cluster/codecs/BooleanType.java
< io/aeron/cluster/codecs/AppendedPositionDecoder.java
< io/aeron/cluster/codecs/ChallengeResponseDecoder.java
< io/aeron/cluster/codecs/BackupResponseEncoder.java
< io/aeron/cluster/codecs/SnapshotMarkerEncoder.java
< io/aeron/cluster/codecs/ClusterActionRequestDecoder.java
< io/aeron/cluster/codecs/JoinClusterEncoder.java
< io/aeron/cluster/codecs/NewLeadershipTermDecoder.java
< io/aeron/cluster/codecs/VarAsciiEncodingEncoder.java
< io/aeron/cluster/codecs/SessionEventDecoder.java
< io/aeron/cluster/codecs/RemoveMemberDecoder.java
< io/aeron/cluster/codecs/TerminationAckDecoder.java
< io/aeron/cluster/codecs/SessionOpenEventDecoder.java
< io/aeron/cluster/codecs/RequestVoteEncoder.java
< io/aeron/cluster/codecs/ScheduleTimerEncoder.java
< io/aeron/cluster/codecs/CloseReason.java
< io/aeron/cluster/codecs/ScheduleTimerDecoder.java
< io/aeron/cluster/codecs/SessionCloseRequestEncoder.java
< io/aeron/cluster/codecs/TimerEncoder.java
< io/aeron/cluster/codecs/VoteDecoder.java
< io/aeron/cluster/codecs/AppendedPositionEncoder.java
< io/aeron/cluster/codecs/ClusterSessionDecoder.java
< io/aeron/cluster/codecs/SnapshotRecordingQueryEncoder.java
< io/aeron/cluster/codecs/GroupSizeEncodingDecoder.java
< io/aeron/cluster/codecs/TerminationAckEncoder.java
< io/aeron/cluster/codecs/TerminationPositionDecoder.java
< io/aeron/cluster/codecs/ClusterMembersQueryEncoder.java
< io/aeron/cluster/codecs/ClusterMembersResponseEncoder.java
< io/aeron/cluster/codecs/ClusterActionRequestEncoder.java
< io/aeron/cluster/codecs/SessionOpenEventEncoder.java
< io/aeron/cluster/codecs/MembershipChangeEventDecoder.java
< io/aeron/cluster/codecs/ClusterMembersChangeDecoder.java
< io/aeron/cluster/codecs/MembershipChangeEventEncoder.java
< io/aeron/cluster/codecs/CanvassPositionDecoder.java
< io/aeron/cluster/codecs/RequestVoteDecoder.java
< io/aeron/cluster/codecs/VarAsciiEncodingDecoder.java
< io/aeron/cluster/codecs/CommitPositionEncoder.java
< io/aeron/cluster/codecs/ElectionStartEventEncoder.java
< io/aeron/cluster/codecs/GroupSizeEncodingEncoder.java
< io/aeron/cluster/codecs/TimerEventDecoder.java
< io/aeron/cluster/codecs/SnapshotMark.java
< io/aeron/cluster/codecs/TerminationPositionEncoder.java
< io/aeron/cluster/codecs/SessionMessageHeaderDecoder.java
< io/aeron/cluster/codecs/NewLeadershipTermEncoder.java
< io/aeron/cluster/codecs/SessionKeepAliveDecoder.java
< io/aeron/cluster/codecs/MetaAttribute.java
< io/aeron/cluster/codecs/mark/
< io/aeron/cluster/codecs/mark/MessageHeaderEncoder.java
< io/aeron/cluster/codecs/mark/VarAsciiEncodingEncoder.java
< io/aeron/cluster/codecs/mark/VarAsciiEncodingDecoder.java
< io/aeron/cluster/codecs/mark/ClusterComponentType.java
< io/aeron/cluster/codecs/mark/MetaAttribute.java
< io/aeron/cluster/codecs/mark/MessageHeaderDecoder.java
< io/aeron/cluster/codecs/mark/MarkFileHeaderDecoder.java
< io/aeron/cluster/codecs/mark/MarkFileHeaderEncoder.java
< io/aeron/cluster/codecs/mark/package-info.java
< io/aeron/cluster/codecs/StopCatchupDecoder.java
< io/aeron/cluster/codecs/CatchupPositionDecoder.java
< io/aeron/cluster/codecs/JoinLogDecoder.java
< io/aeron/cluster/codecs/EventCode.java
< io/aeron/cluster/codecs/SessionCloseEventEncoder.java
< io/aeron/cluster/codecs/SessionConnectRequestDecoder.java
< io/aeron/cluster/codecs/CancelTimerDecoder.java
< io/aeron/cluster/codecs/NewLeadershipTermEventEncoder.java
< io/aeron/cluster/codecs/ServiceAckEncoder.java
< io/aeron/cluster/codecs/MessageHeaderDecoder.java
< io/aeron/cluster/codecs/ClusterMembersQueryDecoder.java
< io/aeron/cluster/codecs/JoinLogEncoder.java
< io/aeron/cluster/codecs/CloseSessionEncoder.java
< io/aeron/cluster/codecs/SessionEventEncoder.java
< io/aeron/cluster/codecs/TimerEventEncoder.java
< io/aeron/cluster/codecs/ClusterMembersEncoder.java
< io/aeron/cluster/codecs/ChallengeDecoder.java
< io/aeron/cluster/codecs/ClusterMembersDecoder.java
< io/aeron/cluster/codecs/ChangeType.java
< io/aeron/cluster/codecs/CancelTimerEncoder.java
< io/aeron/cluster/codecs/ConsensusModuleDecoder.java
< io/aeron/cluster/codecs/ConsensusModuleEncoder.java
< io/aeron/cluster/codecs/ServiceAckDecoder.java
< io/aeron/cluster/codecs/NewLeadershipTermEventDecoder.java
< io/aeron/cluster/codecs/VoteEncoder.java
< io/aeron/cluster/codecs/SessionMessageHeaderEncoder.java
< io/aeron/cluster/codecs/BackupQueryDecoder.java
< io/aeron/cluster/codecs/ServiceTerminationPositionDecoder.java
< io/aeron/cluster/codecs/SnapshotMarkerDecoder.java
< io/aeron/cluster/codecs/package-info.java
```

Similarly, the task `shadowJar` conflicts wit the task `jar`. Specifically, the name of the generated shadow jar (i.e., `aeron-all/build/libs/aeron-all-1.24.0-SNAPSHOT.jar`) conflicts with that produced by the naive jar task. So depending on the order in which Gradle processes task, the resulting jar might have incorrect contents.