### PR TITLE
Meta info on bindings

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -691,6 +691,9 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
         (void *)context->termination_hook_func,
         aeron_dlinfo((const void *)context->termination_hook_func, buffer, sizeof(buffer)));
     fprintf(fpout, "\n    termination_hook_state=%p", context->termination_hook_state);
+    fprintf(fpout, "\n    udp_channel_transport_bindings=%p%s",
+        (void *)context->udp_channel_transport_bindings,
+        aeron_dlinfo((const void *)context->udp_channel_transport_bindings, buffer, sizeof(buffer)));
 
 #pragma GCC diagnostic pop
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -691,9 +691,18 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
         (void *)context->termination_hook_func,
         aeron_dlinfo((const void *)context->termination_hook_func, buffer, sizeof(buffer)));
     fprintf(fpout, "\n    termination_hook_state=%p", context->termination_hook_state);
-    fprintf(fpout, "\n    udp_channel_transport_bindings=%p%s",
-        (void *)context->udp_channel_transport_bindings,
-        aeron_dlinfo((const void *)context->udp_channel_transport_bindings, buffer, sizeof(buffer)));
+
+    const aeron_udp_channel_transport_bindings_t *bindings = context->udp_channel_transport_bindings;
+    while (NULL != bindings)
+    {
+        fprintf(
+            fpout, "\n    udp_channel_transport_bindings.%s=%s,%p%s",
+            bindings->meta_info.type, bindings->meta_info.name,
+            bindings->meta_info.source_symbol, aeron_dlinfo(bindings->meta_info.source_symbol, buffer, sizeof(buffer)));
+
+        bindings = bindings->meta_info.next_binding;
+    }
+
 
 #pragma GCC diagnostic pop
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -45,7 +45,13 @@ aeron_udp_channel_transport_bindings_t aeron_udp_channel_transport_bindings_defa
         aeron_udp_transport_poller_close,
         aeron_udp_transport_poller_add,
         aeron_udp_transport_poller_remove,
-        aeron_udp_transport_poller_poll
+        aeron_udp_transport_poller_poll,
+        {
+            "default",
+            "media",
+            NULL,
+            NULL
+        }
     };
 
 aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_load_media(const char *bindings_name)
@@ -69,6 +75,7 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
             aeron_set_err(
                 EINVAL, "could not find UDP channel transport bindings %s: dlsym - %s", bindings_name, aeron_dlerror());
         }
+        bindings->meta_info.source_symbol = bindings;
     }
 
     return bindings;
@@ -156,6 +163,11 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
             aeron_set_err(EINVAL, "Failed to load UDP transport bindings interceptor: %s", interceptor_name);
             return NULL;
         }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+        current_bindings->meta_info.source_symbol = (const void*)interceptor_load_func;
+#pragma GCC diagnostic pop
     }
 
     return current_bindings;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -118,7 +118,7 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
         if (strncmp(interceptor_name, "loss", sizeof("loss")) == 0)
         {
             // TODO: Dynamically load this function.
-            current_bindings = aeron_udp_channel_transport_loss_set_delegate(current_bindings);
+            current_bindings = aeron_udp_channel_transport_loss_load(current_bindings);
 
             if (NULL == current_bindings)
             {
@@ -128,8 +128,6 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
         }
         else
         {
-            current_bindings = NULL;
-
             // TODO: Allow truly dynamic interceptors.  Need to have a function to set the delegate binding
             // TODO: as part of the transport bindings struct.
             aeron_set_err(EINVAL, "could not find UDP channel transport bindings interceptor: %s", interceptor_name);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -74,6 +74,37 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
     return bindings;
 }
 
+static aeron_udp_channel_transport_interceptor_load_func_t *aeron_udp_channel_transport_bindings_load_interceptor(
+    const char *interceptor_name)
+{
+    aeron_udp_channel_transport_interceptor_load_func_t *load_interceptor = NULL;
+
+    if (NULL == interceptor_name)
+    {
+        return NULL;
+    }
+
+    if (strncmp(interceptor_name, "loss", sizeof("loss")) == 0)
+    {
+        return aeron_udp_channel_transport_bindings_load_interceptor("aeron_udp_channel_transport_loss_load");
+    }
+    else
+    {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+        if ((load_interceptor = (aeron_udp_channel_transport_interceptor_load_func_t *)aeron_dlsym(
+            RTLD_DEFAULT, interceptor_name)) == NULL)
+        {
+            aeron_set_err(
+                EINVAL, "could not find UDP transport bindings interceptor %s: dlsym - %s", interceptor_name,
+                aeron_dlerror());
+        }
+#pragma GCC diagnostic pop
+    }
+
+    return load_interceptor;
+}
+
 aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_load_interceptors(
     aeron_udp_channel_transport_bindings_t *media_bindings,
     const char *interceptors)
@@ -115,22 +146,14 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
     for (int i = 0; i < num_interceptors; i++)
     {
         const char *interceptor_name = interceptor_names[i];
-        if (strncmp(interceptor_name, "loss", sizeof("loss")) == 0)
-        {
-            // TODO: Dynamically load this function.
-            current_bindings = aeron_udp_channel_transport_loss_load(current_bindings);
 
-            if (NULL == current_bindings)
-            {
-                aeron_set_err(EINVAL, "Failed to load loss transport bindings");
-                return NULL;
-            }
-        }
-        else
+        aeron_udp_channel_transport_interceptor_load_func_t *interceptor_load_func =
+            aeron_udp_channel_transport_bindings_load_interceptor(interceptor_name);
+
+        current_bindings = interceptor_load_func(current_bindings);
+        if (NULL == current_bindings)
         {
-            // TODO: Allow truly dynamic interceptors.  Need to have a function to set the delegate binding
-            // TODO: as part of the transport bindings struct.
-            aeron_set_err(EINVAL, "could not find UDP channel transport bindings interceptor: %s", interceptor_name);
+            aeron_set_err(EINVAL, "Failed to load UDP transport bindings interceptor: %s", interceptor_name);
             return NULL;
         }
     }

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -75,6 +75,7 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
             aeron_set_err(
                 EINVAL, "could not find UDP channel transport bindings %s: dlsym - %s", bindings_name, aeron_dlerror());
         }
+        bindings->meta_info.next_binding = NULL; // Make sure it is not some random data.
         bindings->meta_info.source_symbol = bindings;
     }
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -91,7 +91,9 @@ typedef int (*aeron_udp_transport_poller_poll_func_t)(
     aeron_udp_channel_transport_recvmmsg_func_t recvmmsg_func,
     void *clientd);
 
-typedef struct aeron_udp_channel_transport_bindings_stct
+typedef struct aeron_udp_channel_transport_bindings_stct aeron_udp_channel_transport_bindings_t;
+
+struct aeron_udp_channel_transport_bindings_stct
 {
     aeron_udp_channel_transport_init_func_t init_func;
     aeron_udp_channel_transport_close_func_t close_func;
@@ -105,8 +107,15 @@ typedef struct aeron_udp_channel_transport_bindings_stct
     aeron_udp_transport_poller_add_func_t poller_add_func;
     aeron_udp_transport_poller_remove_func_t poller_remove_func;
     aeron_udp_transport_poller_poll_func_t poller_poll_func;
-}
-aeron_udp_channel_transport_bindings_t;
+    struct meta_info_fields
+    {
+        const char *name;
+        const char *type;
+        const aeron_udp_channel_transport_bindings_t *next_binding;
+        const void *source_symbol;
+    }
+    meta_info;
+};
 
 aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_load_media(const char *bindings_name);
 aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_load_interceptors(

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -91,7 +91,6 @@ typedef int (*aeron_udp_transport_poller_poll_func_t)(
     aeron_udp_channel_transport_recvmmsg_func_t recvmmsg_func,
     void *clientd);
 
-
 typedef struct aeron_udp_channel_transport_bindings_stct
 {
     aeron_udp_channel_transport_init_func_t init_func;
@@ -114,5 +113,7 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
     aeron_udp_channel_transport_bindings_t *media_bindings,
     const char *interceptors);
 
+typedef aeron_udp_channel_transport_bindings_t *(aeron_udp_channel_transport_interceptor_load_func_t)(
+    aeron_udp_channel_transport_bindings_t *delegate_bindings);
 
 #endif //AERON_UDP_CHANNEL_TRANSPORT_BINDINGS_H

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
@@ -71,6 +71,10 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_loss_load(
     interceptor_bindings->init_func = aeron_udp_channel_transport_loss_init;
     interceptor_bindings->recvmmsg_func = aeron_udp_channel_transport_loss_recvmmsg;
 
+    interceptor_bindings->meta_info.name = "loss";
+    interceptor_bindings->meta_info.type = "interceptor";
+    interceptor_bindings->meta_info.next_binding = delegate_bindings;
+
     aeron_udp_channel_transport_loss_delegate = delegate_bindings;
 
     return interceptor_bindings;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
@@ -57,7 +57,7 @@ typedef struct aeron_udp_channel_transport_loss_clientd_stct
 }
 aeron_udp_channel_transport_loss_clientd_t;
 
-aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_loss_set_delegate(
+aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_loss_load(
     const aeron_udp_channel_transport_bindings_t *delegate_bindings)
 {
     aeron_udp_channel_transport_bindings_t *interceptor_bindings;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
@@ -27,7 +27,7 @@ typedef struct aeron_udp_channel_transport_loss_params_stct
 }
 aeron_udp_channel_transport_loss_params_t;
 
-aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_loss_set_delegate(
+aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_loss_load(
     const aeron_udp_channel_transport_bindings_t *delegate_bindings);
 
 int aeron_udp_channel_transport_loss_configure(const aeron_udp_channel_transport_loss_params_t *loss_params);

--- a/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
+++ b/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
@@ -104,7 +104,7 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardAllPacketsWithRateOfOne)
 
     bindings.recvmmsg_func = delegate_return_packets_recvmmsg;
 
-    aeron_udp_channel_transport_loss_set_delegate(&bindings);
+    aeron_udp_channel_transport_loss_load(&bindings);
     aeron_udp_channel_transport_loss_configure(&params);
 
     int messages_received = aeron_udp_channel_transport_loss_recvmmsg(
@@ -142,7 +142,7 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfOneWithD
 
     bindings.recvmmsg_func = delegate_return_packets_recvmmsg;
 
-    aeron_udp_channel_transport_loss_set_delegate(&bindings);
+    aeron_udp_channel_transport_loss_load(&bindings);
     aeron_udp_channel_transport_loss_configure(&params);
 
     int messages_received = aeron_udp_channel_transport_loss_recvmmsg(
@@ -179,7 +179,7 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfZero)
 
     bindings.recvmmsg_func = delegate_return_packets_recvmmsg;
 
-    aeron_udp_channel_transport_loss_set_delegate(&bindings);
+    aeron_udp_channel_transport_loss_load(&bindings);
     aeron_udp_channel_transport_loss_configure(&params);
 
     int messages_received = aeron_udp_channel_transport_loss_recvmmsg(
@@ -216,7 +216,7 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardRoughlyHalfTheMessages)
 
     bindings.recvmmsg_func = delegate_return_packets_recvmmsg;
 
-    aeron_udp_channel_transport_loss_set_delegate(&bindings);
+    aeron_udp_channel_transport_loss_load(&bindings);
     aeron_udp_channel_transport_loss_configure(&params);
 
     int messages_received = aeron_udp_channel_transport_loss_recvmmsg(


### PR DESCRIPTION
Adds an inner struct to track meta information (name, type, source_symbol, next_binding) that can be useful when printing out the binding configuration.  Currently this happens in the `print_configuration` function in the driver.  Output will look something like:
```
udp_channel_transport_bindings.interceptor=loss,0x7f13fee9539f(/home/mike/sources/aeron/aeron-native/cmake-build-debug/lib/libaeron_driver.so:aeron_udp_channel_transport_loss_load)
udp_channel_transport_bindings.media=default,0x7f13feea93e0(/home/mike/sources/aeron/aeron-native/cmake-build-debug/lib/libaeron_driver.so:aeron_udp_channel_transport_bindings_default)
```
Where the order printed is the order that the bindings are applied, so there could be multiple `udp_channel_transport_bindings.interceptor` lines.