### PR TITLE
[Java] Remove 'compile' and 'testCompile' scope dependencies from Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,7 @@ project(':aeron-driver') {
     mainClassName = 'io.aeron.driver.MediaDriver'
 
     dependencies {
-        compile project(':aeron-client')
+        api project(':aeron-client')
         testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -808,11 +808,11 @@ project(':aeron-all') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     dependencies {
-        compile project(':aeron-client')
-        compile project(':aeron-driver')
-        compile project(':aeron-archive')
-        compile project(':aeron-cluster')
-        compile project(':aeron-samples')
+        implementation project(':aeron-client')
+        implementation project(':aeron-driver')
+        implementation project(':aeron-archive')
+        implementation project(':aeron-cluster')
+        implementation project(':aeron-samples')
         implementation "org.hdrhistogram:HdrHistogram:${hdrHistogramVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -146,8 +146,6 @@ subprojects {
     jar.enabled = true
 
     dependencies {
-        checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
-
         api "org.agrona:agrona:${agronaVersion}"
 
         testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -379,8 +379,8 @@ project(':aeron-archive') {
     }
 
     dependencies {
-        compile project(':aeron-driver')
-        compile files('build/classes/java/generated')
+        api project(':aeron-driver')
+        api files('build/classes/java/generated')
         codecGeneration "uk.co.real-logic:sbe-tool:${sbeVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -910,7 +910,6 @@ task uploadToMavenCentral {
     dependsOn 'aeron-client:uploadArchives',
         'aeron-driver:uploadArchives',
         'aeron-samples:uploadArchives',
-        'aeron-system-tests:uploadArchives',
         'aeron-archive:uploadArchives',
         'aeron-all:uploadArchives',
         'aeron-all:uploadShadow',

--- a/build.gradle
+++ b/build.gradle
@@ -604,7 +604,7 @@ project(':aeron-agent') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     dependencies {
-        compile project(':aeron-cluster')
+        api project(':aeron-cluster')
         implementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -500,8 +500,8 @@ project(':aeron-cluster') {
     }
 
     dependencies {
-        compile project(':aeron-archive')
-        compile files('build/classes/java/generated')
+        api project(':aeron-archive')
+        api files('build/classes/java/generated')
         codecGeneration "uk.co.real-logic:sbe-tool:${sbeVersion}"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -760,7 +760,7 @@ project(':aeron-samples') {
 
 project(':aeron-system-tests') {
     dependencies {
-        compile project(':aeron-archive')
+        testImplementation project(':aeron-archive')
         testImplementation project(path: ':aeron-client', configuration: 'tests')
         testImplementation project(path: ':aeron-archive', configuration: 'tests')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -711,8 +711,8 @@ project(':aeron-samples') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
     dependencies {
-        compile project(':aeron-archive')
-        compile "org.hdrhistogram:HdrHistogram:${hdrHistogramVersion}"
+        api project(':aeron-archive')
+        implementation "org.hdrhistogram:HdrHistogram:${hdrHistogramVersion}"
     }
 
     uploadArchives {
@@ -813,6 +813,7 @@ project(':aeron-all') {
         compile project(':aeron-archive')
         compile project(':aeron-cluster')
         compile project(':aeron-samples')
+        implementation "org.hdrhistogram:HdrHistogram:${hdrHistogramVersion}"
     }
 
     javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,7 @@ project(':aeron-client') {
     apply plugin: 'biz.aQute.bnd.builder'
 
     dependencies {
-        testCompile "org.mockito:mockito-inline:${mockitoVersion}"
+        testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     }
 
     uploadArchives {
@@ -313,7 +313,7 @@ project(':aeron-driver') {
 
     dependencies {
         compile project(':aeron-client')
-        testCompile "org.mockito:mockito-inline:${mockitoVersion}"
+        testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     }
 
     uploadArchives {
@@ -761,8 +761,8 @@ project(':aeron-samples') {
 project(':aeron-system-tests') {
     dependencies {
         compile project(':aeron-archive')
-        testCompile project(path: ':aeron-client', configuration: 'tests')
-        testCompile project(path: ':aeron-archive', configuration: 'tests')
+        testImplementation project(path: ':aeron-client', configuration: 'tests')
+        testImplementation project(path: ':aeron-archive', configuration: 'tests')
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 }
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'idea'
     id 'io.freefair.javadoc-links' version '4.1.6' apply false
     id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
@@ -133,7 +133,7 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'maven'
     apply plugin: 'checkstyle'
     apply plugin: 'signing'
@@ -148,7 +148,7 @@ subprojects {
     dependencies {
         checkstyle "com.puppycrawl.tools:checkstyle:${checkstyleVersion}"
 
-        compile "org.agrona:agrona:${agronaVersion}"
+        api "org.agrona:agrona:${agronaVersion}"
 
         testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
         testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -607,7 +607,7 @@ project(':aeron-agent') {
 
     dependencies {
         compile project(':aeron-cluster')
-        compile "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+        implementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
     }
 
     jar {


### PR DESCRIPTION
In Gradle `compile` and `testCompile` dependency scopes were deprecated and will be removed in Gradle 7.0. They need to migrated to `implementation` or `api` for `compile` and `testImplementation` for `testCompile`.

**_Note: changing from `compile` to `implementation` makes a dependency non-transitive._**

See [API and implementation separation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation).