### PR TITLE
Recreate cluster member's publications by hostname when it is in the unconnected state

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/media/MultiDestination.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/MultiDestination.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.net.PortUnreachableException;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
+import java.nio.channels.UnresolvedAddressException;
 
 import static io.aeron.driver.media.UdpChannelTransport.sendError;
 
@@ -56,7 +57,7 @@ abstract class MultiDestination
                 bytesSent = datagramChannel.send(buffer, destination);
             }
         }
-        catch (final PortUnreachableException ignore)
+        catch (final PortUnreachableException | UnresolvedAddressException ignore)
         {
         }
         catch (final IOException ex)


### PR DESCRIPTION
It is the next iteration of https://github.com/real-logic/aeron/pull/751 and I need still a solution for it.
I have seen https://github.com/real-logic/aeron/pull/749 and it partially resolves the problem. And this PR is an attempt to make the hostname resolving automatically. 
So on each slow tick, the `ConsensusModuleAgent` verifies status cluster member publications and if it is `NOT_CONNECTED` and if the cluster member IP address was resolved and was changed the agent will recreate necessary publications. I spotted that `io.aeron.cluster.MemberStatusPublisher#checkResult` doesn't check `NOT_CONNECTED` and it means that if a node was gone, everything, that was sent via such publication, will be skipped. And no need to take care of such publications in that status.
It seems like a working solution and I can specify hostnames and it will be resolved automatically when IP address.

What do you think guys?