### PR TITLE
[Java] Agent fine grained weaving

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -17,6 +17,8 @@ package io.aeron.agent;
 
 import org.agrona.MutableDirectBuffer;
 
+import java.util.Arrays;
+
 /**
  * Events that can be enabled for logging in the archive module.
  */
@@ -56,16 +58,17 @@ public enum ArchiveEventCode implements EventCode
         (event, buffer, offset, builder) -> ArchiveEventDissector.controlResponse(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();
-    private static final int MAX_ID = 63;
-    private static final ArchiveEventCode[] EVENT_CODE_BY_ID = new ArchiveEventCode[MAX_ID];
+    private static final ArchiveEventCode[] EVENT_CODE_BY_ID;
 
-    private final long tagBit;
     private final int id;
     private final DissectFunction<ArchiveEventCode> dissector;
 
     static
     {
-        for (final ArchiveEventCode code : ArchiveEventCode.values())
+        final ArchiveEventCode[] codes = ArchiveEventCode.values();
+        final int maxId = Arrays.stream(codes).mapToInt(ArchiveEventCode::id).max().orElse(0);
+        EVENT_CODE_BY_ID = new ArchiveEventCode[maxId + 1];
+        for (final ArchiveEventCode code : codes)
         {
             final int id = code.id();
             if (null != EVENT_CODE_BY_ID[id])
@@ -80,7 +83,6 @@ public enum ArchiveEventCode implements EventCode
     ArchiveEventCode(final int id, final DissectFunction<ArchiveEventCode> dissector)
     {
         this.id = id;
-        this.tagBit = 1L << id;
         this.dissector = dissector;
     }
 
@@ -97,29 +99,8 @@ public enum ArchiveEventCode implements EventCode
         return id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public long tagBit()
-    {
-        return tagBit;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public EventCodeType eventCodeType()
-    {
-        return EventCodeType.ARCHIVE;
-    }
-
     public void decode(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
         dissector.dissect(this, buffer, offset, builder);
-    }
-
-    public static boolean isEnabled(final ArchiveEventCode code, final long mask)
-    {
-        return (mask & code.tagBit()) == code.tagBit();
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -50,7 +50,10 @@ public enum ArchiveEventCode implements EventCode
     CMD_IN_MIGRATE_SEGMENTS(26, ArchiveEventDissector::controlRequest),
     CMD_IN_AUTH_CONNECT(27, ArchiveEventDissector::controlRequest),
     CMD_IN_KEEP_ALIVE(28, ArchiveEventDissector::controlRequest),
-    CMD_IN_TAGGED_REPLICATE(29, ArchiveEventDissector::controlRequest);
+    CMD_IN_TAGGED_REPLICATE(29, ArchiveEventDissector::controlRequest),
+
+    CMD_OUT_RESPONSE(30,
+        (event, buffer, offset, builder) -> ArchiveEventDissector.controlResponse(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();
     private static final int MAX_ID = 63;

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -350,11 +350,13 @@ final class ArchiveEventDissector
         final int offset,
         final StringBuilder builder)
     {
+        HEADER_DECODER.wrap(buffer, offset);
+
         CONTROL_RESPONSE_DECODER.wrap(
             buffer,
-            offset,
-            ControlResponseDecoder.BLOCK_LENGTH,
-            ControlResponseDecoder.SCHEMA_VERSION);
+            offset + MessageHeaderDecoder.ENCODED_LENGTH,
+            HEADER_DECODER.blockLength(),
+            HEADER_DECODER.version());
 
         builder.append("ARCHIVE: CONTROL_RESPONSE")
             .append(", controlSessionId=").append(CONTROL_RESPONSE_DECODER.controlSessionId())

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -66,6 +66,7 @@ final class ArchiveEventDissector
     private static final KeepAliveRequestDecoder KEEP_ALIVE_REQUEST_DECODER = new KeepAliveRequestDecoder();
     private static final TaggedReplicateRequestDecoder TAGGED_REPLICATE_REQUEST_DECODER =
         new TaggedReplicateRequestDecoder();
+    private static final ControlResponseDecoder CONTROL_RESPONSE_DECODER = new ControlResponseDecoder();
 
     @SuppressWarnings("MethodLength")
     static void controlRequest(
@@ -342,6 +343,28 @@ final class ArchiveEventDissector
             default:
                 builder.append("ARCHIVE: COMMAND UNKNOWN: ").append(event);
         }
+    }
+
+    static void controlResponse(
+        final MutableDirectBuffer buffer,
+        final int offset,
+        final StringBuilder builder)
+    {
+        CONTROL_RESPONSE_DECODER.wrap(
+            buffer,
+            offset,
+            ControlResponseDecoder.BLOCK_LENGTH,
+            ControlResponseDecoder.SCHEMA_VERSION);
+
+        builder.append("ARCHIVE: CONTROL_RESPONSE")
+            .append(", controlSessionId=").append(CONTROL_RESPONSE_DECODER.controlSessionId())
+            .append(", correlationId=").append(CONTROL_RESPONSE_DECODER.correlationId())
+            .append(", relevantId=").append(CONTROL_RESPONSE_DECODER.relevantId())
+            .append(", code=").append(CONTROL_RESPONSE_DECODER.code())
+            .append(", version=").append(CONTROL_RESPONSE_DECODER.version())
+            .append(", errorMessage=");
+
+        CONTROL_RESPONSE_DECODER.getErrorMessage(builder);
     }
 
     private static void appendConnect(final StringBuilder builder)

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -20,11 +20,9 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 
-import java.util.List;
+import java.util.EnumSet;
 
 import static io.aeron.agent.ArchiveEventCode.*;
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 
 /**
  * Event logger interface used by interceptors for recording events into a {@link RingBuffer} for an
@@ -34,37 +32,7 @@ public final class ArchiveEventLogger
 {
     static final long ENABLED_EVENT_CODES = EventConfiguration.getEnabledArchiveEventCodes();
 
-    static final List<ArchiveEventCode> CONTROL_REQUEST_EVENTS = unmodifiableList(asList(
-        CMD_IN_CONNECT,
-        CMD_IN_CLOSE_SESSION,
-        CMD_IN_START_RECORDING,
-        CMD_IN_STOP_RECORDING,
-        CMD_IN_REPLAY,
-        CMD_IN_STOP_REPLAY,
-        CMD_IN_LIST_RECORDINGS,
-        CMD_IN_LIST_RECORDINGS_FOR_URI,
-        CMD_IN_LIST_RECORDING,
-        CMD_IN_EXTEND_RECORDING,
-        CMD_IN_RECORDING_POSITION,
-        CMD_IN_TRUNCATE_RECORDING,
-        CMD_IN_STOP_RECORDING_SUBSCRIPTION,
-        CMD_IN_STOP_POSITION,
-        CMD_IN_FIND_LAST_MATCHING_RECORD,
-        CMD_IN_LIST_RECORDING_SUBSCRIPTIONS,
-        CMD_IN_START_BOUNDED_REPLAY,
-        CMD_IN_STOP_ALL_REPLAYS,
-        CMD_IN_REPLICATE,
-        CMD_IN_STOP_REPLICATION,
-        CMD_IN_START_POSITION,
-        CMD_IN_DETACH_SEGMENTS,
-        CMD_IN_DELETE_DETACHED_SEGMENTS,
-        CMD_IN_PURGE_SEGMENTS,
-        CMD_IN_ATTACH_SEGMENTS,
-        CMD_IN_MIGRATE_SEGMENTS,
-        CMD_IN_AUTH_CONNECT,
-        CMD_IN_KEEP_ALIVE,
-        CMD_IN_TAGGED_REPLICATE
-    ));
+    static final EnumSet<ArchiveEventCode> CONTROL_REQUEST_EVENTS = EnumSet.allOf(ArchiveEventCode.class);
 
     public static final ArchiveEventLogger LOGGER = new ArchiveEventLogger(EventConfiguration.EVENT_RING_BUFFER);
 

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -23,7 +23,7 @@ import org.agrona.concurrent.ringbuffer.RingBuffer;
 import java.util.EnumSet;
 
 import static io.aeron.agent.ArchiveEventCode.*;
-import static io.aeron.agent.EventConfiguration.archiveEventCodes;
+import static io.aeron.agent.EventConfiguration.ARCHIVE_EVENT_CODES;
 import static java.util.EnumSet.complementOf;
 import static java.util.EnumSet.of;
 
@@ -182,7 +182,7 @@ public final class ArchiveEventLogger
         final int length,
         final ArchiveEventCode eventCode)
     {
-        if (ArchiveEventCode.isEnabled(eventCode, archiveEventCodes))
+        if (ARCHIVE_EVENT_CODES.contains(eventCode))
         {
             ringBuffer.write(toEventCodeId(eventCode), buffer, offset, length);
         }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -20,7 +20,11 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 
+import java.util.List;
+
 import static io.aeron.agent.ArchiveEventCode.*;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Event logger interface used by interceptors for recording events into a {@link RingBuffer} for an
@@ -29,6 +33,39 @@ import static io.aeron.agent.ArchiveEventCode.*;
 public final class ArchiveEventLogger
 {
     static final long ENABLED_EVENT_CODES = EventConfiguration.getEnabledArchiveEventCodes();
+
+    static final List<ArchiveEventCode> CONTROL_REQUEST_EVENTS = unmodifiableList(asList(
+        CMD_IN_CONNECT,
+        CMD_IN_CLOSE_SESSION,
+        CMD_IN_START_RECORDING,
+        CMD_IN_STOP_RECORDING,
+        CMD_IN_REPLAY,
+        CMD_IN_STOP_REPLAY,
+        CMD_IN_LIST_RECORDINGS,
+        CMD_IN_LIST_RECORDINGS_FOR_URI,
+        CMD_IN_LIST_RECORDING,
+        CMD_IN_EXTEND_RECORDING,
+        CMD_IN_RECORDING_POSITION,
+        CMD_IN_TRUNCATE_RECORDING,
+        CMD_IN_STOP_RECORDING_SUBSCRIPTION,
+        CMD_IN_STOP_POSITION,
+        CMD_IN_FIND_LAST_MATCHING_RECORD,
+        CMD_IN_LIST_RECORDING_SUBSCRIPTIONS,
+        CMD_IN_START_BOUNDED_REPLAY,
+        CMD_IN_STOP_ALL_REPLAYS,
+        CMD_IN_REPLICATE,
+        CMD_IN_STOP_REPLICATION,
+        CMD_IN_START_POSITION,
+        CMD_IN_DETACH_SEGMENTS,
+        CMD_IN_DELETE_DETACHED_SEGMENTS,
+        CMD_IN_PURGE_SEGMENTS,
+        CMD_IN_ATTACH_SEGMENTS,
+        CMD_IN_MIGRATE_SEGMENTS,
+        CMD_IN_AUTH_CONNECT,
+        CMD_IN_KEEP_ALIVE,
+        CMD_IN_TAGGED_REPLICATE
+    ));
+
     public static final ArchiveEventLogger LOGGER = new ArchiveEventLogger(EventConfiguration.EVENT_RING_BUFFER);
 
     private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -23,6 +23,7 @@ import org.agrona.concurrent.ringbuffer.RingBuffer;
 import java.util.EnumSet;
 
 import static io.aeron.agent.ArchiveEventCode.*;
+import static io.aeron.agent.EventConfiguration.archiveEventCodes;
 import static java.util.EnumSet.complementOf;
 import static java.util.EnumSet.of;
 
@@ -32,8 +33,6 @@ import static java.util.EnumSet.of;
  */
 public final class ArchiveEventLogger
 {
-    static final long ENABLED_EVENT_CODES = EventConfiguration.getEnabledArchiveEventCodes();
-
     static final EnumSet<ArchiveEventCode> CONTROL_REQUEST_EVENTS = complementOf(of(CMD_OUT_RESPONSE));
 
     public static final ArchiveEventLogger LOGGER = new ArchiveEventLogger(EventConfiguration.EVENT_RING_BUFFER);
@@ -183,7 +182,7 @@ public final class ArchiveEventLogger
         final int length,
         final ArchiveEventCode eventCode)
     {
-        if (ArchiveEventCode.isEnabled(eventCode, ENABLED_EVENT_CODES))
+        if (ArchiveEventCode.isEnabled(eventCode, archiveEventCodes))
         {
             ringBuffer.write(toEventCodeId(eventCode), buffer, offset, length);
         }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -17,11 +17,9 @@ package io.aeron.agent;
 
 import io.aeron.archive.codecs.*;
 import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 
-import java.nio.ByteBuffer;
 import java.util.EnumSet;
 
 import static io.aeron.agent.ArchiveEventCode.*;
@@ -40,9 +38,6 @@ public final class ArchiveEventLogger
 
     public static final ArchiveEventLogger LOGGER = new ArchiveEventLogger(EventConfiguration.EVENT_RING_BUFFER);
 
-    private final UnsafeBuffer encodedBuffer =
-        new UnsafeBuffer(ByteBuffer.allocateDirect(EventConfiguration.MAX_EVENT_LENGTH));
-    private final ControlResponseEncoder controlResponseEncoder = new ControlResponseEncoder();
     private final MessageHeaderDecoder headerDecoder = new MessageHeaderDecoder();
     private final ManyToOneRingBuffer ringBuffer;
 
@@ -194,20 +189,8 @@ public final class ArchiveEventLogger
         }
     }
 
-    public void logControlResponse(
-        final long controlSessionId,
-        final long correlationId,
-        final long relevantId,
-        final ControlResponseCode code,
-        final String errorMessage)
+    public void logControlResponse(final DirectBuffer buffer, final int length)
     {
-        controlResponseEncoder.wrap(encodedBuffer, 0)
-            .controlSessionId(controlSessionId)
-            .correlationId(correlationId)
-            .relevantId(relevantId)
-            .code(code)
-            .errorMessage(errorMessage);
-
-        ringBuffer.write(toEventCodeId(CMD_OUT_RESPONSE), encodedBuffer, 0, controlResponseEncoder.encodedLength());
+        ringBuffer.write(toEventCodeId(CMD_OUT_RESPONSE), buffer, 0, length);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
@@ -38,7 +38,7 @@ class ChannelEndpointInterceptor
             @Advice.OnMethodEnter
             public static void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
             {
-                LOGGER.logChannelCreated(SEND_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+                LOGGER.logString(SEND_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
             }
         }
 
@@ -47,7 +47,7 @@ class ChannelEndpointInterceptor
             @Advice.OnMethodEnter
             public static void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
             {
-                LOGGER.logChannelCreated(SEND_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+                LOGGER.logString(SEND_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
             }
         }
     }
@@ -59,7 +59,7 @@ class ChannelEndpointInterceptor
             @Advice.OnMethodEnter
             public static void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
             {
-                LOGGER.logChannelCreated(RECEIVE_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
+                LOGGER.logString(RECEIVE_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
             }
         }
 
@@ -68,7 +68,7 @@ class ChannelEndpointInterceptor
             @Advice.OnMethodEnter
             public static void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
             {
-                LOGGER.logChannelCreated(RECEIVE_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
+                LOGGER.logString(RECEIVE_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
             }
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
@@ -33,7 +33,6 @@ import static io.aeron.agent.ClusterEventCode.*;
  */
 public final class ClusterEventLogger
 {
-    static final long ENABLED_EVENT_CODES = EventConfiguration.getEnabledClusterEventCodes();
     public static final ClusterEventLogger LOGGER = new ClusterEventLogger(EventConfiguration.EVENT_RING_BUFFER);
 
     private final MutableDirectBuffer encodedBuffer =

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
@@ -47,14 +47,11 @@ public final class ClusterEventLogger
 
     public void logElectionStateChange(final Election.State oldState, final Election.State newState, final int memberId)
     {
-        if (ClusterEventCode.isEnabled(ELECTION_STATE_CHANGE, ENABLED_EVENT_CODES))
-        {
-            final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
-            final int encodedLength = ClusterEventEncoder.encodeElectionStateChange(
-                encodedBuffer, oldState, newState, memberId);
+        final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
+        final int encodedLength = ClusterEventEncoder.encodeElectionStateChange(
+            encodedBuffer, oldState, newState, memberId);
 
-            ringBuffer.write(toEventCodeId(ELECTION_STATE_CHANGE), encodedBuffer, 0, encodedLength);
-        }
+        ringBuffer.write(toEventCodeId(ELECTION_STATE_CHANGE), encodedBuffer, 0, encodedLength);
     }
 
     public void logNewLeadershipTerm(
@@ -65,43 +62,34 @@ public final class ClusterEventLogger
         final int leaderMemberId,
         final int logSessionId)
     {
-        if (ClusterEventCode.isEnabled(NEW_LEADERSHIP_TERM, ENABLED_EVENT_CODES))
-        {
-            final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
-            final int encodedLength = ClusterEventEncoder.newLeadershipTerm(
-                encodedBuffer,
-                logLeadershipTermId,
-                leadershipTermId,
-                logPosition,
-                timestamp,
-                leaderMemberId,
-                logSessionId);
+        final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
+        final int encodedLength = ClusterEventEncoder.newLeadershipTerm(
+            encodedBuffer,
+            logLeadershipTermId,
+            leadershipTermId,
+            logPosition,
+            timestamp,
+            leaderMemberId,
+            logSessionId);
 
-            ringBuffer.write(toEventCodeId(NEW_LEADERSHIP_TERM), encodedBuffer, 0, encodedLength);
-        }
+        ringBuffer.write(toEventCodeId(NEW_LEADERSHIP_TERM), encodedBuffer, 0, encodedLength);
     }
 
     public void logStateChange(
         final ConsensusModule.State oldState, final ConsensusModule.State newState, final int memberId)
     {
-        if (ClusterEventCode.isEnabled(STATE_CHANGE, ENABLED_EVENT_CODES))
-        {
-            final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
-            final int encodedLength = ClusterEventEncoder.stateChange(encodedBuffer, oldState, newState, memberId);
+        final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
+        final int encodedLength = ClusterEventEncoder.stateChange(encodedBuffer, oldState, newState, memberId);
 
-            ringBuffer.write(toEventCodeId(STATE_CHANGE), encodedBuffer, 0, encodedLength);
-        }
+        ringBuffer.write(toEventCodeId(STATE_CHANGE), encodedBuffer, 0, encodedLength);
     }
 
     public void logRoleChange(final Cluster.Role oldRole, final Cluster.Role newRole, final int memberId)
     {
-        if (ClusterEventCode.isEnabled(ROLE_CHANGE, ENABLED_EVENT_CODES))
-        {
-            final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
-            final int encodedLength = ClusterEventEncoder.roleChange(encodedBuffer, oldRole, newRole, memberId);
+        final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
+        final int encodedLength = ClusterEventEncoder.roleChange(encodedBuffer, oldRole, newRole, memberId);
 
-            ringBuffer.write(toEventCodeId(ROLE_CHANGE), encodedBuffer, 0, encodedLength);
-        }
+        ringBuffer.write(toEventCodeId(ROLE_CHANGE), encodedBuffer, 0, encodedLength);
     }
 
     public static int toEventCodeId(final ClusterEventCode code)

--- a/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
@@ -18,115 +18,340 @@ package io.aeron.agent;
 import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import static io.aeron.agent.DriverEventCode.*;
 import static io.aeron.agent.DriverEventLogger.LOGGER;
 import static io.aeron.command.ControlProtocolEvents.*;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Intercepts calls for the command protocol from clients to the driver for logging.
  */
-class CmdInterceptor
+final class CmdInterceptor
 {
-    @Advice.OnMethodEnter
-    static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+    static final Map<DriverEventCode, Class<?>> EVENT_TO_ADVICE_MAPPING;
+
+    static
     {
-        switch (msgTypeId)
+        final Map<DriverEventCode, Class<?>> map = new EnumMap<>(DriverEventCode.class);
+        map.put(CMD_IN_ADD_PUBLICATION, AddPublication.class);
+        map.put(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, AddExclusivePublication.class);
+        map.put(CMD_IN_ADD_SUBSCRIPTION, AddSubcription.class);
+        map.put(CMD_IN_REMOVE_PUBLICATION, RemovePublication.class);
+        map.put(CMD_IN_REMOVE_SUBSCRIPTION, RemoveSubscription.class);
+        map.put(CMD_IN_KEEPALIVE_CLIENT, ClientKeepAlive.class);
+        map.put(CMD_IN_ADD_DESTINATION, AddDestination.class);
+        map.put(CMD_IN_REMOVE_DESTINATION, RemoveDestination.class);
+        map.put(CMD_OUT_AVAILABLE_IMAGE, OnAvailableImage.class);
+        map.put(CMD_OUT_ERROR, OnError.class);
+        map.put(CMD_OUT_ON_OPERATION_SUCCESS, OnOperationSuccess.class);
+        map.put(CMD_OUT_PUBLICATION_READY, OnPublicationReady.class);
+        map.put(CMD_OUT_ON_UNAVAILABLE_IMAGE, OnUnavailableImage.class);
+        map.put(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, OnExclusivePublicationReady.class);
+        map.put(CMD_OUT_SUBSCRIPTION_READY, OnSubscriptionReady.class);
+        map.put(CMD_OUT_COUNTER_READY, OnCounterReady.class);
+        map.put(CMD_OUT_ON_UNAVAILABLE_COUNTER, OnUnavailableCounter.class);
+        map.put(CMD_IN_ADD_COUNTER, AddCounter.class);
+        map.put(CMD_IN_REMOVE_COUNTER, RemoveCounter.class);
+        map.put(CMD_IN_CLIENT_CLOSE, ClientClose.class);
+        map.put(CMD_IN_ADD_RCV_DESTINATION, AddRcvDestination.class);
+        map.put(CMD_IN_REMOVE_RCV_DESTINATION, RemoveRcvDestination.class);
+        map.put(CMD_OUT_ON_CLIENT_TIMEOUT, OnClientTimeout.class);
+        map.put(CMD_IN_TERMINATE_DRIVER, TerminateDriver.class);
+        EVENT_TO_ADVICE_MAPPING = unmodifiableMap(map);
+    }
+
+    static final class AddPublication
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
         {
-            case ADD_PUBLICATION:
+            if (ADD_PUBLICATION == msgTypeId)
+            {
                 LOGGER.log(CMD_IN_ADD_PUBLICATION, buffer, index, length);
-                break;
-
-            case REMOVE_PUBLICATION:
-                LOGGER.log(CMD_IN_REMOVE_PUBLICATION, buffer, index, length);
-                break;
-
-            case ADD_EXCLUSIVE_PUBLICATION:
-                LOGGER.log(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, buffer, index, length);
-                break;
-
-            case ADD_SUBSCRIPTION:
-                LOGGER.log(CMD_IN_ADD_SUBSCRIPTION, buffer, index, length);
-                break;
-
-            case REMOVE_SUBSCRIPTION:
-                LOGGER.log(CMD_IN_REMOVE_SUBSCRIPTION, buffer, index, length);
-                break;
-
-            case CLIENT_KEEPALIVE:
-                LOGGER.log(CMD_IN_KEEPALIVE_CLIENT, buffer, index, length);
-                break;
-
-            case ADD_DESTINATION:
-                LOGGER.log(CMD_IN_ADD_DESTINATION, buffer, index, length);
-                break;
-
-            case REMOVE_DESTINATION:
-                LOGGER.log(CMD_IN_REMOVE_DESTINATION, buffer, index, length);
-                break;
-
-            case ON_AVAILABLE_IMAGE:
-                LOGGER.log(CMD_OUT_AVAILABLE_IMAGE, buffer, index, length);
-                break;
-
-            case ON_ERROR:
-                LOGGER.log(CMD_OUT_ERROR, buffer, index, length);
-                break;
-
-            case ON_OPERATION_SUCCESS:
-                LOGGER.log(CMD_OUT_ON_OPERATION_SUCCESS, buffer, index, length);
-                break;
-
-            case ON_PUBLICATION_READY:
-                LOGGER.log(CMD_OUT_PUBLICATION_READY, buffer, index, length);
-                break;
-
-            case ON_UNAVAILABLE_IMAGE:
-                LOGGER.log(CMD_OUT_ON_UNAVAILABLE_IMAGE, buffer, index, length);
-                break;
-
-            case ON_EXCLUSIVE_PUBLICATION_READY:
-                LOGGER.log(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, buffer, index, length);
-                break;
-
-            case ON_SUBSCRIPTION_READY:
-                LOGGER.log(CMD_OUT_SUBSCRIPTION_READY, buffer, index, length);
-                break;
-
-            case ON_COUNTER_READY:
-                LOGGER.log(CMD_OUT_COUNTER_READY, buffer, index, length);
-                break;
-
-            case ON_UNAVAILABLE_COUNTER:
-                LOGGER.log(CMD_OUT_ON_UNAVAILABLE_COUNTER, buffer, index, length);
-                break;
-
-            case ADD_COUNTER:
-                LOGGER.log(CMD_IN_ADD_COUNTER, buffer, index, length);
-                break;
-
-            case REMOVE_COUNTER:
-                LOGGER.log(CMD_IN_REMOVE_COUNTER, buffer, index, length);
-                break;
-
-            case CLIENT_CLOSE:
-                LOGGER.log(CMD_IN_CLIENT_CLOSE, buffer, index, length);
-                break;
-
-            case ADD_RCV_DESTINATION:
-                LOGGER.log(CMD_IN_ADD_RCV_DESTINATION, buffer, index, length);
-                break;
-
-            case REMOVE_RCV_DESTINATION:
-                LOGGER.log(CMD_IN_REMOVE_RCV_DESTINATION, buffer, index, length);
-                break;
-
-            case ON_CLIENT_TIMEOUT:
-                LOGGER.log(CMD_OUT_ON_CLIENT_TIMEOUT, buffer, index, length);
-                break;
-
-            case TERMINATE_DRIVER:
-                LOGGER.log(CMD_IN_TERMINATE_DRIVER, buffer, index, length);
-                break;
+            }
         }
+    }
+
+    static final class AddExclusivePublication
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ADD_EXCLUSIVE_PUBLICATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class AddSubcription
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ADD_SUBSCRIPTION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_ADD_SUBSCRIPTION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class RemovePublication
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (REMOVE_PUBLICATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_REMOVE_PUBLICATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class RemoveSubscription
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (REMOVE_SUBSCRIPTION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_REMOVE_SUBSCRIPTION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class ClientKeepAlive
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (CLIENT_KEEPALIVE == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_KEEPALIVE_CLIENT, buffer, index, length);
+            }
+        }
+    }
+
+    static final class AddDestination
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ADD_DESTINATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_ADD_DESTINATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class RemoveDestination
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (REMOVE_DESTINATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_REMOVE_DESTINATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnAvailableImage
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_AVAILABLE_IMAGE == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_AVAILABLE_IMAGE, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnError
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_ERROR == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_ERROR, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnOperationSuccess
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_OPERATION_SUCCESS == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_ON_OPERATION_SUCCESS, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnPublicationReady
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_PUBLICATION_READY == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_PUBLICATION_READY, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnUnavailableImage
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_UNAVAILABLE_IMAGE == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_ON_UNAVAILABLE_IMAGE, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnExclusivePublicationReady
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_EXCLUSIVE_PUBLICATION_READY == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnSubscriptionReady
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_SUBSCRIPTION_READY == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_SUBSCRIPTION_READY, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnCounterReady
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_COUNTER_READY == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_COUNTER_READY, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnUnavailableCounter
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_UNAVAILABLE_COUNTER == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_ON_UNAVAILABLE_COUNTER, buffer, index, length);
+            }
+        }
+    }
+
+    static final class AddCounter
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ADD_COUNTER == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_ADD_COUNTER, buffer, index, length);
+            }
+        }
+    }
+
+    static final class RemoveCounter
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (REMOVE_COUNTER == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_REMOVE_COUNTER, buffer, index, length);
+            }
+        }
+    }
+
+    static final class ClientClose
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (CLIENT_CLOSE == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_CLIENT_CLOSE, buffer, index, length);
+            }
+        }
+    }
+
+    static final class AddRcvDestination
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ADD_RCV_DESTINATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_ADD_RCV_DESTINATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class RemoveRcvDestination
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (REMOVE_RCV_DESTINATION == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_REMOVE_RCV_DESTINATION, buffer, index, length);
+            }
+        }
+    }
+
+    static final class OnClientTimeout
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (ON_CLIENT_TIMEOUT == msgTypeId)
+            {
+                LOGGER.log(CMD_OUT_ON_CLIENT_TIMEOUT, buffer, index, length);
+            }
+        }
+    }
+
+    static final class TerminateDriver
+    {
+        @Advice.OnMethodEnter
+        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        {
+            if (TERMINATE_DRIVER == msgTypeId)
+            {
+                LOGGER.log(CMD_IN_TERMINATE_DRIVER, buffer, index, length);
+            }
+        }
+    }
+
+    private CmdInterceptor()
+    {
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
@@ -18,20 +18,18 @@ package io.aeron.agent;
 import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
 
-import java.util.List;
+import java.util.EnumSet;
 
 import static io.aeron.agent.DriverEventCode.*;
 import static io.aeron.agent.DriverEventLogger.LOGGER;
 import static io.aeron.command.ControlProtocolEvents.*;
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 
 /**
  * Intercepts calls for the command protocol from clients to the driver for logging.
  */
 class CmdInterceptor
 {
-    static final List<DriverEventCode> EVENTS = unmodifiableList(asList(
+    static final EnumSet<DriverEventCode> EVENTS = EnumSet.of(
         CMD_IN_ADD_PUBLICATION,
         CMD_IN_REMOVE_PUBLICATION,
         CMD_IN_ADD_EXCLUSIVE_PUBLICATION,
@@ -56,7 +54,7 @@ class CmdInterceptor
         CMD_IN_REMOVE_RCV_DESTINATION,
         CMD_OUT_ON_CLIENT_TIMEOUT,
         CMD_IN_TERMINATE_DRIVER
-    ));
+    );
 
     @Advice.OnMethodEnter
     static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)

--- a/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
@@ -18,340 +18,146 @@ package io.aeron.agent;
 import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
 
-import java.util.EnumMap;
-import java.util.Map;
+import java.util.List;
 
 import static io.aeron.agent.DriverEventCode.*;
 import static io.aeron.agent.DriverEventLogger.LOGGER;
 import static io.aeron.command.ControlProtocolEvents.*;
-import static java.util.Collections.unmodifiableMap;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Intercepts calls for the command protocol from clients to the driver for logging.
  */
-final class CmdInterceptor
+class CmdInterceptor
 {
-    static final Map<DriverEventCode, Class<?>> EVENT_TO_ADVICE_MAPPING;
+    static final List<DriverEventCode> EVENTS = unmodifiableList(asList(
+        CMD_IN_ADD_PUBLICATION,
+        CMD_IN_REMOVE_PUBLICATION,
+        CMD_IN_ADD_EXCLUSIVE_PUBLICATION,
+        CMD_IN_ADD_SUBSCRIPTION,
+        CMD_IN_REMOVE_SUBSCRIPTION,
+        CMD_IN_KEEPALIVE_CLIENT,
+        CMD_IN_ADD_DESTINATION,
+        CMD_IN_REMOVE_DESTINATION,
+        CMD_OUT_AVAILABLE_IMAGE,
+        CMD_OUT_ERROR,
+        CMD_OUT_ON_OPERATION_SUCCESS,
+        CMD_OUT_PUBLICATION_READY,
+        CMD_OUT_ON_UNAVAILABLE_IMAGE,
+        CMD_OUT_EXCLUSIVE_PUBLICATION_READY,
+        CMD_OUT_SUBSCRIPTION_READY,
+        CMD_OUT_COUNTER_READY,
+        CMD_OUT_ON_UNAVAILABLE_COUNTER,
+        CMD_IN_ADD_COUNTER,
+        CMD_IN_REMOVE_COUNTER,
+        CMD_IN_CLIENT_CLOSE,
+        CMD_IN_ADD_RCV_DESTINATION,
+        CMD_IN_REMOVE_RCV_DESTINATION,
+        CMD_OUT_ON_CLIENT_TIMEOUT,
+        CMD_IN_TERMINATE_DRIVER
+    ));
 
-    static
+    @Advice.OnMethodEnter
+    static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
     {
-        final Map<DriverEventCode, Class<?>> map = new EnumMap<>(DriverEventCode.class);
-        map.put(CMD_IN_ADD_PUBLICATION, AddPublication.class);
-        map.put(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, AddExclusivePublication.class);
-        map.put(CMD_IN_ADD_SUBSCRIPTION, AddSubcription.class);
-        map.put(CMD_IN_REMOVE_PUBLICATION, RemovePublication.class);
-        map.put(CMD_IN_REMOVE_SUBSCRIPTION, RemoveSubscription.class);
-        map.put(CMD_IN_KEEPALIVE_CLIENT, ClientKeepAlive.class);
-        map.put(CMD_IN_ADD_DESTINATION, AddDestination.class);
-        map.put(CMD_IN_REMOVE_DESTINATION, RemoveDestination.class);
-        map.put(CMD_OUT_AVAILABLE_IMAGE, OnAvailableImage.class);
-        map.put(CMD_OUT_ERROR, OnError.class);
-        map.put(CMD_OUT_ON_OPERATION_SUCCESS, OnOperationSuccess.class);
-        map.put(CMD_OUT_PUBLICATION_READY, OnPublicationReady.class);
-        map.put(CMD_OUT_ON_UNAVAILABLE_IMAGE, OnUnavailableImage.class);
-        map.put(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, OnExclusivePublicationReady.class);
-        map.put(CMD_OUT_SUBSCRIPTION_READY, OnSubscriptionReady.class);
-        map.put(CMD_OUT_COUNTER_READY, OnCounterReady.class);
-        map.put(CMD_OUT_ON_UNAVAILABLE_COUNTER, OnUnavailableCounter.class);
-        map.put(CMD_IN_ADD_COUNTER, AddCounter.class);
-        map.put(CMD_IN_REMOVE_COUNTER, RemoveCounter.class);
-        map.put(CMD_IN_CLIENT_CLOSE, ClientClose.class);
-        map.put(CMD_IN_ADD_RCV_DESTINATION, AddRcvDestination.class);
-        map.put(CMD_IN_REMOVE_RCV_DESTINATION, RemoveRcvDestination.class);
-        map.put(CMD_OUT_ON_CLIENT_TIMEOUT, OnClientTimeout.class);
-        map.put(CMD_IN_TERMINATE_DRIVER, TerminateDriver.class);
-        EVENT_TO_ADVICE_MAPPING = unmodifiableMap(map);
-    }
-
-    static final class AddPublication
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
+        switch (msgTypeId)
         {
-            if (ADD_PUBLICATION == msgTypeId)
-            {
+            case ADD_PUBLICATION:
                 LOGGER.log(CMD_IN_ADD_PUBLICATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class AddExclusivePublication
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ADD_EXCLUSIVE_PUBLICATION == msgTypeId)
-            {
-                LOGGER.log(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, buffer, index, length);
-            }
-        }
-    }
-
-    static final class AddSubcription
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ADD_SUBSCRIPTION == msgTypeId)
-            {
-                LOGGER.log(CMD_IN_ADD_SUBSCRIPTION, buffer, index, length);
-            }
-        }
-    }
-
-    static final class RemovePublication
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (REMOVE_PUBLICATION == msgTypeId)
-            {
+            case REMOVE_PUBLICATION:
                 LOGGER.log(CMD_IN_REMOVE_PUBLICATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class RemoveSubscription
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (REMOVE_SUBSCRIPTION == msgTypeId)
-            {
+            case ADD_EXCLUSIVE_PUBLICATION:
+                LOGGER.log(CMD_IN_ADD_EXCLUSIVE_PUBLICATION, buffer, index, length);
+                break;
+
+            case ADD_SUBSCRIPTION:
+                LOGGER.log(CMD_IN_ADD_SUBSCRIPTION, buffer, index, length);
+                break;
+
+            case REMOVE_SUBSCRIPTION:
                 LOGGER.log(CMD_IN_REMOVE_SUBSCRIPTION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class ClientKeepAlive
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (CLIENT_KEEPALIVE == msgTypeId)
-            {
+            case CLIENT_KEEPALIVE:
                 LOGGER.log(CMD_IN_KEEPALIVE_CLIENT, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class AddDestination
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ADD_DESTINATION == msgTypeId)
-            {
+            case ADD_DESTINATION:
                 LOGGER.log(CMD_IN_ADD_DESTINATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class RemoveDestination
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (REMOVE_DESTINATION == msgTypeId)
-            {
+            case REMOVE_DESTINATION:
                 LOGGER.log(CMD_IN_REMOVE_DESTINATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnAvailableImage
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_AVAILABLE_IMAGE == msgTypeId)
-            {
+            case ON_AVAILABLE_IMAGE:
                 LOGGER.log(CMD_OUT_AVAILABLE_IMAGE, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnError
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_ERROR == msgTypeId)
-            {
+            case ON_ERROR:
                 LOGGER.log(CMD_OUT_ERROR, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnOperationSuccess
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_OPERATION_SUCCESS == msgTypeId)
-            {
+            case ON_OPERATION_SUCCESS:
                 LOGGER.log(CMD_OUT_ON_OPERATION_SUCCESS, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnPublicationReady
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_PUBLICATION_READY == msgTypeId)
-            {
+            case ON_PUBLICATION_READY:
                 LOGGER.log(CMD_OUT_PUBLICATION_READY, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnUnavailableImage
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_UNAVAILABLE_IMAGE == msgTypeId)
-            {
+            case ON_UNAVAILABLE_IMAGE:
                 LOGGER.log(CMD_OUT_ON_UNAVAILABLE_IMAGE, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnExclusivePublicationReady
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_EXCLUSIVE_PUBLICATION_READY == msgTypeId)
-            {
+            case ON_EXCLUSIVE_PUBLICATION_READY:
                 LOGGER.log(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnSubscriptionReady
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_SUBSCRIPTION_READY == msgTypeId)
-            {
+            case ON_SUBSCRIPTION_READY:
                 LOGGER.log(CMD_OUT_SUBSCRIPTION_READY, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnCounterReady
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_COUNTER_READY == msgTypeId)
-            {
+            case ON_COUNTER_READY:
                 LOGGER.log(CMD_OUT_COUNTER_READY, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnUnavailableCounter
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_UNAVAILABLE_COUNTER == msgTypeId)
-            {
+            case ON_UNAVAILABLE_COUNTER:
                 LOGGER.log(CMD_OUT_ON_UNAVAILABLE_COUNTER, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class AddCounter
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ADD_COUNTER == msgTypeId)
-            {
+            case ADD_COUNTER:
                 LOGGER.log(CMD_IN_ADD_COUNTER, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class RemoveCounter
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (REMOVE_COUNTER == msgTypeId)
-            {
+            case REMOVE_COUNTER:
                 LOGGER.log(CMD_IN_REMOVE_COUNTER, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class ClientClose
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (CLIENT_CLOSE == msgTypeId)
-            {
+            case CLIENT_CLOSE:
                 LOGGER.log(CMD_IN_CLIENT_CLOSE, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class AddRcvDestination
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ADD_RCV_DESTINATION == msgTypeId)
-            {
+            case ADD_RCV_DESTINATION:
                 LOGGER.log(CMD_IN_ADD_RCV_DESTINATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class RemoveRcvDestination
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (REMOVE_RCV_DESTINATION == msgTypeId)
-            {
+            case REMOVE_RCV_DESTINATION:
                 LOGGER.log(CMD_IN_REMOVE_RCV_DESTINATION, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class OnClientTimeout
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (ON_CLIENT_TIMEOUT == msgTypeId)
-            {
+            case ON_CLIENT_TIMEOUT:
                 LOGGER.log(CMD_OUT_ON_CLIENT_TIMEOUT, buffer, index, length);
-            }
-        }
-    }
+                break;
 
-    static final class TerminateDriver
-    {
-        @Advice.OnMethodEnter
-        static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
-        {
-            if (TERMINATE_DRIVER == msgTypeId)
-            {
+            case TERMINATE_DRIVER:
                 LOGGER.log(CMD_IN_TERMINATE_DRIVER, buffer, index, length);
-            }
+                break;
         }
-    }
-
-    private CmdInterceptor()
-    {
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
@@ -15,8 +15,6 @@
  */
 package io.aeron.agent;
 
-import io.aeron.archive.codecs.ControlResponseCode;
-import io.aeron.logbuffer.Header;
 import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
 
@@ -30,7 +28,10 @@ final class ControlInterceptor
     static class ControlRequest
     {
         @Advice.OnMethodEnter
-        static void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
+        static void onFragment(
+            @Advice.Argument(0) final DirectBuffer buffer,
+            @Advice.Argument(1) final int offset,
+            @Advice.Argument(2) final int length)
         {
             LOGGER.logControlRequest(buffer, offset, length);
         }
@@ -39,14 +40,11 @@ final class ControlInterceptor
     static class ControlResponse
     {
         @Advice.OnMethodEnter
-        static void sendResponse(
-            final long controlSessionId,
-            final long correlationId,
-            final long relevantId,
-            final ControlResponseCode code,
-            final String errorMessage)
+        static void sendResponseHook(
+            @Advice.Argument(1) final DirectBuffer buffer,
+            @Advice.Argument(2) final int length)
         {
-            LOGGER.logControlResponse(controlSessionId, correlationId, relevantId, code, errorMessage);
+            LOGGER.logControlResponse(buffer, length);
         }
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.agent;
 
+import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.logbuffer.Header;
 import net.bytebuddy.asm.Advice;
 import org.agrona.DirectBuffer;
@@ -24,7 +25,7 @@ import static io.aeron.agent.ArchiveEventLogger.LOGGER;
 /**
  * Intercepts requests to the archive.
  */
-final class ControlRequestInterceptor
+final class ControlInterceptor
 {
     static class ControlRequest
     {
@@ -32,6 +33,20 @@ final class ControlRequestInterceptor
         static void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
         {
             LOGGER.logControlRequest(buffer, offset, length);
+        }
+    }
+
+    static class ControlResponse
+    {
+        @Advice.OnMethodEnter
+        static void sendResponse(
+            final long controlSessionId,
+            final long correlationId,
+            final long relevantId,
+            final ControlResponseCode code,
+            final String errorMessage)
+        {
+            LOGGER.logControlResponse(controlSessionId, correlationId, relevantId, code, errorMessage);
         }
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -23,6 +23,8 @@ import org.agrona.concurrent.ringbuffer.RingBuffer;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
+import static io.aeron.agent.EventConfiguration.DRIVER_EVENT_CODES;
+
 /**
  * Event logger interface used by interceptors for recording into a {@link RingBuffer} for a
  * {@link io.aeron.driver.MediaDriver} via a Java Agent.
@@ -43,7 +45,7 @@ public final class DriverEventLogger
 
     public void log(final DriverEventCode code, final DirectBuffer buffer, final int offset, final int length)
     {
-        if (DriverEventCode.isEnabled(code, EventConfiguration.driverEventCodes))
+        if (DRIVER_EVENT_CODES.contains(code))
         {
             final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
             final int encodedLength = DriverEventEncoder.encode(encodedBuffer, buffer, offset, length);

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -29,8 +29,6 @@ import java.nio.ByteBuffer;
  */
 public final class DriverEventLogger
 {
-    public static final long ENABLED_EVENT_CODES = EventConfiguration.getEnabledDriverEventCodes();
-
     public static final DriverEventLogger LOGGER = new DriverEventLogger(EventConfiguration.EVENT_RING_BUFFER);
 
     private static final ThreadLocal<MutableDirectBuffer> ENCODING_BUFFER = ThreadLocal.withInitial(
@@ -45,7 +43,7 @@ public final class DriverEventLogger
 
     public void log(final DriverEventCode code, final DirectBuffer buffer, final int offset, final int length)
     {
-        if (DriverEventCode.isEnabled(code, ENABLED_EVENT_CODES))
+        if (DriverEventCode.isEnabled(code, EventConfiguration.driverEventCodes))
         {
             final MutableDirectBuffer encodedBuffer = ENCODING_BUFFER.get();
             final int encodedLength = DriverEventEncoder.encode(encodedBuffer, buffer, offset, length);

--- a/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
@@ -126,6 +126,31 @@ public class EventConfiguration
         EVENT_RING_BUFFER = new ManyToOneRingBuffer(new UnsafeBuffer(ByteBuffer.allocateDirect(bufferLength)));
     }
 
+    public static long driverEventCodes;
+    public static long archiveEventCodes;
+    public static long clusterEventCodes;
+
+    /**
+     * Initialize configuration.
+     */
+    static void init()
+    {
+        driverEventCodes = getEnabledDriverEventCodes();
+        archiveEventCodes = getEnabledArchiveEventCodes();
+        clusterEventCodes = getEnabledClusterEventCodes();
+    }
+
+    /**
+     * Reset configuration.
+     */
+    static void reset()
+    {
+        driverEventCodes = 0;
+        archiveEventCodes = 0;
+        clusterEventCodes = 0;
+        EVENT_RING_BUFFER.unblock();
+    }
+
     public static long getEnabledDriverEventCodes()
     {
         return makeTagBitSet(getEnabledDriverEventCodes(System.getProperty(ENABLED_EVENT_CODES_PROP_NAME)));

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -105,9 +105,9 @@ public class EventLogAgent
 
         EventConfiguration.init();
 
-        if (0 == driverEventCodes &&
-            0 == archiveEventCodes &&
-            0 == clusterEventCodes)
+        if (DRIVER_EVENT_CODES.isEmpty() &&
+            ARCHIVE_EVENT_CODES.isEmpty() &&
+            CLUSTER_EVENT_CODES.isEmpty())
         {
             return;
         }
@@ -149,13 +149,11 @@ public class EventLogAgent
     private static AgentBuilder addDriverConductorInstrumentation(final AgentBuilder agentBuilder)
     {
         final boolean cleanupImage =
-            DriverEventCode.isEnabled(DriverEventCode.REMOVE_IMAGE_CLEANUP, driverEventCodes);
+            DRIVER_EVENT_CODES.contains(DriverEventCode.REMOVE_IMAGE_CLEANUP);
         final boolean cleanupPublication =
-            DriverEventCode
-                .isEnabled(DriverEventCode.REMOVE_PUBLICATION_CLEANUP, driverEventCodes);
+            DRIVER_EVENT_CODES.contains(DriverEventCode.REMOVE_PUBLICATION_CLEANUP);
         final boolean cleanupSubscriptionLink =
-            DriverEventCode
-                .isEnabled(DriverEventCode.REMOVE_SUBSCRIPTION_CLEANUP, driverEventCodes);
+            DRIVER_EVENT_CODES.contains(DriverEventCode.REMOVE_SUBSCRIPTION_CLEANUP);
 
         if (!cleanupImage && !cleanupPublication && !cleanupSubscriptionLink)
         {
@@ -186,8 +184,7 @@ public class EventLogAgent
 
     private static AgentBuilder addDriverCommandInstrumentation(final AgentBuilder agentBuilder)
     {
-        if (CmdInterceptor.EVENTS.stream()
-            .noneMatch(e -> DriverEventCode.isEnabled(e, driverEventCodes)))
+        if (CmdInterceptor.EVENTS.stream().noneMatch(DRIVER_EVENT_CODES::contains))
         {
             return agentBuilder;
         }
@@ -205,10 +202,8 @@ public class EventLogAgent
 
     private static AgentBuilder addDriverSenderProxyInstrumentation(final AgentBuilder agentBuilder)
     {
-        final boolean registerChannel =
-            DriverEventCode.isEnabled(DriverEventCode.SEND_CHANNEL_CREATION, driverEventCodes);
-        final boolean closeChannel =
-            DriverEventCode.isEnabled(DriverEventCode.SEND_CHANNEL_CLOSE, driverEventCodes);
+        final boolean registerChannel = DRIVER_EVENT_CODES.contains(DriverEventCode.SEND_CHANNEL_CREATION);
+        final boolean closeChannel = DRIVER_EVENT_CODES.contains(DriverEventCode.SEND_CHANNEL_CLOSE);
 
         if (!registerChannel && !closeChannel)
         {
@@ -237,10 +232,8 @@ public class EventLogAgent
 
     private static AgentBuilder addDriverReceiverProxyInstrumentation(final AgentBuilder agentBuilder)
     {
-        final boolean registerChannel =
-            DriverEventCode.isEnabled(DriverEventCode.RECEIVE_CHANNEL_CREATION, driverEventCodes);
-        final boolean closeChannel =
-            DriverEventCode.isEnabled(DriverEventCode.RECEIVE_CHANNEL_CLOSE, driverEventCodes);
+        final boolean registerChannel = DRIVER_EVENT_CODES.contains(DriverEventCode.RECEIVE_CHANNEL_CREATION);
+        final boolean closeChannel = DRIVER_EVENT_CODES.contains(DriverEventCode.RECEIVE_CHANNEL_CLOSE);
 
         if (!registerChannel && !closeChannel)
         {
@@ -269,10 +262,8 @@ public class EventLogAgent
 
     private static AgentBuilder addDriverUdpChannelTransportInstrumentation(final AgentBuilder agentBuilder)
     {
-        final boolean frameOut =
-            DriverEventCode.isEnabled(DriverEventCode.FRAME_OUT, driverEventCodes);
-        final boolean frameIn =
-            DriverEventCode.isEnabled(DriverEventCode.FRAME_IN, driverEventCodes);
+        final boolean frameOut = DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_OUT);
+        final boolean frameIn = DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_IN);
 
         if (!frameOut && !frameIn)
         {
@@ -309,8 +300,7 @@ public class EventLogAgent
 
     private static AgentBuilder addArchiveControlSessionDemuxerInstrumentation(final AgentBuilder agentBuilder)
     {
-        if (ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream()
-            .noneMatch(e -> ArchiveEventCode.isEnabled(e, archiveEventCodes)))
+        if (ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream().noneMatch(ARCHIVE_EVENT_CODES::contains))
         {
             return agentBuilder;
         }
@@ -324,7 +314,7 @@ public class EventLogAgent
 
     private static AgentBuilder addArchiveControlResponseProxyInstrumentation(final AgentBuilder agentBuilder)
     {
-        if (!ArchiveEventCode.isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE, archiveEventCodes))
+        if (!ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CMD_OUT_RESPONSE))
         {
             return agentBuilder;
         }
@@ -346,7 +336,7 @@ public class EventLogAgent
 
     private static AgentBuilder addClusterElectionInstrumentation(final AgentBuilder agentBuilder)
     {
-        if (!ClusterEventCode.isEnabled(ClusterEventCode.ELECTION_STATE_CHANGE, clusterEventCodes))
+        if (!CLUSTER_EVENT_CODES.contains(ClusterEventCode.ELECTION_STATE_CHANGE))
         {
             return agentBuilder;
         }
@@ -360,12 +350,9 @@ public class EventLogAgent
 
     private static AgentBuilder addClusterConsensusModuleAgentInstrumentation(final AgentBuilder agentBuilder)
     {
-        final boolean newLeadershipTerm = ClusterEventCode
-            .isEnabled(ClusterEventCode.NEW_LEADERSHIP_TERM, clusterEventCodes);
-        final boolean stateChange = ClusterEventCode
-            .isEnabled(ClusterEventCode.STATE_CHANGE, clusterEventCodes);
-        final boolean roleChange = ClusterEventCode
-            .isEnabled(ClusterEventCode.ROLE_CHANGE, clusterEventCodes);
+        final boolean newLeadershipTerm = CLUSTER_EVENT_CODES.contains(ClusterEventCode.NEW_LEADERSHIP_TERM);
+        final boolean stateChange = CLUSTER_EVENT_CODES.contains(ClusterEventCode.STATE_CHANGE);
+        final boolean roleChange = CLUSTER_EVENT_CODES.contains(ClusterEventCode.ROLE_CHANGE);
 
         if (!newLeadershipTerm && !stateChange && !roleChange)
         {

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -300,6 +300,7 @@ public class EventLogAgent
     {
         AgentBuilder tempBuilder = agentBuilder;
         tempBuilder = addArchiveControlSessionDemuxerInstrumentation(tempBuilder);
+        tempBuilder = addArchiveControlResponseProxyInstrumentation(tempBuilder);
         return tempBuilder;
     }
 
@@ -314,8 +315,22 @@ public class EventLogAgent
         return agentBuilder
             .type(nameEndsWith("ControlSessionDemuxer"))
             .transform(((builder, typeDescription, classLoader, module) -> builder
-                .visit(to(ControlRequestInterceptor.ControlRequest.class)
+                .visit(to(ControlInterceptor.ControlRequest.class)
                     .on(named("onFragment")))));
+    }
+
+    private static AgentBuilder addArchiveControlResponseProxyInstrumentation(final AgentBuilder agentBuilder)
+    {
+        if (!ArchiveEventCode.isEnabled(ArchiveEventCode.CMD_OUT_RESPONSE, ArchiveEventLogger.ENABLED_EVENT_CODES))
+        {
+            return agentBuilder;
+        }
+
+        return agentBuilder
+            .type(nameEndsWith("ControlResponseProxy"))
+            .transform(((builder, typeDescription, classLoader, module) -> builder
+                .visit(to(ControlInterceptor.ControlResponse.class)
+                    .on(named("sendResponse")))));
     }
 
     private static AgentBuilder addClusterInstrumentation(final AgentBuilder agentBuilder)

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -330,7 +330,7 @@ public class EventLogAgent
             .type(nameEndsWith("ControlResponseProxy"))
             .transform(((builder, typeDescription, classLoader, module) -> builder
                 .visit(to(ControlInterceptor.ControlResponse.class)
-                    .on(named("sendResponse")))));
+                    .on(named("sendResponseHook")))));
     }
 
     private static AgentBuilder addClusterInstrumentation(final AgentBuilder agentBuilder)

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -298,12 +298,18 @@ public class EventLogAgent
 
     private static AgentBuilder addArchiveInstrumentation(final AgentBuilder agentBuilder)
     {
-        if (ArchiveEventLogger.ENABLED_EVENT_CODES == 0)
+        AgentBuilder tempBuilder = agentBuilder;
+        tempBuilder = addArchiveControlSessionDemuxerInstrumentation(tempBuilder);
+        return tempBuilder;
+    }
+
+    private static AgentBuilder addArchiveControlSessionDemuxerInstrumentation(final AgentBuilder agentBuilder)
+    {
+        if (ArchiveEventLogger.CONTROL_REQUEST_EVENTS.stream()
+            .noneMatch(e -> ArchiveEventCode.isEnabled(e, ArchiveEventLogger.ENABLED_EVENT_CODES)))
         {
             return agentBuilder;
         }
-
-        // FIXME: Deal with individual events
 
         return agentBuilder
             .type(nameEndsWith("ControlSessionDemuxer"))

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventCodeTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventCodeTest.java
@@ -15,15 +15,17 @@
  */
 package io.aeron.agent;
 
-/**
- * Identifies an event that can be enabled for logging.
- */
-public interface EventCode
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ArchiveEventCodeTest
 {
-    /**
-     * Returns the unique event identifier withing an {@link EventCodeType}.
-     *
-     * @return the unique event identifier withing an {@link EventCodeType}.
-     */
-    int id();
+    @ParameterizedTest
+    @EnumSource(ArchiveEventCode.class)
+    void getCodeById(final ArchiveEventCode code)
+    {
+        assertSame(code, ArchiveEventCode.get(code.id()));
+    }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -2,6 +2,7 @@ package io.aeron.agent;
 
 import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.archive.codecs.ControlResponseEncoder;
+import io.aeron.archive.codecs.MessageHeaderEncoder;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +16,7 @@ class ArchiveEventDissectorTest
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(1024, 32));
         final ControlResponseEncoder responseEncoder = new ControlResponseEncoder();
-        responseEncoder.wrap(buffer, 16)
+        responseEncoder.wrapAndApplyHeader(buffer, 16, new MessageHeaderEncoder())
             .controlSessionId(13)
             .correlationId(42)
             .relevantId(8)

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -1,0 +1,38 @@
+package io.aeron.agent;
+
+import io.aeron.archive.codecs.ControlResponseCode;
+import io.aeron.archive.codecs.ControlResponseEncoder;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArchiveEventDissectorTest
+{
+    @Test
+    void controlResponse()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(1024, 32));
+        final ControlResponseEncoder responseEncoder = new ControlResponseEncoder();
+        responseEncoder.wrap(buffer, 16)
+            .controlSessionId(13)
+            .correlationId(42)
+            .relevantId(8)
+            .code(ControlResponseCode.NULL_VAL)
+            .version(111)
+            .errorMessage("the %ERR% msg");
+        final StringBuilder builder = new StringBuilder();
+
+        ArchiveEventDissector.controlResponse(buffer, 16, builder);
+
+        assertEquals("ARCHIVE: CONTROL_RESPONSE" +
+            ", controlSessionId=13" +
+            ", correlationId=42" +
+            ", relevantId=8" +
+            ", code=" + ControlResponseCode.NULL_VAL +
+            ", version=111" +
+            ", errorMessage=the %ERR% msg",
+            builder.toString());
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
@@ -1,0 +1,71 @@
+package io.aeron.agent;
+
+import io.aeron.archive.codecs.ControlResponseDecoder;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static io.aeron.agent.ArchiveEventCode.CMD_OUT_RESPONSE;
+import static io.aeron.agent.ArchiveEventCode.EVENT_CODE_TYPE;
+import static io.aeron.agent.ArchiveEventLogger.CONTROL_REQUEST_EVENTS;
+import static io.aeron.archive.codecs.ControlResponseCode.RECORDING_UNKNOWN;
+import static io.aeron.archive.codecs.ControlResponseDecoder.BLOCK_LENGTH;
+import static io.aeron.archive.codecs.ControlResponseDecoder.SCHEMA_VERSION;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.encodedMsgOffset;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.typeOffset;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
+
+class ArchiveEventLoggerTest
+{
+
+    @ParameterizedTest
+    @EnumSource(ArchiveEventCode.class)
+    void toEventCodeId(final ArchiveEventCode code)
+    {
+        assertEquals(0xFFFF + EVENT_CODE_TYPE + code.id(), ArchiveEventLogger.toEventCodeId(code));
+    }
+
+    @Test
+    void logControlResponse()
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirect(2048 + TRAILER_LENGTH));
+        final ArchiveEventLogger logger = new ArchiveEventLogger(new ManyToOneRingBuffer(buffer));
+
+        logger.logControlResponse(
+            Long.MIN_VALUE,
+            -100,
+            Long.MAX_VALUE,
+            RECORDING_UNKNOWN,
+            "the ERROR message");
+
+        assertEquals(ArchiveEventLogger.toEventCodeId(CMD_OUT_RESPONSE), buffer.getInt(typeOffset(0), LITTLE_ENDIAN));
+        final ControlResponseDecoder controlResponseDecoder = new ControlResponseDecoder();
+        controlResponseDecoder.wrap(buffer, encodedMsgOffset(0), BLOCK_LENGTH, SCHEMA_VERSION);
+        assertEquals(Long.MIN_VALUE, controlResponseDecoder.controlSessionId());
+        assertEquals(-100, controlResponseDecoder.correlationId());
+        assertEquals(Long.MAX_VALUE, controlResponseDecoder.relevantId());
+        assertEquals(RECORDING_UNKNOWN, controlResponseDecoder.code());
+        assertEquals("the ERROR message", controlResponseDecoder.errorMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ArchiveEventCode.class, mode = EXCLUDE, names = { "CMD_OUT_RESPONSE" })
+    void controlRequestEvents(final ArchiveEventCode code)
+    {
+        assertTrue(CONTROL_REQUEST_EVENTS.contains(code));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ArchiveEventCode.class, mode = INCLUDE, names = { "CMD_OUT_RESPONSE" })
+    void nonControlRequestEvents(final ArchiveEventCode code)
+    {
+        assertFalse(CONTROL_REQUEST_EVENTS.contains(code));
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -18,6 +18,9 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 
+import static io.aeron.agent.ArchiveEventCode.CMD_IN_AUTH_CONNECT;
+import static io.aeron.agent.ArchiveEventCode.CMD_OUT_RESPONSE;
+import static io.aeron.agent.ArchiveEventLogger.toEventCodeId;
 import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static java.time.Duration.ofSeconds;
@@ -25,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class ArchiveLoggingAgentTest
 {
-    private static final CountDownLatch LATCH = new CountDownLatch(1);
+    private static final CountDownLatch LATCH = new CountDownLatch(2);
 
     private String testDirName;
 
@@ -109,7 +112,7 @@ public class ArchiveLoggingAgentTest
 
         public void onMessage(final int msgTypeId, final MutableDirectBuffer buffer, final int index, final int length)
         {
-            if (ArchiveEventLogger.toEventCodeId(ArchiveEventCode.CMD_IN_AUTH_CONNECT) == msgTypeId)
+            if (toEventCodeId(CMD_IN_AUTH_CONNECT) == msgTypeId || toEventCodeId(CMD_OUT_RESPONSE) == msgTypeId)
             {
                 LATCH.countDown();
             }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -33,6 +33,7 @@ public class ArchiveLoggingAgentTest
     public void before()
     {
         System.setProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME, StubEventLogReaderAgent.class.getName());
+        System.setProperty(EventConfiguration.ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME, "all");
         Common.beforeAgent();
 
         testDirName = Paths.get(IoUtil.tmpDirName(), "archive-test").toString();

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -42,7 +42,7 @@ public class ArchiveLoggingAgentTest
     @AfterEach
     public void after()
     {
-        Common.afterAfter();
+        Common.afterAgent();
 
         CloseHelper.close(aeronArchive);
         CloseHelper.close(archivingMediaDriver);

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventCodeTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventCodeTest.java
@@ -15,15 +15,17 @@
  */
 package io.aeron.agent;
 
-/**
- * Identifies an event that can be enabled for logging.
- */
-public interface EventCode
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ClusterEventCodeTest
 {
-    /**
-     * Returns the unique event identifier withing an {@link EventCodeType}.
-     *
-     * @return the unique event identifier withing an {@link EventCodeType}.
-     */
-    int id();
+    @ParameterizedTest
+    @EnumSource(ClusterEventCode.class)
+    void getCodeById(final ClusterEventCode code)
+    {
+        assertSame(code, ClusterEventCode.get(code.id()));
+    }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -54,6 +54,7 @@ public class ClusterLoggingAgentTest
     public void before()
     {
         System.setProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME, StubEventLogReaderAgent.class.getName());
+        System.setProperty(EventConfiguration.ENABLED_CLUSTER_EVENT_CODES_PROP_NAME, "all");
         Common.beforeAgent();
 
         testDirName = Paths.get(IoUtil.tmpDirName(), "cluster-test").toString();

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -77,13 +77,17 @@ public class ClusterLoggingAgentTest
     @Test
     public void logRoleChange()
     {
-        testClusterEventsLogging(ROLE_CHANGE.name(), EnumSet.of(ROLE_CHANGE));
+        // FIXME: ELECTION_STATE_CHANGE is only added to ensure clean termination of the cluster
+        testClusterEventsLogging(ROLE_CHANGE.name() + "," + ELECTION_STATE_CHANGE.name(),
+            EnumSet.of(ROLE_CHANGE, ELECTION_STATE_CHANGE));
     }
 
     @Test
     public void logStateChange()
     {
-        testClusterEventsLogging(STATE_CHANGE.name(), EnumSet.of(STATE_CHANGE));
+        // FIXME: ELECTION_STATE_CHANGE is only added to ensure clean termination of the cluster
+        testClusterEventsLogging(STATE_CHANGE.name() + "," + ELECTION_STATE_CHANGE.name(),
+            EnumSet.of(STATE_CHANGE, ELECTION_STATE_CHANGE));
     }
 
     @Test

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -63,7 +63,7 @@ public class ClusterLoggingAgentTest
     @AfterEach
     public void after()
     {
-        Common.afterAfter();
+        Common.afterAgent();
 
         CloseHelper.close(clusteredServiceContainer);
         CloseHelper.close(clusteredMediaDriver);

--- a/aeron-agent/src/test/java/io/aeron/agent/Common.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/Common.java
@@ -27,7 +27,7 @@ public class Common
         EventLogAgent.agentmain("", ByteBuddyAgent.install());
     }
 
-    public static void afterAfter()
+    public static void afterAgent()
     {
         EventLogAgent.removeTransformer();
         System.clearProperty(EventConfiguration.ENABLED_EVENT_CODES_PROP_NAME);

--- a/aeron-agent/src/test/java/io/aeron/agent/Common.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/Common.java
@@ -21,9 +21,6 @@ public class Common
 {
     public static void beforeAgent()
     {
-        System.setProperty(EventConfiguration.ENABLED_EVENT_CODES_PROP_NAME, "all");
-        System.setProperty(EventConfiguration.ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME, "all");
-        System.setProperty(EventConfiguration.ENABLED_CLUSTER_EVENT_CODES_PROP_NAME, "all");
         EventLogAgent.agentmain("", ByteBuddyAgent.install());
     }
 
@@ -34,5 +31,6 @@ public class Common
         System.clearProperty(EventConfiguration.ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME);
         System.clearProperty(EventConfiguration.ENABLED_CLUSTER_EVENT_CODES_PROP_NAME);
         System.clearProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME);
+        EventConfiguration.reset();
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventCodeTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventCodeTest.java
@@ -15,22 +15,17 @@
  */
 package io.aeron.agent;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DriverEventCodeTest
 {
-    @Test
-    public void allTagsBitsAreUnique()
+    @ParameterizedTest
+    @EnumSource(DriverEventCode.class)
+    void getCodeById(final DriverEventCode code)
     {
-        final Set<Long> seenTagBits = new HashSet<>();
-        for (final DriverEventCode code : DriverEventCode.values())
-        {
-            assertTrue(seenTagBits.add(code.tagBit()));
-        }
+        assertSame(code, DriverEventCode.get(code.id()));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
@@ -54,6 +54,7 @@ public class DriverLoggingAgentTest
     public void before()
     {
         System.setProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME, StubEventLogReaderAgent.class.getName());
+        System.setProperty(EventConfiguration.ENABLED_EVENT_CODES_PROP_NAME, "all");
         Common.beforeAgent();
 
         testDirName = Paths.get(IoUtil.tmpDirName(), "driver-test").toString();

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
@@ -55,7 +55,7 @@ public class DriverLoggingAgentTest
     @AfterAll
     public static void removeAgent()
     {
-        Common.afterAfter();
+        Common.afterAgent();
     }
 
     @Test

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -22,7 +22,8 @@ import java.io.PrintStream;
 import java.util.EnumSet;
 import java.util.Set;
 
-import static io.aeron.agent.EventConfiguration.*;
+import static io.aeron.agent.EventConfiguration.getEnabledClusterEventCodes;
+import static io.aeron.agent.EventConfiguration.getEnabledDriverEventCodes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,7 +57,7 @@ public class EventConfigurationTest
     @Test
     public void allPropertyShouldReturnAllEventCodes()
     {
-        assertEquals(ALL_LOGGER_EVENT_CODES, getEnabledDriverEventCodes("all"));
+        assertEquals(EnumSet.allOf(DriverEventCode.class), getEnabledDriverEventCodes("all"));
     }
 
     @Test
@@ -70,13 +71,5 @@ public class EventConfigurationTest
     public void allClusterEventsShouldBeEnabled()
     {
         assertEquals(EnumSet.allOf(ClusterEventCode.class), getEnabledClusterEventCodes("all"));
-    }
-
-    @Test
-    public void makeTagBitSet()
-    {
-        final Set<DriverEventCode> eventCodes = EnumSet.of(DriverEventCode.FRAME_OUT, DriverEventCode.FRAME_IN);
-        final long bitSet = EventConfiguration.makeTagBitSet(eventCodes);
-        assertEquals((DriverEventCode.FRAME_OUT.tagBit() | DriverEventCode.FRAME_IN.tagBit()), bitSet);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
@@ -176,7 +176,6 @@ class ControlResponseProxy
 
     private boolean sendResponseHook(final ControlSession session, final DirectBuffer buffer, final int length)
     {
-        System.out.println(Thread.currentThread().getName() + " => sendResponseHook");
         return send(session, buffer, length);
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlResponseProxy.java
@@ -176,6 +176,7 @@ class ControlResponseProxy
 
     private boolean sendResponseHook(final ControlSession session, final DirectBuffer buffer, final int length)
     {
+        System.out.println(Thread.currentThread().getName() + " => sendResponseHook");
         return send(session, buffer, length);
     }
 


### PR DESCRIPTION
This PR contains the following changes:
- Conditionally weave based on the enabled events where possible, i.e. where mapping is one to one. In other cases keep runtime check to not log what was not configured to be logged.
- Add logging event for `io.aeron.archive.ControlResponseProxy#sendResponseHook`.
- Implement proper de-instumentation to allow testing different event combinations
- Switch to `EnumSet` for enabled events, i.e. lift 63 events per category limitation.

Open points:
- Should `io.aeron.agent.EventConfiguration#EVENT_RING_BUFFER` be re-created upon `init`.