### PR TITLE
[Java] Increase timeouts when running in debug.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1214,7 +1214,7 @@ public class Aeron implements AutoCloseable
          */
         public long interServiceTimeoutNs()
         {
-            return interServiceTimeoutNs;
+            return CommonContext.checkDebugTimeout(interServiceTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -523,16 +523,15 @@ public class CommonContext implements Cloneable
             final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
             final String methodName = stackTrace[2].getMethodName();
             final String className = stackTrace[2].getClassName();
-
-            String message =
+            final String message =
                 "Using debug timeout [" + debugTimeout + "] for " + className + "::" + methodName + " replacing [" +
-                    timeout + "]";
+                timeout + "]";
 
             System.out.println(message);
 
             return debugTimeout;
         }
-        catch (NumberFormatException e)
+        catch (final NumberFormatException e)
         {
             return timeout;
         }

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -32,6 +32,7 @@ import java.nio.MappedByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
@@ -79,6 +80,12 @@ public class CommonContext implements Cloneable
      * Property name for driver timeout after which the driver is considered inactive.
      */
     public static final String DRIVER_TIMEOUT_PROP_NAME = "aeron.driver.timeout";
+
+    /**
+     * Property name for the timeout to use in debug mode.  By default this is not set and the configured
+     * timeouts will be used.  Setting this value enables the debug timeouts.
+     */
+    public static final String DEBUG_TIMEOUT_NS = "aeron.debug.timeout.ns";
 
     /**
      * Default timeout in which the driver is expected to respond or heartbeat.
@@ -489,7 +496,46 @@ public class CommonContext implements Cloneable
      */
     public long driverTimeoutMs()
     {
-        return driverTimeoutMs;
+        return checkDebugTimeout(driverTimeoutMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Override the supplied timeout with the debug value if it has been set and we are in debug mode.
+     *
+     * @param timeout The timeout value currently in use.
+     * @param timeUnit The units of the timeout value.  Debug timeout is specified in ns, so will be converted to this
+     *                 unit.
+     * @return The debug timeout if specified and we are being debugged or the supplied value if not.  Will be in
+     *         timeUnit units.
+     */
+    public static long checkDebugTimeout(final long timeout, final TimeUnit timeUnit)
+    {
+        final String debugTimeoutNsString = getProperty(DEBUG_TIMEOUT_NS);
+        if (null == debugTimeoutNsString || !SystemUtil.isDebuggerAttached())
+        {
+            return timeout;
+        }
+
+        try
+        {
+            final long debugTimeoutNs = Long.parseLong(debugTimeoutNsString);
+            final long debugTimeout = timeUnit.convert(debugTimeoutNs, TimeUnit.NANOSECONDS);
+            final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            final String methodName = stackTrace[2].getMethodName();
+            final String className = stackTrace[2].getClassName();
+
+            String message =
+                "Using debug timeout [" + debugTimeout + "] for " + className + "::" + methodName + " replacing [" +
+                    timeout + "]";
+
+            System.out.println(message);
+
+            return debugTimeout;
+        }
+        catch (NumberFormatException e)
+        {
+            return timeout;
+        }
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -997,7 +997,7 @@ public final class AeronCluster implements AutoCloseable
          */
         public long messageTimeoutNs()
         {
-            return messageTimeoutNs;
+            return CommonContext.checkDebugTimeout(messageTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -1272,7 +1272,7 @@ public final class MediaDriver implements AutoCloseable
          */
         public long clientLivenessTimeoutNs()
         {
-            return clientLivenessTimeoutNs;
+            return CommonContext.checkDebugTimeout(clientLivenessTimeoutNs, TimeUnit.NANOSECONDS);
         }
 
         /**


### PR DESCRIPTION
Basic implementation, intended for discussion.

Set aeron.debug.timeout.ns to some value.  For timeouts that need to be overridden, it calls `CommonContext::checkDebugTimeout` and replaces them with this value (if the debugger is attached).  It prints out a message to `stdout` when this occurs.  I didn't cover all of the timeouts, but enough that it allowed me to debug a couple of the cluster tests.
