### PR TITLE
[Java] Print timestamp with stacktraces in DEFAULT_ERROR_HANDLER

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -521,12 +521,16 @@ public class Aeron implements AutoCloseable
         public static final ErrorHandler DEFAULT_ERROR_HANDLER =
             (throwable) ->
             {
-                throwable.printStackTrace();
-                if (throwable instanceof DriverTimeoutException)
+                synchronized (System.err)
                 {
-                    System.err.printf(
-                        "%n***%n*** timeout for the Media Driver - is it currently running? exiting%n***%n");
-                    System.exit(-1);
+                    System.err.println(System.currentTimeMillis() + " Exception:");
+                    throwable.printStackTrace();
+                    if (throwable instanceof DriverTimeoutException)
+                    {
+                        System.err.printf(
+                            "%n***%n*** timeout for the Media Driver - is it currently running? exiting%n***%n");
+                        System.exit(-1);
+                    }
                 }
             };
 


### PR DESCRIPTION
Could we print a timestamp along with stacktraces to help cross-reference them against an application's log file?  I haven't formatted the timestamp to keep it simple and avoid garbage.  It's using synchronized on System.err to keep the logging together.  It's going to take a synchronized lock on it in printStackTrace() anyway.