### PR TITLE
[Java] improve Image toString() information

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Image.java
+++ b/aeron-client/src/main/java/io/aeron/Image.java
@@ -799,7 +799,7 @@ public class Image
             "correlationId=" + correlationId +
             ", sessionId=" + sessionId +
             ", isClosed=" + isClosed +
-            ", isEos=" + isEos +
+            ", isEos=" + isEndOfStream() +
             ", initialTermId=" + initialTermId +
             ", termLength=" + termBufferLength() +
             ", joinPosition=" + joinPosition +


### PR DESCRIPTION
it might be a case when an image is end of stream but if you print out the image statistic (toStirng() method) you see
```
isEos=false
```