### PR TITLE
[Java] Enforce stacktrace printing to `System.err`

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -521,14 +521,15 @@ public class Aeron implements AutoCloseable
         public static final ErrorHandler DEFAULT_ERROR_HANDLER =
             (throwable) ->
             {
-                synchronized (System.err)
+                final PrintStream err = System.err;
+                synchronized (err)
                 {
-                    System.err.println(System.currentTimeMillis() + " Exception:");
-                    throwable.printStackTrace();
+                    err.println(System.currentTimeMillis() + " Exception:");
+                    throwable.printStackTrace(err);
                 }
                 if (throwable instanceof DriverTimeoutException)
                 {
-                    System.err.printf(
+                    err.printf(
                         "%n***%n*** timeout for the Media Driver - is it currently running? exiting%n***%n");
                     System.exit(-1);
                 }


### PR DESCRIPTION
Enforce `DEFAULT_ERROR_HANDLER` to print stacktrace to the same `System.err` instance upon which synchronization is performed.