### PR TITLE
[Java] Reduce the chance of deadlock when shutdown hook writes to `System.err`

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -525,12 +525,12 @@ public class Aeron implements AutoCloseable
                 {
                     System.err.println(System.currentTimeMillis() + " Exception:");
                     throwable.printStackTrace();
-                    if (throwable instanceof DriverTimeoutException)
-                    {
-                        System.err.printf(
-                            "%n***%n*** timeout for the Media Driver - is it currently running? exiting%n***%n");
-                        System.exit(-1);
-                    }
+                }
+                if (throwable instanceof DriverTimeoutException)
+                {
+                    System.err.printf(
+                        "%n***%n*** timeout for the Media Driver - is it currently running? exiting%n***%n");
+                    System.exit(-1);
                 }
             };
 


### PR DESCRIPTION
A recent change made the default `ErrorHandler` synchronize on `System.err` while calling `System.exit`. Any shutdown hook registered with the JVM that attempted to write to `System.err` could produce a deadlock.
This change applies the synchronization block to the logging only.