### PR TITLE
Tombstoned snapshots

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -369,7 +369,8 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
                     NULL_TIMESTAMP,
                     NULL_VALUE,
                     RecordingLog.ENTRY_TYPE_TERM,
-                    -1);
+                    true, -1
+                );
             }
 
             if (null == lastTerm ||
@@ -384,7 +385,9 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
                     NULL_TIMESTAMP,
                     NULL_VALUE,
                     RecordingLog.ENTRY_TYPE_TERM,
-                    -1);
+                    true,
+                    -1
+                );
             }
 
             timeOfLastBackupQueryMs = 0;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2561,7 +2561,8 @@ class ConsensusModuleAgent implements Agent
                 final CountersReader counters = aeron.countersReader();
                 final int counterId = awaitRecordingCounter(counters, publication.sessionId());
                 final long recordingId = RecordingPos.getRecordingId(counters, counterId);
-                final long termBaseLogPosition = recordingLog.getTermEntry(snapshotLeadershipTermId).termBaseLogPosition;
+                final long termBaseLogPosition =
+                    recordingLog.getTermEntry(snapshotLeadershipTermId).termBaseLogPosition;
 
                 snapshotState(publication, logPosition, snapshotLeadershipTermId);
                 awaitRecordingComplete(recordingId, publication.position(), counters, counterId);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -45,8 +45,8 @@ import static io.aeron.Aeron.NULL_VALUE;
 public class ClusterMarkFile implements AutoCloseable
 {
     public static final int MAJOR_VERSION = 0;
-    public static final int MINOR_VERSION = 0;
-    public static final int PATCH_VERSION = 1;
+    public static final int MINOR_VERSION = 1;
+    public static final int PATCH_VERSION = 0;
     public static final int SEMANTIC_VERSION = SemanticVersion.compose(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION);
 
     public static final int HEADER_LENGTH = 8 * 1024;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -876,10 +876,6 @@ public class ClusterTest
                 cluster.sendMessages(numMessages);
                 awaitMessageCountForAllServices(cluster, 3, numMessages);
 
-                cluster.awaitNeutralControlToggle(leader0);
-                cluster.takeSnapshot(leader0);
-                cluster.awaitNeutralControlToggle(leader0);
-
                 // Leadership Term 1
                 cluster.stopNode(leader0);
                 final TestNode leader1 = cluster.awaitLeader(leader0.index());
@@ -888,6 +884,7 @@ public class ClusterTest
                 cluster.sendMessages(numMessages);
                 awaitMessageCountForAllServices(cluster, 3, numMessages * 2);
 
+                // Snapshot
                 cluster.awaitNeutralControlToggle(leader1);
                 cluster.takeSnapshot(leader1);
                 cluster.awaitNeutralControlToggle(leader1);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -860,10 +860,9 @@ public class ClusterTest
     }
 
     @Test
-    @Disabled
-    void shouldRecoverWhenLastSnapshotIsTombstoned()
+    void shouldRecoverWhenLastSnapshotIsMarkedWithTombstone()
     {
-        assertTimeoutPreemptively(ofSeconds(6000), () ->
+        assertTimeoutPreemptively(ofSeconds(60), () ->
         {
             final int numMessages = 3;
 
@@ -891,7 +890,7 @@ public class ClusterTest
 
                 // Leadership Term 1
                 cluster.stopNode(leader0);
-                final TestNode leader1 = cluster.awaitLeader(leader0.index());
+                @SuppressWarnings("unused") final TestNode leader1 = cluster.awaitLeader(leader0.index());
                 cluster.startStaticNode(leader0.index(), false);
 
                 cluster.sendMessages(numMessages);
@@ -921,7 +920,7 @@ public class ClusterTest
     }
 
     @Test
-    @Disabled
+//    @Disabled
     void shouldRecoverWhenLastSnapshotIsTombstonedAndWasBetweenTwoElections()
     {
         assertTimeoutPreemptively(ofSeconds(6000), () ->
@@ -952,7 +951,7 @@ public class ClusterTest
 
                 // Leadership Term 2
                 cluster.stopNode(leader1);
-                final TestNode leader2 = cluster.awaitLeader(leader1.index());
+                @SuppressWarnings("unused") final TestNode leader2 = cluster.awaitLeader(leader1.index());
                 cluster.startStaticNode(leader1.index(), false);
 
                 cluster.sendMessages(numMessages);
@@ -988,14 +987,6 @@ public class ClusterTest
         for (int i = 0; i < numNodes; i++)
         {
             cluster.awaitMessageCountForService(cluster.node(i), numMessages);
-        }
-    }
-
-    private void awaitSnapshotCountForAllServices(final TestCluster cluster, final int numNodes, final int numSnapshots)
-    {
-        for (int i = 0; i < numNodes; i++)
-        {
-            cluster.awaitSnapshotCounter(cluster.node(i), numSnapshots);
         }
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -32,7 +32,7 @@ import static io.aeron.cluster.service.CommitPos.COMMIT_POSITION_TYPE_ID;
 import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.*;
 
-//@Disabled
+@Disabled
 public class ClusterTest
 {
     private static final String MSG = "Hello World!";

--- a/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
@@ -234,7 +234,7 @@ public class RecordingLogTest
     }
 
     @Test
-    public void shouldTombstoneEntry()
+    public void shouldRemoveEntry()
     {
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -29,10 +29,7 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.MinMulticastFlowControlSupplier;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.Header;
-import org.agrona.BitUtil;
-import org.agrona.CloseHelper;
-import org.agrona.DirectBuffer;
-import org.agrona.ExpandableArrayBuffer;
+import org.agrona.*;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.EpochClock;
 import org.agrona.concurrent.YieldingIdleStrategy;
@@ -42,11 +39,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import static io.aeron.Aeron.NULL_VALUE;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCluster implements AutoCloseable
 {
@@ -853,6 +851,18 @@ public class TestCluster implements AutoCloseable
     private static String clusterBackupTransferEndpoint(final int maxMemberCount)
     {
         return "localhost:2044" + maxMemberCount;
+    }
+
+    public void tombstoneLatestSnapshots()
+    {
+        for (TestNode node : nodes)
+        {
+            if (null != node)
+            {
+                final RecordingLog recordingLog = new RecordingLog(node.consensusModule().context().clusterDir());
+                assertTrue(recordingLog.tombstoneLatestSnapshot());
+            }
+        }
     }
 
     static class ServiceContext

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -29,7 +29,10 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.MinMulticastFlowControlSupplier;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.Header;
-import org.agrona.*;
+import org.agrona.BitUtil;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.EpochClock;
 import org.agrona.concurrent.YieldingIdleStrategy;
@@ -39,12 +42,11 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import static io.aeron.Aeron.NULL_VALUE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestCluster implements AutoCloseable
 {
@@ -855,7 +857,7 @@ public class TestCluster implements AutoCloseable
 
     public void tombstoneLatestSnapshots()
     {
-        for (TestNode node : nodes)
+        for (final TestNode node : nodes)
         {
             if (null != node)
             {
@@ -863,6 +865,13 @@ public class TestCluster implements AutoCloseable
                 assertTrue(recordingLog.tombstoneLatestSnapshot());
             }
         }
+    }
+
+    public void printRecordingLogEntries(final int nodeId)
+    {
+        final TestNode node = node(nodeId);
+        final RecordingLog recordingLog = new RecordingLog(node.consensusModule().context().clusterDir());
+        recordingLog.entries().forEach((e) -> System.out.println(node.index() + " - " + e));
     }
 
     static class ServiceContext


### PR DESCRIPTION
The intention of this patch is to allow tombstoned snapshots to be restored correctly when being replayed.  To make this work.

1. The RecordingLog does not remove tombstoned entries from its caches when `tombstoneEntry` is called.  Instead it marks the entry, but keeps it in the `entryCache`.  It is removed from the `cacheIndexByLeadershipTermIdMap` if applicable.
1. The on-disk state is updated to flip the top bit of the type id field to indicate that the entry is invalid.  This is to allow compatibility with the existing RecordingLog on disk format.
1. The ClusterMarkFile version is bumped to 0.1.0.
1. When the RecordingLog is loaded or a snapshot is tombstoned, the index of the invalid snapshot is added to the `invalidSnapshots` list.
1. When the `appendSnapshot` is called, it will look through the list of `invalidSnapshots` and check if any of the tombstoned snapshots match the snapshot being taken (checks leadershipTermId, termBaseLogPosition, logPosition, and serviceId).  If so the snapshot entry is marked as valid and restored.  The on disk version is updated, clearing the tombstone flag and updating with the new recordingId.
1. In `ClusterModuleAgent` the `leadershipTermId` doesn't accurately the reflect the leadership term during replay.  This is due to this field being explicitly set to the leadershipTermId from the RecoveryPlan.  To make this work, I've added an additional field `snapshotLeadershipTermId` (probably needs a better name) which is only changed as a result of snapshot load, replay of leadership events and normal leadership elections.  This value is used in `takeSnapshot`.  The original `leadershipTermId` is used in quite a few places so changing the behaviour of this field may break other functions.  To make the manipulation of the two leadership term fields more understandable, I've added `updateLeadershipTermId` and `initialiseLeadershipTermId` to distinguish between types of update.

- There are possible optimisations around culling entries in the `invalidSnapshots` list.
- There is a bit of mixing of the terms invalid and tombstone.  If we are comfortable with using tombstone as a verb, then I'll update to make it more consistent.
