### PR TITLE
[C] Separate clocks in to separate compilcation unit (aeron_clock.{c,…

### DIFF
--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -132,6 +132,7 @@ SET(SOURCE
     util/aeron_strutil.c
     util/aeron_fileutil.c
     util/aeron_arrayutil.c
+    util/aeron_clock.c
     util/aeron_error.c
     util/aeron_math.c
     util/aeron_netutil.c
@@ -182,6 +183,7 @@ SET(HEADERS
     util/aeron_dlopen.h
     util/aeron_platform.h
     util/aeron_bitutil.h
+    util/aeron_clock.h
     util/aeron_math.h
     util/aeron_strutil.h
     util/aeron_fileutil.h

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <errno.h>
+#include "util/aeron_clock.h"
 #include "media/aeron_receive_channel_endpoint.h"
 #include "util/aeron_netutil.h"
 #include "util/aeron_error.h"
@@ -92,13 +93,13 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
     }
 
     int64_t free_to_reuse_timeout_ms = 0;
-    aeron_clock_func_t clock_func = aeron_driver_conductor_null_epoch_clock;
+    aeron_counters_manager_clock_func_t clock_func = aeron_driver_conductor_null_epoch_clock;
 
     if (context->counter_free_to_reuse_ns > 0)
     {
         free_to_reuse_timeout_ms = context->counter_free_to_reuse_ns / (1000 * 1000L);
         free_to_reuse_timeout_ms = free_to_reuse_timeout_ms <= 0 ? 1 : free_to_reuse_timeout_ms;
-        clock_func = aeron_epoch_clock;
+        clock_func = aeron_clock_epoch_time;
     }
 
     if (aeron_counters_manager_init(
@@ -122,7 +123,6 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
         &conductor->error_log,
         context->error_buffer,
         context->error_buffer_length,
-        context->epoch_clock,
         aeron_error_log_resource_linger,
         conductor) < 0)
     {
@@ -219,10 +219,8 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
     conductor->client_timeouts_counter = aeron_counter_addr(
         &conductor->counters_manager, AERON_SYSTEM_COUNTER_CLIENT_TIMEOUTS);
 
-    int64_t now_ns = context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
-    conductor->nano_clock = context->nano_clock;
-    conductor->epoch_clock = context->epoch_clock;
     conductor->time_of_last_timeout_check_ns = now_ns;
     conductor->time_of_last_to_driver_position_change_ns = now_ns;
     conductor->next_session_id = aeron_randomised_int32();
@@ -280,7 +278,7 @@ aeron_client_t *aeron_driver_conductor_get_or_add_client(aeron_driver_conductor_
 
                 client->heartbeat_timestamp.counter_id = client_heartbeat.counter_id;
                 client->heartbeat_timestamp.value_addr = client_heartbeat.value_addr;
-                aeron_counter_set_ordered(client->heartbeat_timestamp.value_addr, conductor->context->epoch_clock());
+                aeron_counter_set_ordered(client->heartbeat_timestamp.value_addr, aeron_clock_epoch_time());
 
                 client->client_liveness_timeout_ms = conductor->context->client_liveness_timeout_ns < 1000000 ?
                     1 : conductor->context->client_liveness_timeout_ns / 1000000;
@@ -928,7 +926,7 @@ aeron_ipc_publication_t *aeron_driver_conductor_get_or_add_ipc_publication(
                     client->publication_links.length++;
 
                     conductor->ipc_publications.array[conductor->ipc_publications.length++].publication = publication;
-                    publication->conductor_fields.managed_resource.time_of_last_state_change = conductor->nano_clock();
+                    publication->conductor_fields.managed_resource.time_of_last_state_change = aeron_clock_nano_time();
                 }
             }
         }
@@ -1138,7 +1136,7 @@ aeron_network_publication_t *aeron_driver_conductor_get_or_add_network_publicati
                     client->publication_links.length++;
 
                     conductor->network_publications.array[conductor->network_publications.length++].publication = publication;
-                    publication->conductor_fields.managed_resource.time_of_last_state_change = conductor->nano_clock();
+                    publication->conductor_fields.managed_resource.time_of_last_state_change = aeron_clock_nano_time();
                 }
             }
         }
@@ -1791,7 +1789,7 @@ int aeron_driver_conductor_do_work(void *clientd)
 {
     aeron_driver_conductor_t *conductor = (aeron_driver_conductor_t *)clientd;
     int work_count = 0;
-    int64_t now_ns = conductor->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     work_count += (int)aeron_mpsc_rb_read(
         &conductor->to_driver_commands, aeron_driver_conductor_on_command, conductor, 10);
@@ -1800,7 +1798,7 @@ int aeron_driver_conductor_do_work(void *clientd)
 
     if (now_ns >= (conductor->time_of_last_timeout_check_ns + (int64_t)conductor->context->timer_interval_ns))
     {
-        int64_t now_ms = conductor->epoch_clock();
+        int64_t now_ms = aeron_clock_epoch_time();
 
         aeron_mpsc_rb_consumer_heartbeat_time(&conductor->to_driver_commands, now_ms);
         aeron_driver_conductor_on_check_managed_resources(conductor, now_ns, now_ms);
@@ -2077,7 +2075,7 @@ int aeron_driver_conductor_on_add_ipc_publication(
         publication->log_file_name,
         publication->log_file_name_length);
 
-    int64_t now_ns = conductor->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0; i < conductor->ipc_subscriptions.length; i++)
     {
@@ -2177,7 +2175,7 @@ int aeron_driver_conductor_on_add_network_publication(
         publication->log_file_name,
         publication->log_file_name_length);
 
-    int64_t now_ns = conductor->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0; i < conductor->spy_subscriptions.length; i++)
     {
@@ -2297,7 +2295,7 @@ int aeron_driver_conductor_on_add_ipc_subscription(
     aeron_driver_conductor_on_subscription_ready(
         conductor, command->correlated.correlation_id, AERON_CHANNEL_STATUS_INDICATOR_NOT_ALLOCATED);
 
-    int64_t now_ns = conductor->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0; i < conductor->ipc_publications.length; i++)
     {
@@ -2382,7 +2380,7 @@ int aeron_driver_conductor_on_add_spy_subscription(
     aeron_driver_conductor_on_subscription_ready(
         conductor, command->correlated.correlation_id, AERON_CHANNEL_STATUS_INDICATOR_NOT_ALLOCATED);
 
-    int64_t now_ns = conductor->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0, length = conductor->network_publications.length; i < length; i++)
     {
@@ -2480,7 +2478,7 @@ int aeron_driver_conductor_on_add_network_subscription(
         aeron_driver_conductor_on_subscription_ready(
             conductor, command->correlated.correlation_id, endpoint->channel_status.counter_id);
 
-        int64_t now_ns = conductor->context->nano_clock();
+        int64_t now_ns = aeron_clock_nano_time();
 
         for (size_t i = 0, length = conductor->publication_images.length; i < length; i++)
         {
@@ -2609,7 +2607,7 @@ int aeron_driver_conductor_on_client_keepalive(aeron_driver_conductor_t *conduct
     if ((index = aeron_driver_conductor_find_client(conductor, client_id)) >= 0)
     {
         aeron_client_t *client = &conductor->clients.array[index];
-        aeron_counter_set_ordered(client->heartbeat_timestamp.value_addr, conductor->epoch_clock());
+        aeron_counter_set_ordered(client->heartbeat_timestamp.value_addr, aeron_clock_epoch_time());
     }
 
     return 0;
@@ -2979,7 +2977,7 @@ void aeron_driver_conductor_on_create_publication_image(void *clientd, void *ite
     }
 
     conductor->publication_images.array[conductor->publication_images.length++].image = image;
-    int64_t now_ns = conductor->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0, length = conductor->network_subscriptions.length; i < length; i++)
     {
@@ -3030,7 +3028,7 @@ void aeron_driver_conductor_on_linger_buffer(void *clientd, void *item)
 
         entry->buffer = command->item;
         entry->has_reached_end_of_life = false;
-        entry->timeout_ns = conductor->nano_clock() + AERON_DRIVER_CONDUCTOR_LINGER_RESOURCE_TIMEOUT_NS;
+        entry->timeout_ns = aeron_clock_nano_time() + AERON_DRIVER_CONDUCTOR_LINGER_RESOURCE_TIMEOUT_NS;
     }
 
     if (AERON_THREADING_MODE_IS_SHARED_OR_INVOKER(conductor->context->threading_mode))

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -268,9 +268,6 @@ typedef struct aeron_driver_conductor_stct
     int64_t *unblocked_commands_counter;
     int64_t *client_timeouts_counter;
 
-    aeron_clock_func_t nano_clock;
-    aeron_clock_func_t epoch_clock;
-
     int32_t next_session_id;
     int32_t publication_reserved_session_id_low;
     int32_t publication_reserved_session_id_high;

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -48,6 +48,7 @@
 #include "protocol/aeron_udp_protocol.h"
 #include "util/aeron_parse_util.h"
 #include "util/aeron_fileutil.h"
+#include "util/aeron_clock.h"
 #include "aeron_driver.h"
 #include "aeron_driver_context.h"
 #include "aeron_alloc.h"
@@ -813,9 +814,6 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->counters_metadata_buffer = NULL;
     _context->error_buffer = NULL;
 
-    _context->nano_clock = aeron_nano_clock;
-    _context->epoch_clock = aeron_epoch_clock;
-
     _context->conductor_idle_strategy_name = aeron_strndup("backoff", AERON_MAX_PATH);
     _context->shared_idle_strategy_name = aeron_strndup("backoff", AERON_MAX_PATH);
     _context->shared_network_idle_strategy_name = aeron_strndup("backoff", AERON_MAX_PATH);
@@ -1000,7 +998,7 @@ bool aeron_is_driver_active_with_cnc(
 
     while (0 == (cnc_version = aeron_cnc_version_volatile(metadata)))
     {
-        if (aeron_epoch_clock() > (now_ms + timeout_ms))
+        if (aeron_clock_epoch_time() > (now_ms + timeout_ms))
         {
             snprintf(buffer, sizeof(buffer) - 1, "ERROR: aeron cnc file version was 0 for timeout");
             return false;
@@ -1074,7 +1072,7 @@ bool aeron_is_driver_active(const char *dirname, int64_t timeout_ms, aeron_log_f
         snprintf(buffer, sizeof(buffer) - 1, "INFO: Aeron CnC file %s/%s exists", dirname, AERON_CNC_FILE);
         log_func(buffer);
 
-        result = aeron_is_driver_active_with_cnc(&cnc_map, timeout_ms, aeron_epoch_clock(), log_func);
+        result = aeron_is_driver_active_with_cnc(&cnc_map, timeout_ms, aeron_clock_epoch_time(), log_func);
 
         aeron_unmap(&cnc_map);
     }

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -125,9 +125,6 @@ typedef struct aeron_driver_context_stct
     uint8_t *counters_metadata_buffer;
     uint8_t *error_buffer;
 
-    aeron_clock_func_t nano_clock;
-    aeron_clock_func_t epoch_clock;
-
     aeron_spsc_concurrent_array_queue_t sender_command_queue;
     aeron_spsc_concurrent_array_queue_t receiver_command_queue;
     aeron_mpsc_concurrent_array_queue_t conductor_command_queue;

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -21,6 +21,7 @@
 
 #include "aeron_socket.h"
 #include <stdio.h>
+#include "util/aeron_clock.h"
 #include "util/aeron_arrayutil.h"
 #include "media/aeron_receive_channel_endpoint.h"
 #include "aeron_driver_receiver.h"
@@ -139,7 +140,7 @@ int aeron_driver_receiver_do_work(void *clientd)
 
     aeron_counter_add_ordered(receiver->total_bytes_received_counter, bytes_received);
 
-    int64_t now_ns = receiver->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     for (size_t i = 0, length = receiver->images.length; i < length; i++)
     {
@@ -406,7 +407,7 @@ int aeron_driver_receiver_add_pending_setup(
     entry->endpoint = endpoint;
     entry->session_id = session_id;
     entry->stream_id = stream_id;
-    entry->time_of_status_message_ns = receiver->context->nano_clock();
+    entry->time_of_status_message_ns = aeron_clock_nano_time();
     entry->is_periodic = false;
     if (NULL != control_addr)
     {

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -31,6 +31,7 @@ struct mmsghdr
 #endif
 
 #include "util/aeron_arrayutil.h"
+#include "util/aeron_clock.h"
 #include "media/aeron_send_channel_endpoint.h"
 #include "aeron_driver_sender.h"
 #include "aeron_driver_conductor_proxy.h"
@@ -118,7 +119,7 @@ int aeron_driver_sender_do_work(void *clientd)
     work_count += aeron_spsc_concurrent_array_queue_drain(
         sender->sender_proxy.command_queue, aeron_driver_sender_on_command, sender, 10);
 
-    int64_t now_ns = sender->context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
     int64_t bytes_received = 0;
     int bytes_sent = aeron_driver_sender_do_send(sender, now_ns);
     int poll_result;

--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -22,6 +22,7 @@
 #include "aeron_ipc_publication.h"
 #include "util/aeron_fileutil.h"
 #include "aeron_alloc.h"
+#include "util/aeron_clock.h"
 #include "protocol/aeron_udp_protocol.h"
 #include "aeron_driver_conductor.h"
 #include "util/aeron_error.h"
@@ -44,7 +45,7 @@ int aeron_ipc_publication_create(
     aeron_ipc_publication_t *_pub = NULL;
     const uint64_t usable_fs_space = context->usable_fs_space_func(context->aeron_dir);
     const uint64_t log_length = aeron_logbuffer_compute_log_length(params->term_length, context->file_page_size);
-    const int64_t now_ns = context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     *publication = NULL;
 
@@ -126,7 +127,6 @@ int aeron_ipc_publication_create(
     aeron_logbuffer_fill_default_header(
         _pub->mapped_raw_log.log_meta_data.addr, session_id, stream_id, initial_term_id);
 
-    _pub->nano_clock = context->nano_clock;
     _pub->conductor_fields.subscribable.array = NULL;
     _pub->conductor_fields.subscribable.length = 0;
     _pub->conductor_fields.subscribable.capacity = 0;

--- a/aeron-driver/src/main/c/aeron_ipc_publication.h
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.h
@@ -39,7 +39,6 @@ typedef struct aeron_ipc_publication_stct
     aeron_logbuffer_metadata_t *log_meta_data;
     aeron_position_t pub_lmt_position;
     aeron_position_t pub_pos_position;
-    aeron_clock_func_t nano_clock;
 
     struct aeron_ipc_publication_conductor_fields_stct
     {

--- a/aeron-driver/src/main/c/aeron_loss_detector.c
+++ b/aeron-driver/src/main/c/aeron_loss_detector.c
@@ -20,9 +20,10 @@
 #endif
 
 #include <stdlib.h>
+#include <stdint.h>
 #include "aeron_loss_detector.h"
-#include "aeronmd.h"
 #include "aeron_windows.h"
+#include "util/aeron_clock.h"
 
 int aeron_loss_detector_init(
     aeron_loss_detector_t *detector,
@@ -107,7 +108,7 @@ int aeron_feedback_delay_state_init(
 
     if (!is_seeded)
     {
-        aeron_srand48(aeron_nano_clock());
+        aeron_srand48(aeron_clock_nano_time());
         is_seeded = true;
     }
 
@@ -123,7 +124,7 @@ int64_t aeron_loss_detector_nak_multicast_delay_generator(aeron_feedback_delay_g
     return (int64_t)(state->optimal_delay.constant_t * log(x * state->optimal_delay.factor_t));
 }
 
-extern int64_t aeron_loss_detector_nak_unicast_delay_generator();
+extern int64_t aeron_loss_detector_nak_unicast_delay_generator(aeron_feedback_delay_generator_state_t *state);
 extern void aeron_loss_detector_on_gap(void *clientd, int32_t term_id, int32_t term_offset, size_t length);
 extern bool aeron_loss_detector_gaps_match(aeron_loss_detector_t *detector);
 extern void aeron_loss_detector_activate_gap(aeron_loss_detector_t *detector, int64_t now_ns);

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -26,6 +26,7 @@
 #include "concurrent/aeron_term_scanner.h"
 #include "util/aeron_netutil.h"
 #include "util/aeron_error.h"
+#include "util/aeron_clock.h"
 #include "aeron_network_publication.h"
 #include "aeron_alloc.h"
 #include "media/aeron_send_channel_endpoint.h"
@@ -65,7 +66,7 @@ int aeron_network_publication_create(
     aeron_network_publication_t *_pub = NULL;
     const uint64_t usable_fs_space = context->usable_fs_space_func(context->aeron_dir);
     const uint64_t log_length = aeron_logbuffer_compute_log_length(params->term_length, context->file_page_size);
-    const int64_t now_ns = context->nano_clock();
+    int64_t now_ns = aeron_clock_nano_time();
 
     *publication = NULL;
 
@@ -161,7 +162,6 @@ int aeron_network_publication_create(
 
     _pub->endpoint = endpoint;
     _pub->flow_control = flow_control_strategy;
-    _pub->nano_clock = context->nano_clock;
     _pub->conductor_fields.subscribable.array = NULL;
     _pub->conductor_fields.subscribable.length = 0;
     _pub->conductor_fields.subscribable.capacity = 0;
@@ -581,7 +581,7 @@ void aeron_network_publication_on_nak(
         term_offset,
         (size_t)length,
         (size_t)(publication->term_length_mask + 1L),
-        publication->nano_clock(),
+        aeron_clock_nano_time(),
         aeron_network_publication_resend,
         publication);
 }
@@ -603,7 +603,7 @@ inline static void aeron_network_publication_update_connected_status(
 void aeron_network_publication_on_status_message(
     aeron_network_publication_t *publication, const uint8_t *buffer, size_t length, struct sockaddr_storage *addr)
 {
-    const int64_t time_ns = publication->nano_clock();
+    const int64_t time_ns = aeron_clock_nano_time();
     publication->status_message_deadline_ns = time_ns + publication->connection_timeout_ns;
 
     if (!publication->has_receivers)
@@ -779,7 +779,7 @@ void aeron_network_publication_decref(void *clientd)
         const int64_t producer_position = aeron_network_publication_producer_position(publication);
 
         publication->conductor_fields.state = AERON_NETWORK_PUBLICATION_STATE_DRAINING;
-        publication->conductor_fields.time_of_last_activity_ns = publication->nano_clock();
+        publication->conductor_fields.time_of_last_activity_ns = aeron_clock_nano_time();
 
         aeron_counter_set_ordered(publication->pub_lmt_position.value_addr, producer_position);
         AERON_PUT_ORDERED(publication->log_meta_data->end_of_stream_position, producer_position);

--- a/aeron-driver/src/main/c/aeron_network_publication.h
+++ b/aeron-driver/src/main/c/aeron_network_publication.h
@@ -71,7 +71,6 @@ typedef struct aeron_network_publication_stct
     aeron_logbuffer_metadata_t *log_meta_data;
     aeron_send_channel_endpoint_t *endpoint;
     aeron_flow_control_strategy_t *flow_control;
-    aeron_clock_func_t nano_clock;
 
     char *log_file_name;
     int64_t term_window_length;

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -61,8 +61,6 @@ typedef struct aeron_publication_image_stct
 
     aeron_receive_channel_endpoint_t *endpoint;
     aeron_congestion_control_strategy_t *congestion_control;
-    aeron_clock_func_t nano_clock;
-    aeron_clock_func_t epoch_clock;
 
     aeron_loss_reporter_t *loss_reporter;
     aeron_loss_reporter_entry_offset_t loss_reporter_offset;

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -739,25 +739,6 @@ int aeron_driver_close(aeron_driver_t *driver);
 int aeron_delete_directory(const char *dirname);
 
 /**
- * Clock function used by aeron.
- */
-typedef int64_t (*aeron_clock_func_t)();
-
-/**
- * Return time in nanoseconds for machine. Is not wall clock time.
- *
- * @return nanoseconds since epoch for machine.
- */
-int64_t aeron_nano_clock();
-
-/**
- * Return time in milliseconds since epoch. Is wall clock time.
- *
- * @return milliseconds since epoch.
- */
-int64_t aeron_epoch_clock();
-
-/**
  * Function to return logging information.
  */
 typedef void (*aeron_log_func_t)(const char *);

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
@@ -24,20 +24,20 @@
 #include <errno.h>
 #include "util/aeron_error.h"
 #include "util/aeron_strutil.h"
+#include "util/aeron_clock.h"
 #include "aeron_alloc.h"
 #include "aeron_distinct_error_log.h"
 #include "aeron_atomic.h"
 #include "aeron_driver_context.h"
 
 int aeron_distinct_error_log_init(
-    aeron_distinct_error_log_t *log,
-    uint8_t *buffer,
+    aeron_distinct_error_log_t* log,
+    uint8_t* buffer,
     size_t buffer_size,
-    aeron_clock_func_t clock,
     aeron_resource_linger_func_t linger,
-    void *clientd)
+    void* clientd)
 {
-    if (NULL == log || NULL == clock || NULL == linger)
+    if (NULL == log || NULL == linger)
     {
         aeron_set_err(EINVAL, "%s:%d: %s", __FILE__, __LINE__, strerror(EINVAL));
         return -1;
@@ -53,7 +53,6 @@ int aeron_distinct_error_log_init(
 
     log->buffer = buffer;
     log->buffer_capacity = buffer_size;
-    log->clock = clock;
     log->linger_resource = linger;
     log->linger_resource_clientd = clientd;
     log->next_offset = 0;
@@ -177,7 +176,7 @@ int aeron_distinct_error_log_record(
         return -1;
     }
 
-    timestamp = log->clock();
+    timestamp = aeron_clock_epoch_time();
     aeron_distinct_error_log_observation_list_t *list = aeron_distinct_error_log_observation_list_load(log);
     size_t num_observations = list->num_observations;
     aeron_distinct_observation_t *observations = list->observations;

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
@@ -65,7 +65,6 @@ typedef struct aeron_distinct_error_log_stct
     aeron_distinct_error_log_observation_list_t *observation_list;
     size_t buffer_capacity;
     size_t next_offset;
-    aeron_clock_func_t clock;
     aeron_resource_linger_func_t linger_resource;
     void *linger_resource_clientd;
     AERON_MUTEX mutex;
@@ -73,12 +72,11 @@ typedef struct aeron_distinct_error_log_stct
 aeron_distinct_error_log_t;
 
 int aeron_distinct_error_log_init(
-    aeron_distinct_error_log_t *log,
-    uint8_t *buffer,
+    aeron_distinct_error_log_t* log,
+    uint8_t* buffer,
     size_t buffer_size,
-    aeron_clock_func_t clock,
     aeron_resource_linger_func_t linger,
-    void *clientd);
+    void* clientd);
 
 void aeron_distinct_error_log_close(aeron_distinct_error_log_t *log);
 

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -70,7 +70,6 @@ int aeron_send_channel_endpoint_create(
             aeron_udp_destination_tracker_init(
                 _endpoint->destination_tracker,
                 context->udp_channel_transport_bindings,
-                context->nano_clock,
                 destination_timeout_ns) < 0)
         {
             return -1;

--- a/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_destination_tracker.h
@@ -43,16 +43,14 @@ typedef struct aeron_udp_destination_tracker_stct
     destinations;
 
     bool is_manual_control_mode;
-    aeron_clock_func_t nano_clock;
     int64_t destination_timeout_ns;
     aeron_udp_channel_transport_bindings_t *transport_bindings;
 }
 aeron_udp_destination_tracker_t;
 
 int aeron_udp_destination_tracker_init(
-    aeron_udp_destination_tracker_t *tracker,
-    aeron_udp_channel_transport_bindings_t *transport_bindings,
-    aeron_clock_func_t clock,
+    aeron_udp_destination_tracker_t* tracker,
+    aeron_udp_channel_transport_bindings_t* transport_bindings,
     int64_t timeout_ns);
 int aeron_udp_destination_tracker_close(aeron_udp_destination_tracker_t *tracker);
 

--- a/aeron-driver/src/main/c/util/aeron_clock.c
+++ b/aeron-driver/src/main/c/util/aeron_clock.c
@@ -67,10 +67,10 @@ int64_t aeron_clock_nano_time()
 
 int64_t aeron_clock_cached_epoch_time(aeron_clock_cache_t *cache)
 {
-    return cache->cached_ms;
+    return cache->cached_epoch_time;
 }
 
 int64_t aeron_clock_cached_nano_time(aeron_clock_cache_t *cache)
 {
-    return cache->cached_ns;
+    return cache->cached_nano_time;
 }

--- a/aeron-driver/src/main/c/util/aeron_clock.h
+++ b/aeron-driver/src/main/c/util/aeron_clock.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2019 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+typedef struct aeron_clock_cache_stct
+{
+    // TODO: pad
+    int64_t cached_ms;
+    int64_t cached_ns;
+    // TODO: pad
+}
+aeron_clock_cache_t;
+
+int64_t aeron_clock_epoch_time();
+int64_t aeron_clock_nano_time();
+int64_t aeron_clock_cached_epoch_time(aeron_clock_cache_t *cache);
+int64_t aeron_clock_cached_nano_time(aeron_clock_cache_t *cache);

--- a/aeron-driver/src/main/c/util/aeron_clock.h
+++ b/aeron-driver/src/main/c/util/aeron_clock.h
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
+#ifndef AERON_CLOCK_H
+#define AERON_CLOCK_H
+
 #include <stdint.h>
+#include "util/aeron_bitutil.h"
 
 typedef struct aeron_clock_cache_stct
 {
-    // TODO: pad
-    int64_t cached_ms;
-    int64_t cached_ns;
-    // TODO: pad
+    uint8_t pre_pad[(2 * AERON_CACHE_LINE_LENGTH)];
+    int64_t cached_epoch_time;
+    int64_t cached_nano_time;
+    uint8_t post_pad[(2 * AERON_CACHE_LINE_LENGTH) - (2 * sizeof(int64_t))];
 }
 aeron_clock_cache_t;
 
@@ -29,3 +33,5 @@ int64_t aeron_clock_epoch_time();
 int64_t aeron_clock_nano_time();
 int64_t aeron_clock_cached_epoch_time(aeron_clock_cache_t *cache);
 int64_t aeron_clock_cached_nano_time(aeron_clock_cache_t *cache);
+
+#endif

--- a/aeron-driver/src/main/c/util/aeron_http_util.c
+++ b/aeron-driver/src/main/c/util/aeron_http_util.c
@@ -27,6 +27,7 @@
 #include "aeron_arrayutil.h"
 #include "concurrent/aeron_thread.h"
 #include "aeronmd.h"
+#include "util/aeron_clock.h"
 
 int aeron_http_parse_url(const char *url, aeron_http_parsed_url_t *parsed_url)
 {
@@ -305,11 +306,11 @@ int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64
     _response->content_length = 0;
     _response->parse_err = false;
 
-    const int64_t start_ns = aeron_nano_clock();
+    const int64_t start_ns = aeron_clock_nano_time();
 
     do
     {
-        const int64_t now_ns = aeron_nano_clock();
+        const int64_t now_ns = aeron_clock_nano_time();
 
         if (-1 != timeout_ns && now_ns > (start_ns + timeout_ns))
         {

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -19,15 +19,20 @@ endif ()
 
 include_directories(${AERON_DRIVER_SOURCE_PATH})
 
-set(TEST_HEADERS aeron_driver_conductor_test.h EmbeddedMediaDriver.h)
+set(TEST_HEADERS aeron_driver_conductor_test.h EmbeddedMediaDriver.h aeron_stub_clock.h)
 
 set(CMAKE_EXTRA_INCLUDE_FILES sys/socket.h)
 check_type_size("struct mmsghdr" STRUCT_MMSGHDR_TYPE_EXISTS)
 set(CMAKE_EXTRA_INCLUDE_FILES)
 
+add_library(aeron_stub_clock SHARED aeron_stub_clock.c aeron_stub_clock.h)
+target_include_directories(aeron_stub_clock
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
 function(aeron_driver_test name file)
     add_executable(${name} ${file} ${TEST_HEADERS})
-    target_link_libraries(${name} aeron_client aeron_driver ${GMOCK_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${AERON_LIB_WINSOCK_LIBS})
+    target_link_libraries(${name} ${ARGV2} aeron_client aeron_driver ${GMOCK_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${AERON_LIB_WINSOCK_LIBS})
     target_compile_definitions(${name} PUBLIC "_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
     if (STRUCT_MMSGHDR_TYPE_EXISTS)
         target_compile_definitions(${name} PUBLIC -DHAVE_STRUCT_MMSGHDR)
@@ -40,11 +45,11 @@ aeron_driver_test(spsc_rb_test aeron_spsc_rb_test.cpp)
 aeron_driver_test(mpsc_rb_test aeron_mpsc_rb_test.cpp)
 aeron_driver_test(broadcast_transmitter_test aeron_broadcast_transmitter_test.cpp)
 aeron_driver_test(counters_manager_test aeron_counters_manager_test.cpp)
-aeron_driver_test(distinct_error_log_test aeron_distinct_error_log_test.cpp)
-aeron_driver_test(driver_conductor_ipc_test aeron_driver_conductor_ipc_test.cpp)
-aeron_driver_test(driver_conductor_network_test aeron_driver_conductor_network_test.cpp)
-aeron_driver_test(driver_conductor_spy_test aeron_driver_conductor_spy_test.cpp)
-aeron_driver_test(driver_conductor_counter_test aeron_driver_conductor_counter_test.cpp)
+aeron_driver_test(distinct_error_log_test aeron_distinct_error_log_test.cpp aeron_stub_clock)
+aeron_driver_test(driver_conductor_ipc_test aeron_driver_conductor_ipc_test.cpp aeron_stub_clock)
+aeron_driver_test(driver_conductor_network_test aeron_driver_conductor_network_test.cpp aeron_stub_clock)
+aeron_driver_test(driver_conductor_spy_test aeron_driver_conductor_spy_test.cpp aeron_stub_clock)
+aeron_driver_test(driver_conductor_counter_test aeron_driver_conductor_counter_test.cpp aeron_stub_clock)
 aeron_driver_test(spsc_queue_test aeron_spsc_concurrent_array_queue_test.cpp)
 aeron_driver_test(mpsc_queue_test aeron_mpsc_concurrent_array_queue_test.cpp)
 aeron_driver_test(uri_test aeron_uri_test.cpp)
@@ -66,3 +71,5 @@ aeron_driver_test(driver_configuration_test aeron_driver_configuration_test.cpp)
 aeron_driver_test(system_test aeron_system_test.cpp)
 aeron_driver_test(udp_channel_transport_loss_test media/aeron_udp_channel_transport_loss_test.cpp)
 aeron_driver_test(strutil_test aeron_strutil_test.cpp)
+
+

--- a/aeron-driver/src/test/c/aeron_driver_conductor_counter_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_counter_test.cpp
@@ -29,9 +29,20 @@ public:
         m_key.fill(0);
     }
 
+    virtual void SetUp()
+    {
+        aeron_stub_clock_set_time_ms(0);
+    }
+
+    virtual void TearDown()
+    {
+        // Need this set up here as the aeron clock calls may happen before setup is called.
+        aeron_stub_clock_set_time_ms(0);
+    }
+
 protected:
     std::string m_label = COUNTER_LABEL;
-    std::array<uint8_t,COUNTER_KEY_LENGTH> m_key;
+    std::array<uint8_t, COUNTER_KEY_LENGTH> m_key;
     AtomicBuffer m_keyBuffer;
 };
 

--- a/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
@@ -23,6 +23,17 @@ public:
     DriverConductorNetworkTest() : DriverConductorTest()
     {
     }
+
+    virtual void SetUp()
+    {
+        aeron_stub_clock_set_time_ms(0);
+    }
+
+    virtual void TearDown()
+    {
+        // Need this set up here as the aeron clock calls may happen before setup is called.
+        aeron_stub_clock_set_time_ms(0);
+    }
 };
 
 TEST_F(DriverConductorNetworkTest, shouldBeAbleToAddSingleNetworkPublication)

--- a/aeron-driver/src/test/c/aeron_stub_clock.c
+++ b/aeron-driver/src/test/c/aeron_stub_clock.c
@@ -29,16 +29,6 @@ int64_t aeron_clock_nano_time()
     return ns_timestamp;
 }
 
-int64_t aeron_clock_cached_epoch_time(aeron_clock_cache_t *cache)
-{
-    return cache->cached_ms;
-}
-
-int64_t aeron_clock_cached_nano_time(aeron_clock_cache_t *cache)
-{
-    return cache->cached_ns;
-}
-
 void aeron_stub_clock_set_time_ms(int64_t time_ms)
 {
     ns_timestamp = time_ms * 1000000;

--- a/aeron-driver/src/test/c/aeron_stub_clock.c
+++ b/aeron-driver/src/test/c/aeron_stub_clock.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2019 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include "aeron_stub_clock.h"
+
+static int64_t ns_timestamp = 0;
+
+int64_t aeron_clock_epoch_time()
+{
+    return ns_timestamp / 1000000;
+}
+
+int64_t aeron_clock_nano_time()
+{
+    return ns_timestamp;
+}
+
+int64_t aeron_clock_cached_epoch_time(aeron_clock_cache_t *cache)
+{
+    return cache->cached_ms;
+}
+
+int64_t aeron_clock_cached_nano_time(aeron_clock_cache_t *cache)
+{
+    return cache->cached_ns;
+}
+
+void aeron_stub_clock_set_time_ms(int64_t time_ms)
+{
+    ns_timestamp = time_ms * 1000000;
+}
+
+void aeron_stub_clock_set_time_ns(int64_t time_ns)
+{
+    ns_timestamp = time_ns;
+}
+
+void aeron_stub_clock_increment_ms(int64_t offset_ms)
+{
+    aeron_stub_clock_set_time_ms(aeron_clock_epoch_time() + offset_ms);
+}

--- a/aeron-driver/src/test/c/aeron_stub_clock.h
+++ b/aeron-driver/src/test/c/aeron_stub_clock.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2019 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <util/aeron_clock.h>
+
+void aeron_stub_clock_set_time_ms(int64_t time_ms);
+void aeron_stub_clock_set_time_ns(int64_t time_ns);
+void aeron_stub_clock_increment_ms(int64_t offset_ms);

--- a/aeron-driver/src/test/c/aeron_stub_clock.h
+++ b/aeron-driver/src/test/c/aeron_stub_clock.h
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+#ifndef AERON_STUB_CLOCK_H
+#define AERON_STUB_CLOCK_H
+
 #include <util/aeron_clock.h>
 
 void aeron_stub_clock_set_time_ms(int64_t time_ms);
 void aeron_stub_clock_set_time_ns(int64_t time_ns);
 void aeron_stub_clock_increment_ms(int64_t offset_ms);
+
+#endif


### PR DESCRIPTION
…h}).  Remove all function pointer indirection to aeron_clock_func_t (and remove typedef).  Add aeron_stub_clock.{c,h} and use it within tests via a link time ordering to override the production clock implementation.

This is initially here for comment and will follow up this with changes to use the cached clocks in various places.