### PR TITLE
[Java] Use `RingBuffer#tryClaim` API to implement zero-copy logging

### DIFF
--- a/aeron-agent/src/test/java/io/aeron/agent/Common.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/Common.java
@@ -51,16 +51,16 @@ public class Common
 
     public static void verifyLogHeader(
         final UnsafeBuffer logBuffer,
+        final int recordOffset,
         final int eventCodeId,
-        final int totalLength,
         final int captureLength,
         final int length)
     {
-        assertEquals(HEADER_LENGTH + LOG_HEADER_LENGTH + totalLength,
-            logBuffer.getInt(lengthOffset(0), LITTLE_ENDIAN));
-        assertEquals(eventCodeId, logBuffer.getInt(typeOffset(0), LITTLE_ENDIAN));
-        assertEquals(captureLength, logBuffer.getInt(encodedMsgOffset(0), LITTLE_ENDIAN));
-        assertEquals(length, logBuffer.getInt(encodedMsgOffset(SIZE_OF_INT), LITTLE_ENDIAN));
-        assertNotEquals(0, logBuffer.getLong(encodedMsgOffset(SIZE_OF_INT * 2), LITTLE_ENDIAN));
+        assertEquals(HEADER_LENGTH + LOG_HEADER_LENGTH + captureLength,
+            logBuffer.getInt(lengthOffset(recordOffset), LITTLE_ENDIAN));
+        assertEquals(eventCodeId, logBuffer.getInt(typeOffset(recordOffset), LITTLE_ENDIAN));
+        assertEquals(captureLength, logBuffer.getInt(encodedMsgOffset(recordOffset), LITTLE_ENDIAN));
+        assertEquals(length, logBuffer.getInt(encodedMsgOffset(recordOffset + SIZE_OF_INT), LITTLE_ENDIAN));
+        assertNotEquals(0, logBuffer.getLong(encodedMsgOffset(recordOffset + SIZE_OF_INT * 2), LITTLE_ENDIAN));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -311,7 +311,7 @@ class DriverEventDissectorTest
         names = { "CMD_IN_REMOVE_PUBLICATION", "CMD_IN_REMOVE_SUBSCRIPTION", "CMD_IN_REMOVE_COUNTER" })
     void dissectAsCommandRemoveEvent(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 87, () -> 21_032_000_000L);
         final RemoveMessageFlyweight flyweight = new RemoveMessageFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.registrationId(11);
@@ -320,7 +320,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/87]: " +
             "11 [" + eventCode.id() + ":16]",
             builder.toString());
     }
@@ -330,7 +330,7 @@ class DriverEventDissectorTest
         names = { "CMD_OUT_PUBLICATION_READY", "CMD_OUT_EXCLUSIVE_PUBLICATION_READY" })
     void dissectAsCommandPublicationReady(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 100, () -> 21_032_000_000L);
         final PublicationBuffersReadyFlyweight flyweight = new PublicationBuffersReadyFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.sessionId(eventCode.ordinal());
@@ -343,7 +343,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
             eventCode.ordinal() + ":42 1 5 [8 " + eventCode.id() + "] log.txt",
             builder.toString());
     }
@@ -352,7 +352,7 @@ class DriverEventDissectorTest
     @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_AVAILABLE_IMAGE" })
     void dissectAsCommandImageReady(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 100, () -> 21_032_000_000L);
         final ImageBuffersReadyFlyweight flyweight = new ImageBuffersReadyFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.sessionId(eventCode.ordinal());
@@ -365,7 +365,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
             eventCode.ordinal() + ":22 [0:245] [767] log2.txt source identity",
             builder.toString());
     }
@@ -374,14 +374,14 @@ class DriverEventDissectorTest
     @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ON_OPERATION_SUCCESS" })
     void dissectAsCommandOperationSuccess(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 111, () -> 21_032_000_000L);
         final OperationSucceededFlyweight flyweight = new OperationSucceededFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.correlationId(eventCode.id());
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/111]: " +
             eventCode.id(),
             builder.toString());
     }
@@ -390,7 +390,7 @@ class DriverEventDissectorTest
     @EnumSource(value = DriverEventCode.class, names = { "CMD_IN_KEEPALIVE_CLIENT", "CMD_IN_CLIENT_CLOSE" })
     void dissectAsCommandCorrelationEvent(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 100, () -> 21_032_000_000L);
         final CorrelatedMessageFlyweight flyweight = new CorrelatedMessageFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.clientId(eventCode.id());
@@ -398,7 +398,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/100]: " +
             "[" + eventCode.id() + ":2]",
             builder.toString());
     }
@@ -407,7 +407,7 @@ class DriverEventDissectorTest
     @EnumSource(value = DriverEventCode.class, names = { "CMD_OUT_ON_UNAVAILABLE_IMAGE" })
     void dissectAsCommandImage(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 99, () -> 21_032_000_000L);
         final ImageMessageFlyweight flyweight = new ImageMessageFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.streamId(300);
@@ -417,7 +417,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/99]: " +
             "300 [" + eventCode.id() + " -19] the channel",
             builder.toString());
     }
@@ -430,7 +430,7 @@ class DriverEventDissectorTest
         "CMD_IN_REMOVE_RCV_DESTINATION" })
     void dissectAsCommandDestination(final DriverEventCode eventCode)
     {
-        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 10, () -> 21_032_000_000L);
+        internalEncodeLogHeader(buffer, 0, eventCode.ordinal(), 77, () -> 21_032_000_000L);
         final DestinationMessageFlyweight flyweight = new DestinationMessageFlyweight();
         flyweight.wrap(buffer, LOG_HEADER_LENGTH);
         flyweight.channel("dst");
@@ -440,7 +440,7 @@ class DriverEventDissectorTest
 
         dissectAsCommand(eventCode, buffer, 0, builder);
 
-        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/10]: " +
+        assertEquals("[21.032] " + CONTEXT + ": " + eventCode.name() + " [" + eventCode.ordinal() + "/77]: " +
             eventCode.id() + " [1010101:404] dst",
             builder.toString());
     }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
@@ -19,148 +19,148 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
 import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.CommonEventEncoder.captureLength;
 import static io.aeron.agent.DriverEventEncoder.*;
 import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
-import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Arrays.fill;
-import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.BitUtil.*;
+import static org.agrona.BufferUtil.allocateDirectAligned;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class DriverEventEncoderTest
 {
-    private final UnsafeBuffer buffer = new UnsafeBuffer(allocateDirect(MAX_EVENT_LENGTH));
+    private final UnsafeBuffer buffer = new UnsafeBuffer(
+        allocateDirectAligned(MAX_EVENT_LENGTH * 10, CACHE_LINE_LENGTH));
 
     @Test
     void encodePublicationRemovalShouldWriteUriLast()
     {
+        final int offset = 10;
         final String uri = "aeron:udp?endpoint=224.10.9.8";
-        final int expectedLength = 3 * SIZE_OF_INT + uri.length();
+        final int sessionId = 42;
+        final int streamId = 5;
+        final int captureLength = 3 * SIZE_OF_INT + uri.length();
 
-        final int encodedLength = encodePublicationRemoval(buffer, uri, 42, 5);
+        encodePublicationRemoval(buffer, offset, captureLength, captureLength, uri, sessionId, streamId);
 
-        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
-        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(42, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(5, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-    }
-
-    @Test
-    void encodePublicationRemovalShouldWriteOutAnEntireUriWhenFitsIntoTheResultMessage()
-    {
-        final char[] data = new char[MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT];
-        fill(data, 'x');
-        final String uri = new String(data);
-
-        final int encodedLength = encodePublicationRemoval(buffer, uri, 555, 222);
-
-        assertEquals(MAX_EVENT_LENGTH, encodedLength);
-        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(555, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(222, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri, buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
     }
 
     @Test
     void encodePublicationRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
     {
-        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT;
-        final char[] data = new char[encodedUriLength + 100];
+        final int offset = 121;
+        final char[] data = new char[MAX_EVENT_LENGTH];
         fill(data, 'z');
         final String uri = new String(data);
+        final int length = data.length + 3 * SIZE_OF_INT;
+        final int captureLength = captureLength(length);
 
-        final int encodedLength = encodePublicationRemoval(buffer, uri, 1, -1);
+        encodePublicationRemoval(buffer, offset, captureLength, length, uri, 1, -1);
 
-        assertEquals(MAX_EVENT_LENGTH, encodedLength);
-        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(3 * SIZE_OF_INT + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(-1, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
-            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(1, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(-1, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, captureLength - 3 * SIZE_OF_INT - 3) + "...",
+            buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
     }
 
     @Test
     void encodeSubscriptionRemovalShouldWriteUriLast()
     {
+        final int offset = 0;
         final String uri = "aeron:udp?endpoint=224.10.9.8";
-        final int expectedLength = 2 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+        final int streamId = 13;
+        final long id = Long.MAX_VALUE;
+        final int captureLength = 2 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
 
-        final int encodedLength = encodeSubscriptionRemoval(buffer, uri, 13, Long.MAX_VALUE);
+        encodeSubscriptionRemoval(buffer, offset, captureLength, captureLength, uri, streamId, id);
 
-        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
-        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(13, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(Long.MAX_VALUE, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri,
+            buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
     void encodeSubscriptionRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
     {
-        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 2 * SIZE_OF_INT - SIZE_OF_LONG;
-        final char[] data = new char[encodedUriLength + 5];
+        final char[] data = new char[MAX_EVENT_LENGTH * 3 + 5];
         fill(data, 'a');
+        final int offset = 0;
+        final int length = SIZE_OF_INT * 2 + SIZE_OF_LONG + data.length;
+        final int captureLength = captureLength(length);
         final String uri = new String(data);
+        final int streamId = 1;
+        final long id = -1;
 
-        final int encodedLength = encodeSubscriptionRemoval(buffer, uri, 1, -1);
+        encodeSubscriptionRemoval(buffer, offset, captureLength, length, uri, streamId, id);
 
-        assertEquals(MAX_EVENT_LENGTH, encodedLength);
-        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(2 * SIZE_OF_INT + SIZE_OF_LONG + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(-1, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
-            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG - 3) + "...",
+            buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
     void encodeImageRemovalShouldWriteUriLast()
     {
+        final int offset = 0;
         final String uri = "aeron:udp?endpoint=224.10.9.8";
-        final int expectedLength = 3 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+        final int sessionId = 13;
+        final int streamId = 42;
+        final long id = Long.MAX_VALUE;
+        final int captureLength = 3 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
 
-        final int encodedLength = encodeImageRemoval(buffer, uri, 13, 42, Long.MAX_VALUE);
+        encodeImageRemoval(buffer, offset, captureLength, captureLength, uri, sessionId, streamId, id);
 
-        assertEquals(LOG_HEADER_LENGTH + expectedLength, encodedLength);
-        assertEquals(expectedLength, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(expectedLength, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(13, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(42, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(Long.MAX_VALUE, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(uri, buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(uri,
+            buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
     void encodeImageRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
     {
-        final int encodedUriLength = MAX_EVENT_LENGTH - LOG_HEADER_LENGTH - 3 * SIZE_OF_INT - SIZE_OF_LONG;
-        final char[] data = new char[encodedUriLength + 8];
+        final char[] data = new char[MAX_EVENT_LENGTH + 8];
         fill(data, 'a');
+        final int offset = 0;
+        final int length = data.length + SIZE_OF_LONG + SIZE_OF_INT * 3;
+        final int captureLength = captureLength(length);
         final String uri = new String(data);
+        final int sessionId = -1;
+        final int streamId = 1;
+        final long id = 0;
 
-        final int encodedLength = encodeImageRemoval(buffer, uri, -1, 1, 0);
+        encodeImageRemoval(buffer, offset, captureLength, length, uri, sessionId, streamId, id);
 
-        assertEquals(MAX_EVENT_LENGTH, encodedLength);
-        assertEquals(MAX_EVENT_LENGTH - LOG_HEADER_LENGTH, buffer.getInt(0, LITTLE_ENDIAN));
-        assertEquals(3 * SIZE_OF_INT + SIZE_OF_LONG + data.length, buffer.getInt(SIZE_OF_INT, LITTLE_ENDIAN));
-        assertNotEquals(0, buffer.getLong(SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(-1, buffer.getInt(LOG_HEADER_LENGTH, LITTLE_ENDIAN));
-        assertEquals(1, buffer.getInt(LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(0, buffer.getLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, encodedUriLength - 3) + "...",
-            buffer.getStringAscii(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
+        assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(uri.substring(0, captureLength - SIZE_OF_LONG - SIZE_OF_INT * 3 - 3) + "...",
+            buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 }


### PR DESCRIPTION
Replace write/offer into the ring buffer with the `tryClaim` call which has the following benefits:
- Zero-copy logging since no intermediate buffers need to be created
- Zero-overhead logging when buffer is full, i.e. now the space is claimed first before the message is encoded whereas previously the message was encoded but then offer might have failed meaning that work would have been wasted

_**NOTE: This PR requires `agrona-1.3.0` so the build will fail until Agrona is released and integrated into Aeron.**_