### PR TITLE
[C] Handle error TLS from DllMain

### DIFF
--- a/aeron-driver/src/main/c/util/aeron_error.h
+++ b/aeron-driver/src/main/c/util/aeron_error.h
@@ -32,8 +32,11 @@ void aeron_set_err(int errcode, const char *format, ...);
 
 const char *aeron_error_code_str(int errcode);
 
-#ifdef _MSC_VER
+#if defined(AERON_COMPILER_MSVC)
 void aeron_set_windows_error();
+bool aeron_error_dll_process_attach();
+void aeron_error_dll_thread_detach();
+void aeron_error_dll_process_detach();
 #endif
 
 #endif //AERON_ERROR_H


### PR DESCRIPTION
This is the change discussed [here](https://github.com/real-logic/aeron/pull/789#discussion_r360052814). When the C media driver is used as a DLL, the TLS slot used to handle the error state is now managed by `DllMain`, and the per-thread memory is correctly freed when a thread exits.