### PR TITLE
[Java] Use `Assertions.assertTimeoutPreemptively` to ensure that long running tests are aborted

### DIFF
--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static java.time.Duration.ofSeconds;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ArchiveLoggingAgentTest
 {
@@ -56,7 +56,7 @@ public class ArchiveLoggingAgentTest
     @Test
     public void shouldLogMessages() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             testDirName = Paths.get(IoUtil.tmpDirName(), "archive-test").toString();
             final File testDir = new File(testDirName);

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 
 public class ClusterLoggingAgentTest
@@ -77,7 +77,7 @@ public class ClusterLoggingAgentTest
     @Test
     public void shouldLogMessages() throws Exception
     {
-        assertTimeout(Duration.ofSeconds(10), () ->
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () ->
         {
             testDirName = Paths.get(IoUtil.tmpDirName(), "cluster-test").toString();
             final File testDir = new File(testDirName);

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
@@ -61,7 +61,7 @@ public class DriverLoggingAgentTest
     @Test
     public void shouldLogMessages() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MediaDriver.Context driverCtx = new MediaDriver.Context()
                 .errorHandler(Throwable::printStackTrace);

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -235,7 +235,7 @@ public class ArchiveTest
     @Test
     public void shouldListRegisteredRecordingSubscriptions()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int expectedStreamId = 7;
             final String channelOne = "aeron:ipc";

--- a/aeron-archive/src/test/java/io/aeron/archive/workloads/ArchiveReplayLoadTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/workloads/ArchiveReplayLoadTest.java
@@ -153,7 +153,7 @@ public class ArchiveReplayLoadTest
     @Test
     public void replay() throws InterruptedException
     {
-        assertTimeout(ofSeconds(TEST_DURATION_SEC * 2000), () ->
+        assertTimeoutPreemptively(ofSeconds(TEST_DURATION_SEC * 2000), () ->
         {
             final String channel = archive.context().recordingEventsChannel();
             final int streamId = archive.context().recordingEventsStreamId();

--- a/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
+++ b/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
@@ -219,7 +219,7 @@ public class ClientConductorTest
     @Test
     public void addPublicationShouldTimeoutWithoutReadyMessage()
     {
-        assertTimeout(ofSeconds(5),
+        assertTimeoutPreemptively(ofSeconds(5),
             () -> assertThrows(DriverTimeoutException.class, () -> conductor.addPublication(CHANNEL, STREAM_ID_1)));
     }
 
@@ -418,7 +418,7 @@ public class ClientConductorTest
     @Test
     public void addSubscriptionShouldTimeoutWithoutOperationSuccessful()
     {
-        assertTimeout(ofSeconds(5),
+        assertTimeoutPreemptively(ofSeconds(5),
             () -> assertThrows(DriverTimeoutException.class, () -> conductor.addSubscription(CHANNEL, STREAM_ID_1)));
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
@@ -29,7 +29,7 @@ public class AppointedLeaderTest
     @Test
     public void shouldConnectAndSendKeepAlive() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(LEADER_ID))
             {
@@ -46,7 +46,7 @@ public class AppointedLeaderTest
     @Test
     public void shouldEchoMessagesViaService() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(LEADER_ID))
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
@@ -74,7 +74,7 @@ public class AuthenticationTest
     @Test
     public void shouldAuthenticateOnConnectRequestWithEmptyCredentials()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0L);
             final MutableLong serviceSessionId = new MutableLong(-1L);
@@ -140,7 +140,7 @@ public class AuthenticationTest
     @Test
     public void shouldAuthenticateOnConnectRequestWithCredentials()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0L);
             final MutableLong serviceSessionId = new MutableLong(-1L);
@@ -206,7 +206,7 @@ public class AuthenticationTest
     @Test
     public void shouldAuthenticateOnChallengeResponse()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0L);
             final MutableLong serviceSessionId = new MutableLong(-1L);
@@ -280,7 +280,7 @@ public class AuthenticationTest
     @Test
     public void shouldRejectOnConnectRequest()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0L);
             final MutableLong serviceSessionId = new MutableLong(-1L);
@@ -346,7 +346,7 @@ public class AuthenticationTest
     @Test
     public void shouldRejectOnChallengeResponse()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0L);
             final MutableLong serviceSessionId = new MutableLong(-1L);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/BackupTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/BackupTest.java
@@ -30,7 +30,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndEmptyLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -54,7 +54,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -86,7 +86,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndThenSendMessages() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -118,7 +118,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterWithSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -155,7 +155,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterWithSnapshotAndNonEmptyLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -200,7 +200,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterWithSnapshotThenSend() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -245,7 +245,7 @@ public class BackupTest
     @Test
     public void shouldBeAbleToGetTimeOfNextBackupQuery() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -264,7 +264,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithReQuery() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -306,7 +306,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogAfterFailure() throws Exception
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -342,7 +342,7 @@ public class BackupTest
     @Test
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithFailure() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
@@ -96,7 +96,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceWithReplay()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
             final AtomicLong restartServiceMsgCounter = new AtomicLong(0);
@@ -129,7 +129,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceWithReplayAndContinue()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
             final AtomicLong restartServiceMsgCounter = new AtomicLong(0);
@@ -164,7 +164,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceFromEmptySnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 
@@ -202,7 +202,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceFromSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 
@@ -250,7 +250,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceFromSnapshotWithFurtherLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 
@@ -306,7 +306,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldTakeMultipleSnapshots() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 
@@ -335,7 +335,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceWithTimerFromSnapshotWithFurtherLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 
@@ -392,7 +392,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldTriggerRescheduledTimerAfterReplay()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger triggeredTimersCounter = new AtomicInteger();
 
@@ -426,7 +426,7 @@ public class ClusterNodeRestartTest
     @Test
     public void shouldRestartServiceTwiceWithTombstoneSnapshotAndFurtherLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicLong serviceMsgCounter = new AtomicLong(0);
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
@@ -92,7 +92,7 @@ public class ClusterNodeTest
     @Test
     public void shouldEchoMessageViaServiceUsingDirectOffer()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
             final String msg = "Hello World!";
@@ -129,7 +129,7 @@ public class ClusterNodeTest
     @Test
     public void shouldEchoMessageViaServiceUsingTryClaim()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
             final String msg = "Hello World!";
@@ -180,7 +180,7 @@ public class ClusterNodeTest
     @Test
     public void shouldScheduleEventInService()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
             final String msg = "Hello World!";
@@ -218,7 +218,7 @@ public class ClusterNodeTest
     @Test
     public void shouldSendResponseAfterServiceMessage()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
             final String msg = "Hello World!";

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -40,7 +40,7 @@ public class ClusterTest
     @Test
     public void shouldStopFollowerAndRestartFollower() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -61,7 +61,7 @@ public class ClusterTest
     @Test
     public void shouldNotifyClientOfNewLeader() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -77,7 +77,7 @@ public class ClusterTest
     @Test
     public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -111,7 +111,7 @@ public class ClusterTest
     @Test
     public void shouldShutdownClusterAndRestartWithSnapshots() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -153,7 +153,7 @@ public class ClusterTest
     @Test
     public void shouldAbortClusterAndRestart() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -195,7 +195,7 @@ public class ClusterTest
     @Test
     public void shouldAbortClusterOnTerminationTimeout() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -230,7 +230,7 @@ public class ClusterTest
     @Test
     public void shouldEchoMessagesThenContinueOnNewLeader() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -267,7 +267,7 @@ public class ClusterTest
     @Test
     public void shouldStopLeaderAndRestartAsFollower() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -289,7 +289,7 @@ public class ClusterTest
     @Test
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -319,7 +319,7 @@ public class ClusterTest
     @Test
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader() throws Exception
     {
-        assertTimeout(ofSeconds(60), () ->
+        assertTimeoutPreemptively(ofSeconds(60), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -353,7 +353,7 @@ public class ClusterTest
     @Test
     public void shouldAcceptMessagesAfterSingleNodeCleanRestart() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -384,7 +384,7 @@ public class ClusterTest
     @Test
     public void shouldReplaySnapshotTakenWhileDown() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -420,7 +420,7 @@ public class ClusterTest
     @Test
     public void shouldTolerateMultipleLeaderFailures() throws Exception
     {
-        assertTimeout(ofSeconds(45), () ->
+        assertTimeoutPreemptively(ofSeconds(45), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -451,7 +451,7 @@ public class ClusterTest
     @Test
     public void shouldAcceptMessagesAfterTwoNodeCleanRestart() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -487,7 +487,7 @@ public class ClusterTest
     @Test
     public void shouldHaveOnlyOneCommitPositionCounter() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -509,7 +509,7 @@ public class ClusterTest
     @Test
     public void shouldCallOnRoleChangeOnBecomingLeader() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -538,7 +538,7 @@ public class ClusterTest
     @Test
     public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -567,7 +567,7 @@ public class ClusterTest
     @Test
     public void shouldRecoverWhileMessagesContinue() throws Exception
     {
-        assertTimeout(ofSeconds(60), () ->
+        assertTimeoutPreemptively(ofSeconds(60), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -604,7 +604,7 @@ public class ClusterTest
     @Test
     public void shouldCatchupFromEmptyLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -629,7 +629,7 @@ public class ClusterTest
     @Test
     public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -684,7 +684,7 @@ public class ClusterTest
     @Test
     public void shouldCatchUpAfterFollowerMissesOneMessage() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             shouldCatchUpAfterFollowerMissesMessage(TestMessages.NO_OP);
         });
@@ -693,7 +693,7 @@ public class ClusterTest
     @Test
     public void shouldCatchUpAfterFollowerMissesTimerRegistration() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             shouldCatchUpAfterFollowerMissesMessage(TestMessages.REGISTER_TIMER);
         });
@@ -702,7 +702,7 @@ public class ClusterTest
     @Test
     public void shouldCatchUpTwoFreshNodesAfterRestart() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -750,7 +750,7 @@ public class ClusterTest
     @Test
     public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -835,7 +835,7 @@ public class ClusterTest
     @Test
     public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne() throws Exception
     {
-        assertTimeout(ofSeconds(30), () ->
+        assertTimeoutPreemptively(ofSeconds(30), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
@@ -82,7 +82,7 @@ public class ClusterTimerTest
     @Test
     public void shouldRestartServiceWithTimerFromSnapshotWithFurtherLog()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger triggeredTimersCounter = new AtomicInteger();
 
@@ -145,7 +145,7 @@ public class ClusterTimerTest
     @Test
     public void shouldTriggerRescheduledTimerAfterReplay()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger triggeredTimersCounter = new AtomicInteger();
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -29,7 +29,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldQueryClusterMembers() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -46,7 +46,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshots() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -69,7 +69,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsThenSend() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -93,7 +93,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithCatchup() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -115,7 +115,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeWithEmptySnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -140,7 +140,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -171,7 +171,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotThenSend() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -208,7 +208,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldRemoveFollower() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -232,7 +232,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldRemoveLeader() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {
@@ -257,7 +257,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldRemoveLeaderAfterDynamicNodeJoined() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(3, 1))
             {
@@ -285,7 +285,7 @@ public class DynamicMembershipTest
     @Test
     public void shouldJoinDynamicNodeToSingleStaticLeader() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startCluster(1, 1))
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/MultiNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/MultiNodeTest.java
@@ -20,14 +20,14 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class MultiNodeTest
 {
     @Test
     public void shouldElectAppointedLeaderWithThreeNodesWithNoReplayNoSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int appointedLeaderIndex = 1;
 
@@ -46,7 +46,7 @@ public class MultiNodeTest
     @Test
     public void shouldReplayWithAppointedLeaderWithThreeNodesWithNoSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int appointedLeaderIndex = 1;
 
@@ -77,7 +77,7 @@ public class MultiNodeTest
     @Test
     public void shouldCatchUpWithAppointedLeaderWithThreeNodesWithNoSnapshot() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int appointedLeaderIndex = 1;
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/MultipleClusteredServicesTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/MultipleClusteredServicesTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Duration.ofSeconds;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class MultipleClusteredServicesTest
 {
@@ -71,7 +71,7 @@ public class MultipleClusteredServicesTest
     @Test
     public void testMultiService()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final List<TestCluster.NodeContext> nodeContexts = new ArrayList<>();
             final List<TestCluster.ServiceContext> serviceContexts = new ArrayList<>();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -19,14 +19,14 @@ import org.junit.jupiter.api.Test;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static java.time.Duration.ofSeconds;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ServiceIpcIngressTest
 {
     @Test
     public void shouldEchoIpcMessages() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -20,14 +20,14 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class SingleNodeTest
 {
     @Test
     public void shouldStartCluster() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
             {
@@ -42,7 +42,7 @@ public class SingleNodeTest
     @Test
     public void shouldSendMessagesToCluster() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
             {
@@ -62,7 +62,7 @@ public class SingleNodeTest
     @Test
     public void shouldReplayLog() throws Exception
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
@@ -148,7 +148,7 @@ public class StartFromTruncatedRecordingLogTest
     @Test
     public void shouldBeAbleToStartClusterFromTruncatedRecordingLog() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             stopAndStartClusterWithTruncationOfRecordingLog();
             assertClusterIsFunctioningCorrectly();

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -48,7 +48,7 @@ import static org.agrona.BitUtil.align;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.*;
 
 public class ReceiverTest
@@ -183,7 +183,7 @@ public class ReceiverTest
     @Test
     public void shouldCreateRcvTermAndSendSmOnSetup() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
             receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);

--- a/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
@@ -34,7 +34,7 @@ import java.nio.ByteBuffer;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.*;
 
 public class SelectorAndTransportTest
@@ -115,7 +115,7 @@ public class SelectorAndTransportTest
     @Test
     public void shouldHandleBasicSetupAndTearDown()
     {
-        assertTimeout(ofSeconds(1), () ->
+        assertTimeoutPreemptively(ofSeconds(1), () ->
         {
             receiveChannelEndpoint = new ReceiveChannelEndpoint(
                 RCV_DST, mockDispatcher, mockReceiveStatusIndicator, context);
@@ -133,7 +133,7 @@ public class SelectorAndTransportTest
     @Test
     public void shouldSendEmptyDataFrameUnicastFromSourceToReceiver()
     {
-        assertTimeout(ofSeconds(1), () ->
+        assertTimeoutPreemptively(ofSeconds(1), () ->
         {
             final MutableInteger dataHeadersReceived = new MutableInteger(0);
 
@@ -186,7 +186,7 @@ public class SelectorAndTransportTest
     @Test
     public void shouldSendMultipleDataFramesPerDatagramUnicastFromSourceToReceiver()
     {
-        assertTimeout(ofSeconds(1), () ->
+        assertTimeoutPreemptively(ofSeconds(1), () ->
         {
             final MutableInteger dataHeadersReceived = new MutableInteger(0);
 
@@ -252,7 +252,7 @@ public class SelectorAndTransportTest
     @Test
     public void shouldHandleSmFrameFromReceiverToSender()
     {
-        assertTimeout(ofSeconds(1), () ->
+        assertTimeoutPreemptively(ofSeconds(1), () ->
         {
             final MutableInteger controlMessagesReceived = new MutableInteger(0);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/TerminateDriverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TerminateDriverTest.java
@@ -31,7 +31,7 @@ public class TerminateDriverTest
     @Test
     public void shouldCallTerminationHookUponValidRequest()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicBoolean hasTerminated = new AtomicBoolean(false);
             final MediaDriver.Context ctx = new MediaDriver.Context()
@@ -59,7 +59,7 @@ public class TerminateDriverTest
     @Test
     public void shouldNotCallTerminationHookUponInvalidRequest()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicBoolean hasTerminated = new AtomicBoolean(false);
             final AtomicBoolean hasCalledTerminationValidator = new AtomicBoolean(false);

--- a/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class BufferClaimMessageTest
 {
@@ -68,7 +68,7 @@ public class BufferClaimMessageTest
     @MethodSource("channels")
     public void shouldReceivePublishedMessageWithInterleavedAbort(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableInteger fragmentCount = new MutableInteger();
             final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> fragmentCount.value++;
@@ -115,7 +115,7 @@ public class BufferClaimMessageTest
     @MethodSource("channels")
     public void shouldTransferReservedValue(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final BufferClaim bufferClaim = new BufferClaim();
 

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
@@ -128,14 +128,14 @@ public class ChannelEndpointStatusTest
     @Test
     public void shouldErrorBadUri()
     {
-        assertTimeout(ofSeconds(5), () ->
+        assertTimeoutPreemptively(ofSeconds(5), () ->
             assertThrows(RegistrationException.class, () -> clientA.addSubscription("bad uri", STREAM_ID)));
     }
 
     @Test
     public void shouldBeAbleToQueryChannelStatusForSubscription()
     {
-        assertTimeout(ofSeconds(5), () ->
+        assertTimeoutPreemptively(ofSeconds(5), () ->
         {
             final Subscription subscription = clientA.addSubscription(URI, STREAM_ID);
 
@@ -152,7 +152,7 @@ public class ChannelEndpointStatusTest
     @Test
     public void shouldBeAbleToQueryChannelStatusForPublication()
     {
-        assertTimeout(ofSeconds(5), () ->
+        assertTimeoutPreemptively(ofSeconds(5), () ->
         {
             final Publication publication = clientA.addPublication(URI, STREAM_ID);
 

--- a/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ControlledMessageTest
 {
@@ -56,7 +56,7 @@ public class ControlledMessageTest
     @Test
     public void shouldReceivePublishedMessage()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID);
                 Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))

--- a/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
@@ -80,7 +80,7 @@ public class CounterTest
     @Test
     public void shouldBeAbleToAddCounter()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -105,7 +105,7 @@ public class CounterTest
     @Test
     public void shouldBeAbleToAddReadableCounterWithinHandler()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             availableCounterHandlerClientB = this::createReadableCounter;
 
@@ -135,7 +135,7 @@ public class CounterTest
     @Test
     public void shouldCloseReadableCounterOnUnavailableCounter()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             availableCounterHandlerClientB = this::createReadableCounter;
             unavailableCounterHandlerClientB = this::unavailableCounterHandler;

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ExclusivePublicationTest
 {
@@ -68,7 +68,7 @@ public class ExclusivePublicationTest
     @MethodSource("channels")
     public void shouldPublishFromIndependentExclusivePublications(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
                 ExclusivePublication publicationOne = aeron.addExclusivePublication(channel, STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/FlowControlStrategiesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FlowControlStrategiesTest.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static java.time.Duration.ofSeconds;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
@@ -114,7 +114,7 @@ public class FlowControlStrategiesTest
     @Test
     public void shouldSpinUpAndShutdown()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -133,7 +133,7 @@ public class FlowControlStrategiesTest
     @Test
     public void shouldTimeoutImageWhenBehindForTooLongWithMaxMulticastFlowControlStrategy()
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
 
@@ -206,7 +206,7 @@ public class FlowControlStrategiesTest
     @Test
     public void shouldSlowDownWhenBehindWithMinMulticastFlowControlStrategy()
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int numMessagesLeftToSend = numMessagesToSend;
@@ -268,7 +268,7 @@ public class FlowControlStrategiesTest
     @Test
     public void shouldRemoveDeadReceiverWithMinMulticastFlowControlStrategy()
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int numMessagesLeftToSend = numMessagesToSend;
@@ -329,7 +329,7 @@ public class FlowControlStrategiesTest
     {
         TestMediaDriver.notSupportedOnCMediaDriverYet("Preferred multicast flow control strategy not available");
 
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int numMessagesLeftToSend = numMessagesToSend;
@@ -404,7 +404,7 @@ public class FlowControlStrategiesTest
     {
         TestMediaDriver.notSupportedOnCMediaDriverYet("Preferred multicast flow control strategy not available");
 
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int numMessagesLeftToSend = numMessagesToSend;

--- a/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
@@ -35,7 +35,7 @@ import static io.aeron.logbuffer.FrameDescriptor.END_FRAG_FLAG;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.*;
 
 public class FragmentedMessageTest
@@ -73,7 +73,7 @@ public class FragmentedMessageTest
     @MethodSource("channels")
     public void shouldReceivePublishedMessage(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final FragmentAssembler assembler = new FragmentAssembler(mockFragmentHandler);
 

--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -37,7 +37,7 @@ import static io.aeron.test.LossReportTestUtil.verifyLossOccurredForStream;
 import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class GapFillLossTest
 {
@@ -58,7 +58,7 @@ public class GapFillLossTest
     @Test
     public void shouldGapFillWhenLossOccurs() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(MSG_LENGTH));
             srcBuffer.setMemory(0, MSG_LENGTH, (byte)7);

--- a/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
@@ -65,7 +65,7 @@ public class ImageAvailabilityTest
     @MethodSource("channels")
     public void shouldCallImageHandlers(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger unavailableImageCount = new AtomicInteger();
             final AtomicInteger availableImageCount = new AtomicInteger();
@@ -121,7 +121,7 @@ public class ImageAvailabilityTest
     @MethodSource("channels")
     public void shouldCallImageHandlersWithPublisherOnDifferentClient(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger unavailableImageCount = new AtomicInteger();
             final AtomicInteger availableImageCount = new AtomicInteger();

--- a/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
@@ -29,7 +29,7 @@ import java.nio.ByteBuffer;
 import static io.aeron.Publication.MAX_POSITION_EXCEEDED;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class MaxPositionPublicationTest
 {
@@ -56,7 +56,7 @@ public class MaxPositionPublicationTest
     @Test
     public void shouldPublishFromExclusivePublication()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int initialTermId = -777;
             final int termLength = 64 * 1024;

--- a/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 
 import static java.time.Duration.ofSeconds;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class MemoryOrderingTest
@@ -65,7 +65,7 @@ public class MemoryOrderingTest
     @Test
     public void shouldReceiveMessagesInOrderWithFirstLongWordIntact() throws Exception
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
             srcBuffer.setMemory(0, MESSAGE_LENGTH, (byte)7);
@@ -118,7 +118,7 @@ public class MemoryOrderingTest
     @Test
     public void shouldReceiveMessagesInOrderWithFirstLongWordIntactFromExclusivePublication() throws Exception
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
             srcBuffer.setMemory(0, MESSAGE_LENGTH, (byte)7);

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.*;
 
 public class MultiDestinationCastTest
@@ -118,7 +118,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldSpinUpAndShutdownWithDynamic()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -138,7 +138,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldSpinUpAndShutdownWithManual()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -163,7 +163,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldSendToTwoPortsWithDynamic()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = MESSAGES_PER_TERM * 3;
 
@@ -207,7 +207,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldSendToTwoPortsWithDynamicSingleDriver()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = MESSAGES_PER_TERM * 3;
 
@@ -251,7 +251,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldSendToTwoPortsWithManualSingleDriver()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = MESSAGES_PER_TERM * 3;
 
@@ -294,7 +294,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldManuallyRemovePortDuringActiveStream() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = MESSAGES_PER_TERM * 3;
             final int numMessageForSub2 = 10;
@@ -358,7 +358,7 @@ public class MultiDestinationCastTest
     @Test
     public void shouldManuallyAddPortDuringActiveStream() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = MESSAGES_PER_TERM * 3;
             final int numMessageForSub2 = 10;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -126,7 +126,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void subscriptionCloseShouldAlsoCloseMediaDriverPorts()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -151,7 +151,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSpinUpAndShutdownWithUnicast()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -171,7 +171,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSpinUpAndShutdownWithMulticast()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -193,7 +193,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSpinUpAndShutdownWithDynamicMdc()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -213,7 +213,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSendToSingleDestinationSubscriptionWithUnicast()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
 
@@ -249,7 +249,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSendToSingleDestinationMultipleSubscriptionsWithUnicast()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             final String tags = "1,2";
@@ -298,7 +298,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSendToSingleDestinationSubscriptionWithMulticast()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
 
@@ -334,7 +334,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSendToSingleDestinationSubscriptionWithDynamicMdc()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
 
@@ -370,7 +370,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldSendToMultipleDestinationSubscriptionWithSameStream()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
             final int numMessagesToSendForA = numMessagesToSend / 2;
@@ -464,7 +464,7 @@ public class MultiDestinationSubscriptionTest
     @Test
     public void shouldMergeStreamsFromMultiplePublicationsWithSameParams()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSend = 30;
             final int numMessagesToSendForA = numMessagesToSend / 2;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDriverTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class MultiDriverTest
 {
@@ -108,7 +108,7 @@ public class MultiDriverTest
     @Test
     public void shouldSpinUpAndShutdown()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -127,7 +127,7 @@ public class MultiDriverTest
     @Test
     public void shouldJoinExistingStreamWithLockStepSendingReceiving() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSendPreJoin = NUM_MESSAGES_PER_TERM / 2;
             final int numMessagesToSendPostJoin = NUM_MESSAGES_PER_TERM;
@@ -202,7 +202,7 @@ public class MultiDriverTest
     @Test
     public void shouldJoinExistingIdleStreamWithLockStepSendingReceiving() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int numMessagesToSendPreJoin = 0;
             final int numMessagesToSendPostJoin = NUM_MESSAGES_PER_TERM;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.*;
 
 public class MultiSubscriberTest
@@ -55,7 +55,7 @@ public class MultiSubscriberTest
     @Test
     public void shouldReceiveMessageOnSeparateSubscriptions()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final FragmentHandler mockFragmentHandlerOne = mock(FragmentHandler.class);
             final FragmentHandler mockFragmentHandlerTwo = mock(FragmentHandler.class);

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -113,7 +113,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldReceivePublishedMessageViaPollFile(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             launch(channel);
 
@@ -155,7 +155,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldContinueAfterBufferRollover(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numMessagesInTermBuffer = 64;
@@ -203,7 +203,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldContinueAfterRolloverWithMinimalPaddingHeader(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int termBufferLengthMinusPaddingHeader = termBufferLength - HEADER_LENGTH;
@@ -307,7 +307,7 @@ public class PubAndSubTest
     {
         assumeFalse(IPC_URI.equals(channel));
 
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numMessagesInTermBuffer = 64;
@@ -366,7 +366,7 @@ public class PubAndSubTest
     {
         assumeFalse(IPC_URI.equals(channel));
 
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numMessagesInTermBuffer = 64;
@@ -429,7 +429,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldContinueAfterBufferRolloverBatched(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numBatchesPerTerm = 4;
@@ -504,7 +504,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldContinueAfterBufferRolloverWithPadding(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             /*
              * 65536 bytes in the buffer
@@ -557,7 +557,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldContinueAfterBufferRolloverWithPaddingBatched(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             /*
              * 65536 bytes in the buffer
@@ -615,7 +615,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldReceiveOnlyAfterSendingUpToFlowControlLimit(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             /*
              * The subscriber will flow control before an entire term buffer. So, send until can't send no 'more.
@@ -686,7 +686,7 @@ public class PubAndSubTest
         // Immediate re-subscription currently doesn't work in the C media driver
         assumeFalse(TestMediaDriver.shouldRunCMediaDriver());
 
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numMessagesInTermBuffer = 64;
@@ -781,7 +781,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldFragmentExactMessageLengthsCorrectly(final String channel)
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int termBufferLength = 64 * 1024;
             final int numFragmentsPerMessage = 2;
@@ -832,7 +832,7 @@ public class PubAndSubTest
     @MethodSource("channels")
     public void shouldNoticeDroppedSubscriber(final String channel) throws Exception
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             launch(channel);
 

--- a/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class PublicationUnblockTest
 {
@@ -72,7 +72,7 @@ public class PublicationUnblockTest
     @MethodSource("channels")
     public void shouldUnblockNonCommittedMessage(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableInteger fragmentCount = new MutableInteger();
             final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> fragmentCount.value++;

--- a/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
@@ -35,7 +35,7 @@ import java.util.Random;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 
 public class PublishFromArbitraryPositionTest
@@ -74,7 +74,7 @@ public class PublishFromArbitraryPositionTest
     @Test
     public void shouldPublishFromArbitraryJoinPosition() throws Exception
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final Random rnd = new Random();
             rnd.setSeed(seed);

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificSubscriptionTest.java
@@ -75,7 +75,7 @@ public class SessionSpecificSubscriptionTest
     @Test
     public void shouldSubscribeToSpecificSessionIdsAndWildcard()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (Subscription subscriptionOne = aeron.addSubscription(channelUriWithSessionIdOne, STREAM_ID);
                 Subscription subscriptionTwo = aeron.addSubscription(channelUriWithSessionIdTwo, STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -101,7 +101,7 @@ public class SpySimulatedConnectionTest
     @MethodSource("channels")
     public void shouldNotSimulateConnectionWhenNotConfiguredTo(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch();
 
@@ -122,7 +122,7 @@ public class SpySimulatedConnectionTest
     @MethodSource("channels")
     public void shouldSimulateConnectionWithNoNetworkSubscriptions(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
 
@@ -174,7 +174,7 @@ public class SpySimulatedConnectionTest
     @MethodSource("channels")
     public void shouldSimulateConnectionWithSlowNetworkSubscription(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int messagesLeftToSend = messagesToSend;
@@ -225,7 +225,7 @@ public class SpySimulatedConnectionTest
     @MethodSource("channels")
     public void shouldSimulateConnectionWithLeavingNetworkSubscription(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
             int messagesLeftToSend = messagesToSend;

--- a/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
@@ -33,7 +33,7 @@ import static io.aeron.SystemTest.spyForChannel;
 import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class SpySubscriptionTest
 {
@@ -74,7 +74,7 @@ public class SpySubscriptionTest
     @MethodSource("channels")
     public void shouldReceivePublishedMessage(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
                 Subscription spy = aeron.addSubscription(spyForChannel(channel), STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/StopStartSecondSubscriberTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/StopStartSecondSubscriberTest.java
@@ -98,7 +98,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldSpinUpAndShutdown()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);
         });
@@ -107,7 +107,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldReceivePublishedMessage()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launch(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);
 
@@ -148,7 +148,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldReceiveMessagesAfterStopStartOnSameChannelSameStream()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL1, STREAM_ID1);
         });
@@ -157,7 +157,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldReceiveMessagesAfterStopStartOnSameChannelDifferentStreams()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL1, STREAM_ID2);
         });
@@ -166,7 +166,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldReceiveMessagesAfterStopStartOnDifferentChannelsSameStream()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID1);
         });
@@ -175,7 +175,7 @@ public class StopStartSecondSubscriberTest
     @Test
     public void shouldReceiveMessagesAfterStopStartOnDifferentChannelsDifferentStreams()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);
         });

--- a/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class TwoBufferOfferMessageTest
 {
@@ -53,7 +53,7 @@ public class TwoBufferOfferMessageTest
     @Test
     public void shouldTransferUnfragmentedTwoPartMessage()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[256]);
             final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);
@@ -91,7 +91,7 @@ public class TwoBufferOfferMessageTest
     @Test
     public void shouldTransferFragmentedTwoPartMessage()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[32 + driver.context().mtuLength()]);
             final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -76,7 +76,7 @@ public class UntetheredSubscriptionTest
     @MethodSource("channels")
     public void shouldBecomeUnavailableWhenNotKeepingUp(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> {};
             final AtomicBoolean unavailableCalled = new AtomicBoolean();
@@ -137,7 +137,7 @@ public class UntetheredSubscriptionTest
     @MethodSource("channels")
     public void shouldRejoinAfterResting(final String channel)
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final AtomicInteger unavailableImageCount = new AtomicInteger();
             final AtomicInteger availableImageCount = new AtomicInteger();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
@@ -75,7 +75,7 @@ public class ArchiveAuthenticationTest
     @Test
     public void shouldBeAbleToRecordWithDefaultCredentialsAndAuthenticator()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             launchArchivingMediaDriver(null);
             connectClient(null);
@@ -87,7 +87,7 @@ public class ArchiveAuthenticationTest
     @Test
     public void shouldBeAbleToRecordWithAuthenticateOnConnectRequestWithCredentials()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableLong authenticatorSessionId = new MutableLong(-1L);
 
@@ -142,7 +142,7 @@ public class ArchiveAuthenticationTest
     @Test
     public void shouldBeAbleToRecordWithAuthenticateOnChallengeResponse()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableLong authenticatorSessionId = new MutableLong(-1L);
 
@@ -205,7 +205,7 @@ public class ArchiveAuthenticationTest
     @Test
     public void shouldNotBeAbleToConnectWithRejectOnConnectRequest()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableLong authenticatorSessionId = new MutableLong(-1L);
 
@@ -267,7 +267,7 @@ public class ArchiveAuthenticationTest
     @Test
     public void shouldNotBeAbleToConnectWithRejectOnChallengeResponse()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final MutableLong authenticatorSessionId = new MutableLong(-1L);
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -181,7 +181,7 @@ public class ArchiveTest
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {
         before(threadingMode, archiveThreadingMode);
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String controlChannel = archive.context().localControlChannel();
             final int controlStreamId = archive.context().localControlStreamId();
@@ -226,7 +226,7 @@ public class ArchiveTest
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {
         before(threadingMode, archiveThreadingMode);
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String controlChannel = archive.context().localControlChannel();
             final int controlStreamId = archive.context().localControlStreamId();
@@ -276,7 +276,7 @@ public class ArchiveTest
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {
         before(threadingMode, archiveThreadingMode);
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String controlChannel = archive.context().localControlChannel();
             final int controlStreamId = archive.context().localControlStreamId();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -35,7 +35,7 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class BasicArchiveTest
 {
@@ -100,7 +100,7 @@ public class BasicArchiveTest
     @Test
     public void shouldRecordThenReplayThenTruncate()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -179,7 +179,7 @@ public class BasicArchiveTest
     @Test
     public void shouldRecordReplayAndCancelReplayEarly()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final long stopPosition;
@@ -222,7 +222,7 @@ public class BasicArchiveTest
     @Test
     public void shouldReplayRecordingFromLateJoinPosition()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
@@ -45,7 +45,7 @@ import static io.aeron.archive.codecs.RecordingSignal.*;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -99,7 +99,7 @@ public class ExtendRecordingTest
     @Test
     public void shouldExtendRecordingAndReplay()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final long controlSessionId = aeronArchive.controlSessionId();
             final RecordingSignalAdapter recordingSignalAdapter;

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
@@ -37,7 +37,7 @@ import static io.aeron.archive.Common.offerToPosition;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ManageRecordingHistoryTest
 {
@@ -96,7 +96,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldPurgeForStreamJoinedAtTheBeginning()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final long targetPosition = (SEGMENT_LENGTH * 3L) + 1;
@@ -126,7 +126,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldPurgeForLateJoinedStream()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int initialTermId = 7;
@@ -160,7 +160,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldDetachThenAttachFullSegments()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final long targetPosition = (SEGMENT_LENGTH * 3L) + 1;
@@ -192,7 +192,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldDetachThenAttachWhenStartNotSegmentAligned()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int initialTermId = 7;
@@ -228,7 +228,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldMigrateSegmentsForStreamJoinedAtTheBeginning()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final long targetPosition = (SEGMENT_LENGTH * 3L) + 1;
@@ -278,7 +278,7 @@ public class ManageRecordingHistoryTest
     @Test
     public void shouldMigrateSegmentsForStreamNotSegmentAligned()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int initialTermId = 7;

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -144,7 +144,7 @@ public class ReplayMergeTest
     @Test
     public void shouldMergeFromReplayToLive()
     {
-        assertTimeout(ofSeconds(20), () ->
+        assertTimeoutPreemptively(ofSeconds(20), () ->
         {
             final int initialMessageCount = MIN_MESSAGES_PER_TERM * 3;
             final int subsequentMessageCount = MIN_MESSAGES_PER_TERM * 3;

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -154,7 +154,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldThrowExceptionWhenDstRecordingIdUnknown()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final long unknownId = 7L;
             try
@@ -176,7 +176,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateStoppedRecording()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -224,7 +224,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateLiveWithoutMergingRecording()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -274,7 +274,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateMoreThanOnce()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -335,7 +335,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateLiveRecordingAndMerge()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -388,7 +388,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateLiveRecordingAndMergeBeforeDataFlows()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;
@@ -436,7 +436,7 @@ public class ReplicateRecordingTest
     @Test
     public void shouldReplicateLiveRecordingAndMergeWhileFollowingWithTaggedSubscription()
     {
-        assertTimeout(ofSeconds(10), () ->
+        assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             final String messagePrefix = "Message-Prefix-";
             final int messageCount = 10;


### PR DESCRIPTION
JUnit 5 provides two sets of APIs for timeout handing:
- `Assertions.assertTimeout` - runs the code on the same thread and fails the test if the execution took longer than the specified timeout.
- Assertions.assertTimeoutPreemptively - run the code on a different thread and aborts running test if timeout reached. This is equivalent to the JUnit 4 `@Test(timeout=...)` and `org.junit.rules.Timeout` rule.