### PR TITLE
[Java] Align and optimize command logging in the Agent

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -15,75 +15,96 @@
  */
 package io.aeron.agent;
 
+import io.aeron.archive.codecs.*;
 import org.agrona.MutableDirectBuffer;
 
 import java.util.Arrays;
+import java.util.function.ToIntFunction;
 
 /**
  * Events that can be enabled for logging in the archive module.
  */
 public enum ArchiveEventCode implements EventCode
 {
-    CMD_IN_CONNECT(1, ArchiveEventDissector::controlRequest),
-    CMD_IN_CLOSE_SESSION(2, ArchiveEventDissector::controlRequest),
-    CMD_IN_START_RECORDING(3, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_RECORDING(4, ArchiveEventDissector::controlRequest),
-    CMD_IN_REPLAY(5, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_REPLAY(6, ArchiveEventDissector::controlRequest),
-    CMD_IN_LIST_RECORDINGS(7, ArchiveEventDissector::controlRequest),
-    CMD_IN_LIST_RECORDINGS_FOR_URI(8, ArchiveEventDissector::controlRequest),
-    CMD_IN_LIST_RECORDING(9, ArchiveEventDissector::controlRequest),
-    CMD_IN_EXTEND_RECORDING(10, ArchiveEventDissector::controlRequest),
-    CMD_IN_RECORDING_POSITION(11, ArchiveEventDissector::controlRequest),
-    CMD_IN_TRUNCATE_RECORDING(12, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_RECORDING_SUBSCRIPTION(13, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_POSITION(14, ArchiveEventDissector::controlRequest),
-    CMD_IN_FIND_LAST_MATCHING_RECORD(15, ArchiveEventDissector::controlRequest),
-    CMD_IN_LIST_RECORDING_SUBSCRIPTIONS(16, ArchiveEventDissector::controlRequest),
-    CMD_IN_START_BOUNDED_REPLAY(17, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_ALL_REPLAYS(18, ArchiveEventDissector::controlRequest),
-    CMD_IN_REPLICATE(19, ArchiveEventDissector::controlRequest),
-    CMD_IN_STOP_REPLICATION(20, ArchiveEventDissector::controlRequest),
-    CMD_IN_START_POSITION(21, ArchiveEventDissector::controlRequest),
-    CMD_IN_DETACH_SEGMENTS(22, ArchiveEventDissector::controlRequest),
-    CMD_IN_DELETE_DETACHED_SEGMENTS(23, ArchiveEventDissector::controlRequest),
-    CMD_IN_PURGE_SEGMENTS(24, ArchiveEventDissector::controlRequest),
-    CMD_IN_ATTACH_SEGMENTS(25, ArchiveEventDissector::controlRequest),
-    CMD_IN_MIGRATE_SEGMENTS(26, ArchiveEventDissector::controlRequest),
-    CMD_IN_AUTH_CONNECT(27, ArchiveEventDissector::controlRequest),
-    CMD_IN_KEEP_ALIVE(28, ArchiveEventDissector::controlRequest),
-    CMD_IN_TAGGED_REPLICATE(29, ArchiveEventDissector::controlRequest),
+    CMD_IN_CONNECT(1, ConnectRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_CLOSE_SESSION(2, CloseSessionRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_START_RECORDING(3, StartRecordingRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_RECORDING(4, StopRecordingRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_REPLAY(5, ReplayRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_REPLAY(6, StopReplayRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_LIST_RECORDINGS(7, ListRecordingsRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_LIST_RECORDINGS_FOR_URI(8, ListRecordingsForUriRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::controlRequest),
+    CMD_IN_LIST_RECORDING(9, ListRecordingRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_EXTEND_RECORDING(10, ExtendRecordingRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_RECORDING_POSITION(11, RecordingPositionRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_TRUNCATE_RECORDING(12, TruncateRecordingRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_RECORDING_SUBSCRIPTION(13, StopRecordingSubscriptionRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_POSITION(14, StopPositionRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_FIND_LAST_MATCHING_RECORD(15, FindLastMatchingRecordingRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::controlRequest),
+    CMD_IN_LIST_RECORDING_SUBSCRIPTIONS(16, ListRecordingSubscriptionsRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::controlRequest),
+    CMD_IN_START_BOUNDED_REPLAY(17, BoundedReplayRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_ALL_REPLAYS(18, StopAllReplaysRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_REPLICATE(19, ReplicateRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_STOP_REPLICATION(20, StopReplicationRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_START_POSITION(21, StartPositionRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_DETACH_SEGMENTS(22, DetachSegmentsRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_DELETE_DETACHED_SEGMENTS(23, DeleteDetachedSegmentsRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::controlRequest),
+    CMD_IN_PURGE_SEGMENTS(24, PurgeSegmentsRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_ATTACH_SEGMENTS(25, AttachSegmentsRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_MIGRATE_SEGMENTS(26, MigrateSegmentsRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_AUTH_CONNECT(27, AuthConnectRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_KEEP_ALIVE(28, KeepAliveRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
+    CMD_IN_TAGGED_REPLICATE(29, TaggedReplicateRequestDecoder.TEMPLATE_ID, ArchiveEventDissector::controlRequest),
 
-    CMD_OUT_RESPONSE(30,
+    CMD_OUT_RESPONSE(30, ControlResponseDecoder.TEMPLATE_ID,
         (event, buffer, offset, builder) -> ArchiveEventDissector.controlResponse(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();
     private static final ArchiveEventCode[] EVENT_CODE_BY_ID;
+    private static final ArchiveEventCode[] EVENT_CODE_BY_TEMPLATE_ID;
 
     private final int id;
+    private final int templateId;
     private final DissectFunction<ArchiveEventCode> dissector;
 
     static
     {
         final ArchiveEventCode[] codes = ArchiveEventCode.values();
-        final int maxId = Arrays.stream(codes).mapToInt(ArchiveEventCode::id).max().orElse(0);
-        EVENT_CODE_BY_ID = new ArchiveEventCode[maxId + 1];
+        EVENT_CODE_BY_ID = createLookupArray(codes, ArchiveEventCode::id);
+        EVENT_CODE_BY_TEMPLATE_ID = createLookupArray(codes, ArchiveEventCode::templateId);
+    }
+
+    private static ArchiveEventCode[] createLookupArray(
+        final ArchiveEventCode[] codes, final ToIntFunction<ArchiveEventCode> idSupplier)
+    {
+        final int maxId = Arrays.stream(codes).mapToInt(idSupplier).max().orElse(0);
+        if (maxId > 100_000)
+        {
+            throw new IllegalStateException("Size of the lookup array exceeds 100000: " + maxId);
+        }
+        final ArchiveEventCode[] array = new ArchiveEventCode[maxId + 1];
 
         for (final ArchiveEventCode code : codes)
         {
-            final int id = code.id();
-            if (null != EVENT_CODE_BY_ID[id])
+            final int id = idSupplier.applyAsInt(code);
+            if (null != array[id])
             {
                 throw new IllegalArgumentException("id already in use: " + id);
             }
-
-            EVENT_CODE_BY_ID[id] = code;
+            array[id] = code;
         }
+        return array;
     }
 
-    ArchiveEventCode(final int id, final DissectFunction<ArchiveEventCode> dissector)
+    ArchiveEventCode(final int id, final int templateId, final DissectFunction<ArchiveEventCode> dissector)
     {
         this.id = id;
+        this.templateId = templateId;
         this.dissector = dissector;
     }
 
@@ -92,12 +113,22 @@ public enum ArchiveEventCode implements EventCode
         return EVENT_CODE_BY_ID[eventCodeId];
     }
 
+    static ArchiveEventCode getByTemplateId(final int templateId)
+    {
+        return EVENT_CODE_BY_TEMPLATE_ID[templateId];
+    }
+
     /**
      * {@inheritDoc}
      */
     public int id()
     {
         return id;
+    }
+
+    public int templateId()
+    {
+        return templateId;
     }
 
     public void decode(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -18,6 +18,9 @@ package io.aeron.agent;
 import io.aeron.archive.codecs.*;
 import org.agrona.MutableDirectBuffer;
 
+import static io.aeron.agent.ArchiveEventCode.CMD_OUT_RESPONSE;
+import static io.aeron.agent.CommonEventDisector.dissectLogHeader;
+
 final class ArchiveEventDissector
 {
     private static final MessageHeaderDecoder HEADER_DECODER = new MessageHeaderDecoder();
@@ -67,22 +70,30 @@ final class ArchiveEventDissector
     private static final TaggedReplicateRequestDecoder TAGGED_REPLICATE_REQUEST_DECODER =
         new TaggedReplicateRequestDecoder();
     private static final ControlResponseDecoder CONTROL_RESPONSE_DECODER = new ControlResponseDecoder();
+    static final String CONTEXT = "ARCHIVE";
+
+    private ArchiveEventDissector()
+    {
+    }
 
     @SuppressWarnings("MethodLength")
     static void controlRequest(
-        final ArchiveEventCode event,
+        final ArchiveEventCode eventCode,
         final MutableDirectBuffer buffer,
         final int offset,
         final StringBuilder builder)
     {
-        HEADER_DECODER.wrap(buffer, offset);
+        int relativeOffset = dissectLogHeader(CONTEXT, eventCode, buffer, offset, builder);
 
-        switch (event)
+        HEADER_DECODER.wrap(buffer, offset + relativeOffset);
+        relativeOffset += MessageHeaderDecoder.ENCODED_LENGTH;
+
+        switch (eventCode)
         {
             case CMD_IN_CONNECT:
                 CONNECT_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendConnect(builder);
@@ -91,7 +102,7 @@ final class ArchiveEventDissector
             case CMD_IN_CLOSE_SESSION:
                 CLOSE_SESSION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendCloseSession(builder);
@@ -100,7 +111,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_RECORDING:
                 START_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartRecording(builder);
@@ -109,7 +120,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_RECORDING:
                 STOP_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecording(builder);
@@ -118,7 +129,7 @@ final class ArchiveEventDissector
             case CMD_IN_REPLAY:
                 REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendReplay(builder);
@@ -127,7 +138,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_REPLAY:
                 STOP_REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopReplay(builder);
@@ -136,7 +147,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDINGS:
                 LIST_RECORDINGS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordings(builder);
@@ -145,7 +156,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDINGS_FOR_URI:
                 LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordingsForUri(builder);
@@ -154,7 +165,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDING:
                 LIST_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecording(builder);
@@ -163,7 +174,7 @@ final class ArchiveEventDissector
             case CMD_IN_EXTEND_RECORDING:
                 EXTEND_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendExtendRecording(builder);
@@ -172,7 +183,7 @@ final class ArchiveEventDissector
             case CMD_IN_RECORDING_POSITION:
                 RECORDING_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendRecordingPosition(builder);
@@ -181,7 +192,7 @@ final class ArchiveEventDissector
             case CMD_IN_TRUNCATE_RECORDING:
                 TRUNCATE_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendTruncateRecording(builder);
@@ -190,7 +201,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_RECORDING_SUBSCRIPTION:
                 STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecordingSubscription(builder);
@@ -199,7 +210,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_POSITION:
                 STOP_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopPosition(builder);
@@ -208,7 +219,7 @@ final class ArchiveEventDissector
             case CMD_IN_FIND_LAST_MATCHING_RECORD:
                 FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendFindLastMatchingRecord(builder);
@@ -217,7 +228,7 @@ final class ArchiveEventDissector
             case CMD_IN_LIST_RECORDING_SUBSCRIPTIONS:
                 LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendListRecordingSubscriptions(builder);
@@ -226,7 +237,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_BOUNDED_REPLAY:
                 BOUNDED_REPLAY_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartBoundedReplay(builder);
@@ -235,7 +246,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_ALL_REPLAYS:
                 STOP_ALL_REPLAYS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopAllReplays(builder);
@@ -244,7 +255,7 @@ final class ArchiveEventDissector
             case CMD_IN_REPLICATE:
                 REPLICATE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendReplicate(builder);
@@ -253,7 +264,7 @@ final class ArchiveEventDissector
             case CMD_IN_STOP_REPLICATION:
                 STOP_REPLICATION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopReplication(builder);
@@ -262,7 +273,7 @@ final class ArchiveEventDissector
             case CMD_IN_START_POSITION:
                 START_POSITION_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStartPosition(builder);
@@ -271,7 +282,7 @@ final class ArchiveEventDissector
             case CMD_IN_DETACH_SEGMENTS:
                 DETACH_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendDetachSegments(builder);
@@ -280,7 +291,7 @@ final class ArchiveEventDissector
             case CMD_IN_DELETE_DETACHED_SEGMENTS:
                 DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendDeleteDetachedSegments(builder);
@@ -289,7 +300,7 @@ final class ArchiveEventDissector
             case CMD_IN_PURGE_SEGMENTS:
                 PURGE_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendPurgeSegments(builder);
@@ -298,7 +309,7 @@ final class ArchiveEventDissector
             case CMD_IN_ATTACH_SEGMENTS:
                 ATTACH_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendAttachSegments(builder);
@@ -307,7 +318,7 @@ final class ArchiveEventDissector
             case CMD_IN_MIGRATE_SEGMENTS:
                 MIGRATE_SEGMENTS_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendMigrateSegments(builder);
@@ -316,7 +327,7 @@ final class ArchiveEventDissector
             case CMD_IN_AUTH_CONNECT:
                 AUTH_CONNECT_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendAuthConnect(builder);
@@ -325,7 +336,7 @@ final class ArchiveEventDissector
             case CMD_IN_KEEP_ALIVE:
                 KEEP_ALIVE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendKeepAlive(builder);
@@ -334,14 +345,14 @@ final class ArchiveEventDissector
             case CMD_IN_TAGGED_REPLICATE:
                 TAGGED_REPLICATE_REQUEST_DECODER.wrap(
                     buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendTaggedReplicate(builder);
                 break;
 
             default:
-                builder.append("ARCHIVE: COMMAND UNKNOWN: ").append(event);
+                builder.append(": unknown command");
         }
     }
 
@@ -350,16 +361,18 @@ final class ArchiveEventDissector
         final int offset,
         final StringBuilder builder)
     {
-        HEADER_DECODER.wrap(buffer, offset);
+        int relativeOffset = dissectLogHeader(CONTEXT, CMD_OUT_RESPONSE, buffer, offset, builder);
+
+        HEADER_DECODER.wrap(buffer, offset + relativeOffset);
+        relativeOffset += MessageHeaderDecoder.ENCODED_LENGTH;
 
         CONTROL_RESPONSE_DECODER.wrap(
             buffer,
-            offset + MessageHeaderDecoder.ENCODED_LENGTH,
+            offset + relativeOffset,
             HEADER_DECODER.blockLength(),
             HEADER_DECODER.version());
 
-        builder.append("ARCHIVE: CONTROL_RESPONSE")
-            .append(", controlSessionId=").append(CONTROL_RESPONSE_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(CONTROL_RESPONSE_DECODER.controlSessionId())
             .append(", correlationId=").append(CONTROL_RESPONSE_DECODER.correlationId())
             .append(", relevantId=").append(CONTROL_RESPONSE_DECODER.relevantId())
             .append(", code=").append(CONTROL_RESPONSE_DECODER.code())
@@ -371,8 +384,7 @@ final class ArchiveEventDissector
 
     private static void appendConnect(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: CONNECT")
-            .append(", correlationId=").append(CONNECT_REQUEST_DECODER.correlationId())
+        builder.append(": correlationId=").append(CONNECT_REQUEST_DECODER.correlationId())
             .append(", responseStreamId=").append(CONNECT_REQUEST_DECODER.responseStreamId())
             .append(", version=").append(CONNECT_REQUEST_DECODER.version())
             .append(", responseChannel=");
@@ -382,8 +394,7 @@ final class ArchiveEventDissector
 
     private static void appendAuthConnect(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: AUTH_CONNECT")
-            .append(", correlationId=").append(AUTH_CONNECT_REQUEST_DECODER.correlationId())
+        builder.append(": correlationId=").append(AUTH_CONNECT_REQUEST_DECODER.correlationId())
             .append(", responseStreamId=").append(AUTH_CONNECT_REQUEST_DECODER.responseStreamId())
             .append(", version=").append(AUTH_CONNECT_REQUEST_DECODER.version())
             .append(", responseChannel=");
@@ -395,14 +406,12 @@ final class ArchiveEventDissector
 
     private static void appendCloseSession(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: CLOSE_SESSION")
-            .append(", controlSessionId=").append(CLOSE_SESSION_REQUEST_DECODER.controlSessionId());
+        builder.append(": controlSessionId=").append(CLOSE_SESSION_REQUEST_DECODER.controlSessionId());
     }
 
     private static void appendStartRecording(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: START_RECORDING")
-            .append(", controlSessionId=").append(START_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(START_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(START_RECORDING_REQUEST_DECODER.correlationId())
             .append(", streamId=").append(START_RECORDING_REQUEST_DECODER.streamId())
             .append(", sourceLocation=").append(START_RECORDING_REQUEST_DECODER.sourceLocation())
@@ -413,8 +422,7 @@ final class ArchiveEventDissector
 
     private static void appendStopRecording(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_RECORDING")
-            .append(", controlSessionId=").append(STOP_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_RECORDING_REQUEST_DECODER.correlationId())
             .append(", streamId=").append(STOP_RECORDING_REQUEST_DECODER.streamId())
             .append(", channel=");
@@ -424,8 +432,7 @@ final class ArchiveEventDissector
 
     private static void appendReplay(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: REPLAY")
-            .append(", controlSessionId=").append(REPLAY_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(REPLAY_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(REPLAY_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(REPLAY_REQUEST_DECODER.recordingId())
             .append(", position=").append(REPLAY_REQUEST_DECODER.position())
@@ -438,16 +445,14 @@ final class ArchiveEventDissector
 
     private static void appendStopReplay(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_REPLAY")
-            .append(", controlSessionId=").append(STOP_REPLAY_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_REPLAY_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_REPLAY_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(STOP_REPLAY_REQUEST_DECODER.replaySessionId());
+            .append(", replaySessionId=").append(STOP_REPLAY_REQUEST_DECODER.replaySessionId());
     }
 
     private static void appendListRecordings(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: LIST_RECORDINGS")
-            .append(", controlSessionId=").append(LIST_RECORDINGS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(LIST_RECORDINGS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(LIST_RECORDINGS_REQUEST_DECODER.correlationId())
             .append(", fromRecordingId=").append(LIST_RECORDINGS_REQUEST_DECODER.fromRecordingId())
             .append(", recordCount=").append(LIST_RECORDINGS_REQUEST_DECODER.recordCount());
@@ -455,16 +460,14 @@ final class ArchiveEventDissector
 
     private static void appendListRecording(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: LIST_RECORDING")
-            .append(", controlSessionId=").append(LIST_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(LIST_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(LIST_RECORDING_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(LIST_RECORDING_REQUEST_DECODER.recordingId());
     }
 
     private static void appendListRecordingsForUri(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: LIST_RECORDINGS_FOR_URI ")
-            .append(", controlSessionId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.correlationId())
             .append(", fromRecordingId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.fromRecordingId())
             .append(", recordCount=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.recordCount())
@@ -476,8 +479,7 @@ final class ArchiveEventDissector
 
     private static void appendExtendRecording(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: EXTEND_RECORDING")
-            .append(", controlSessionId=").append(EXTEND_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(EXTEND_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(EXTEND_RECORDING_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(EXTEND_RECORDING_REQUEST_DECODER.recordingId())
             .append(", streamId=").append(EXTEND_RECORDING_REQUEST_DECODER.streamId())
@@ -489,16 +491,14 @@ final class ArchiveEventDissector
 
     private static void appendRecordingPosition(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: RECORDING_POSITION")
-            .append(", controlSessionId=").append(RECORDING_POSITION_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(RECORDING_POSITION_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(RECORDING_POSITION_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(RECORDING_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendTruncateRecording(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: TRUNCATE_RECORDING")
-            .append(", controlSessionId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.recordingId())
             .append(", position=").append(TRUNCATE_RECORDING_REQUEST_DECODER.position());
@@ -506,24 +506,21 @@ final class ArchiveEventDissector
 
     private static void appendStopRecordingSubscription(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_RECORDING_SUBSCRIPTION")
-            .append(", controlSessionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.correlationId())
             .append(", subscriptionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.subscriptionId());
     }
 
     private static void appendStopPosition(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_POSITION")
-            .append(", controlSessionId=").append(STOP_POSITION_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_POSITION_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_POSITION_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(STOP_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendFindLastMatchingRecord(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: FIND_LAST_MATCHING_RECORDING")
-            .append(", controlSessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.correlationId())
             .append(", minRecordingId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.minRecordingId())
             .append(", sessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.sessionId())
@@ -535,8 +532,7 @@ final class ArchiveEventDissector
 
     private static void appendListRecordingSubscriptions(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: LIST_RECORDING_SUBSCRIPTIONS ")
-            .append(", controlSessionId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.correlationId())
             .append(", pseudoIndex=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.pseudoIndex())
             .append(", applyStreamId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.applyStreamId())
@@ -549,8 +545,7 @@ final class ArchiveEventDissector
 
     private static void appendStartBoundedReplay(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: START_BOUNDED_REPLAY")
-            .append(", controlSessionId=").append(BOUNDED_REPLAY_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(BOUNDED_REPLAY_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(BOUNDED_REPLAY_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(BOUNDED_REPLAY_REQUEST_DECODER.recordingId())
             .append(", position=").append(BOUNDED_REPLAY_REQUEST_DECODER.position())
@@ -564,61 +559,57 @@ final class ArchiveEventDissector
 
     private static void appendStopAllReplays(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_ALL_REPLAYS")
-            .append(", controlSessionId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendReplicate(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: REPLICATE")
-            .append(", controlSessionId=").append(REPLICATE_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(REPLICATE_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(REPLICATE_REQUEST_DECODER.correlationId())
             .append(", srcRecordingId=").append(REPLICATE_REQUEST_DECODER.srcRecordingId())
             .append(", dstRecordingId=").append(REPLICATE_REQUEST_DECODER.dstRecordingId())
-            .append(", srcControlStreamId=").append(REPLICATE_REQUEST_DECODER.srcControlStreamId());
+            .append(", srcControlStreamId=").append(REPLICATE_REQUEST_DECODER.srcControlStreamId())
+            .append(", srcControlChannel=");
 
         REPLICATE_REQUEST_DECODER.getSrcControlChannel(builder);
+
+        builder.append(", liveDestination=");
         REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
 
     private static void appendStopReplication(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: STOP_REPLICATION")
-            .append(", controlSessionId=").append(STOP_REPLICATION_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(STOP_REPLICATION_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(STOP_REPLICATION_REQUEST_DECODER.correlationId())
             .append(", replicationId=").append(STOP_REPLICATION_REQUEST_DECODER.replicationId());
     }
 
     private static void appendStartPosition(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: START_POSITION")
-            .append(", controlSessionId=").append(START_POSITION_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(START_POSITION_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(START_POSITION_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(START_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendDetachSegments(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: DETACH_SEGMENTS")
-            .append(", controlSessionId=").append(DETACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(DETACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(DETACH_SEGMENTS_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(DETACH_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendDeleteDetachedSegments(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: DELETE_DETACHED_SEGMENTS")
-            .append(", controlSessionId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendPurgeSegments(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: PURGE_SEGMENTS")
-            .append(", controlSessionId=").append(PURGE_SEGMENTS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(PURGE_SEGMENTS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(PURGE_SEGMENTS_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(PURGE_SEGMENTS_REQUEST_DECODER.recordingId())
             .append(", newStartPosition=").append(PURGE_SEGMENTS_REQUEST_DECODER.newStartPosition());
@@ -626,16 +617,14 @@ final class ArchiveEventDissector
 
     private static void appendAttachSegments(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: ATTACH_SEGMENTS")
-            .append(", controlSessionId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.correlationId())
             .append(", recordingId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendMigrateSegments(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: MIGRATE_SEGMENTS")
-            .append(", controlSessionId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.correlationId())
             .append(", srcRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.srcRecordingId())
             .append(", dstRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.dstRecordingId());
@@ -643,23 +632,24 @@ final class ArchiveEventDissector
 
     private static void appendKeepAlive(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: KEEP_ALIVE")
-            .append(", controlSessionId=").append(KEEP_ALIVE_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(KEEP_ALIVE_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(KEEP_ALIVE_REQUEST_DECODER.correlationId());
     }
 
     private static void appendTaggedReplicate(final StringBuilder builder)
     {
-        builder.append("ARCHIVE: TAGGED_REPLICATE")
-            .append(", controlSessionId=").append(TAGGED_REPLICATE_REQUEST_DECODER.controlSessionId())
+        builder.append(": controlSessionId=").append(TAGGED_REPLICATE_REQUEST_DECODER.controlSessionId())
             .append(", correlationId=").append(TAGGED_REPLICATE_REQUEST_DECODER.correlationId())
             .append(", srcRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcRecordingId())
             .append(", dstRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.dstRecordingId())
             .append(", channelTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.channelTagId())
             .append(", subscriptionTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.subscriptionTagId())
-            .append(", srcControlStreamId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcControlStreamId());
+            .append(", srcControlStreamId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcControlStreamId())
+            .append(", srcControlChannel=");
 
         TAGGED_REPLICATE_REQUEST_DECODER.getSrcControlChannel(builder);
+
+        builder.append(", liveDestination=");
         TAGGED_REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
@@ -31,63 +31,63 @@ import static io.aeron.agent.DriverEventLogger.LOGGER;
  */
 class ChannelEndpointInterceptor
 {
-    public static class SenderProxy
+    static class SenderProxy
     {
-        public static class RegisterSendChannelEndpoint
+        static class RegisterSendChannelEndpoint
         {
             @Advice.OnMethodEnter
-            public static void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
+            static void registerSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
             {
                 LOGGER.logString(SEND_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
             }
         }
 
-        public static class CloseSendChannelEndpoint
+        static class CloseSendChannelEndpoint
         {
             @Advice.OnMethodEnter
-            public static void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
+            static void closeSendChannelEndpoint(final SendChannelEndpoint channelEndpoint)
             {
                 LOGGER.logString(SEND_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
             }
         }
     }
 
-    public static class ReceiverProxy
+    static class ReceiverProxy
     {
-        public static class RegisterReceiveChannelEndpoint
+        static class RegisterReceiveChannelEndpoint
         {
             @Advice.OnMethodEnter
-            public static void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
+            static void registerReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
             {
                 LOGGER.logString(RECEIVE_CHANNEL_CREATION, channelEndpoint.udpChannel().description());
             }
         }
 
-        public static class CloseReceiveChannelEndpoint
+        static class CloseReceiveChannelEndpoint
         {
             @Advice.OnMethodEnter
-            public static void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
+            static void closeReceiveChannelEndpoint(final ReceiveChannelEndpoint channelEndpoint)
             {
                 LOGGER.logString(RECEIVE_CHANNEL_CLOSE, channelEndpoint.udpChannel().description());
             }
         }
     }
 
-    public static class UdpChannelTransport
+    static class UdpChannelTransport
     {
-        public static class SendHook
+        static class SendHook
         {
             @Advice.OnMethodEnter
-            public static void sendHook(final ByteBuffer buffer, final InetSocketAddress address)
+            static void sendHook(final ByteBuffer buffer, final InetSocketAddress address)
             {
                 LOGGER.logFrameOut(buffer, address);
             }
         }
 
-        public static class ReceiveHook
+        static class ReceiveHook
         {
             @Advice.OnMethodEnter
-            public static void receiveHook(final UnsafeBuffer buffer, final int length, final InetSocketAddress address)
+            static void receiveHook(final UnsafeBuffer buffer, final int length, final InetSocketAddress address)
             {
                 LOGGER.logFrameIn(buffer, 0, length, address);
             }

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
@@ -19,15 +19,17 @@ import org.agrona.MutableDirectBuffer;
 
 import java.util.Arrays;
 
+import static io.aeron.agent.ClusterEventDissector.dissectNewLeadershipTerm;
+
 /**
  * Events that can be enabled for logging in the cluster module.
  */
 public enum ClusterEventCode implements EventCode
 {
-    ELECTION_STATE_CHANGE(1, ClusterEventDissector::electionStateChange),
-    NEW_LEADERSHIP_TERM(2, ClusterEventDissector::newLeadershipTerm),
-    STATE_CHANGE(3, ClusterEventDissector::stateChange),
-    ROLE_CHANGE(4, ClusterEventDissector::roleChange);
+    ELECTION_STATE_CHANGE(1, ClusterEventDissector::dissectStateChange),
+    NEW_LEADERSHIP_TERM(2, (eventCode, buffer, offset, builder) -> dissectNewLeadershipTerm(buffer, offset, builder)),
+    STATE_CHANGE(3, ClusterEventDissector::dissectStateChange),
+    ROLE_CHANGE(4, ClusterEventDissector::dissectStateChange);
 
     static final int EVENT_CODE_TYPE = EventCodeType.CLUSTER.getTypeCode();
     private static final ClusterEventCode[] EVENT_CODE_BY_ID;

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
@@ -20,19 +20,20 @@ import io.aeron.cluster.Election;
 import io.aeron.cluster.service.Cluster;
 import net.bytebuddy.asm.Advice;
 
+import static io.aeron.agent.ClusterEventCode.*;
 import static io.aeron.agent.ClusterEventLogger.LOGGER;
 
 /**
  * Intercepts calls in the cluster which relate to state changes.
  */
-final class ClusterInterceptor
+class ClusterInterceptor
 {
     static class ElectionStateChange
     {
         @Advice.OnMethodEnter
         static void stateChange(final Election.State oldState, final Election.State newState, final int memberId)
         {
-            LOGGER.logElectionStateChange(oldState, newState, memberId);
+            LOGGER.logStateChange(ELECTION_STATE_CHANGE, oldState, newState, memberId);
         }
     }
 
@@ -63,7 +64,7 @@ final class ClusterInterceptor
         static void stateChange(
             final ConsensusModule.State oldState, final ConsensusModule.State newState, final int memberId)
         {
-            LOGGER.logStateChange(oldState, newState, memberId);
+            LOGGER.logStateChange(STATE_CHANGE, oldState, newState, memberId);
         }
     }
 
@@ -72,7 +73,7 @@ final class ClusterInterceptor
         @Advice.OnMethodEnter
         static void roleChange(final Cluster.Role oldRole, final Cluster.Role newRole, final int memberId)
         {
-            LOGGER.logRoleChange(oldRole, newRole, memberId);
+            LOGGER.logStateChange(ROLE_CHANGE, oldRole, newRole, memberId);
         }
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/CommonEventDisector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CommonEventDisector.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.MutableDirectBuffer;
+
+import java.time.format.DateTimeFormatter;
+
+import static java.lang.Integer.toHexString;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.time.Instant.ofEpochMilli;
+import static java.time.OffsetDateTime.ofInstant;
+import static java.time.ZoneId.systemDefault;
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+final class CommonEventDisector
+{
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = ofPattern("uuuu-MM-dd HH:mm:ss.SSSZ");
+    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+
+    private CommonEventDisector()
+    {
+    }
+
+    static void dissectLogStartMessage(
+        final long timestampNs, final long timestampMs, final StringBuilder builder)
+    {
+        builder
+            .append('[')
+            .append(((double)timestampNs) / NANOS_PER_SECOND)
+            .append("] log started ")
+            .append(DATE_TIME_FORMATTER.format(ofInstant(ofEpochMilli(timestampMs), systemDefault())));
+    }
+
+    static int dissectLogHeader(
+        final String context,
+        final Enum<?> code,
+        final MutableDirectBuffer buffer,
+        final int offset,
+        final StringBuilder builder)
+    {
+        int relativeOffset = 0;
+
+        final int captureLength = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        final int bufferLength = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        final long timestampNs = buffer.getLong(offset + relativeOffset, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_LONG;
+
+        builder
+            .append('[')
+            .append(((double)timestampNs) / NANOS_PER_SECOND)
+            .append("] ")
+            .append(context)
+            .append(": ")
+            .append(code.name())
+            .append(" [")
+            .append(captureLength)
+            .append('/')
+            .append(bufferLength)
+            .append(']');
+
+        return relativeOffset;
+    }
+
+    static int dissectSocketAddress(
+        final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int relativeOffset = 0;
+
+        final int port = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        final int addressLength = buffer.getInt(offset + relativeOffset);
+        relativeOffset += SIZE_OF_INT;
+
+        if (4 == addressLength)
+        {
+            final int i = offset + relativeOffset;
+            builder
+                .append(buffer.getByte(i) & 0xFF)
+                .append('.')
+                .append(buffer.getByte(i + 1) & 0xFF)
+                .append('.')
+                .append(buffer.getByte(i + 2) & 0xFF)
+                .append('.')
+                .append(buffer.getByte(i + 3) & 0xFF)
+                .append(':')
+                .append(port);
+        }
+        else if (16 == addressLength)
+        {
+            final int i = offset + relativeOffset;
+            builder
+                .append(toHexString(((buffer.getByte(i) << 8) & 0xFF00) | buffer.getByte(i + 1) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 2) << 8) & 0xFF00) | buffer.getByte(i + 3) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 4) << 8) & 0xFF00) | buffer.getByte(i + 5) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 6) << 8) & 0xFF00) | buffer.getByte(i + 7) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 8) << 8) & 0xFF00) | buffer.getByte(i + 9) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 10) << 8) & 0xFF00) | buffer.getByte(i + 11) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 12) << 8) & 0xFF00) | buffer.getByte(i + 13) & 0xFF))
+                .append(':')
+                .append(toHexString(((buffer.getByte(i + 14) << 8) & 0xFF00) | buffer.getByte(i + 15) & 0xFF))
+                .append(':')
+                .append(port);
+        }
+        else
+        {
+            builder.append("unknown-address:").append(port);
+        }
+
+        relativeOffset += addressLength;
+
+        return relativeOffset;
+    }
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/CommonEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CommonEventEncoder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.NanoClock;
+import org.agrona.concurrent.SystemNanoClock;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.net.InetSocketAddress;
+
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.lang.Math.min;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+final class CommonEventEncoder
+{
+    static final int LOG_HEADER_LENGTH = 16;
+    static final int SOCKET_ADDRESS_MAX_LENGTH = 24;
+    static final int MAX_CAPTURE_LENGTH = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH;
+
+    private CommonEventEncoder()
+    {
+    }
+
+    static int encodeLogHeader(
+        final UnsafeBuffer encodingBuffer, final int captureLength, final int length)
+    {
+        return internalEncodeLogHeader(encodingBuffer, captureLength, length, SystemNanoClock.INSTANCE);
+    }
+
+    static int internalEncodeLogHeader(
+        final UnsafeBuffer encodingBuffer, final int captureLength, final int length, final NanoClock nanoClock)
+    {
+        int relativeOffset = 0;
+        /*
+         * Stream of values:
+         * - capture buffer length (int)
+         * - total buffer length (int)
+         * - timestamp (long)
+         * - buffer (until end)
+         */
+
+        encodingBuffer.putInt(relativeOffset, captureLength, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putInt(relativeOffset, length, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putLong(relativeOffset, nanoClock.nanoTime(), LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_LONG;
+
+        return relativeOffset;
+    }
+
+    static int encodeSocketAddress(
+        final UnsafeBuffer encodingBuffer, final int offset, final InetSocketAddress dstAddress)
+    {
+        int relativeOffset = 0;
+        /*
+         * Stream of values:
+         * - port (int) (unsigned short int)
+         * - IP address length (int) (4 or 16)
+         * - IP address (4 or 16 bytes)
+         */
+
+        encodingBuffer.putInt(offset + relativeOffset, dstAddress.getPort(), LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        final byte[] addressBytes = dstAddress.getAddress().getAddress();
+        encodingBuffer.putInt(offset + relativeOffset, addressBytes.length, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putBytes(offset + relativeOffset, addressBytes);
+        relativeOffset += addressBytes.length;
+
+        return relativeOffset;
+    }
+
+    static int encodeTrailingString(
+        final UnsafeBuffer encodingBuffer, final int offset, final String value)
+    {
+        int relativeOffset = 0;
+        final int maxLength = MAX_EVENT_LENGTH - offset - SIZE_OF_INT;
+        if (value.length() <= maxLength)
+        {
+            relativeOffset += encodingBuffer.putStringAscii(relativeOffset + offset, value, LITTLE_ENDIAN);
+        }
+        else
+        {
+            encodingBuffer.putInt(relativeOffset + offset, maxLength, LITTLE_ENDIAN);
+            relativeOffset += SIZE_OF_INT;
+            relativeOffset +=
+                encodingBuffer.putStringWithoutLengthAscii(relativeOffset + offset, value, 0, maxLength - 3);
+            relativeOffset += encodingBuffer.putStringWithoutLengthAscii(relativeOffset + offset, "...");
+        }
+        return relativeOffset;
+    }
+
+    static int encode(
+        final UnsafeBuffer encodingBuffer, final DirectBuffer buffer, final int offset, final int length)
+    {
+        final int captureLength = min(length, MAX_CAPTURE_LENGTH);
+        int relativeOffset = encodeLogHeader(encodingBuffer, captureLength, length);
+
+        encodingBuffer.putBytes(relativeOffset, buffer, offset, captureLength);
+        relativeOffset += captureLength;
+
+        return relativeOffset;
+    }
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ControlInterceptor.java
@@ -23,7 +23,7 @@ import static io.aeron.agent.ArchiveEventLogger.LOGGER;
 /**
  * Intercepts requests to the archive.
  */
-final class ControlInterceptor
+class ControlInterceptor
 {
     static class ControlRequest
     {

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -19,6 +19,8 @@ import org.agrona.MutableDirectBuffer;
 
 import java.util.Arrays;
 
+import static io.aeron.agent.DriverEventDissector.*;
+
 /**
  * Events and codecs for encoding/decoding events recorded to the {@link EventConfiguration#EVENT_RING_BUFFER}.
  */
@@ -33,14 +35,16 @@ public enum DriverEventCode implements EventCode
     CMD_IN_REMOVE_SUBSCRIPTION(6, DriverEventDissector::dissectAsCommand),
     CMD_OUT_PUBLICATION_READY(7, DriverEventDissector::dissectAsCommand),
     CMD_OUT_AVAILABLE_IMAGE(8, DriverEventDissector::dissectAsCommand),
-    INVOCATION(9, DriverEventDissector::dissectAsInvocation),
 
     CMD_OUT_ON_OPERATION_SUCCESS(12, DriverEventDissector::dissectAsCommand),
     CMD_IN_KEEPALIVE_CLIENT(13, DriverEventDissector::dissectAsCommand),
-    REMOVE_PUBLICATION_CLEANUP(14, DriverEventDissector::dissectAsString),
-    REMOVE_SUBSCRIPTION_CLEANUP(15, DriverEventDissector::dissectAsString),
+    REMOVE_PUBLICATION_CLEANUP(14,
+        (code, buffer, offset, builder) -> dissectRemovePublicationCleanup(buffer, offset, builder)),
+    REMOVE_SUBSCRIPTION_CLEANUP(15,
+        (code, buffer, offset, builder) -> dissectRemoveSubscriptionCleanup(buffer, offset, builder)),
 
-    REMOVE_IMAGE_CLEANUP(16, DriverEventDissector::dissectAsString),
+    REMOVE_IMAGE_CLEANUP(16,
+        (code, buffer, offset, builder) -> dissectRemoveImageCleanup(buffer, offset, builder)),
     CMD_OUT_ON_UNAVAILABLE_IMAGE(17, DriverEventDissector::dissectAsCommand),
 
     SEND_CHANNEL_CREATION(23, DriverEventDissector::dissectAsString),

--- a/aeron-agent/src/main/java/io/aeron/agent/EventCodeType.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventCodeType.java
@@ -18,7 +18,7 @@ package io.aeron.agent;
 /**
  * Specifies the type of EventCode that can be handled by the logging agent.
  */
-public enum EventCodeType
+enum EventCodeType
 {
     /**
      * Events related to media driver operation.

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -40,7 +40,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * which is consumed and appended asynchronous to a log as defined by the class {@link #READER_CLASSNAME_PROP_NAME}
  * which defaults to {@link EventLogReaderAgent}.
  */
-public class EventLogAgent
+public final class EventLogAgent
 {
     /**
      * Event reader {@link Agent} which consumes the {@link EventConfiguration#EVENT_RING_BUFFER} to output log events.
@@ -389,7 +389,7 @@ public class EventLogAgent
     }
 }
 
-class AgentBuilderListener implements AgentBuilder.Listener
+final class AgentBuilderListener implements AgentBuilder.Listener
 {
     public void onDiscovery(
         final String typeName,

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -15,40 +15,690 @@
  */
 package io.aeron.agent;
 
-import io.aeron.archive.codecs.ControlResponseCode;
-import io.aeron.archive.codecs.ControlResponseEncoder;
-import io.aeron.archive.codecs.MessageHeaderEncoder;
+import io.aeron.archive.codecs.*;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
+import static io.aeron.agent.ArchiveEventCode.*;
+import static io.aeron.agent.ArchiveEventDissector.CONTEXT;
+import static io.aeron.agent.ArchiveEventDissector.controlRequest;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.CommonEventEncoder.internalEncodeLogHeader;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static io.aeron.archive.codecs.ControlResponseCode.NULL_VAL;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 import static org.agrona.BufferUtil.allocateDirectAligned;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ArchiveEventDissectorTest
 {
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH, CACHE_LINE_LENGTH));
+    private final StringBuilder builder = new StringBuilder();
+    private final MessageHeaderEncoder headerEncoder = new MessageHeaderEncoder();
+
     @Test
     void controlResponse()
     {
-        final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(1024, 32));
+        internalEncodeLogHeader(buffer, 100, 100, () -> 1_250_000_000);
         final ControlResponseEncoder responseEncoder = new ControlResponseEncoder();
-        responseEncoder.wrapAndApplyHeader(buffer, 16, new MessageHeaderEncoder())
+        responseEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
             .controlSessionId(13)
             .correlationId(42)
             .relevantId(8)
-            .code(ControlResponseCode.NULL_VAL)
+            .code(NULL_VAL)
             .version(111)
             .errorMessage("the %ERR% msg");
-        final StringBuilder builder = new StringBuilder();
 
-        ArchiveEventDissector.controlResponse(buffer, 16, builder);
+        ArchiveEventDissector.controlResponse(buffer, 0, builder);
 
-        assertEquals("ARCHIVE: CONTROL_RESPONSE" +
-            ", controlSessionId=13" +
+        assertEquals("[1.25] " + CONTEXT + ": " + CMD_OUT_RESPONSE.name() + " [100/100]: " +
+            "controlSessionId=13" +
             ", correlationId=42" +
             ", relevantId=8" +
-            ", code=" + ControlResponseCode.NULL_VAL +
+            ", code=" + NULL_VAL +
             ", version=111" +
             ", errorMessage=the %ERR% msg",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestConnect()
+    {
+        internalEncodeLogHeader(buffer, 32, 64, () -> 5_600_000_000L);
+        final ConnectRequestEncoder requestEncoder = new ConnectRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .correlationId(88)
+            .responseStreamId(42)
+            .version(-10)
+            .responseChannel("call me maybe");
+
+        controlRequest(CMD_IN_CONNECT, buffer, 0, builder);
+
+        assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_CONNECT.name() + " [32/64]: " +
+            "correlationId=88" +
+            ", responseStreamId=42" +
+            ", version=-10" +
+            ", responseChannel=call me maybe",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestCloseSession()
+    {
+        internalEncodeLogHeader(buffer, 32, 64, () -> 5_600_000_000L);
+        final CloseSessionRequestEncoder requestEncoder = new CloseSessionRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(-1);
+
+        controlRequest(CMD_IN_CLOSE_SESSION, buffer, 0, builder);
+
+        assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_CLOSE_SESSION.name() + " [32/64]: controlSessionId=-1",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStartRecording()
+    {
+        internalEncodeLogHeader(buffer, 32, 64, () -> 5_600_000_000L);
+        final StartRecordingRequestEncoder requestEncoder = new StartRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(5)
+            .correlationId(13)
+            .streamId(7)
+            .sourceLocation(SourceLocation.REMOTE)
+            .channel("foo");
+
+        controlRequest(CMD_IN_START_RECORDING, buffer, 0, builder);
+
+        assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_START_RECORDING.name() + " [32/64]:" +
+            " controlSessionId=5" +
+            ", correlationId=13" +
+            ", streamId=7" +
+            ", sourceLocation=" + SourceLocation.REMOTE +
+            ", channel=foo",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopRecording()
+    {
+        internalEncodeLogHeader(buffer, 32, 64, () -> 5_600_000_000L);
+        final StopRecordingRequestEncoder requestEncoder = new StopRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(5)
+            .correlationId(42)
+            .streamId(7)
+            .channel("bar");
+
+        controlRequest(CMD_IN_STOP_RECORDING, buffer, 0, builder);
+
+        assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_STOP_RECORDING.name() + " [32/64]:" +
+            " controlSessionId=5" +
+            ", correlationId=42" +
+            ", streamId=7" +
+            ", channel=bar",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestReplay()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 1_125_000_000L);
+        final ReplayRequestEncoder requestEncoder = new ReplayRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(5)
+            .correlationId(42)
+            .recordingId(178)
+            .position(Long.MAX_VALUE)
+            .length(2000)
+            .replayStreamId(99)
+            .replayChannel("replay channel");
+
+        controlRequest(CMD_IN_REPLAY, buffer, 0, builder);
+
+        assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_REPLAY.name() + " [90/90]:" +
+            " controlSessionId=5" +
+            ", correlationId=42" +
+            ", recordingId=178" +
+            ", position=" + Long.MAX_VALUE +
+            ", length=2000" +
+            ", replayStreamId=99" +
+            ", replayChannel=replay channel",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopReplay()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 1_125_000_000L);
+        final StopReplayRequestEncoder requestEncoder = new StopReplayRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(5)
+            .correlationId(42)
+            .replaySessionId(66);
+
+        controlRequest(CMD_IN_STOP_REPLAY, buffer, 0, builder);
+
+        assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_STOP_REPLAY.name() + " [90/90]:" +
+            " controlSessionId=5" +
+            ", correlationId=42" +
+            ", replaySessionId=66",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestListRecordings()
+    {
+        internalEncodeLogHeader(buffer, 32, 32, () -> 100_000_000L);
+        final ListRecordingsRequestEncoder requestEncoder = new ListRecordingsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(9)
+            .correlationId(78)
+            .fromRecordingId(45)
+            .recordCount(10);
+
+        controlRequest(CMD_IN_LIST_RECORDINGS, buffer, 0, builder);
+
+        assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDINGS.name() + " [32/32]:" +
+            " controlSessionId=9" +
+            ", correlationId=78" +
+            ", fromRecordingId=45" +
+            ", recordCount=10",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestListRecordingsForUri()
+    {
+        internalEncodeLogHeader(buffer, 32, 32, () -> 100_000_000L);
+        final ListRecordingsForUriRequestEncoder requestEncoder = new ListRecordingsForUriRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(9)
+            .correlationId(78)
+            .fromRecordingId(45)
+            .recordCount(10)
+            .streamId(200)
+            .channel("CH");
+
+        controlRequest(CMD_IN_LIST_RECORDINGS_FOR_URI, buffer, 0, builder);
+
+        assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDINGS_FOR_URI.name() + " [32/32]:" +
+            " controlSessionId=9" +
+            ", correlationId=78" +
+            ", fromRecordingId=45" +
+            ", recordCount=10" +
+            ", streamId=200" +
+            ", channel=CH",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestListRecording()
+    {
+        internalEncodeLogHeader(buffer, 32, 32, () -> 100_000_000L);
+        final ListRecordingRequestEncoder requestEncoder = new ListRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(19)
+            .correlationId(178)
+            .recordingId(1010101);
+
+        controlRequest(CMD_IN_LIST_RECORDING, buffer, 0, builder);
+
+        assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDING.name() + " [32/32]:" +
+            " controlSessionId=19" +
+            ", correlationId=178" +
+            ", recordingId=1010101",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestExtendRecording()
+    {
+        internalEncodeLogHeader(buffer, 12, 32, () -> 10_000_000_000L);
+        final ExtendRecordingRequestEncoder requestEncoder = new ExtendRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(9)
+            .correlationId(78)
+            .recordingId(1010101)
+            .streamId(43)
+            .sourceLocation(SourceLocation.LOCAL)
+            .channel("extend me");
+
+        controlRequest(CMD_IN_EXTEND_RECORDING, buffer, 0, builder);
+
+        assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_EXTEND_RECORDING.name() + " [12/32]:" +
+            " controlSessionId=9" +
+            ", correlationId=78" +
+            ", recordingId=1010101" +
+            ", streamId=43" +
+            ", sourceLocation=" + SourceLocation.LOCAL +
+            ", channel=extend me",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestRecordingPosition()
+    {
+        internalEncodeLogHeader(buffer, 12, 32, () -> 10_000_000_000L);
+        final RecordingPositionRequestEncoder requestEncoder = new RecordingPositionRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(2)
+            .correlationId(3)
+            .recordingId(6);
+
+        controlRequest(CMD_IN_RECORDING_POSITION, buffer, 0, builder);
+
+        assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_RECORDING_POSITION.name() + " [12/32]:" +
+            " controlSessionId=2" +
+            ", correlationId=3" +
+            ", recordingId=6",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestTruncateRecording()
+    {
+        internalEncodeLogHeader(buffer, 12, 32, () -> 10_000_000_000L);
+        final TruncateRecordingRequestEncoder requestEncoder = new TruncateRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(2)
+            .correlationId(3)
+            .recordingId(8)
+            .position(1_000_000);
+
+        controlRequest(CMD_IN_TRUNCATE_RECORDING, buffer, 0, builder);
+
+        assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_TRUNCATE_RECORDING.name() + " [12/32]:" +
+            " controlSessionId=2" +
+            ", correlationId=3" +
+            ", recordingId=8" +
+            ", position=1000000",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopRecordingSubscription()
+    {
+        internalEncodeLogHeader(buffer, 12, 32, () -> 10_000_000_000L);
+        final StopRecordingSubscriptionRequestEncoder requestEncoder = new StopRecordingSubscriptionRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(22)
+            .correlationId(33)
+            .subscriptionId(888);
+
+        controlRequest(CMD_IN_STOP_RECORDING_SUBSCRIPTION, buffer, 0, builder);
+
+        assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_STOP_RECORDING_SUBSCRIPTION.name() + " [12/32]:" +
+            " controlSessionId=22" +
+            ", correlationId=33" +
+            ", subscriptionId=888",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopPosition()
+    {
+        internalEncodeLogHeader(buffer, 12, 32, () -> 10_000_000_000L);
+        final StopPositionRequestEncoder requestEncoder = new StopPositionRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(22)
+            .correlationId(33)
+            .recordingId(44);
+
+        controlRequest(CMD_IN_STOP_POSITION, buffer, 0, builder);
+
+        assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_STOP_POSITION.name() + " [12/32]:" +
+            " controlSessionId=22" +
+            ", correlationId=33" +
+            ", recordingId=44",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestFindLastMatchingRecording()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 10_325_000_000L);
+        final FindLastMatchingRecordingRequestEncoder requestEncoder = new FindLastMatchingRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(1)
+            .correlationId(2)
+            .minRecordingId(3)
+            .sessionId(4)
+            .streamId(5)
+            .channel("this is a channel");
+
+        controlRequest(CMD_IN_FIND_LAST_MATCHING_RECORD, buffer, 0, builder);
+
+        assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_FIND_LAST_MATCHING_RECORD.name() + " [90/90]:" +
+            " controlSessionId=1" +
+            ", correlationId=2" +
+            ", minRecordingId=3" +
+            ", sessionId=4" +
+            ", streamId=5" +
+            ", channel=this is a channel",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestListRecordingSubscriptions()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 10_325_000_000L);
+        final ListRecordingSubscriptionsRequestEncoder requestEncoder = new ListRecordingSubscriptionsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(1)
+            .correlationId(2)
+            .pseudoIndex(1111111)
+            .applyStreamId(BooleanType.TRUE)
+            .subscriptionCount(777)
+            .streamId(555)
+            .channel("ch2");
+
+        controlRequest(CMD_IN_LIST_RECORDING_SUBSCRIPTIONS, buffer, 0, builder);
+
+        assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_LIST_RECORDING_SUBSCRIPTIONS.name() + " [90/90]:" +
+            " controlSessionId=1" +
+            ", correlationId=2" +
+            ", pseudoIndex=1111111" +
+            ", applyStreamId=" + BooleanType.TRUE +
+            ", subscriptionCount=777" +
+            ", streamId=555" +
+            ", channel=ch2",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStartBoundedReplay()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 10_325_000_000L);
+        final BoundedReplayRequestEncoder requestEncoder = new BoundedReplayRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(10)
+            .correlationId(20)
+            .recordingId(30)
+            .position(40)
+            .length(50)
+            .limitCounterId(-123)
+            .replayStreamId(14)
+            .replayChannel("rep ch");
+
+        controlRequest(CMD_IN_START_BOUNDED_REPLAY, buffer, 0, builder);
+
+        assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_START_BOUNDED_REPLAY.name() + " [90/90]:" +
+            " controlSessionId=10" +
+            ", correlationId=20" +
+            ", recordingId=30" +
+            ", position=40" +
+            ", length=50" +
+            ", limitCounterId=-123" +
+            ", replayStreamId=14" +
+            ", replayChannel=rep ch",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopAllReplays()
+    {
+        internalEncodeLogHeader(buffer, 90, 90, () -> 10_325_000_000L);
+        final StopAllReplaysRequestEncoder requestEncoder = new StopAllReplaysRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(10)
+            .correlationId(20)
+            .recordingId(30);
+
+        controlRequest(CMD_IN_STOP_ALL_REPLAYS, buffer, 0, builder);
+
+        assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_STOP_ALL_REPLAYS.name() + " [90/90]:" +
+            " controlSessionId=10" +
+            ", correlationId=20" +
+            ", recordingId=30",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestReplicate()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final ReplicateRequestEncoder requestEncoder = new ReplicateRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(2)
+            .correlationId(5)
+            .srcRecordingId(17)
+            .dstRecordingId(2048)
+            .srcControlStreamId(10)
+            .srcControlChannel("CTRL ch")
+            .liveDestination("live destination");
+
+        controlRequest(CMD_IN_REPLICATE, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_REPLICATE.name() + " [1000/1000]:" +
+            " controlSessionId=2" +
+            ", correlationId=5" +
+            ", srcRecordingId=17" +
+            ", dstRecordingId=2048" +
+            ", srcControlStreamId=10" +
+            ", srcControlChannel=CTRL ch" +
+            ", liveDestination=live destination",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStopReplication()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final StopReplicationRequestEncoder requestEncoder = new StopReplicationRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(-2)
+            .correlationId(-5)
+            .replicationId(-999);
+
+        controlRequest(CMD_IN_STOP_REPLICATION, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_STOP_REPLICATION.name() + " [1000/1000]:" +
+            " controlSessionId=-2" +
+            ", correlationId=-5" +
+            ", replicationId=-999",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestStartPosition()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final StartPositionRequestEncoder requestEncoder = new StartPositionRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(3)
+            .correlationId(16)
+            .recordingId(1);
+
+        controlRequest(CMD_IN_START_POSITION, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_START_POSITION.name() + " [1000/1000]:" +
+            " controlSessionId=3" +
+            ", correlationId=16" +
+            ", recordingId=1",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestDetachSegments()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final DetachSegmentsRequestEncoder requestEncoder = new DetachSegmentsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(3)
+            .correlationId(16)
+            .recordingId(1);
+
+        controlRequest(CMD_IN_DETACH_SEGMENTS, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_DETACH_SEGMENTS.name() + " [1000/1000]:" +
+            " controlSessionId=3" +
+            ", correlationId=16" +
+            ", recordingId=1",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestDeleteDetachedSegments()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final DeleteDetachedSegmentsRequestEncoder requestEncoder = new DeleteDetachedSegmentsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(53)
+            .correlationId(516)
+            .recordingId(51);
+
+        controlRequest(CMD_IN_DELETE_DETACHED_SEGMENTS, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_DELETE_DETACHED_SEGMENTS.name() + " [1000/1000]:" +
+            " controlSessionId=53" +
+            ", correlationId=516" +
+            ", recordingId=51",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestPurgeSegments()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final PurgeSegmentsRequestEncoder requestEncoder = new PurgeSegmentsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(3)
+            .correlationId(56)
+            .recordingId(15)
+            .newStartPosition(100);
+
+        controlRequest(CMD_IN_PURGE_SEGMENTS, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_PURGE_SEGMENTS.name() + " [1000/1000]:" +
+            " controlSessionId=3" +
+            ", correlationId=56" +
+            ", recordingId=15" +
+            ", newStartPosition=100",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestAttachSegments()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final AttachSegmentsRequestEncoder requestEncoder = new AttachSegmentsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(30)
+            .correlationId(560)
+            .recordingId(50);
+
+        controlRequest(CMD_IN_ATTACH_SEGMENTS, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_ATTACH_SEGMENTS.name() + " [1000/1000]:" +
+            " controlSessionId=30" +
+            ", correlationId=560" +
+            ", recordingId=50",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestMigrateSegments()
+    {
+        internalEncodeLogHeader(buffer, 1000, 1000, () -> 500_000_000L);
+        final MigrateSegmentsRequestEncoder requestEncoder = new MigrateSegmentsRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(7)
+            .correlationId(6)
+            .srcRecordingId(1)
+            .dstRecordingId(21902);
+
+        controlRequest(CMD_IN_MIGRATE_SEGMENTS, buffer, 0, builder);
+
+        assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_MIGRATE_SEGMENTS.name() + " [1000/1000]:" +
+            " controlSessionId=7" +
+            ", correlationId=6" +
+            ", srcRecordingId=1" +
+            ", dstRecordingId=21902",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestAuthConnect()
+    {
+        internalEncodeLogHeader(buffer, 3, 6, () -> 5_500_000_000L);
+        final AuthConnectRequestEncoder requestEncoder = new AuthConnectRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .correlationId(16)
+            .responseStreamId(19)
+            .version(2)
+            .responseChannel("English Channel")
+            .putEncodedCredentials("hello".getBytes(US_ASCII), 0, 5);
+
+        controlRequest(CMD_IN_AUTH_CONNECT, buffer, 0, builder);
+
+        assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_AUTH_CONNECT.name() + " [3/6]:" +
+            " correlationId=16" +
+            ", responseStreamId=19" +
+            ", version=2" +
+            ", responseChannel=English Channel" +
+            ", encodedCredentialsLength=5",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestKeepAlive()
+    {
+        internalEncodeLogHeader(buffer, 3, 6, () -> 5_500_000_000L);
+        final KeepAliveRequestEncoder requestEncoder = new KeepAliveRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(31)
+            .correlationId(119);
+
+        controlRequest(CMD_IN_KEEP_ALIVE, buffer, 0, builder);
+
+        assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_KEEP_ALIVE.name() + " [3/6]:" +
+            " controlSessionId=31" +
+            ", correlationId=119",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestTaggedReplicate()
+    {
+        internalEncodeLogHeader(buffer, 3, 6, () -> 5_500_000_000L);
+        final TaggedReplicateRequestEncoder requestEncoder = new TaggedReplicateRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(1)
+            .correlationId(-10)
+            .srcRecordingId(9)
+            .dstRecordingId(31)
+            .channelTagId(4)
+            .subscriptionTagId(7)
+            .srcControlStreamId(15)
+            .srcControlChannel("src")
+            .liveDestination("alive and well");
+
+        controlRequest(CMD_IN_TAGGED_REPLICATE, buffer, 0, builder);
+
+        assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_TAGGED_REPLICATE.name() + " [3/6]:" +
+            " controlSessionId=1" +
+            ", correlationId=-10" +
+            ", srcRecordingId=9" +
+            ", dstRecordingId=31" +
+            ", channelTagId=4" +
+            ", subscriptionTagId=7" +
+            ", srcControlStreamId=15" +
+            ", srcControlChannel=src" +
+            ", liveDestination=alive and well",
+            builder.toString());
+    }
+
+    @Test
+    void controlRequestUnknownCommand()
+    {
+        internalEncodeLogHeader(buffer, 10, 20, () -> 2_500_000_000L);
+        headerEncoder.wrap(buffer, LOG_HEADER_LENGTH).templateId(Integer.MIN_VALUE);
+
+        controlRequest(CMD_OUT_RESPONSE, buffer, 0, builder);
+
+        assertEquals("[2.5] " + CONTEXT + ": " + CMD_OUT_RESPONSE.name() + " [10/20]: unknown command",
             builder.toString());
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
@@ -15,18 +15,29 @@
  */
 package io.aeron.agent;
 
+import io.aeron.archive.codecs.ListRecordingRequestDecoder;
+import io.aeron.archive.codecs.MessageHeaderEncoder;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.aeron.agent.ArchiveEventCode.CMD_OUT_RESPONSE;
 import static io.aeron.agent.ArchiveEventCode.EVENT_CODE_TYPE;
 import static io.aeron.agent.ArchiveEventLogger.CONTROL_REQUEST_EVENTS;
+import static io.aeron.agent.ArchiveEventLogger.toEventCodeId;
+import static io.aeron.agent.Common.verifyLogHeader;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.CommonEventEncoder.MAX_CAPTURE_LENGTH;
+import static io.aeron.agent.EventConfiguration.*;
+import static io.aeron.archive.codecs.MessageHeaderEncoder.ENCODED_LENGTH;
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.encodedMsgOffset;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.lengthOffset;
 import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
@@ -34,44 +45,80 @@ import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 
 class ArchiveEventLoggerTest
 {
+    private final UnsafeBuffer logBuffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH * 8 + TRAILER_LENGTH));
+    private final ArchiveEventLogger logger = new ArchiveEventLogger(new ManyToOneRingBuffer(logBuffer));
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH * 3));
+
+    @AfterEach
+    void after()
+    {
+        reset();
+    }
+
     @ParameterizedTest
     @EnumSource(ArchiveEventCode.class)
-    void toEventCodeId(final ArchiveEventCode code)
+    void toEventCodeIdComputesEventId(final ArchiveEventCode eventCode)
     {
-        assertEquals(0xFFFF + EVENT_CODE_TYPE + code.id(), ArchiveEventLogger.toEventCodeId(code));
+        assertEquals(0xFFFF + EVENT_CODE_TYPE + eventCode.id(), toEventCodeId(eventCode));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ArchiveEventCode.class, mode = EXCLUDE, names = { "CMD_OUT_RESPONSE" })
+    void logControlRequest(final ArchiveEventCode eventCode)
+    {
+        ARCHIVE_EVENT_CODES.add(eventCode);
+        final int offset = 100;
+        final int dataLength = MAX_EVENT_LENGTH * 2;
+        new MessageHeaderEncoder().wrap(buffer, offset).templateId(eventCode.templateId());
+        buffer.setMemory(offset + ENCODED_LENGTH, dataLength, (byte)3);
+        final int captureLength = MAX_CAPTURE_LENGTH;
+
+        logger.logControlRequest(buffer, offset, dataLength);
+
+        verifyLogHeader(logBuffer, toEventCodeId(eventCode), captureLength, captureLength, MAX_EVENT_LENGTH * 2);
+        for (int i = 0; i < captureLength - ENCODED_LENGTH; i++)
+        {
+            assertEquals((byte)3, logBuffer.getByte(encodedMsgOffset(LOG_HEADER_LENGTH + ENCODED_LENGTH + i)));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, ListRecordingRequestDecoder.TEMPLATE_ID })
+    void logControlRequestNoOp(final int templateId)
+    {
+        new MessageHeaderEncoder().wrap(buffer, 0).templateId(templateId);
+        buffer.setMemory(ENCODED_LENGTH, 100, (byte)3);
+
+        logger.logControlRequest(buffer, 0, 100);
+
+        assertEquals(0, logBuffer.getInt(lengthOffset(0), LITTLE_ENDIAN));
     }
 
     @Test
     void logControlResponse()
     {
-        final UnsafeBuffer dest = new UnsafeBuffer(allocateDirect(2048 + TRAILER_LENGTH));
-        final ArchiveEventLogger logger = new ArchiveEventLogger(new ManyToOneRingBuffer(dest));
-        final UnsafeBuffer src = new UnsafeBuffer(allocateDirect(128));
-        src.setMemory(0, 64, (byte)1);
+        buffer.setMemory(0, 64, (byte)1);
 
-        logger.logControlResponse(src, 64);
+        logger.logControlResponse(buffer, 64);
 
-        assertEquals(64 + HEADER_LENGTH, dest.getInt(lengthOffset(0), LITTLE_ENDIAN));
-        assertEquals(ArchiveEventLogger.toEventCodeId(CMD_OUT_RESPONSE), dest.getInt(typeOffset(0), LITTLE_ENDIAN));
-        final byte[] data = new byte[64];
-        dest.getBytes(encodedMsgOffset(0), data);
-        for (final byte b : data)
+        verifyLogHeader(logBuffer, toEventCodeId(CMD_OUT_RESPONSE), 64, 64, 64);
+        for (int i = 0; i < 64; i++)
         {
-            assertEquals((byte)1, b);
+            assertEquals((byte)1, logBuffer.getByte(encodedMsgOffset(LOG_HEADER_LENGTH + i)));
         }
     }
 
     @ParameterizedTest
     @EnumSource(value = ArchiveEventCode.class, mode = EXCLUDE, names = { "CMD_OUT_RESPONSE" })
-    void controlRequestEvents(final ArchiveEventCode code)
+    void controlRequestEvents(final ArchiveEventCode eventCode)
     {
-        assertTrue(CONTROL_REQUEST_EVENTS.contains(code));
+        assertTrue(CONTROL_REQUEST_EVENTS.contains(eventCode));
     }
 
     @ParameterizedTest
     @EnumSource(value = ArchiveEventCode.class, mode = INCLUDE, names = { "CMD_OUT_RESPONSE" })
-    void nonControlRequestEvents(final ArchiveEventCode code)
+    void nonControlRequestEvents(final ArchiveEventCode eventCode)
     {
-        assertFalse(CONTROL_REQUEST_EVENTS.contains(code));
+        assertFalse(CONTROL_REQUEST_EVENTS.contains(eventCode));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.agent.ClusterEventCode.ELECTION_STATE_CHANGE;
+import static io.aeron.agent.ClusterEventCode.NEW_LEADERSHIP_TERM;
+import static io.aeron.agent.ClusterEventDissector.CONTEXT;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.CommonEventEncoder.internalEncodeLogHeader;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.*;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClusterEventDissectorTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH, CACHE_LINE_LENGTH));
+    private final StringBuilder builder = new StringBuilder();
+
+    @Test
+    void dissectNewLeadershipTerm()
+    {
+        internalEncodeLogHeader(buffer, 8, 9, () -> 33_000_000_000L);
+        buffer.putLong(LOG_HEADER_LENGTH, 1, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_LONG, 2, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_LONG * 2, 3, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_LONG * 3, 4, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4, 100, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4 + SIZE_OF_INT, 200, LITTLE_ENDIAN);
+
+        ClusterEventDissector.dissectNewLeadershipTerm(buffer, 0, builder);
+
+        assertEquals("[33.0] " + CONTEXT + ": " + NEW_LEADERSHIP_TERM.name() + " [8/9]: logLeadershipTermId=1" +
+            ", leadershipTermId=2, logPosition=3, timestamp=4, leaderMemberId=100, logSessionId=200",
+            builder.toString());
+    }
+
+    @Test
+    void dissectStateChange()
+    {
+        internalEncodeLogHeader(buffer, 100, 200, () -> -1_000_000_000);
+        buffer.putInt(LOG_HEADER_LENGTH, 42, LITTLE_ENDIAN);
+        buffer.putStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT, "a -> b");
+
+        ClusterEventDissector.dissectStateChange(ELECTION_STATE_CHANGE, buffer, 0, builder);
+
+        assertEquals("[-1.0] " + CONTEXT + ": " + ELECTION_STATE_CHANGE.name() + " [100/200]: a -> b, memberId=42",
+            builder.toString());
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventEncoderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import io.aeron.cluster.Election;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.agent.ClusterEventEncoder.SEPARATOR;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ClusterEventEncoderTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(256, 32));
+
+    @Test
+    void encodeStateChange()
+    {
+        final Election.State from = Election.State.CANDIDATE_BALLOT;
+        final Election.State to = Election.State.CANVASS;
+        final String payload = from.name() + SEPARATOR + to.name();
+        final int captureLength = SIZE_OF_INT * 2 + payload.length();
+
+        final int encodedLength = ClusterEventEncoder.encodeStateChange(buffer, from, to, 42);
+
+        assertEquals(LOG_HEADER_LENGTH + captureLength, encodedLength);
+        assertEquals(captureLength, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(42, buffer.getInt(LOG_HEADER_LENGTH));
+        assertEquals(payload, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT));
+    }
+
+    @Test
+    void encodeNewLeadershipTerm()
+    {
+        final int logLeadershipTermId = 111;
+        final int leadershipTermId = 222;
+        final int logPosition = 1024;
+        final int timestamp = 32423436;
+        final int leaderMemberId = 42;
+        final int logSessionId = 18;
+        final int length = SIZE_OF_LONG * 4 + SIZE_OF_INT * 2;
+
+        final int encodedLength = ClusterEventEncoder.encodeNewLeadershipTerm(
+            buffer,
+            logLeadershipTermId,
+            leadershipTermId,
+            logPosition,
+            timestamp,
+            leaderMemberId,
+            logSessionId);
+
+        assertEquals(LOG_HEADER_LENGTH + length, encodedLength);
+        int offset = 0;
+        assertEquals(length, buffer.getInt(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_INT;
+        assertEquals(length, buffer.getInt(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_INT;
+        assertNotEquals(0, buffer.getLong(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_LONG;
+        assertEquals(logLeadershipTermId, buffer.getLong(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_LONG;
+        assertEquals(leadershipTermId, buffer.getLong(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_LONG;
+        assertEquals(logPosition, buffer.getLong(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_LONG;
+        assertEquals(timestamp, buffer.getLong(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_LONG;
+        assertEquals(leaderMemberId, buffer.getInt(offset, LITTLE_ENDIAN));
+        offset += SIZE_OF_INT;
+        assertEquals(logSessionId, buffer.getInt(offset, LITTLE_ENDIAN));
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.agent.ClusterEventCode.NEW_LEADERSHIP_TERM;
+import static io.aeron.agent.ClusterEventCode.STATE_CHANGE;
+import static io.aeron.agent.ClusterEventEncoder.SEPARATOR;
+import static io.aeron.agent.ClusterEventLogger.toEventCodeId;
+import static io.aeron.agent.Common.verifyLogHeader;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.encodedMsgOffset;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClusterEventLoggerTest
+{
+
+    private final UnsafeBuffer logBuffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH + TRAILER_LENGTH));
+    private final ClusterEventLogger logger = new ClusterEventLogger(new ManyToOneRingBuffer(logBuffer));
+
+    @ParameterizedTest
+    @EnumSource(ClusterEventCode.class)
+    void toEventCodeIdComputesEventId(final ClusterEventCode eventCode)
+    {
+        assertEquals(131072 + eventCode.id(), toEventCodeId(eventCode));
+    }
+
+    @Test
+    void logNewLeadershipTerm()
+    {
+        final long logLeadershipTermId = 434;
+        final long leadershipTermId = -500;
+        final long logPosition = 43;
+        final long timestamp = 2;
+        final int leaderMemberId = 0;
+        final int logSessionId = 3;
+        final int captureLength = SIZE_OF_LONG * 4 + SIZE_OF_INT * 2;
+
+        logger.logNewLeadershipTerm(
+            logLeadershipTermId, leadershipTermId, logPosition, timestamp, leaderMemberId, logSessionId);
+
+        verifyLogHeader(logBuffer, toEventCodeId(NEW_LEADERSHIP_TERM), captureLength, captureLength, captureLength);
+        assertEquals(logLeadershipTermId, logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(leadershipTermId,
+            logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_LONG), LITTLE_ENDIAN));
+        assertEquals(logPosition,
+            logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_LONG * 2), LITTLE_ENDIAN));
+        assertEquals(timestamp,
+            logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_LONG * 3), LITTLE_ENDIAN));
+        assertEquals(leaderMemberId,
+            logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4), LITTLE_ENDIAN));
+        assertEquals(logSessionId,
+            logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4 + SIZE_OF_INT), LITTLE_ENDIAN));
+    }
+
+    @Test
+    void logStateChange()
+    {
+        final TimeUnit from = MINUTES;
+        final TimeUnit to = SECONDS;
+        final String payload = from.name() + SEPARATOR + to.name();
+        final int captureLength = SIZE_OF_INT * 2 + payload.length();
+
+        logger.logStateChange(STATE_CHANGE, from, to, 42);
+
+        verifyLogHeader(logBuffer, toEventCodeId(STATE_CHANGE), captureLength, captureLength, captureLength);
+        assertEquals(42, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(payload, logBuffer.getStringAscii(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT)));
+    }
+
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static io.aeron.agent.ClusterEventCode.*;
 import static io.aeron.agent.ClusterEventLogger.toEventCodeId;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
 import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static java.time.Duration.ofSeconds;
@@ -188,9 +189,10 @@ public class ClusterLoggingAgentTest
         {
             LOGGED_EVENTS.add(msgTypeId);
 
+            final int offset = LOG_HEADER_LENGTH + index + SIZE_OF_INT;
             if (toEventCodeId(ROLE_CHANGE) == msgTypeId)
             {
-                final String roleChange = buffer.getStringAscii(index + SIZE_OF_INT);
+                final String roleChange = buffer.getStringAscii(offset);
                 if (roleChange.contains("LEADER"))
                 {
                     latch.countDown();
@@ -198,7 +200,7 @@ public class ClusterLoggingAgentTest
             }
             else if (toEventCodeId(STATE_CHANGE) == msgTypeId)
             {
-                final String stateChange = buffer.getStringAscii(index + SIZE_OF_INT);
+                final String stateChange = buffer.getStringAscii(offset);
                 if (stateChange.contains("ACTIVE"))
                 {
                     latch.countDown();
@@ -206,7 +208,7 @@ public class ClusterLoggingAgentTest
             }
             else if (toEventCodeId(ELECTION_STATE_CHANGE) == msgTypeId)
             {
-                final String stateChange = buffer.getStringAscii(index + SIZE_OF_INT);
+                final String stateChange = buffer.getStringAscii(offset);
                 if (stateChange.contains("CLOSE"))
                 {
                     latch.countDown();

--- a/aeron-agent/src/test/java/io/aeron/agent/Common.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/Common.java
@@ -16,8 +16,13 @@
 package io.aeron.agent;
 
 import net.bytebuddy.agent.ByteBuddyAgent;
+import org.agrona.concurrent.UnsafeBuffer;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Common
 {
@@ -42,5 +47,20 @@ public class Common
         {
             fail("unexpected interrupt - test likely to have timed out");
         }
+    }
+
+    public static void verifyLogHeader(
+        final UnsafeBuffer logBuffer,
+        final int eventCodeId,
+        final int totalLength,
+        final int captureLength,
+        final int length)
+    {
+        assertEquals(HEADER_LENGTH + LOG_HEADER_LENGTH + totalLength,
+            logBuffer.getInt(lengthOffset(0), LITTLE_ENDIAN));
+        assertEquals(eventCodeId, logBuffer.getInt(typeOffset(0), LITTLE_ENDIAN));
+        assertEquals(captureLength, logBuffer.getInt(encodedMsgOffset(0), LITTLE_ENDIAN));
+        assertEquals(length, logBuffer.getInt(encodedMsgOffset(SIZE_OF_INT), LITTLE_ENDIAN));
+        assertNotEquals(0, logBuffer.getLong(encodedMsgOffset(SIZE_OF_INT * 2), LITTLE_ENDIAN));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/CommonEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/CommonEventDissectorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.CommonEventEncoder.internalEncodeLogHeader;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommonEventDissectorTest
+{
+
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH, CACHE_LINE_LENGTH));
+    private final StringBuilder builder = new StringBuilder();
+
+    @Test
+    void dissectLogStartMessage()
+    {
+
+        final long timestampNs = 10_000_001_055L;
+        final long timestampMs = 10_000_001L;
+
+        CommonEventDisector.dissectLogStartMessage(timestampNs, timestampMs, builder);
+
+        assertThat(builder.toString(), allOf(
+            startsWith("[10.000001055] log started 1970-01-01 0"),
+            containsString(":46:40.001+")));
+    }
+
+    @Test
+    void dissectLogHeader()
+    {
+        internalEncodeLogHeader(buffer, 100, 222, () -> 1234567890);
+
+        final int decodedLength = CommonEventDisector
+            .dissectLogHeader("test ctx", ArchiveEventCode.CMD_OUT_RESPONSE, buffer, 0, builder);
+
+        assertEquals(LOG_HEADER_LENGTH, decodedLength);
+        assertEquals("[1.23456789] test ctx: CMD_OUT_RESPONSE [100/222]", builder.toString());
+    }
+
+    @Test
+    void dissectSocketAddressIpv4()
+    {
+        final int offset = 16;
+        buffer.putInt(offset, 12121, LITTLE_ENDIAN);
+        buffer.putInt(offset + SIZE_OF_INT, 4, LITTLE_ENDIAN);
+        buffer.putBytes(offset + SIZE_OF_INT * 2, new byte[]{ 127, 0, 0, 1 });
+
+        final int decodedLength = CommonEventDisector.dissectSocketAddress(buffer, offset, builder);
+
+        assertEquals(12, decodedLength);
+        assertEquals("127.0.0.1:12121", builder.toString());
+    }
+
+    @Test
+    void dissectSocketAddressIpv6()
+    {
+        final int offset = 16;
+        buffer.putInt(offset, 7777, LITTLE_ENDIAN);
+        buffer.putInt(offset + SIZE_OF_INT, 16, LITTLE_ENDIAN);
+        buffer.putBytes(offset + SIZE_OF_INT * 2,
+            new byte[]{ -100, 124, 0, 18, 120, -128, 44, 44, 10, -80, 80, 22, 122, 5, 5, -99 });
+
+        final int decodedLength = CommonEventDisector.dissectSocketAddress(buffer, offset, builder);
+
+        assertEquals(24, decodedLength);
+        assertEquals("9c7c:12:7880:2c2c:ab0:5016:7a05:59d:7777", builder.toString());
+    }
+
+    @Test
+    void dissectSocketAddressInvalidLength()
+    {
+        final int offset = 16;
+        buffer.putInt(offset, 555, LITTLE_ENDIAN);
+        buffer.putInt(offset + SIZE_OF_INT, 7, LITTLE_ENDIAN);
+
+        final int decodedLength = CommonEventDisector.dissectSocketAddress(buffer, offset, builder);
+
+        assertEquals(15, decodedLength);
+        assertEquals("unknown-address:555", builder.toString());
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/CommonEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/CommonEventEncoderTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+
+import static io.aeron.agent.CommonEventEncoder.*;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Arrays.fill;
+import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommonEventEncoderTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH, CACHE_LINE_LENGTH));
+
+    @Test
+    void encodeLogHeader()
+    {
+        final int encodedLength = internalEncodeLogHeader(buffer, 100, Integer.MAX_VALUE, () -> 555_000L);
+
+        assertEquals(LOG_HEADER_LENGTH, encodedLength);
+        assertEquals(100, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(Integer.MAX_VALUE, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(555_000L, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodeSocketAddress()
+    {
+        final InetSocketAddress socketAddress = new InetSocketAddress(15015);
+        final byte[] address = socketAddress.getAddress().getAddress();
+
+        final int encodedLength = CommonEventEncoder.encodeSocketAddress(buffer, 4, socketAddress);
+
+        assertEquals(SIZE_OF_INT * 2 + address.length, encodedLength);
+        assertEquals(15015, buffer.getInt(4, LITTLE_ENDIAN));
+        assertEquals(address.length, buffer.getInt(4 + SIZE_OF_INT, LITTLE_ENDIAN));
+        final byte[] encodedAddress = new byte[address.length];
+        buffer.getBytes(4 + SIZE_OF_INT * 2, encodedAddress);
+        assertArrayEquals(address, encodedAddress);
+    }
+
+    @Test
+    void encodeTrailingStringAsAsciiWhenPayloadIsSmallerThanMaxMessageSizeWithoutHeader()
+    {
+        final int encodedLength = encodeTrailingString(buffer, LOG_HEADER_LENGTH, "ab©d️");
+
+        assertEquals(SIZE_OF_INT + 5, encodedLength);
+        assertEquals("ab?d?", buffer.getStringAscii(LOG_HEADER_LENGTH));
+    }
+
+    @Test
+    void encodeTrailingStringAsAsciiWhenPayloadExceedsMaxMessageSizeWithoutHeader()
+    {
+        final int offset = 100;
+        final char[] chars = new char[MAX_EVENT_LENGTH - offset - SIZE_OF_INT + 1];
+        fill(chars, 'x');
+        final String value = new String(chars);
+
+        final int encodedLength = encodeTrailingString(buffer, offset, value);
+
+        assertEquals(MAX_EVENT_LENGTH - offset, encodedLength);
+        assertEquals(value.substring(0, MAX_EVENT_LENGTH - offset - SIZE_OF_INT - 3) + "...",
+            buffer.getStringAscii(offset));
+    }
+
+    @Test
+    void encodeBufferSmallerThanMaxCaptureSize()
+    {
+        final int offset = 20;
+        final int length = 128;
+        final UnsafeBuffer src = new UnsafeBuffer(allocateDirectAligned(256, CACHE_LINE_LENGTH));
+        src.setMemory(offset, length, (byte)111);
+
+        final int encodedLength = encode(buffer, src, offset, length);
+
+        assertEquals(LOG_HEADER_LENGTH + length, encodedLength);
+        assertEquals(length, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        for (int i = 0; i < length; i++)
+        {
+            assertEquals(111, buffer.getByte(LOG_HEADER_LENGTH + i));
+        }
+    }
+
+    @Test
+    void encodeBufferBuggerThanMaxCaptureSize()
+    {
+        final int offset = 20;
+        final int length = MAX_EVENT_LENGTH + 1000;
+        final UnsafeBuffer src = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH * 2, CACHE_LINE_LENGTH));
+        src.setMemory(offset, length, (byte)-5);
+
+        final int encodedLength = encode(buffer, src, offset, length);
+
+        assertEquals(MAX_EVENT_LENGTH, encodedLength);
+        assertEquals(MAX_CAPTURE_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        for (int i = 0; i < MAX_CAPTURE_LENGTH; i++)
+        {
+            assertEquals(-5, buffer.getByte(LOG_HEADER_LENGTH + i));
+        }
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -1,0 +1,569 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import io.aeron.ErrorCode;
+import io.aeron.command.*;
+import io.aeron.protocol.*;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.InetSocketAddress;
+
+import static io.aeron.agent.CommonEventEncoder.*;
+import static io.aeron.agent.DriverEventCode.*;
+import static io.aeron.agent.DriverEventDissector.*;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static io.aeron.protocol.HeaderFlyweight.*;
+import static java.nio.ByteBuffer.allocate;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.*;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DriverEventDissectorTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirectAligned(MAX_EVENT_LENGTH, CACHE_LINE_LENGTH));
+    private final StringBuilder builder = new StringBuilder();
+
+    @Test
+    void dissectRemovePublicationCleanup()
+    {
+        internalEncodeLogHeader(buffer, 22, 88, () -> 2_500_000_000L);
+        buffer.putInt(LOG_HEADER_LENGTH, 42, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_INT, 11, LITTLE_ENDIAN);
+        buffer.putStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, "channel uri");
+
+        DriverEventDissector.dissectRemovePublicationCleanup(buffer, 0, builder);
+
+        assertEquals("[2.5] " + CONTEXT + ": " + REMOVE_PUBLICATION_CLEANUP.name() +
+            " [22/88]: sessionId=42, streamId=11, uri=channel uri",
+            builder.toString());
+    }
+
+    @Test
+    void dissectRemoveSubscriptionCleanup()
+    {
+        internalEncodeLogHeader(buffer, 100, 100, () -> 100_000_000L);
+        buffer.putInt(LOG_HEADER_LENGTH, 33, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_INT, 111_111_111_111L, LITTLE_ENDIAN);
+        buffer.putStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, "test");
+
+        DriverEventDissector.dissectRemoveSubscriptionCleanup(buffer, 0, builder);
+
+        assertEquals("[0.1] " + CONTEXT + ": " + REMOVE_SUBSCRIPTION_CLEANUP.name() +
+            " [100/100]: streamId=33, id=111111111111, uri=test",
+            builder.toString());
+    }
+
+    @Test
+    void dissectRemoveImageCleanup()
+    {
+        internalEncodeLogHeader(buffer, 66, 99, () -> 12345678900L);
+        buffer.putInt(LOG_HEADER_LENGTH, 77, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_INT, 55, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, 1_000_000L, LITTLE_ENDIAN);
+        buffer.putStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, "URI");
+
+        DriverEventDissector.dissectRemoveImageCleanup(buffer, 0, builder);
+
+        assertEquals("[12.3456789] " + CONTEXT + ": " + REMOVE_IMAGE_CLEANUP.name() +
+            " [66/99]: sessionId=77, streamId=55, id=1000000, uri=URI",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypePad()
+    {
+        internalEncodeLogHeader(buffer, 5, 5, () -> 1_000_000_000);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8080));
+        final DataHeaderFlyweight flyweight = new DataHeaderFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_PAD);
+        flyweight.flags((short)13);
+        flyweight.frameLength(100);
+        flyweight.sessionId(42);
+        flyweight.streamId(5);
+        flyweight.termId(16);
+        flyweight.termOffset(1045);
+
+        dissectAsFrame(CMD_IN_ADD_COUNTER, buffer, 0, builder);
+
+        assertEquals("[1.0] " + CONTEXT + ": " + CMD_IN_ADD_COUNTER.name() + " [5/5]: 127.0.0.1:8080 " +
+            "PAD 00001101 len 100 42:5:16 @1045",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeData()
+    {
+        internalEncodeLogHeader(buffer, 5, 5, () -> 1_000_000_000);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final DataHeaderFlyweight flyweight = new DataHeaderFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_DATA);
+        flyweight.flags((short)23);
+        flyweight.frameLength(77);
+        flyweight.sessionId(12);
+        flyweight.streamId(51);
+        flyweight.termId(6);
+        flyweight.termOffset(444);
+
+        dissectAsFrame(CMD_IN_ADD_PUBLICATION, buffer, 0, builder);
+
+        assertEquals("[1.0] " + CONTEXT + ": " + CMD_IN_ADD_PUBLICATION.name() + " [5/5]: 127.0.0.1:8888 " +
+            "DATA 00010111 len 77 12:51:6 @444",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeStatusMessage()
+    {
+        internalEncodeLogHeader(buffer, 5, 5, () -> 1_000_000_000);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final StatusMessageFlyweight flyweight = new StatusMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_SM);
+        flyweight.flags((short)7);
+        flyweight.frameLength(121);
+        flyweight.sessionId(5);
+        flyweight.streamId(8);
+        flyweight.consumptionTermId(4);
+        flyweight.consumptionTermOffset(18);
+        flyweight.receiverWindowLength(2048);
+        flyweight.receiverId(11);
+
+        dissectAsFrame(CMD_OUT_ERROR, buffer, 0, builder);
+
+        assertEquals("[1.0] " + CONTEXT + ": " + CMD_OUT_ERROR.name() + " [5/5]: 127.0.0.1:8888 " +
+            "SM 00000111 len 121 5:8:4 @18 2048 11",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeNak()
+    {
+        internalEncodeLogHeader(buffer, 3, 3, () -> 3_000_000_000L);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final NakFlyweight flyweight = new NakFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_NAK);
+        flyweight.flags((short)2);
+        flyweight.frameLength(54);
+        flyweight.sessionId(5);
+        flyweight.streamId(8);
+        flyweight.termId(20);
+        flyweight.termOffset(0);
+        flyweight.length(999999);
+
+        dissectAsFrame(CMD_OUT_ERROR, buffer, 0, builder);
+
+        assertEquals("[3.0] " + CONTEXT + ": " + CMD_OUT_ERROR.name() + " [3/3]: 127.0.0.1:8888 " +
+            "NAK 00000010 len 54 5:8:20 @0 999999",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeSetup()
+    {
+        internalEncodeLogHeader(buffer, 3, 3, () -> 3_000_000_000L);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final SetupFlyweight flyweight = new SetupFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_SETUP);
+        flyweight.flags((short)200);
+        flyweight.frameLength(1);
+        flyweight.sessionId(15);
+        flyweight.streamId(18);
+        flyweight.activeTermId(81);
+        flyweight.initialTermId(69);
+        flyweight.termOffset(10);
+        flyweight.termLength(444);
+        flyweight.mtuLength(8096);
+        flyweight.ttl(20_000);
+
+        dissectAsFrame(CMD_OUT_EXCLUSIVE_PUBLICATION_READY, buffer, 0, builder);
+
+        assertEquals("[3.0] " + CONTEXT + ": " + CMD_OUT_EXCLUSIVE_PUBLICATION_READY.name() +
+            " [3/3]: 127.0.0.1:8888 " +
+            "SETUP 11001000 len 1 15:18:81 69 @10 444 MTU 8096 TTL 20000",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeRtt()
+    {
+        internalEncodeLogHeader(buffer, 3, 3, () -> 3_000_000_000L);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final RttMeasurementFlyweight flyweight = new RttMeasurementFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(HDR_TYPE_RTTM);
+        flyweight.flags((short)20);
+        flyweight.frameLength(100);
+        flyweight.sessionId(0);
+        flyweight.streamId(1);
+        flyweight.echoTimestampNs(123456789);
+        flyweight.receptionDelta(354);
+        flyweight.receiverId(22);
+
+        dissectAsFrame(CMD_IN_ADD_RCV_DESTINATION, buffer, 0, builder);
+
+        assertEquals("[3.0] " + CONTEXT + ": " + CMD_IN_ADD_RCV_DESTINATION.name() + " [3/3]: 127.0.0.1:8888 " +
+            "RTT 00010100 len 100 0:1 123456789 354 22",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsFrameTypeUnknown()
+    {
+        internalEncodeLogHeader(buffer, 3, 3, () -> 3_000_000_000L);
+        final int socketAddressOffset =
+            encodeSocketAddress(buffer, LOG_HEADER_LENGTH, new InetSocketAddress("localhost", 8888));
+        final DataHeaderFlyweight flyweight = new DataHeaderFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH + socketAddressOffset, 300);
+        flyweight.headerType(Integer.MAX_VALUE);
+
+        dissectAsFrame(CMD_OUT_ON_OPERATION_SUCCESS, buffer, 0, builder);
+
+        assertEquals("[3.0] " + CONTEXT + ": " + CMD_OUT_ON_OPERATION_SUCCESS.name() + " [3/3]: 127.0.0.1:8888 " +
+            "FRAME_UNKNOWN: " + HDR_TYPE_EXT,
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsString()
+    {
+        internalEncodeLogHeader(buffer, 1, 1, () -> 1_100_000_000L);
+        buffer.putStringAscii(LOG_HEADER_LENGTH, "Hello, World!");
+
+        DriverEventDissector.dissectAsString(CMD_IN_CLIENT_CLOSE, buffer, 0, builder);
+
+        assertEquals("[1.1] " + CONTEXT + ": " + CMD_IN_CLIENT_CLOSE.name() + " [1/1]: Hello, World!",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_ADD_PUBLICATION", "CMD_IN_ADD_EXCLUSIVE_PUBLICATION" })
+    void dissectAsCommandPublication(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, 10, 10, () -> 1_780_000_000L);
+        final PublicationMessageFlyweight flyweight = new PublicationMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.channel("pub channel");
+        flyweight.streamId(3);
+        flyweight.clientId(eventCode.id());
+        flyweight.correlationId(15);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.78] " + CONTEXT + ": " + eventCode.name() + " [10/10]: " +
+            "pub channel 3 [" + eventCode.id() + ":15]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_ADD_SUBSCRIPTION" })
+    void dissectAsCommandSubscription(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 1_780_000_000L);
+        final SubscriptionMessageFlyweight flyweight = new SubscriptionMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.channel("sub channel");
+        flyweight.streamId(31);
+        flyweight.registrationCorrelationId(90);
+        flyweight.clientId(eventCode.id());
+        flyweight.correlationId(6);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.78] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            "sub channel 31 [90][" + eventCode.id() + ":6]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class,
+        names = { "CMD_IN_REMOVE_PUBLICATION", "CMD_IN_REMOVE_SUBSCRIPTION", "CMD_IN_REMOVE_COUNTER" })
+    void dissectAsCommandRemoveEvent(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final RemoveMessageFlyweight flyweight = new RemoveMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.registrationId(11);
+        flyweight.clientId(eventCode.id());
+        flyweight.correlationId(16);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            "11 [" + eventCode.id() + ":16]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class,
+        names = { "CMD_OUT_PUBLICATION_READY", "CMD_OUT_EXCLUSIVE_PUBLICATION_READY" })
+    void dissectAsCommandPublicationReady(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final PublicationBuffersReadyFlyweight flyweight = new PublicationBuffersReadyFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.sessionId(eventCode.ordinal());
+        flyweight.streamId(42);
+        flyweight.publicationLimitCounterId(1);
+        flyweight.channelStatusCounterId(5);
+        flyweight.correlationId(8);
+        flyweight.registrationId(eventCode.id());
+        flyweight.logFileName("log.txt");
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            eventCode.ordinal() + ":42 1 5 [8 " + eventCode.id() + "] log.txt",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_AVAILABLE_IMAGE" })
+    void dissectAsCommandImageReady(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final ImageBuffersReadyFlyweight flyweight = new ImageBuffersReadyFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.sessionId(eventCode.ordinal());
+        flyweight.streamId(22);
+        flyweight.subscriberPositionId(0);
+        flyweight.subscriptionRegistrationId(245);
+        flyweight.correlationId(767);
+        flyweight.logFileName("log2.txt");
+        flyweight.sourceIdentity("source identity");
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            eventCode.ordinal() + ":22 [0:245] \"source identity\" [767] log2.txt",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ON_OPERATION_SUCCESS" })
+    void dissectAsCommandOperationSuccess(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final OperationSucceededFlyweight flyweight = new OperationSucceededFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.correlationId(eventCode.id());
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            eventCode.id(),
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_KEEPALIVE_CLIENT", "CMD_IN_CLIENT_CLOSE" })
+    void dissectAsCommandCorrelationEvent(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final CorrelatedMessageFlyweight flyweight = new CorrelatedMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.clientId(eventCode.id());
+        flyweight.correlationId(2);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            "[" + eventCode.id() + ":2]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ON_UNAVAILABLE_IMAGE" })
+    void dissectAsCommandImage(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final ImageMessageFlyweight flyweight = new ImageMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.streamId(300);
+        flyweight.correlationId(eventCode.id());
+        flyweight.subscriptionRegistrationId(-19);
+        flyweight.channel("the channel");
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            "the channel 300 [" + eventCode.id() + " -19]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = {
+        "CMD_IN_ADD_DESTINATION",
+        "CMD_IN_REMOVE_DESTINATION",
+        "CMD_IN_ADD_RCV_DESTINATION",
+        "CMD_IN_REMOVE_RCV_DESTINATION" })
+    void dissectAsCommandDestination(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        final DestinationMessageFlyweight flyweight = new DestinationMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.channel("dst");
+        flyweight.registrationCorrelationId(eventCode.id());
+        flyweight.clientId(1010101);
+        flyweight.correlationId(404);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+            "dst " + eventCode.id() + " [1010101:404]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ERROR" })
+    void dissectAsCommandError(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final ErrorResponseFlyweight flyweight = new ErrorResponseFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.offendingCommandCorrelationId(eventCode.id());
+        flyweight.errorCode(ErrorCode.MALFORMED_COMMAND);
+        flyweight.errorMessage("Huge stacktrace!");
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            eventCode.id() + " " + ErrorCode.MALFORMED_COMMAND + " Huge stacktrace!",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_ADD_COUNTER" })
+    void dissectAsCommandCounter(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final CounterMessageFlyweight flyweight = new CounterMessageFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.typeId(3);
+        flyweight.keyBuffer(newBuffer(new byte[20]), 0, 10);
+        flyweight.labelBuffer(newBuffer(new byte[100]), 26, 13);
+        flyweight.clientId(eventCode.id());
+        flyweight.correlationId(42);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            "3 [" + flyweight.keyBufferOffset() + " 10][" + flyweight.labelBufferOffset() + " 13][" +
+            eventCode.id() + ":42]",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_SUBSCRIPTION_READY" })
+    void dissectAsCommandSubscriptionReady(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final SubscriptionReadyFlyweight flyweight = new SubscriptionReadyFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.correlationId(42);
+        flyweight.channelStatusCounterId(eventCode.id());
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            "42 " + eventCode.id(),
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_COUNTER_READY", "CMD_OUT_ON_UNAVAILABLE_COUNTER" })
+    void dissectAsCommandCounterUpdate(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final CounterUpdateFlyweight flyweight = new CounterUpdateFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.correlationId(eventCode.id());
+        flyweight.counterId(18);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            eventCode.id() + " 18",
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ON_CLIENT_TIMEOUT" })
+    void dissectAsCommandClientTimeout(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final ClientTimeoutFlyweight flyweight = new ClientTimeoutFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.clientId(eventCode.id());
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            eventCode.id(),
+            builder.toString());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_TERMINATE_DRIVER" })
+    void dissectAsCommandTerminateDriver(final DriverEventCode eventCode)
+    {
+        internalEncodeLogHeader(buffer, eventCode.ordinal(), 100, () -> 1_900_000_000L);
+        final TerminateDriverFlyweight flyweight = new TerminateDriverFlyweight();
+        flyweight.wrap(buffer, LOG_HEADER_LENGTH);
+        flyweight.clientId(eventCode.id());
+        flyweight.tokenBuffer(newBuffer(new byte[15]), 4, 11);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.9] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
+            eventCode.id() + " 11",
+            builder.toString());
+    }
+
+    @Test
+    void dissectAsCommandUnknown()
+    {
+        final DriverEventCode eventCode = SEND_CHANNEL_CREATION;
+        internalEncodeLogHeader(buffer, 5, 5, () -> 1_000_000_000L);
+
+        dissectAsCommand(eventCode, buffer, 0, builder);
+
+        assertEquals("[1.0] " + CONTEXT + ": " + eventCode.name() + " [5/5]: COMMAND_UNKNOWN: " + eventCode,
+            builder.toString());
+    }
+
+    private DirectBuffer newBuffer(final byte[] bytes)
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(allocate(bytes.length));
+        buffer.putBytes(0, bytes);
+        return buffer;
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.DriverEventEncoder.*;
+import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Arrays.fill;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class DriverEventEncoderTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH));
+
+    @Test
+    void encodePublicationRemovalShouldWriteUriLast()
+    {
+        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final int expectedLength = 3 * SIZE_OF_INT + uri.length();
+
+        final int encodedLength = encodePublicationRemoval(buffer, uri, 42, 5);
+
+        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
+        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(42, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(5, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodePublicationRemovalShouldWriteOutAnEntireUriWhenFitsIntoTheResultMessage()
+    {
+        final char[] data = new char[MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT];
+        fill(data, 'x');
+        final String uri = new String(data);
+
+        final int encodedLength = encodePublicationRemoval(buffer, uri, 555, 222);
+
+        assertEquals(MAX_EVENT_LENGTH, encodedLength);
+        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(555, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(222, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodePublicationRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    {
+        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT;
+        final char[] data = new char[encodedUriLength + 100];
+        fill(data, 'z');
+        final String uri = new String(data);
+
+        final int encodedLength = encodePublicationRemoval(buffer, uri, 1, -1);
+
+        assertEquals(MAX_EVENT_LENGTH, encodedLength);
+        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(3 * SIZE_OF_INT + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(-1, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
+            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodeSubscriptionRemovalShouldWriteUriLast()
+    {
+        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final int expectedLength = 2 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+
+        final int encodedLength = encodeSubscriptionRemoval(buffer, uri, 13, Long.MAX_VALUE);
+
+        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
+        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(13, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(Long.MAX_VALUE, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodeSubscriptionRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    {
+        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 2 * SIZE_OF_INT - SIZE_OF_LONG;
+        final char[] data = new char[encodedUriLength + 5];
+        fill(data, 'a');
+        final String uri = new String(data);
+
+        final int encodedLength = encodeSubscriptionRemoval(buffer, uri, 1, -1);
+
+        assertEquals(MAX_EVENT_LENGTH, encodedLength);
+        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(2 * SIZE_OF_INT + SIZE_OF_LONG + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(-1, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
+            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodeImageRemovalShouldWriteUriLast()
+    {
+        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final int expectedLength = 3 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+
+        final int encodedLength = encodeImageRemoval(buffer, uri, 13, 42, Long.MAX_VALUE);
+
+        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
+        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(13, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(42, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(Long.MAX_VALUE, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
+    }
+
+    @Test
+    void encodeImageRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    {
+        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT - SIZE_OF_LONG;
+        final char[] data = new char[encodedUriLength + 8];
+        fill(data, 'a');
+        final String uri = new String(data);
+
+        final int encodedLength = encodeImageRemoval(buffer, uri, -1, 1, 0);
+
+        assertEquals(MAX_EVENT_LENGTH, encodedLength);
+        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
+        assertEquals(3 * SIZE_OF_INT + SIZE_OF_LONG + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(-1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(0, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
+            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
+    }
+
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventLoggerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import static io.aeron.agent.Common.verifyLogHeader;
+import static io.aeron.agent.CommonEventEncoder.*;
+import static io.aeron.agent.DriverEventCode.*;
+import static io.aeron.agent.DriverEventLogger.toEventCodeId;
+import static io.aeron.agent.EventConfiguration.*;
+import static java.nio.ByteBuffer.allocateDirect;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Arrays.fill;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.encodedMsgOffset;
+import static org.agrona.concurrent.ringbuffer.RecordDescriptor.lengthOffset;
+import static org.agrona.concurrent.ringbuffer.RingBufferDescriptor.TRAILER_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DriverEventLoggerTest
+{
+    private final UnsafeBuffer logBuffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH * 8 + TRAILER_LENGTH));
+    private final DriverEventLogger logger = new DriverEventLogger(new ManyToOneRingBuffer(logBuffer));
+    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH * 3));
+
+    @AfterEach
+    void after()
+    {
+        reset();
+    }
+
+    @ParameterizedTest
+    @EnumSource(DriverEventCode.class)
+    void toEventCodeIdComputesEventId(final DriverEventCode eventCode)
+    {
+        assertEquals(eventCode.id(), toEventCodeId(eventCode));
+    }
+
+    @Test
+    void logIsNoOpIfEventIsNotEnabled()
+    {
+        buffer.setMemory(20, 100, (byte)5);
+
+        logger.log(CMD_OUT_ERROR, buffer, 20, 100);
+
+        assertEquals(0, logBuffer.getInt(lengthOffset(0), LITTLE_ENDIAN));
+    }
+
+    @Test
+    void log()
+    {
+        final DriverEventCode eventCode = CMD_IN_TERMINATE_DRIVER;
+        DRIVER_EVENT_CODES.add(eventCode);
+        buffer.setMemory(20, 100, (byte)5);
+
+        logger.log(eventCode, buffer, 20, 100);
+
+        verifyLogHeader(logBuffer, toEventCodeId(eventCode), 100, 100, 100);
+        for (int i = 0; i < 100; i++)
+        {
+            assertEquals(5, logBuffer.getByte(encodedMsgOffset(LOG_HEADER_LENGTH + i)));
+        }
+    }
+
+    @Test
+    void logFrameIn()
+    {
+        final int captureLength = MAX_CAPTURE_LENGTH - SOCKET_ADDRESS_MAX_LENGTH;
+        buffer.setMemory(4, MAX_CAPTURE_LENGTH, (byte)3);
+
+        logger.logFrameIn(buffer, 4, 10_000, new InetSocketAddress("localhost", 5555));
+
+        verifyLogHeader(logBuffer, toEventCodeId(FRAME_IN), captureLength + 12, captureLength, 10_000);
+        assertEquals(5555, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(4, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
+        for (int i = 0; i < captureLength; i++)
+        {
+            assertEquals(3, logBuffer.getByte(encodedMsgOffset(LOG_HEADER_LENGTH + 12 + i)));
+        }
+    }
+
+    @Test
+    void logFrameOut()
+    {
+        final ByteBuffer byteBuffer = this.buffer.byteBuffer();
+        byteBuffer.position(8);
+        final byte[] bytes = new byte[32];
+        fill(bytes, (byte)-1);
+        byteBuffer.put(bytes);
+        byteBuffer.flip().position(10).limit(38);
+        final int captureLength = 28;
+
+        logger.logFrameOut(byteBuffer, new InetSocketAddress("localhost", 3232));
+
+        verifyLogHeader(logBuffer, toEventCodeId(FRAME_OUT), captureLength + 12, captureLength, captureLength);
+        assertEquals(3232, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(4, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
+        for (int i = 0; i < captureLength; i++)
+        {
+            assertEquals(-1, logBuffer.getByte(encodedMsgOffset(LOG_HEADER_LENGTH + 12 + i)));
+        }
+    }
+
+    @Test
+    void logString()
+    {
+        final DriverEventCode eventCode = CMD_IN_ADD_PUBLICATION;
+        final String value = "abc";
+        final int captureLength = value.length() + SIZE_OF_INT;
+
+        logger.logString(eventCode, value);
+
+        verifyLogHeader(logBuffer, toEventCodeId(eventCode), captureLength, captureLength, captureLength);
+        assertEquals(value, logBuffer.getStringAscii(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+    }
+
+    @Test
+    void logPublicationRemoval()
+    {
+        final String uri = "uri";
+        final int sessionId = 42;
+        final int streamId = 19;
+        final int captureLength = uri.length() + SIZE_OF_INT * 3;
+
+        logger.logPublicationRemoval(uri, sessionId, streamId);
+
+        verifyLogHeader(
+            logBuffer, toEventCodeId(REMOVE_PUBLICATION_CLEANUP), captureLength, captureLength, captureLength);
+        assertEquals(sessionId, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(streamId, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
+        assertEquals(uri,
+            logBuffer.getStringAscii(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT * 2), LITTLE_ENDIAN));
+    }
+
+    @Test
+    void logSubscriptionRemoval()
+    {
+        final String uri = "uri";
+        final int streamId = 42;
+        final long id = 19;
+        final int captureLength = uri.length() + SIZE_OF_INT * 2 + SIZE_OF_LONG;
+
+        logger.logSubscriptionRemoval(uri, streamId, id);
+
+        verifyLogHeader(
+            logBuffer, toEventCodeId(REMOVE_SUBSCRIPTION_CLEANUP), captureLength, captureLength, captureLength);
+        assertEquals(streamId, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(id, logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
+        assertEquals(uri,
+            logBuffer.getStringAscii(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG), LITTLE_ENDIAN));
+    }
+
+    @Test
+    void logImageRemoval()
+    {
+        final String uri = "uri";
+        final int sessionId = 8;
+        final int streamId = 61;
+        final long id = 19;
+        final int captureLength = uri.length() + SIZE_OF_INT * 3 + SIZE_OF_LONG;
+
+        logger.logImageRemoval(uri, sessionId, streamId, id);
+
+        verifyLogHeader(
+            logBuffer, toEventCodeId(REMOVE_IMAGE_CLEANUP), captureLength, captureLength, captureLength);
+        assertEquals(sessionId, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(streamId, logBuffer.getInt(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
+        assertEquals(id, logBuffer.getLong(encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT * 2), LITTLE_ENDIAN));
+        assertEquals(uri, logBuffer.getStringAscii(
+            encodedMsgOffset(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG), LITTLE_ENDIAN));
+    }
+}

--- a/aeron-client/src/main/java/io/aeron/command/ImageBuffersReadyFlyweight.java
+++ b/aeron-client/src/main/java/io/aeron/command/ImageBuffersReadyFlyweight.java
@@ -240,10 +240,22 @@ public class ImageBuffersReadyFlyweight
     }
 
     /**
-     * Set the source identity string in ASCII
+     * Append the source identity to an {@link Appendable}.
+     *
+     * @param appendable to append source identity to.
+     */
+    public void appendSourceIdentity(final Appendable appendable)
+    {
+        buffer.getStringAscii(offset + sourceIdentityOffset(), appendable);
+    }
+
+    /**
+     * Set the source identity string in ASCII.
+     * <p>Note: Can be called only after log file name was set!</p>
      *
      * @param value for the source identity
      * @return flyweight
+     * @see #logFileName(String)
      */
     public ImageBuffersReadyFlyweight sourceIdentity(final String value)
     {


### PR DESCRIPTION
Changes to command logging include:
- Always write a log header for each command logged
- Use `LITTLE_ENDIAN` when writing integral values
- Write strings without creating intermediate objects
- Protect against buffer overruns when logging commands
- Re-structured logging of the `REMOVE_PUBLICATION_CLEANUP`, `REMOVE_SUBSCRIPTION_CLEANUP` and `REMOVE_IMAGE_CLEANUP` to log channel URI at the end
- Add tests for all commands being logged including encoder, dissector and logger tests
- Refactored archive command logging to lookup commands by templateId
- Add `CommonEncoder` and `CommonDissector` to share code across different logging domains