### PR TITLE
Stream id in uri

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CmdInterceptor.java
@@ -53,8 +53,13 @@ class CmdInterceptor
         CMD_IN_ADD_RCV_DESTINATION,
         CMD_IN_REMOVE_RCV_DESTINATION,
         CMD_OUT_ON_CLIENT_TIMEOUT,
-        CMD_IN_TERMINATE_DRIVER);
+        CMD_IN_TERMINATE_DRIVER,
+        CMD_IN_ADD_PUBLICATION_V1,
+        CMD_IN_ADD_EXCLUSIVE_PUBLICATION_V1,
+        CMD_IN_ADD_SUBSCRIPTION_V1,
+        CMD_OUT_SUBSCRIPTION_READY_V1);
 
+    @SuppressWarnings("MethodLength")
     @Advice.OnMethodEnter
     static void logCmd(final int msgTypeId, final DirectBuffer buffer, final int index, final int length)
     {
@@ -154,6 +159,22 @@ class CmdInterceptor
 
             case TERMINATE_DRIVER:
                 LOGGER.log(CMD_IN_TERMINATE_DRIVER, buffer, index, length);
+                break;
+
+            case ADD_PUBLICATION_V1:
+                LOGGER.log(CMD_IN_ADD_PUBLICATION_V1, buffer, index, length);
+                break;
+
+            case ADD_SUBSCRIPTION_V1:
+                LOGGER.log(CMD_IN_ADD_SUBSCRIPTION_V1, buffer, index, length);
+                break;
+
+            case ADD_EXCLUSIVE_PUBLICATION_V1:
+                LOGGER.log(CMD_IN_ADD_EXCLUSIVE_PUBLICATION_V1, buffer, index, length);
+                break;
+
+            case ON_SUBSCRIPTION_READY_V1:
+                LOGGER.log(CMD_OUT_SUBSCRIPTION_READY_V1, buffer, index, length);
                 break;
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -71,7 +71,12 @@ public enum DriverEventCode implements EventCode
     CMD_IN_REMOVE_RCV_DESTINATION(42, DriverEventDissector::dissectAsCommand),
 
     CMD_OUT_ON_CLIENT_TIMEOUT(43, DriverEventDissector::dissectAsCommand),
-    CMD_IN_TERMINATE_DRIVER(44, DriverEventDissector::dissectAsCommand);
+    CMD_IN_TERMINATE_DRIVER(44, DriverEventDissector::dissectAsCommand),
+
+    CMD_IN_ADD_PUBLICATION_V1(45, DriverEventDissector::dissectAsCommand),
+    CMD_IN_ADD_EXCLUSIVE_PUBLICATION_V1(46, DriverEventDissector::dissectAsCommand),
+    CMD_IN_ADD_SUBSCRIPTION_V1(47, DriverEventDissector::dissectAsCommand),
+    CMD_OUT_SUBSCRIPTION_READY_V1(48, DriverEventDissector::dissectAsCommand);
 
     static final int EVENT_CODE_TYPE = EventCodeType.DRIVER.getTypeCode();
 

--- a/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
@@ -97,7 +97,11 @@ final class EventConfiguration
         SEND_CHANNEL_CREATION,
         RECEIVE_CHANNEL_CREATION,
         SEND_CHANNEL_CLOSE,
-        RECEIVE_CHANNEL_CLOSE);
+        RECEIVE_CHANNEL_CLOSE,
+        CMD_IN_ADD_PUBLICATION_V1,
+        CMD_IN_ADD_EXCLUSIVE_PUBLICATION_V1,
+        CMD_IN_ADD_SUBSCRIPTION_V1,
+        CMD_OUT_SUBSCRIPTION_READY_V1);
 
     /**
      * Event Buffer default length (in bytes).

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -301,7 +301,7 @@ public class Aeron implements AutoCloseable
      */
     public Subscription addSubscription(final String channel)
     {
-        return conductor.addSubscription(channel, 0);
+        return conductor.addSubscription(channel);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -249,6 +249,19 @@ public class Aeron implements AutoCloseable
     }
 
     /**
+     * Add a {@link Publication} for publishing messages to subscribers. The publication returned is threadsafe.
+     * This expects the the stream id to be included in the channel as a parameter.
+     *
+     * @param channel  for sending the messages known to the media layer.  This should include stream-id as a parameter.
+     * @return a new {@link ConcurrentPublication}.
+     * @see CommonContext#STREAM_ID_PARAM_NAME
+     */
+    public ConcurrentPublication addPublication(final String channel)
+    {
+        return conductor.addPublication(channel);
+    }
+
+    /**
      * Add an {@link ExclusivePublication} for publishing messages to subscribers from a single thread.
      *
      * @param channel  for sending the messages known to the media layer.
@@ -274,6 +287,21 @@ public class Aeron implements AutoCloseable
     public Subscription addSubscription(final String channel, final int streamId)
     {
         return conductor.addSubscription(channel, streamId);
+    }
+
+    /**
+     * Add a new {@link Subscription} for subscribing to messages from publishers.
+     * <p>
+     * The method will set up the {@link Subscription} to use the
+     * {@link Aeron.Context#availableImageHandler(AvailableImageHandler)} and
+     * {@link Aeron.Context#unavailableImageHandler(UnavailableImageHandler)} from the {@link Aeron.Context}.
+     *
+     * @param channel  for receiving the messages known to the media layer.
+     * @return the {@link Subscription} for the channel and streamId pair.
+     */
+    public Subscription addSubscription(final String channel)
+    {
+        return conductor.addSubscription(channel, 0);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -250,7 +250,7 @@ public class Aeron implements AutoCloseable
 
     /**
      * Add a {@link Publication} for publishing messages to subscribers. The publication returned is threadsafe.
-     * This expects the the stream id to be included in the channel as a parameter.
+     * It expects that the stream id is included in the uri as a parameter.
      *
      * @param channel  for sending the messages known to the media layer.  This should include stream-id as a parameter.
      * @return a new {@link ConcurrentPublication}.
@@ -271,6 +271,19 @@ public class Aeron implements AutoCloseable
     public ExclusivePublication addExclusivePublication(final String channel, final int streamId)
     {
         return conductor.addExclusivePublication(channel, streamId);
+    }
+
+    /**
+     * Add an {@link ExclusivePublication} for publishing messages to subscribers from a single thread.  It expects
+     * that the stream id is included in the uri as a parameter.
+     *
+     * @param channel  for sending the messages known to the media layer.
+     * @return a new {@link ExclusivePublication}.
+     * @see CommonContext#STREAM_ID_PARAM_NAME
+     */
+    public ExclusivePublication addExclusivePublication(final String channel)
+    {
+        return conductor.addExclusivePublication(channel);
     }
 
     /**
@@ -295,9 +308,12 @@ public class Aeron implements AutoCloseable
      * The method will set up the {@link Subscription} to use the
      * {@link Aeron.Context#availableImageHandler(AvailableImageHandler)} and
      * {@link Aeron.Context#unavailableImageHandler(UnavailableImageHandler)} from the {@link Aeron.Context}.
+     * <p>
+     * It expects that the stream id is included in the uri as a parameter.
      *
      * @param channel  for receiving the messages known to the media layer.
      * @return the {@link Subscription} for the channel and streamId pair.
+     * @see CommonContext#STREAM_ID_PARAM_NAME
      */
     public Subscription addSubscription(final String channel)
     {
@@ -327,6 +343,32 @@ public class Aeron implements AutoCloseable
         final UnavailableImageHandler unavailableImageHandler)
     {
         return conductor.addSubscription(channel, streamId, availableImageHandler, unavailableImageHandler);
+    }
+
+
+    /**
+     * Add a new {@link Subscription} for subscribing to messages from publishers.
+     * <p>
+     * This method will override the default handlers from the {@link Aeron.Context}, i.e.
+     * {@link Aeron.Context#availableImageHandler(AvailableImageHandler)} and
+     * {@link Aeron.Context#unavailableImageHandler(UnavailableImageHandler)}. Null values are valid and will
+     * result in no action being taken.
+     * <p>
+     * It expects that the stream id is included in the uri as a parameter.
+     *
+     * @param channel                 for receiving the messages known to the media layer.
+     * @param availableImageHandler   called when {@link Image}s become available for consumption. Null is valid if no
+     *                                action is to be taken.
+     * @param unavailableImageHandler called when {@link Image}s go unavailable for consumption. Null is valid if no
+     *                                action is to be taken.
+     * @return the {@link Subscription} for the channel and streamId pair.
+     */
+    public Subscription addSubscription(
+        final String channel,
+        final AvailableImageHandler availableImageHandler,
+        final UnavailableImageHandler unavailableImageHandler)
+    {
+        return conductor.addSubscription(channel, availableImageHandler, unavailableImageHandler);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/ChannelUriStringBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/ChannelUriStringBuilder.java
@@ -110,6 +110,7 @@ public class ChannelUriStringBuilder
 
     public ChannelUriStringBuilder(final ChannelUri channelUri)
     {
+        prefix(channelUri);
         media(channelUri);
         endpoint(channelUri);
         networkInterface(channelUri);

--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -337,6 +337,10 @@ class ClientConductor implements Agent, DriverEventsListener
             stashedUnavailableImageHandler);
         subscription.channelStatusId(statusIndicatorId);
 
+        stashedChannel = null;
+        stashedUnavailableImageHandler = null;
+        stashedAvailableImageHandler = null;
+
         resourceByRegIdMap.put(correlationId, subscription);
     }
 

--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -506,6 +506,26 @@ class ClientConductor implements Agent, DriverEventsListener
         }
     }
 
+    ExclusivePublication addExclusivePublication(final String channel)
+    {
+        clientLock.lock();
+        try
+        {
+            ensureActive();
+            ensureNotReentrant();
+
+            stashedChannel = channel;
+            final long registrationId = driverProxy.addExclusivePublication(channel);
+            awaitResponse(registrationId);
+
+            return (ExclusivePublication)resourceByRegIdMap.get(registrationId);
+        }
+        finally
+        {
+            clientLock.unlock();
+        }
+    }
+
     ConcurrentPublication addPublication(final String channel)
     {
         clientLock.lock();

--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -490,6 +490,26 @@ class ClientConductor implements Agent, DriverEventsListener
         }
     }
 
+    ConcurrentPublication addPublication(final String channel)
+    {
+        clientLock.lock();
+        try
+        {
+            ensureActive();
+            ensureNotReentrant();
+
+            stashedChannel = channel;
+            final long registrationId = driverProxy.addPublication(channel);
+            awaitResponse(registrationId);
+
+            return (ConcurrentPublication)resourceByRegIdMap.get(registrationId);
+        }
+        finally
+        {
+            clientLock.unlock();
+        }
+    }
+
     void releasePublication(final Publication publication)
     {
         clientLock.lock();

--- a/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
+++ b/aeron-client/src/main/java/io/aeron/CncFileDescriptor.java
@@ -79,7 +79,7 @@ public class CncFileDescriptor
     /**
      * Version of the CnC file using semantic versioning ({@link SemanticVersion}) stored in an integer.
      */
-    public static final int CNC_VERSION = SemanticVersion.compose(0, 0, 16);
+    public static final int CNC_VERSION = SemanticVersion.compose(0, 1, 0);
 
     public static final int CNC_VERSION_FIELD_OFFSET;
     public static final int TO_DRIVER_BUFFER_LENGTH_FIELD_OFFSET;

--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -189,6 +189,11 @@ public class CommonContext implements Cloneable
     public static final String MDC_CONTROL_MODE_DYNAMIC = "dynamic";
 
     /**
+     * Key for the stream id for a publication or restricted subscription.
+     */
+    public static final String STREAM_ID_PARAM_NAME = "stream-id";
+
+    /**
      * Key for the session id for a publication or restricted subscription.
      */
     public static final String SESSION_ID_PARAM_NAME = "session-id";

--- a/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
+++ b/aeron-client/src/main/java/io/aeron/DriverEventsAdapter.java
@@ -32,6 +32,7 @@ class DriverEventsAdapter implements MessageHandler
     private final ErrorResponseFlyweight errorResponse = new ErrorResponseFlyweight();
     private final PublicationBuffersReadyFlyweight publicationReady = new PublicationBuffersReadyFlyweight();
     private final SubscriptionReadyFlyweight subscriptionReady = new SubscriptionReadyFlyweight();
+    private final SubscriptionReadyFlyweightV1 subscriptionReadyV1 = new SubscriptionReadyFlyweightV1();
     private final ImageBuffersReadyFlyweight imageReady = new ImageBuffersReadyFlyweight();
     private final OperationSucceededFlyweight operationSucceeded = new OperationSucceededFlyweight();
     private final ImageMessageFlyweight imageMessage = new ImageMessageFlyweight();
@@ -165,6 +166,22 @@ class DriverEventsAdapter implements MessageHandler
                 {
                     receivedCorrelationId = correlationId;
                     listener.onNewSubscription(correlationId, subscriptionReady.channelStatusCounterId());
+                }
+                break;
+            }
+
+            case ON_SUBSCRIPTION_READY_V1:
+            {
+                subscriptionReadyV1.wrap(buffer, index);
+
+                final long correlationId = subscriptionReadyV1.correlationId();
+                if (correlationId == activeCorrelationId)
+                {
+                    receivedCorrelationId = correlationId;
+                    listener.onNewSubscription(
+                        correlationId,
+                        subscriptionReadyV1.channelStatusCounterId(),
+                        subscriptionReadyV1.streamId());
                 }
                 break;
             }

--- a/aeron-client/src/main/java/io/aeron/DriverEventsListener.java
+++ b/aeron-client/src/main/java/io/aeron/DriverEventsListener.java
@@ -43,6 +43,8 @@ interface DriverEventsListener
 
     void onNewSubscription(long correlationId, int statusIndicatorId);
 
+    void onNewSubscription(long correlationId, int statusIndicatorId, int streamId);
+
     void onUnavailableImage(long correlationId, long subscriptionRegistrationId);
 
     void onNewExclusivePublication(

--- a/aeron-client/src/main/java/io/aeron/DriverProxy.java
+++ b/aeron-client/src/main/java/io/aeron/DriverProxy.java
@@ -35,8 +35,7 @@ public class DriverProxy
 {
     private final MutableDirectBuffer buffer = new ExpandableArrayBuffer(1024);
     private final PublicationMessageFlyweight publicationMessage = new PublicationMessageFlyweight();
-    private final PublicationUriOnlyMessageFlyweight publicationUriOnlyMessage =
-        new PublicationUriOnlyMessageFlyweight();
+    private final ChannelMessageFlyweight channelMessage = new ChannelMessageFlyweight();
     private final SubscriptionMessageFlyweight subscriptionMessage = new SubscriptionMessageFlyweight();
     private final RemoveMessageFlyweight removeMessage = new RemoveMessageFlyweight();
     private final CorrelatedMessageFlyweight correlatedMessage = new CorrelatedMessageFlyweight();
@@ -50,7 +49,7 @@ public class DriverProxy
         this.toDriverCommandBuffer = toDriverCommandBuffer;
 
         publicationMessage.wrap(buffer, 0);
-        publicationUriOnlyMessage.wrap(buffer, 0);
+        channelMessage.wrap(buffer, 0);
         subscriptionMessage.wrap(buffer, 0);
         correlatedMessage.wrap(buffer, 0);
         removeMessage.wrap(buffer, 0);
@@ -109,10 +108,10 @@ public class DriverProxy
     {
         final long correlationId = toDriverCommandBuffer.nextCorrelationId();
 
-        publicationUriOnlyMessage.correlationId(correlationId);
-        publicationUriOnlyMessage.channel(channel);
+        channelMessage.correlationId(correlationId);
+        channelMessage.channel(channel);
 
-        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_URI_ONLY, buffer, 0, publicationUriOnlyMessage.length()))
+        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_URI_ONLY, buffer, 0, channelMessage.length()))
         {
             throw new AeronException("could not write add exclusive publication command");
         }

--- a/aeron-client/src/main/java/io/aeron/DriverProxy.java
+++ b/aeron-client/src/main/java/io/aeron/DriverProxy.java
@@ -87,6 +87,21 @@ public class DriverProxy
         return correlationId;
     }
 
+    public long addPublication(final String channel)
+    {
+        final long correlationId = toDriverCommandBuffer.nextCorrelationId();
+
+        channelMessage.correlationId(correlationId);
+        channelMessage.channel(channel);
+
+        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_V1, buffer, 0, channelMessage.length()))
+        {
+            throw new AeronException("could not write add exclusive publication command");
+        }
+
+        return correlationId;
+    }
+
     public long addExclusivePublication(final String channel, final int streamId)
     {
         final long correlationId = toDriverCommandBuffer.nextCorrelationId();
@@ -104,14 +119,14 @@ public class DriverProxy
         return correlationId;
     }
 
-    public long addPublication(final String channel)
+    public long addExclusivePublication(final String channel)
     {
         final long correlationId = toDriverCommandBuffer.nextCorrelationId();
 
         channelMessage.correlationId(correlationId);
         channelMessage.channel(channel);
 
-        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_V1, buffer, 0, channelMessage.length()))
+        if (!toDriverCommandBuffer.write(ADD_EXCLUSIVE_PUBLICATION_V1, buffer, 0, channelMessage.length()))
         {
             throw new AeronException("could not write add exclusive publication command");
         }

--- a/aeron-client/src/main/java/io/aeron/DriverProxy.java
+++ b/aeron-client/src/main/java/io/aeron/DriverProxy.java
@@ -111,7 +111,7 @@ public class DriverProxy
         channelMessage.correlationId(correlationId);
         channelMessage.channel(channel);
 
-        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_URI_ONLY, buffer, 0, channelMessage.length()))
+        if (!toDriverCommandBuffer.write(ADD_PUBLICATION_V1, buffer, 0, channelMessage.length()))
         {
             throw new AeronException("could not write add exclusive publication command");
         }
@@ -130,6 +130,21 @@ public class DriverProxy
         if (!toDriverCommandBuffer.write(REMOVE_PUBLICATION, buffer, 0, RemoveMessageFlyweight.length()))
         {
             throw new AeronException("could not write remove publication command");
+        }
+
+        return correlationId;
+    }
+
+    public long addSubscription(final String channel)
+    {
+        final long correlationId = toDriverCommandBuffer.nextCorrelationId();
+
+        channelMessage.correlationId(correlationId);
+        channelMessage.channel(channel);
+
+        if (!toDriverCommandBuffer.write(ADD_SUBSCRIPTION_V1, buffer, 0, channelMessage.length()))
+        {
+            throw new AeronException("could not write add subscription command");
         }
 
         return correlationId;

--- a/aeron-client/src/main/java/io/aeron/command/ChannelMessageFlyweight.java
+++ b/aeron-client/src/main/java/io/aeron/command/ChannelMessageFlyweight.java
@@ -37,7 +37,7 @@ import static org.agrona.BitUtil.SIZE_OF_LONG;
  *  +---------------------------------------------------------------+
  * </pre>
  */
-public class PublicationUriOnlyMessageFlyweight extends CorrelatedMessageFlyweight
+public class ChannelMessageFlyweight extends CorrelatedMessageFlyweight
 {
     private static final int CHANNEL_OFFSET = CORRELATION_ID_FIELD_OFFSET + SIZE_OF_LONG;
 
@@ -71,7 +71,7 @@ public class PublicationUriOnlyMessageFlyweight extends CorrelatedMessageFlyweig
      * @param channel field value
      * @return flyweight
      */
-    public PublicationUriOnlyMessageFlyweight channel(final String channel)
+    public ChannelMessageFlyweight channel(final String channel)
     {
         lengthOfChannel = buffer.putStringAscii(offset + CHANNEL_OFFSET, channel);
 

--- a/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
+++ b/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
@@ -92,6 +92,11 @@ public class ControlProtocolEvents
      */
     public static final int TERMINATE_DRIVER = 0x0E;
 
+    /**
+     * Add a Publication with the only the URI (which will include the stream-id)
+     */
+    public static final int ADD_PUBLICATION_URI_ONLY = 0x0F;
+
     // Media Driver to Clients
 
     /**

--- a/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
+++ b/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
@@ -106,6 +106,13 @@ public class ControlProtocolEvents
      */
     public static final int ADD_SUBSCRIPTION_V1 = 0x10;
 
+    /**
+     * Add an Exclusive Publication.
+     *
+     * @since 0.1.0 (Cnc)
+     */
+    public static final int ADD_EXCLUSIVE_PUBLICATION_V1 = 0x11;
+
     // Media Driver to Clients
 
     /**

--- a/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
+++ b/aeron-client/src/main/java/io/aeron/command/ControlProtocolEvents.java
@@ -94,8 +94,17 @@ public class ControlProtocolEvents
 
     /**
      * Add a Publication with the only the URI (which will include the stream-id)
+     *
+     * @since 0.1.0 (CnC)
      */
-    public static final int ADD_PUBLICATION_URI_ONLY = 0x0F;
+    public static final int ADD_PUBLICATION_V1 = 0x0F;
+
+    /**
+     * Add a Subscription with the only the URI (which will include the stream-id)
+     *
+     * @since 0.1.0 (CnC)
+     */
+    public static final int ADD_SUBSCRIPTION_V1 = 0x10;
 
     // Media Driver to Clients
 
@@ -148,4 +157,12 @@ public class ControlProtocolEvents
      * Inform clients of client timeout.
      */
     public static final int ON_CLIENT_TIMEOUT = 0x0F0A;
+
+    /**
+     * New Subscription is ready notification, in response to an add subscription that
+     * only includes a channel uri.
+     *
+     * @since 0.1.0 (CnC)
+     */
+    public static final int ON_SUBSCRIPTION_READY_V1 = 0x0F0B;
 }

--- a/aeron-client/src/main/java/io/aeron/command/PublicationUriOnlyMessageFlyweight.java
+++ b/aeron-client/src/main/java/io/aeron/command/PublicationUriOnlyMessageFlyweight.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.command;
+
+import io.aeron.ErrorCode;
+import io.aeron.exceptions.ControlProtocolException;
+
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+/**
+ * Control message for adding or removing a publication with only the channel URI specified
+ * <pre>
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                       Correlation ID                          |
+ *  |                                                               |
+ *  +---------------------------------------------------------------+
+ *  |                       Channel Length                          |
+ *  +---------------------------------------------------------------+
+ *  |                       Channel (ASCII)                        ...
+ * ...                                                              |
+ *  +---------------------------------------------------------------+
+ * </pre>
+ */
+public class PublicationUriOnlyMessageFlyweight extends CorrelatedMessageFlyweight
+{
+    private static final int CHANNEL_OFFSET = CORRELATION_ID_FIELD_OFFSET + SIZE_OF_LONG;
+
+    private static final int MINIMUM_LENGTH = CHANNEL_OFFSET + SIZE_OF_INT;
+
+    private int lengthOfChannel;
+
+    /**
+     * Get the channel field in ASCII
+     *
+     * @return channel field
+     */
+    public String channel()
+    {
+        return buffer.getStringAscii(offset + CHANNEL_OFFSET);
+    }
+
+    /**
+     * Append the channel value to an {@link Appendable}.
+     *
+     * @param appendable to append channel to.
+     */
+    public void appendChannel(final Appendable appendable)
+    {
+        buffer.getStringAscii(offset + CHANNEL_OFFSET, appendable);
+    }
+
+    /**
+     * Set the channel field in ASCII
+     *
+     * @param channel field value
+     * @return flyweight
+     */
+    public PublicationUriOnlyMessageFlyweight channel(final String channel)
+    {
+        lengthOfChannel = buffer.putStringAscii(offset + CHANNEL_OFFSET, channel);
+
+        return this;
+    }
+
+    /**
+     * Get the length of the current message
+     * <p>
+     * NB: must be called after the data is written in order to be accurate.
+     *
+     * @return the length of the current message
+     */
+    public int length()
+    {
+        return CHANNEL_OFFSET + lengthOfChannel;
+    }
+
+    /**
+     * Validate buffer length is long enough for message.
+     *
+     * @param msgTypeId type of message.
+     * @param length of message in bytes to validate.
+     */
+    public void validateLength(final int msgTypeId, final int length)
+    {
+        if (length < MINIMUM_LENGTH)
+        {
+            throw new ControlProtocolException(
+                ErrorCode.MALFORMED_COMMAND, "command=" + msgTypeId + " too short: length=" + length);
+        }
+
+        if ((length - MINIMUM_LENGTH) < buffer.getInt(offset + CHANNEL_OFFSET))
+        {
+            throw new ControlProtocolException(
+                ErrorCode.MALFORMED_COMMAND, "command=" + msgTypeId + " too short for channel: length=" + length);
+        }
+    }
+}

--- a/aeron-client/src/main/java/io/aeron/command/SubscriptionReadyFlyweightV1.java
+++ b/aeron-client/src/main/java/io/aeron/command/SubscriptionReadyFlyweightV1.java
@@ -119,7 +119,7 @@ public class SubscriptionReadyFlyweightV1
      */
     public int streamId()
     {
-        return buffer.getInt(STREAM_ID_OFFSET);
+        return buffer.getInt(offset + STREAM_ID_OFFSET);
     }
 
     /**
@@ -130,7 +130,7 @@ public class SubscriptionReadyFlyweightV1
      */
     public SubscriptionReadyFlyweightV1 streamId(final int streamId)
     {
-        buffer.putInt(STREAM_ID_OFFSET, streamId);
+        buffer.putInt(offset + STREAM_ID_OFFSET, streamId);
 
         return this;
     }

--- a/aeron-client/src/main/java/io/aeron/command/SubscriptionReadyFlyweightV1.java
+++ b/aeron-client/src/main/java/io/aeron/command/SubscriptionReadyFlyweightV1.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.command;
+
+import org.agrona.MutableDirectBuffer;
+
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+/**
+ * Message to denote that a Subscription has been successfully set up.
+ *
+ * @see ControlProtocolEvents
+ * <pre>
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                         Correlation ID                        |
+ *  |                                                               |
+ *  +---------------------------------------------------------------+
+ *  |                  Channel Status Indicator ID                  |
+ *  +---------------------------------------------------------------+
+ *  |                            Stream ID                          |
+ *  +---------------------------------------------------------------+
+ * </pre>
+ *
+ * @since 0.1.0 (CnC)
+ */
+public class SubscriptionReadyFlyweightV1
+{
+    private static final int CORRELATION_ID_OFFSET = 0;
+    private static final int CHANNEL_STATUS_INDICATOR_ID_OFFSET = CORRELATION_ID_OFFSET + SIZE_OF_LONG;
+    private static final int STREAM_ID_OFFSET = CHANNEL_STATUS_INDICATOR_ID_OFFSET + SIZE_OF_INT;
+
+    public static final int LENGTH = STREAM_ID_OFFSET + SIZE_OF_INT;
+
+    private MutableDirectBuffer buffer;
+    private int offset;
+
+    /**
+     * Wrap the buffer at a given offset for updates.
+     *
+     * @param buffer to wrap
+     * @param offset at which the message begins.
+     * @return for fluent API
+     */
+    public final SubscriptionReadyFlyweightV1 wrap(final MutableDirectBuffer buffer, final int offset)
+    {
+        this.buffer = buffer;
+        this.offset = offset;
+
+        return this;
+    }
+
+    /**
+     * Get the correlation id field
+     *
+     * @return correlation id field
+     */
+    public long correlationId()
+    {
+        return buffer.getLong(offset + CORRELATION_ID_OFFSET);
+    }
+
+    /**
+     * Set the correlation id field
+     *
+     * @param correlationId field value
+     * @return flyweight
+     */
+    public SubscriptionReadyFlyweightV1 correlationId(final long correlationId)
+    {
+        buffer.putLong(offset + CORRELATION_ID_OFFSET, correlationId);
+
+        return this;
+    }
+
+    /**
+     * The channel status counter id.
+     *
+     * @return channel status counter id.
+     */
+    public int channelStatusCounterId()
+    {
+        return buffer.getInt(offset + CHANNEL_STATUS_INDICATOR_ID_OFFSET);
+    }
+
+    /**
+     * Set channel status counter id field
+     *
+     * @param counterId field value
+     * @return flyweight
+     */
+    public SubscriptionReadyFlyweightV1 channelStatusCounterId(final int counterId)
+    {
+        buffer.putInt(offset + CHANNEL_STATUS_INDICATOR_ID_OFFSET, counterId);
+
+        return this;
+    }
+
+    /**
+     * The stream id that will of been parsed out of an incoming addSubscription that included it in the channel uri.
+     *
+     * @return stream id.
+     * @see ChannelMessageFlyweight
+     */
+    public int streamId()
+    {
+        return buffer.getInt(STREAM_ID_OFFSET);
+    }
+
+    /**
+     * Set the stream id.
+     *
+     * @param streamId field value
+     * @return flyweight.
+     */
+    public SubscriptionReadyFlyweightV1 streamId(final int streamId)
+    {
+        buffer.putInt(STREAM_ID_OFFSET, streamId);
+
+        return this;
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/ChannelUriStringBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/ChannelUriStringBuilderTest.java
@@ -17,6 +17,8 @@ package io.aeron;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -99,5 +101,18 @@ public class ChannelUriStringBuilderTest
         assertEquals(
             "aeron:udp?endpoint=address:9999|term-length=131072|init-term-id=777|term-id=999|term-offset=64",
             builder.build());
+    }
+
+    @Test
+    void shouldRetainSpyPrefix()
+    {
+        final String uri = "aeron-spy:aeron:udp?endpoint=localhost:4000";
+
+        final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(uri)
+            .streamId(12354);
+
+        final String uriWithStreamId = builder.build();
+
+        assertThat(uriWithStreamId, startsWith("aeron-spy:"));
     }
 }

--- a/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
+++ b/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
@@ -54,6 +54,7 @@ public class ClientConductorTest
     private static final int SESSION_ID_2 = 15;
 
     private static final String CHANNEL = "aeron:udp?endpoint=localhost:40124";
+    private static final String CHANNEL_WITH_STREAM_ID = "aeron:udp?endpoint=localhost:40124|stream-id=1002";
     private static final int STREAM_ID_1 = 1002;
     private static final int STREAM_ID_2 = 1004;
     private static final int SEND_BUFFER_CAPACITY = 1024;
@@ -131,6 +132,7 @@ public class ClientConductorTest
 
         when(driverProxy.addPublication(CHANNEL, STREAM_ID_1)).thenReturn(CORRELATION_ID);
         when(driverProxy.addPublication(CHANNEL, STREAM_ID_2)).thenReturn(CORRELATION_ID_2);
+        when(driverProxy.addPublication(CHANNEL_WITH_STREAM_ID)).thenReturn(CORRELATION_ID);
         when(driverProxy.removePublication(CORRELATION_ID)).thenReturn(CLOSE_CORRELATION_ID);
         when(driverProxy.addSubscription(anyString(), anyInt())).thenReturn(CORRELATION_ID);
         when(driverProxy.removeSubscription(CORRELATION_ID)).thenReturn(CLOSE_CORRELATION_ID);
@@ -201,6 +203,19 @@ public class ClientConductorTest
         conductor.addPublication(CHANNEL, STREAM_ID_1);
 
         verify(driverProxy).addPublication(CHANNEL, STREAM_ID_1);
+    }
+
+    @Test
+    public void addPublicationUriOnlyShouldNotifyMediaDriver()
+    {
+        whenReceiveBroadcastOnMessage(
+            ControlProtocolEvents.ON_PUBLICATION_READY,
+            publicationReadyBuffer,
+            (buffer) -> publicationReady.length());
+
+        conductor.addPublication(CHANNEL_WITH_STREAM_ID);
+
+        verify(driverProxy).addPublication(CHANNEL_WITH_STREAM_ID);
     }
 
     @Test

--- a/aeron-client/src/test/java/io/aeron/DriverProxyTest.java
+++ b/aeron-client/src/test/java/io/aeron/DriverProxyTest.java
@@ -51,7 +51,7 @@ public class DriverProxyTest
     public void threadSendsAddPublicationUriOnlyMessage()
     {
         threadSendsAddPublicationUriOnlyMessage(
-            () -> conductor.addPublication(CHANNEL), ADD_PUBLICATION_URI_ONLY);
+            () -> conductor.addPublication(CHANNEL), ADD_PUBLICATION_V1);
     }
 
     @Test

--- a/aeron-client/src/test/java/io/aeron/DriverProxyTest.java
+++ b/aeron-client/src/test/java/io/aeron/DriverProxyTest.java
@@ -15,7 +15,7 @@
  */
 package io.aeron;
 
-import io.aeron.command.PublicationUriOnlyMessageFlyweight;
+import io.aeron.command.ChannelMessageFlyweight;
 import org.junit.jupiter.api.Test;
 import io.aeron.command.PublicationMessageFlyweight;
 import io.aeron.command.RemoveMessageFlyweight;
@@ -94,7 +94,7 @@ public class DriverProxyTest
         assertReadsOneMessage(
             (msgTypeId, buffer, index, length) ->
             {
-                final PublicationUriOnlyMessageFlyweight publicationMessage = new PublicationUriOnlyMessageFlyweight();
+                final ChannelMessageFlyweight publicationMessage = new ChannelMessageFlyweight();
                 publicationMessage.wrap(buffer, index);
 
                 assertEquals(expectedMsgTypeId, msgTypeId);

--- a/aeron-client/src/test/java/io/aeron/FlyweightTest.java
+++ b/aeron-client/src/test/java/io/aeron/FlyweightTest.java
@@ -15,6 +15,7 @@
  */
 package io.aeron;
 
+import io.aeron.command.PublicationUriOnlyMessageFlyweight;
 import org.junit.jupiter.api.Test;
 import io.aeron.command.PublicationMessageFlyweight;
 import io.aeron.protocol.DataHeaderFlyweight;
@@ -37,6 +38,10 @@ public class FlyweightTest
     private final DataHeaderFlyweight decodeDataHeader = new DataHeaderFlyweight();
     private final PublicationMessageFlyweight encodePublication = new PublicationMessageFlyweight();
     private final PublicationMessageFlyweight decodePublication = new PublicationMessageFlyweight();
+    private final PublicationUriOnlyMessageFlyweight encodeUriOnlyPublication =
+        new PublicationUriOnlyMessageFlyweight();
+    private final PublicationUriOnlyMessageFlyweight decodeUriOnlyPublication =
+        new PublicationUriOnlyMessageFlyweight();
     private final NakFlyweight encodeNakHeader = new NakFlyweight();
     private final NakFlyweight decodeNakHeader = new NakFlyweight();
 
@@ -163,9 +168,24 @@ public class FlyweightTest
 
         final String channel = "aeron:udp?endpoint=localhost:4000";
         encodePublication.channel(channel);
+        encodePublication.streamId(1001);
 
         decodePublication.wrap(aBuff, 0);
 
         assertEquals(channel, decodePublication.channel());
+        assertEquals(1001, decodePublication.streamId());
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeChannelsUriOnlyCorrectly()
+    {
+        decodeUriOnlyPublication.wrap(aBuff, 0);
+
+        final String channel = "aeron:udp?endpoint=localhost:4000|stream-id=1001";
+        decodeUriOnlyPublication.channel(channel);
+
+        decodeUriOnlyPublication.wrap(aBuff, 0);
+
+        assertEquals(channel, decodeUriOnlyPublication.channel());
     }
 }

--- a/aeron-client/src/test/java/io/aeron/FlyweightTest.java
+++ b/aeron-client/src/test/java/io/aeron/FlyweightTest.java
@@ -15,7 +15,7 @@
  */
 package io.aeron;
 
-import io.aeron.command.PublicationUriOnlyMessageFlyweight;
+import io.aeron.command.ChannelMessageFlyweight;
 import org.junit.jupiter.api.Test;
 import io.aeron.command.PublicationMessageFlyweight;
 import io.aeron.protocol.DataHeaderFlyweight;
@@ -38,10 +38,10 @@ public class FlyweightTest
     private final DataHeaderFlyweight decodeDataHeader = new DataHeaderFlyweight();
     private final PublicationMessageFlyweight encodePublication = new PublicationMessageFlyweight();
     private final PublicationMessageFlyweight decodePublication = new PublicationMessageFlyweight();
-    private final PublicationUriOnlyMessageFlyweight encodeUriOnlyPublication =
-        new PublicationUriOnlyMessageFlyweight();
-    private final PublicationUriOnlyMessageFlyweight decodeUriOnlyPublication =
-        new PublicationUriOnlyMessageFlyweight();
+    private final ChannelMessageFlyweight encodeUriOnlyPublication =
+        new ChannelMessageFlyweight();
+    private final ChannelMessageFlyweight decodeUriOnlyPublication =
+        new ChannelMessageFlyweight();
     private final NakFlyweight encodeNakHeader = new NakFlyweight();
     private final NakFlyweight decodeNakHeader = new NakFlyweight();
 

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -35,8 +35,7 @@ import static io.aeron.command.ControlProtocolEvents.*;
 class ClientCommandAdapter implements MessageHandler
 {
     private final PublicationMessageFlyweight publicationMsgFlyweight = new PublicationMessageFlyweight();
-    private final PublicationUriOnlyMessageFlyweight publicationUriOnlyMessageFlyweight =
-        new PublicationUriOnlyMessageFlyweight();
+    private final ChannelMessageFlyweight channelMessageFlyweight = new ChannelMessageFlyweight();
     private final SubscriptionMessageFlyweight subscriptionMsgFlyweight = new SubscriptionMessageFlyweight();
     private final CorrelatedMessageFlyweight correlatedMsgFlyweight = new CorrelatedMessageFlyweight();
     private final RemoveMessageFlyweight removeMsgFlyweight = new RemoveMessageFlyweight();
@@ -148,10 +147,10 @@ class ClientCommandAdapter implements MessageHandler
 
                 case ADD_PUBLICATION_URI_ONLY:
                 {
-                    publicationUriOnlyMessageFlyweight.wrap(buffer, index);
-                    publicationUriOnlyMessageFlyweight.validateLength(msgTypeId, length);
+                    channelMessageFlyweight.wrap(buffer, index);
+                    channelMessageFlyweight.validateLength(msgTypeId, length);
 
-                    correlationId = publicationUriOnlyMessageFlyweight.correlationId();
+                    correlationId = channelMessageFlyweight.correlationId();
                     addPublicationUriOnly(correlationId, false);
 
                     break;
@@ -310,8 +309,8 @@ class ClientCommandAdapter implements MessageHandler
 
     public void addPublicationUriOnly(final long correlationId, final boolean isExclusive)
     {
-        final long clientId = publicationUriOnlyMessageFlyweight.clientId();
-        final String channel = publicationUriOnlyMessageFlyweight.channel();
+        final long clientId = channelMessageFlyweight.clientId();
+        final String channel = channelMessageFlyweight.channel();
 
         if (channel.startsWith(IPC_CHANNEL))
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -90,6 +90,16 @@ class ClientCommandAdapter implements MessageHandler
                     break;
                 }
 
+                case ADD_PUBLICATION_V1:
+                {
+                    channelMessageFlyweight.wrap(buffer, index);
+                    channelMessageFlyweight.validateLength(msgTypeId, length);
+
+                    correlationId = channelMessageFlyweight.correlationId();
+                    addPublication(channelMessageFlyweight, false);
+                    break;
+                }
+
                 case REMOVE_PUBLICATION:
                 {
                     removeMsgFlyweight.wrap(buffer, index);
@@ -110,13 +120,13 @@ class ClientCommandAdapter implements MessageHandler
                     break;
                 }
 
-                case ADD_PUBLICATION_V1:
+                case ADD_EXCLUSIVE_PUBLICATION_V1:
                 {
                     channelMessageFlyweight.wrap(buffer, index);
                     channelMessageFlyweight.validateLength(msgTypeId, length);
 
                     correlationId = channelMessageFlyweight.correlationId();
-                    addPublication(channelMessageFlyweight, false);
+                    addPublication(channelMessageFlyweight, true);
                     break;
                 }
 
@@ -145,16 +155,6 @@ class ClientCommandAdapter implements MessageHandler
                     break;
                 }
 
-                case REMOVE_SUBSCRIPTION:
-                {
-                    removeMsgFlyweight.wrap(buffer, index);
-                    removeMsgFlyweight.validateLength(msgTypeId, length);
-
-                    correlationId = removeMsgFlyweight.correlationId();
-                    conductor.onRemoveSubscription(removeMsgFlyweight.registrationId(), correlationId);
-                    break;
-                }
-
                 case ADD_SUBSCRIPTION_V1:
                 {
                     channelMessageFlyweight.wrap(buffer, index);
@@ -178,6 +178,16 @@ class ClientCommandAdapter implements MessageHandler
                     }
                     break;
 
+                }
+
+                case REMOVE_SUBSCRIPTION:
+                {
+                    removeMsgFlyweight.wrap(buffer, index);
+                    removeMsgFlyweight.validateLength(msgTypeId, length);
+
+                    correlationId = removeMsgFlyweight.correlationId();
+                    conductor.onRemoveSubscription(removeMsgFlyweight.registrationId(), correlationId);
+                    break;
                 }
 
                 case ADD_DESTINATION:

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientProxy.java
@@ -35,6 +35,7 @@ public class ClientProxy
     private final ErrorResponseFlyweight errorResponse = new ErrorResponseFlyweight();
     private final PublicationBuffersReadyFlyweight publicationReady = new PublicationBuffersReadyFlyweight();
     private final SubscriptionReadyFlyweight subscriptionReady = new SubscriptionReadyFlyweight();
+    private final SubscriptionReadyFlyweightV1 subscriptionReadyV1 = new SubscriptionReadyFlyweightV1();
     private final ImageBuffersReadyFlyweight imageReady = new ImageBuffersReadyFlyweight();
     private final OperationSucceededFlyweight operationSucceeded = new OperationSucceededFlyweight();
     private final ImageMessageFlyweight imageMessage = new ImageMessageFlyweight();
@@ -49,6 +50,7 @@ public class ClientProxy
         imageReady.wrap(buffer, 0);
         publicationReady.wrap(buffer, 0);
         subscriptionReady.wrap(buffer, 0);
+        subscriptionReadyV1.wrap(buffer, 0);
         operationSucceeded.wrap(buffer, 0);
         imageMessage.wrap(buffer, 0);
         counterUpdate.wrap(buffer, 0);
@@ -119,6 +121,17 @@ public class ClientProxy
             .channelStatusCounterId(channelStatusCounterId);
 
         transmit(ON_SUBSCRIPTION_READY, buffer, 0, SubscriptionReadyFlyweight.LENGTH);
+    }
+
+    public void onSubscriptionReady(
+        final long correlationId, final int channelStatusCounterId, final int streamId)
+    {
+        subscriptionReadyV1
+            .correlationId(correlationId)
+            .channelStatusCounterId(channelStatusCounterId)
+            .streamId(streamId);
+
+        transmit(ON_SUBSCRIPTION_READY_V1, buffer, 0, SubscriptionReadyFlyweightV1.LENGTH);
     }
 
     public void operationSucceeded(final long correlationId)

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
@@ -34,8 +34,10 @@ final class PublicationParams
     int termId = 0;
     int termOffset = 0;
     int sessionId = 0;
+    int streamId = 0;
     boolean hasPosition = false;
     boolean hasSessionId = false;
+    boolean hasStreamId = false;
     boolean isSessionIdTagged = false;
     boolean isSparse;
     boolean signalEos = true;
@@ -60,6 +62,7 @@ final class PublicationParams
         params.getLingerTimeoutNs(channelUri);
         params.getSparse(channelUri);
         params.getEos(channelUri);
+        params.getStreamId(channelUri);
 
         int count = 0;
 
@@ -227,6 +230,16 @@ final class PublicationParams
         {
             lingerTimeoutNs = SystemUtil.parseDuration(LINGER_PARAM_NAME, lingerParam);
             Configuration.validatePublicationLingerTimeoutNs(lingerTimeoutNs, lingerTimeoutNs);
+        }
+    }
+
+    private void getStreamId(final ChannelUri channelUri)
+    {
+        final String streamIdStr = channelUri.get(STREAM_ID_PARAM_NAME);
+        if (null != streamIdStr)
+        {
+            streamId = Integer.parseInt(streamIdStr);
+            hasStreamId = true;
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/SubscriptionParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SubscriptionParams.java
@@ -28,8 +28,10 @@ class SubscriptionParams
     int termId = 0;
     int termOffset = 0;
     int sessionId = 0;
+    int streamId = 0;
     boolean hasJoinPosition = false;
     boolean hasSessionId = false;
+    boolean hasStreamId;
     boolean isReliable = true;
     boolean isSparse = true;
     boolean isTether = true;
@@ -45,6 +47,13 @@ class SubscriptionParams
         {
             params.sessionId = Integer.parseInt(sessionIdStr);
             params.hasSessionId = true;
+        }
+
+        final String streamIdStr = channelUri.get(CommonContext.SESSION_ID_PARAM_NAME);
+        if (null != streamIdStr)
+        {
+            params.streamId = Integer.parseInt(streamIdStr);
+            params.hasStreamId = true;
         }
 
         int count = 0;

--- a/aeron-driver/src/main/java/io/aeron/driver/SubscriptionParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SubscriptionParams.java
@@ -49,7 +49,7 @@ class SubscriptionParams
             params.hasSessionId = true;
         }
 
-        final String streamIdStr = channelUri.get(CommonContext.SESSION_ID_PARAM_NAME);
+        final String streamIdStr = channelUri.get(STREAM_ID_PARAM_NAME);
         if (null != streamIdStr)
         {
             params.streamId = Integer.parseInt(streamIdStr);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorUriOnlyTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorUriOnlyTest.java
@@ -1,0 +1,1735 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.ChannelUriStringBuilder;
+import io.aeron.CommonContext;
+import io.aeron.DriverProxy;
+import io.aeron.ErrorCode;
+import io.aeron.driver.buffer.RawLog;
+import io.aeron.driver.buffer.TestLogFactory;
+import io.aeron.driver.exceptions.InvalidChannelException;
+import io.aeron.driver.media.ReceiveChannelEndpoint;
+import io.aeron.driver.media.ReceiveChannelEndpointThreadLocals;
+import io.aeron.driver.media.UdpChannel;
+import io.aeron.driver.status.SystemCounters;
+import io.aeron.logbuffer.HeaderWriter;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.logbuffer.TermAppender;
+import io.aeron.protocol.StatusMessageFlyweight;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.*;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+import org.agrona.concurrent.ringbuffer.RingBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.CountersManager;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.LongConsumer;
+
+import static io.aeron.ErrorCode.*;
+import static io.aeron.driver.Configuration.*;
+import static io.aeron.protocol.DataHeaderFlyweight.createDefaultHeader;
+import static org.agrona.concurrent.status.CountersReader.METADATA_LENGTH;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DriverConductorUriOnlyTest
+{
+    private static final String CHANNEL_4000 = "aeron:udp?endpoint=localhost:4000";
+    private static final String CHANNEL_4001 = "aeron:udp?endpoint=localhost:4001";
+    private static final String CHANNEL_4002 = "aeron:udp?endpoint=localhost:4002";
+    private static final String CHANNEL_4003 = "aeron:udp?endpoint=localhost:4003";
+    private static final String CHANNEL_4004 = "aeron:udp?endpoint=localhost:4004";
+    private static final String CHANNEL_4000_TAG_ID_1 = "aeron:udp?endpoint=localhost:4000|tags=1001";
+    private static final String CHANNEL_TAG_ID_1 = "aeron:udp?tags=1001";
+    private static final String CHANNEL_SUB_CONTROL_MODE_MANUAL = "aeron:udp?control-mode=manual";
+    private static final String CHANNEL_IPC = "aeron:ipc";
+    private static final String INVALID_URI = "aeron:udp://";
+    private static final String COUNTER_LABEL = "counter label";
+    private static final int SESSION_ID = 100;
+    private static final int STREAM_ID_1 = 1010;
+    private static final int STREAM_ID_2 = 1020;
+    private static final int STREAM_ID_3 = 1030;
+    private static final int STREAM_ID_4 = 1040;
+    private static final int TERM_BUFFER_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
+    private static final int BUFFER_LENGTH = 16 * 1024;
+    private static final int COUNTER_TYPE_ID = 101;
+    private static final int COUNTER_KEY_OFFSET = 0;
+    private static final int COUNTER_KEY_LENGTH = 12;
+    private static final int COUNTER_LABEL_OFFSET = COUNTER_KEY_OFFSET + COUNTER_KEY_LENGTH;
+    private static final int COUNTER_LABEL_LENGTH = COUNTER_LABEL.length();
+    private static final long CLIENT_LIVENESS_TIMEOUT_NS = CLIENT_LIVENESS_TIMEOUT_DEFAULT_NS;
+    private static final long PUBLICATION_LINGER_TIMEOUT_NS = PUBLICATION_LINGER_DEFAULT_NS;
+    private static final int MTU_LENGTH = MTU_LENGTH_DEFAULT;
+
+    private final ByteBuffer conductorBuffer = ByteBuffer.allocate(CONDUCTOR_BUFFER_LENGTH_DEFAULT);
+    private final UnsafeBuffer counterKeyAndLabel = new UnsafeBuffer(new byte[BUFFER_LENGTH]);
+
+    private final RingBuffer toDriverCommands = new ManyToOneRingBuffer(new UnsafeBuffer(conductorBuffer));
+    private final ClientProxy mockClientProxy = mock(ClientProxy.class);
+
+    private final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
+    private final AtomicCounter mockErrorCounter = mock(AtomicCounter.class);
+
+    private final SenderProxy senderProxy = mock(SenderProxy.class);
+    private final ReceiverProxy receiverProxy = mock(ReceiverProxy.class);
+    private final DriverConductorProxy driverConductorProxy = mock(DriverConductorProxy.class);
+
+    private long currentTimeMs;
+    private final EpochClock epochClock = () -> currentTimeMs;
+    private long currentTimeNs;
+    private final NanoClock nanoClock = () -> currentTimeNs;
+
+    private CountersManager spyCountersManager;
+    private DriverProxy driverProxy;
+    private DriverConductor driverConductor;
+
+    private final Answer<Void> closeChannelEndpointAnswer = (invocation) ->
+    {
+        final Object[] args = invocation.getArguments();
+        final ReceiveChannelEndpoint channelEndpoint = (ReceiveChannelEndpoint)args[0];
+        channelEndpoint.close();
+
+        return null;
+    };
+
+    @BeforeEach
+    public void before()
+    {
+        currentTimeNs = 0;
+
+        counterKeyAndLabel.putInt(COUNTER_KEY_OFFSET, 42);
+        counterKeyAndLabel.putStringAscii(COUNTER_LABEL_OFFSET, COUNTER_LABEL);
+
+        final UnsafeBuffer counterBuffer = new UnsafeBuffer(ByteBuffer.allocate(BUFFER_LENGTH));
+        spyCountersManager = spy(new CountersManager(
+            new UnsafeBuffer(ByteBuffer.allocate(BUFFER_LENGTH * 2)), counterBuffer, StandardCharsets.US_ASCII));
+
+        final SystemCounters mockSystemCounters = mock(SystemCounters.class);
+        when(mockSystemCounters.get(any())).thenReturn(mockErrorCounter);
+
+        final MediaDriver.Context ctx = new MediaDriver.Context()
+            .tempBuffer(new UnsafeBuffer(new byte[METADATA_LENGTH]))
+            .timerIntervalNs(DEFAULT_TIMER_INTERVAL_NS)
+            .publicationTermBufferLength(TERM_BUFFER_LENGTH)
+            .ipcTermBufferLength(TERM_BUFFER_LENGTH)
+            .applicationSpecificFeedback(Configuration.applicationSpecificFeedback())
+            .unicastFlowControlSupplier(Configuration.unicastFlowControlSupplier())
+            .multicastFlowControlSupplier(Configuration.multicastFlowControlSupplier())
+            .driverCommandQueue(new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
+            .errorHandler(mockErrorHandler)
+            .logFactory(new TestLogFactory())
+            .countersManager(spyCountersManager)
+            .epochClock(epochClock)
+            .nanoClock(nanoClock)
+            .cachedEpochClock(new CachedEpochClock())
+            .cachedNanoClock(new CachedNanoClock())
+            .sendChannelEndpointSupplier(Configuration.sendChannelEndpointSupplier())
+            .receiveChannelEndpointSupplier(Configuration.receiveChannelEndpointSupplier())
+            .congestControlSupplier(Configuration.congestionControlSupplier())
+            .toDriverCommands(toDriverCommands)
+            .clientProxy(mockClientProxy)
+            .countersValuesBuffer(counterBuffer)
+            .systemCounters(mockSystemCounters)
+            .receiverProxy(receiverProxy)
+            .senderProxy(senderProxy)
+            .driverConductorProxy(driverConductorProxy);
+
+        ctx.receiveChannelEndpointThreadLocals(new ReceiveChannelEndpointThreadLocals(ctx));
+
+        driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
+        driverConductor = new DriverConductor(ctx);
+
+        doAnswer(closeChannelEndpointAnswer).when(receiverProxy).closeReceiveChannelEndpoint(any());
+    }
+
+    @AfterEach
+    public void after()
+    {
+        driverConductor.closeChannelEndpoints();
+        driverConductor.onClose();
+    }
+
+    @Test
+    public void shouldErrorWhenOriginalPublicationHasNoDistinguishingCharacteristicBeyondTag()
+    {
+        final String expectedMessage =
+            "URI must have explicit control, endpoint, or be manual control-mode when original:";
+
+        addPublication(driverProxy, "aeron:udp?tags=1001", STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockErrorHandler).onError(argThat(
+            (ex) ->
+            {
+                assertThat(ex, instanceOf(InvalidChannelException.class));
+                assertThat(ex.getMessage(), containsString(expectedMessage));
+                return true;
+            }));
+    }
+
+
+    @Test
+    public void shouldBeAbleToAddSinglePublication()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(senderProxy).registerSendChannelEndpoint(any());
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+
+        final NetworkPublication publication = captor.getValue();
+        assertEquals(STREAM_ID_1, publication.streamId());
+
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), anyLong(), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+    }
+
+    @Test
+    public void shouldBeAbleToAddPublicationForReplay()
+    {
+        final int mtu = 1024 * 8;
+        final int termLength = 128 * 1024;
+        final int initialTermId = 7;
+        final int termId = 11;
+        final int termOffset = 64;
+        final String params =
+            "|mtu=" + mtu +
+            "|term-length=" + termLength +
+            "|init-term-id=" + initialTermId +
+            "|term-id=" + termId +
+            "|term-offset=" + termOffset;
+
+        driverProxy.addExclusivePublication(CHANNEL_4000 + params, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(senderProxy).registerSendChannelEndpoint(any());
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+
+        final NetworkPublication publication = captor.getValue();
+        assertEquals(STREAM_ID_1, publication.streamId());
+        assertEquals(mtu, publication.mtuLength());
+
+        final long expectedPosition = termLength * (termId - initialTermId) + termOffset;
+        assertEquals(expectedPosition, publication.producerPosition());
+        assertEquals(expectedPosition, publication.consumerPosition());
+
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), anyLong(), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(true));
+    }
+
+    @Test
+    public void shouldBeAbleToAddIpcPublicationForReplay()
+    {
+        final int termLength = 128 * 1024;
+        final int initialTermId = 7;
+        final int termId = 11;
+        final int termOffset = 64;
+        final String params =
+            "?term-length=" + termLength +
+            "|init-term-id=" + initialTermId +
+            "|term-id=" + termId +
+            "|term-offset=" + termOffset;
+
+        driverProxy.addExclusivePublication(CHANNEL_IPC + params, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<Long> captor = ArgumentCaptor.forClass(Long.class);
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), captor.capture(), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(true));
+
+        final long registrationId = captor.getValue();
+        final IpcPublication publication = driverConductor.getIpcPublication(registrationId);
+        assertEquals(STREAM_ID_1, publication.streamId());
+
+        final long expectedPosition = termLength * (termId - initialTermId) + termOffset;
+        assertEquals(expectedPosition, publication.producerPosition());
+        assertEquals(expectedPosition, publication.consumerPosition());
+    }
+
+    @Test
+    public void shouldBeAbleToAddSingleSubscription()
+    {
+        final long id = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(receiverProxy).registerReceiveChannelEndpoint(any());
+        verify(receiverProxy).addSubscription(any(), eq(STREAM_ID_1));
+        verify(mockClientProxy).onSubscriptionReady(eq(id), anyInt());
+
+        assertNotNull(driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveSingleSubscription()
+    {
+        final long id = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        driverProxy.removeSubscription(id);
+
+        driverConductor.doWork();
+
+        assertNull(driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldBeAbleToAddMultipleStreams()
+    {
+        addPublication(driverProxy, CHANNEL_4001, STREAM_ID_1);
+        addPublication(driverProxy, CHANNEL_4002, STREAM_ID_2);
+        addPublication(driverProxy, CHANNEL_4003, STREAM_ID_3);
+        addPublication(driverProxy, CHANNEL_4004, STREAM_ID_4);
+
+        driverConductor.doWork();
+
+        verify(senderProxy, times(4)).newNetworkPublication(any());
+    }
+
+    @Test
+    public void shouldBeAbleToRemoveSingleStream()
+    {
+        final long id = addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverProxy.removePublication(id);
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS + PUBLICATION_LINGER_TIMEOUT_NS * 2) - nanoClock.nanoTime() < 0);
+
+        verify(senderProxy).removeNetworkPublication(any());
+        assertNull(driverConductor.senderChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldBeAbleToRemoveMultipleStreams()
+    {
+        final long id1 = addPublication(driverProxy, CHANNEL_4001, STREAM_ID_1);
+        final long id2 = addPublication(driverProxy, CHANNEL_4002, STREAM_ID_2);
+        final long id3 = addPublication(driverProxy, CHANNEL_4003, STREAM_ID_3);
+        final long id4 = addPublication(driverProxy, CHANNEL_4004, STREAM_ID_4);
+
+        driverProxy.removePublication(id1);
+        driverProxy.removePublication(id2);
+        driverProxy.removePublication(id3);
+        driverProxy.removePublication(id4);
+
+        doWorkUntil(
+            () -> (CLIENT_LIVENESS_TIMEOUT_NS * 2 + PUBLICATION_LINGER_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(senderProxy, times(4)).removeNetworkPublication(any());
+    }
+
+    @Test
+    public void shouldKeepSubscriptionMediaEndpointUponRemovalOfAllButOneSubscriber()
+    {
+        final UdpChannel udpChannel = UdpChannel.parse(CHANNEL_4000);
+
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_2);
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_3);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint channelEndpoint = driverConductor.receiverChannelEndpoint(udpChannel);
+
+        assertNotNull(channelEndpoint);
+        assertEquals(3, channelEndpoint.streamCount());
+
+        driverProxy.removeSubscription(id1);
+        driverProxy.removeSubscription(id2);
+
+        driverConductor.doWork();
+
+        assertNotNull(driverConductor.receiverChannelEndpoint(udpChannel));
+        assertEquals(1, channelEndpoint.streamCount());
+    }
+
+    @Test
+    public void shouldOnlyRemoveSubscriptionMediaEndpointUponRemovalOfAllSubscribers()
+    {
+        final UdpChannel udpChannel = UdpChannel.parse(CHANNEL_4000);
+
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_2);
+        final long id3 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_3);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint channelEndpoint = driverConductor.receiverChannelEndpoint(udpChannel);
+
+        assertNotNull(channelEndpoint);
+        assertEquals(3, channelEndpoint.streamCount());
+
+        driverProxy.removeSubscription(id2);
+        driverProxy.removeSubscription(id3);
+
+        driverConductor.doWork();
+
+        assertNotNull(driverConductor.receiverChannelEndpoint(udpChannel));
+        assertEquals(1, channelEndpoint.streamCount());
+
+        driverProxy.removeSubscription(id1);
+
+        driverConductor.doWork();
+
+        assertNull(driverConductor.receiverChannelEndpoint(udpChannel));
+    }
+
+    @Test
+    public void shouldErrorOnRemovePublicationOnUnknownRegistrationId()
+    {
+        final long id = addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverProxy.removePublication(id + 1);
+
+        driverConductor.doWork();
+
+        final InOrder inOrder = inOrder(senderProxy, mockClientProxy);
+
+        inOrder.verify(senderProxy).newNetworkPublication(any());
+        inOrder.verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(id), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+        inOrder.verify(mockClientProxy).onError(anyLong(), eq(UNKNOWN_PUBLICATION), anyString());
+        inOrder.verifyNoMoreInteractions();
+
+        verify(mockErrorCounter).increment();
+        verify(mockErrorHandler).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void shouldAddPublicationWithMtu()
+    {
+        final int mtuLength = 4096;
+        final String mtuParam = "|" + CommonContext.MTU_LENGTH_PARAM_NAME + "=" + mtuLength;
+        addPublication(driverProxy, CHANNEL_4000 + mtuParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        assertEquals(mtuLength, argumentCaptor.getValue().mtuLength());
+    }
+
+    @Test
+    public void shouldErrorOnRemoveSubscriptionOnUnknownRegistrationId()
+    {
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        driverProxy.removeSubscription(id1 + 100);
+
+        driverConductor.doWork();
+
+        final InOrder inOrder = inOrder(receiverProxy, mockClientProxy);
+
+        inOrder.verify(receiverProxy).addSubscription(any(), anyInt());
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(id1), anyInt());
+        inOrder.verify(mockClientProxy).onError(anyLong(), eq(UNKNOWN_SUBSCRIPTION), anyString());
+        inOrder.verifyNoMoreInteractions();
+
+        verify(mockErrorHandler).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void shouldErrorOnAddSubscriptionWithInvalidChannel()
+    {
+        driverProxy.addSubscription(INVALID_URI, STREAM_ID_1);
+
+        driverConductor.doWork();
+        driverConductor.doWork();
+
+        verify(senderProxy, never()).newNetworkPublication(any());
+
+        verify(mockClientProxy).onError(anyLong(), eq(INVALID_CHANNEL), anyString());
+        verify(mockClientProxy, never()).operationSucceeded(anyLong());
+
+        verify(mockErrorCounter).increment();
+        verify(mockErrorHandler).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void shouldTimeoutPublication()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+
+        final NetworkPublication publication = captor.getValue();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS + PUBLICATION_LINGER_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(mockClientProxy, times(1))
+            .onClientTimeout(driverProxy.clientId());
+        verify(senderProxy).removeNetworkPublication(eq(publication));
+        assertNull(driverConductor.senderChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldNotTimeoutPublicationOnKeepAlive()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+
+        final NetworkPublication publication = captor.getValue();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS / 2) - nanoClock.nanoTime() <= 0);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS + 1000) - nanoClock.nanoTime() <= 0);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS * 2);
+
+        verify(senderProxy, never()).removeNetworkPublication(eq(publication));
+    }
+
+    @Test
+    public void shouldTimeoutPublicationWithNoKeepaliveButNotDrained()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+
+        final NetworkPublication publication = captor.getValue();
+
+        final int termId = 101;
+        final int index = LogBufferDescriptor.indexByTerm(termId, termId);
+        final RawLog rawLog = publication.rawLog();
+        LogBufferDescriptor.rawTail(rawLog.metaData(), index, LogBufferDescriptor.packTail(termId, 0));
+        final TermAppender appender = new TermAppender(rawLog.termBuffers()[index], rawLog.metaData(), index);
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[256]);
+        final HeaderWriter headerWriter = HeaderWriter.newInstance(
+            createDefaultHeader(SESSION_ID, STREAM_ID_1, termId));
+
+        final StatusMessageFlyweight msg = mock(StatusMessageFlyweight.class);
+        when(msg.consumptionTermId()).thenReturn(termId);
+        when(msg.consumptionTermOffset()).thenReturn(0);
+        when(msg.receiverWindowLength()).thenReturn(10);
+
+        publication.onStatusMessage(msg, new InetSocketAddress("localhost", 4059));
+        appender.appendUnfragmentedMessage(headerWriter, srcBuffer, 0, 256, null, termId);
+
+        assertEquals(NetworkPublication.State.ACTIVE, publication.state());
+
+        doWorkUntil(
+            () -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS * 2,
+            (timeNs) ->
+            {
+                publication.onStatusMessage(msg, new InetSocketAddress("localhost", 4059));
+                publication.updateHasReceivers(timeNs);
+            });
+
+        assertThat(publication.state(),
+            Matchers.anyOf(is(NetworkPublication.State.DRAINING), is(NetworkPublication.State.LINGER)));
+
+        final long endTime = nanoClock.nanoTime() + publicationConnectionTimeoutNs() + DEFAULT_TIMER_INTERVAL_NS;
+        doWorkUntil(() -> nanoClock.nanoTime() >= endTime, publication::updateHasReceivers);
+
+        assertThat(publication.state(),
+            Matchers.anyOf(is(NetworkPublication.State.LINGER), is(NetworkPublication.State.CLOSING)));
+
+        currentTimeNs += DEFAULT_TIMER_INTERVAL_NS + PUBLICATION_LINGER_TIMEOUT_NS;
+        driverConductor.doWork();
+        assertEquals(NetworkPublication.State.CLOSING, publication.state());
+
+        verify(senderProxy).removeNetworkPublication(eq(publication));
+        assertNull(driverConductor.senderChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldTimeoutSubscription()
+    {
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        verify(receiverProxy).addSubscription(eq(receiveChannelEndpoint), eq(STREAM_ID_1));
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS * 2);
+
+        verify(mockClientProxy, times(1))
+            .onClientTimeout(driverProxy.clientId());
+        verify(receiverProxy, times(1))
+            .removeSubscription(eq(receiveChannelEndpoint), eq(STREAM_ID_1));
+
+        assertNull(driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldNotTimeoutSubscriptionOnKeepAlive()
+    {
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        verify(receiverProxy).addSubscription(eq(receiveChannelEndpoint), eq(STREAM_ID_1));
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS + 1000);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS * 2);
+
+        verify(receiverProxy, never()).removeSubscription(any(), anyInt());
+        assertNotNull(driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldCreateImageOnSubscription()
+    {
+        final InetSocketAddress sourceAddress = new InetSocketAddress("localhost", 4400);
+        final int initialTermId = 1;
+        final int activeTermId = 2;
+        final int termOffset = 100;
+
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
+
+        driverConductor.onCreatePublicationImage(
+            SESSION_ID, STREAM_ID_1, initialTermId, activeTermId, termOffset, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
+            mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
+
+        final ArgumentCaptor<PublicationImage> captor = ArgumentCaptor.forClass(PublicationImage.class);
+        verify(receiverProxy).newPublicationImage(eq(receiveChannelEndpoint), captor.capture());
+
+        final PublicationImage publicationImage = captor.getValue();
+        assertEquals(SESSION_ID, publicationImage.sessionId());
+        assertEquals(STREAM_ID_1, publicationImage.streamId());
+
+        verify(mockClientProxy).onAvailableImage(
+            anyLong(), eq(STREAM_ID_1), eq(SESSION_ID), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldNotCreateImageOnUnknownSubscription()
+    {
+        final InetSocketAddress sourceAddress = new InetSocketAddress("localhost", 4400);
+
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
+
+        driverConductor.onCreatePublicationImage(
+            SESSION_ID, STREAM_ID_2, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
+            mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
+
+        verify(receiverProxy, never()).newPublicationImage(any(), any());
+        verify(mockClientProxy, never()).onAvailableImage(
+            anyLong(), anyInt(), anyInt(), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldSignalInactiveImageWhenImageTimesOut()
+    {
+        final InetSocketAddress sourceAddress = new InetSocketAddress("localhost", 4400);
+
+        final long subId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
+
+        driverConductor.onCreatePublicationImage(
+            SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
+            mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
+
+        final ArgumentCaptor<PublicationImage> captor = ArgumentCaptor.forClass(PublicationImage.class);
+        verify(receiverProxy).newPublicationImage(eq(receiveChannelEndpoint), captor.capture());
+
+        final PublicationImage publicationImage = captor.getValue();
+
+        publicationImage.activate();
+        publicationImage.ifActiveGoInactive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= imageLivenessTimeoutNs() + 1000);
+
+        verify(mockClientProxy).onUnavailableImage(
+            eq(publicationImage.correlationId()), eq(subId), eq(STREAM_ID_1), anyString());
+    }
+
+    @Test
+    public void shouldAlwaysGiveNetworkPublicationCorrelationIdToClientCallbacks()
+    {
+        final InetSocketAddress sourceAddress = new InetSocketAddress("localhost", 4400);
+
+        final long subId1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
+
+        driverConductor.onCreatePublicationImage(
+            SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
+            mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
+
+        final ArgumentCaptor<PublicationImage> captor = ArgumentCaptor.forClass(PublicationImage.class);
+        verify(receiverProxy).newPublicationImage(eq(receiveChannelEndpoint), captor.capture());
+
+        final PublicationImage publicationImage = captor.getValue();
+
+        publicationImage.activate();
+
+        final long subId2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        publicationImage.ifActiveGoInactive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= imageLivenessTimeoutNs() + 1000);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy, times(2)).onAvailableImage(
+            eq(publicationImage.correlationId()),
+            eq(STREAM_ID_1),
+            eq(SESSION_ID),
+            anyLong(),
+            anyInt(),
+            anyString(),
+            anyString());
+        inOrder.verify(mockClientProxy, times(1)).onUnavailableImage(
+            eq(publicationImage.correlationId()), eq(subId1), eq(STREAM_ID_1), anyString());
+        inOrder.verify(mockClientProxy, times(1)).onUnavailableImage(
+            eq(publicationImage.correlationId()), eq(subId2), eq(STREAM_ID_1), anyString());
+    }
+
+    @Test
+    public void shouldNotSendAvailableImageWhileImageNotActiveOnAddSubscription()
+    {
+        final InetSocketAddress sourceAddress = new InetSocketAddress("localhost", 4400);
+
+        final long subOneId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ReceiveChannelEndpoint receiveChannelEndpoint =
+            driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000));
+        assertNotNull(receiveChannelEndpoint);
+
+        receiveChannelEndpoint.openChannel(driverConductorProxy);
+
+        driverConductor.onCreatePublicationImage(
+            SESSION_ID, STREAM_ID_1, 1, 1, 0, TERM_BUFFER_LENGTH, MTU_LENGTH, 0,
+            mock(InetSocketAddress.class), sourceAddress, receiveChannelEndpoint);
+
+        final ArgumentCaptor<PublicationImage> captor = ArgumentCaptor.forClass(PublicationImage.class);
+        verify(receiverProxy).newPublicationImage(eq(receiveChannelEndpoint), captor.capture());
+
+        final PublicationImage publicationImage = captor.getValue();
+
+        publicationImage.activate();
+        publicationImage.ifActiveGoInactive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= imageLivenessTimeoutNs() / 2);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= imageLivenessTimeoutNs() + 1000);
+
+        final long subTwoId = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy, times(1)).onSubscriptionReady(eq(subOneId), anyInt());
+        inOrder.verify(mockClientProxy, times(1)).onAvailableImage(
+            eq(publicationImage.correlationId()),
+            eq(STREAM_ID_1),
+            eq(SESSION_ID),
+            anyLong(),
+            anyInt(),
+            anyString(),
+            anyString());
+        inOrder.verify(mockClientProxy, times(1)).onUnavailableImage(
+            eq(publicationImage.correlationId()), eq(subOneId), eq(STREAM_ID_1), anyString());
+        inOrder.verify(mockClientProxy, times(1)).onSubscriptionReady(eq(subTwoId), anyInt());
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    public void shouldBeAbleToAddSingleIpcPublication()
+    {
+        final long id = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        assertNotNull(driverConductor.getSharedIpcPublication(STREAM_ID_1));
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(id), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+    }
+
+    @Test
+    public void shouldBeAbleToAddIpcPublicationThenSubscription()
+    {
+        final long idPub = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(idPub), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(idSub), anyInt());
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublication.registrationId()), eq(STREAM_ID_1), eq(ipcPublication.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldBeAbleToAddThenRemoveTheAddIpcPublicationWithExistingSubscription()
+    {
+        final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
+        final long idPubOne = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublicationOne = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublicationOne);
+
+        final long idPubOneRemove = driverProxy.removePublication(idPubOne);
+        driverConductor.doWork();
+
+        final long idPubTwo = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublicationTwo = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublicationTwo);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(idSub), anyInt());
+        inOrder.verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(idPubOne), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublicationOne.registrationId()), eq(STREAM_ID_1), eq(ipcPublicationOne.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublicationOne.rawLog().fileName()), anyString());
+        inOrder.verify(mockClientProxy).operationSucceeded(eq(idPubOneRemove));
+        inOrder.verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(idPubTwo), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublicationTwo.registrationId()), eq(STREAM_ID_1), eq(ipcPublicationTwo.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublicationTwo.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldBeAbleToAddSubscriptionThenIpcPublication()
+    {
+        final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
+        final long idPub = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(idSub), anyInt());
+        inOrder.verify(mockClientProxy).onPublicationReady(
+            anyLong(), eq(idPub), eq(STREAM_ID_1), anyInt(), any(), anyInt(), anyInt(), eq(false));
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublication.registrationId()), eq(STREAM_ID_1), eq(ipcPublication.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveIpcPublication()
+    {
+        final long idAdd = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        driverProxy.removePublication(idAdd);
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS);
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveSubscriptionToIpcPublication()
+    {
+        final long idAdd = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
+        driverProxy.removeSubscription(idAdd);
+
+        doWorkUntil(() -> nanoClock.nanoTime() >= CLIENT_LIVENESS_TIMEOUT_NS);
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveTwoIpcPublications()
+    {
+        final long idAdd1 = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        final long idAdd2 = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        driverProxy.removePublication(idAdd1);
+
+        driverConductor.doWork();
+
+        IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        driverProxy.removePublication(idAdd2);
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldBeAbleToAddAndRemoveIpcPublicationAndSubscription()
+    {
+        final long idAdd1 = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
+        final long idAdd2 = addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+        driverProxy.removeSubscription(idAdd1);
+
+        driverConductor.doWork();
+
+        IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        driverProxy.removePublication(idAdd2);
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldTimeoutIpcPublication()
+    {
+        addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldNotTimeoutIpcPublicationWithKeepalive()
+    {
+        addPublication(driverProxy, CHANNEL_IPC, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+    }
+
+    @Test
+    public void shouldBeAbleToAddSingleSpy()
+    {
+        final long id = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(receiverProxy, never()).registerReceiveChannelEndpoint(any());
+        verify(receiverProxy, never()).addSubscription(any(), eq(STREAM_ID_1));
+        verify(mockClientProxy).onSubscriptionReady(eq(id), anyInt());
+
+        assertNull(driverConductor.receiverChannelEndpoint(UdpChannel.parse(CHANNEL_4000)));
+    }
+
+    @Test
+    public void shouldBeAbleToAddNetworkPublicationThenSingleSpy()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(idSpy), anyInt());
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(networkPublicationCorrelationId(publication)), eq(STREAM_ID_1), eq(publication.sessionId()),
+            anyLong(), anyInt(), eq(publication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldBeAbleToAddSingleSpyThenNetworkPublication()
+    {
+        final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onSubscriptionReady(eq(idSpy), anyInt());
+        inOrder.verify(mockClientProxy).onAvailableImage(
+            eq(networkPublicationCorrelationId(publication)), eq(STREAM_ID_1), eq(publication.sessionId()),
+            anyLong(), anyInt(), eq(publication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldBeAbleToAddNetworkPublicationThenSingleSpyThenRemoveSpy()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+        driverProxy.removeSubscription(idSpy);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertFalse(publication.hasSpies());
+    }
+
+    @Test
+    public void shouldTimeoutSpy()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        assertFalse(publication.hasSpies());
+    }
+
+    @Test
+    public void shouldNotTimeoutSpyWithKeepalive()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        driverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> CLIENT_LIVENESS_TIMEOUT_NS - nanoClock.nanoTime() <= 0);
+
+        assertTrue(publication.hasSpies());
+    }
+
+    @Test
+    public void shouldTimeoutNetworkPublicationWithSpy()
+    {
+        final long clientId = toDriverCommands.nextCorrelationId();
+        final DriverProxy spyDriverProxy = new DriverProxy(toDriverCommands, clientId);
+
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        final long subId = spyDriverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS / 2) - nanoClock.nanoTime() <= 0);
+
+        spyDriverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS + 1000) - nanoClock.nanoTime() <= 0);
+
+        spyDriverProxy.sendClientKeepalive();
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(mockClientProxy).onUnavailableImage(
+            eq(networkPublicationCorrelationId(publication)), eq(subId), eq(STREAM_ID_1), anyString());
+    }
+
+    @Test
+    public void shouldOnlyCloseSendChannelEndpointOnceWithMultiplePublications()
+    {
+        final long id1 = addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        final long id2 = addPublication(driverProxy, CHANNEL_4000, STREAM_ID_2);
+        driverProxy.removePublication(id1);
+        driverProxy.removePublication(id2);
+
+        doWorkUntil(() ->
+        {
+            driverProxy.sendClientKeepalive();
+            return (PUBLICATION_LINGER_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0;
+        });
+
+        verify(senderProxy, times(1)).closeSendChannelEndpoint(any());
+    }
+
+    @Test
+    public void shouldOnlyCloseReceiveChannelEndpointOnceWithMultipleSubscriptions()
+    {
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_2);
+        driverProxy.removeSubscription(id1);
+        driverProxy.removeSubscription(id2);
+
+        doWorkUntil(() ->
+        {
+            driverProxy.sendClientKeepalive();
+            return (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0;
+        });
+
+        verify(receiverProxy, times(1)).closeReceiveChannelEndpoint(any());
+    }
+
+    @Test
+    public void shouldErrorWhenConflictingUnreliableSubscriptionAdded()
+    {
+        driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
+    }
+
+    @Test
+    public void shouldErrorWhenConflictingDefaultReliableSubscriptionAdded()
+    {
+        driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
+        driverConductor.doWork();
+
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
+    }
+
+    @Test
+    public void shouldErrorWhenConflictingReliableSubscriptionAdded()
+    {
+        driverProxy.addSubscription(CHANNEL_4000 + "|reliable=false", STREAM_ID_1);
+        driverConductor.doWork();
+
+        final long id2 = driverProxy.addSubscription(CHANNEL_4000 + "|reliable=true", STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onError(eq(id2), any(ErrorCode.class), anyString());
+    }
+
+    @Test
+    public void shouldAddSingleCounter()
+    {
+        final long registrationId = driverProxy.addCounter(
+            COUNTER_TYPE_ID,
+            counterKeyAndLabel,
+            COUNTER_KEY_OFFSET,
+            COUNTER_KEY_LENGTH,
+            counterKeyAndLabel,
+            COUNTER_LABEL_OFFSET,
+            COUNTER_LABEL_LENGTH);
+
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onCounterReady(eq(registrationId), anyInt());
+        verify(spyCountersManager).newCounter(
+            eq(COUNTER_TYPE_ID),
+            any(),
+            anyInt(),
+            eq(COUNTER_KEY_LENGTH),
+            any(),
+            anyInt(),
+            eq(COUNTER_LABEL_LENGTH));
+    }
+
+    @Test
+    public void shouldRemoveSingleCounter()
+    {
+        final long registrationId = driverProxy.addCounter(
+            COUNTER_TYPE_ID,
+            counterKeyAndLabel,
+            COUNTER_KEY_OFFSET,
+            COUNTER_KEY_LENGTH,
+            counterKeyAndLabel,
+            COUNTER_LABEL_OFFSET,
+            COUNTER_LABEL_LENGTH);
+
+        driverConductor.doWork();
+
+        final long removeCorrelationId = driverProxy.removeCounter(registrationId);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onCounterReady(eq(registrationId), captor.capture());
+        inOrder.verify(mockClientProxy).operationSucceeded(removeCorrelationId);
+
+        verify(spyCountersManager).free(captor.getValue());
+    }
+
+    @Test
+    public void shouldRemoveCounterOnClientTimeout()
+    {
+        final long registrationId = driverProxy.addCounter(
+            COUNTER_TYPE_ID,
+            counterKeyAndLabel,
+            COUNTER_KEY_OFFSET,
+            COUNTER_KEY_LENGTH,
+            counterKeyAndLabel,
+            COUNTER_LABEL_OFFSET,
+            COUNTER_LABEL_LENGTH);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+
+        verify(mockClientProxy).onCounterReady(eq(registrationId), captor.capture());
+
+        doWorkUntil(() -> (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(spyCountersManager).free(captor.getValue());
+    }
+
+    @Test
+    public void shouldNotRemoveCounterOnClientKeepalive()
+    {
+        final long registrationId = driverProxy.addCounter(
+            COUNTER_TYPE_ID,
+            counterKeyAndLabel,
+            COUNTER_KEY_OFFSET,
+            COUNTER_KEY_LENGTH,
+            counterKeyAndLabel,
+            COUNTER_LABEL_OFFSET,
+            COUNTER_LABEL_LENGTH);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+
+        verify(mockClientProxy).onCounterReady(eq(registrationId), captor.capture());
+
+        doWorkUntil(() ->
+        {
+            driverProxy.sendClientKeepalive();
+            return (CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0;
+        });
+
+        verify(spyCountersManager, never()).free(captor.getValue());
+    }
+
+    @Test
+    public void shouldInformClientsOfRemovedCounter()
+    {
+        final long registrationId = driverProxy.addCounter(
+            COUNTER_TYPE_ID,
+            counterKeyAndLabel,
+            COUNTER_KEY_OFFSET,
+            COUNTER_KEY_LENGTH,
+            counterKeyAndLabel,
+            COUNTER_LABEL_OFFSET,
+            COUNTER_LABEL_LENGTH);
+
+        driverConductor.doWork();
+
+        final long removeCorrelationId = driverProxy.removeCounter(registrationId);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<Integer> captor = ArgumentCaptor.forClass(Integer.class);
+
+        final InOrder inOrder = inOrder(mockClientProxy);
+        inOrder.verify(mockClientProxy).onCounterReady(eq(registrationId), captor.capture());
+        inOrder.verify(mockClientProxy).operationSucceeded(removeCorrelationId);
+        inOrder.verify(mockClientProxy).onUnavailableCounter(eq(registrationId), captor.capture());
+
+        verify(spyCountersManager).free(captor.getValue());
+    }
+
+    @Test
+    public void shouldAddPublicationWithSessionId()
+    {
+        final int sessionId = 4096;
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        assertEquals(sessionId, argumentCaptor.getValue().sessionId());
+    }
+
+    @Test
+    public void shouldAddExclusivePublicationWithSessionId()
+    {
+        final int sessionId = 4096;
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        assertEquals(sessionId, argumentCaptor.getValue().sessionId());
+    }
+
+    @Test
+    public void shouldAddPublicationWithSameSessionId()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        final int sessionId = argumentCaptor.getValue().sessionId();
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy, times(2)).onPublicationReady(
+            anyLong(), anyLong(), eq(STREAM_ID_1), eq(sessionId), anyString(), anyInt(), anyInt(), eq(false));
+    }
+
+    @Test
+    public void shouldAddExclusivePublicationWithSameSessionId()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        final int sessionId = argumentCaptor.getValue().sessionId();
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + (sessionId + 1);
+        driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), anyLong(), eq(STREAM_ID_1), eq(sessionId), anyString(), anyInt(), anyInt(), eq(false));
+        verify(mockClientProxy).onPublicationReady(
+            anyLong(), anyLong(), eq(STREAM_ID_1), eq(sessionId + 1), anyString(), anyInt(), anyInt(), eq(true));
+    }
+
+    @Test
+    public void shouldErrorOnAddPublicationWithNonEqualSessionId()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        final String sessionIdParam =
+            "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + (argumentCaptor.getValue().sessionId() + 1);
+        final long correlationId = addPublication(driverProxy, CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onError(eq(correlationId), eq(GENERIC_ERROR), anyString());
+        verify(mockErrorCounter).increment();
+        verify(mockErrorHandler).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void shouldErrorOnAddPublicationWithClashingSessionId()
+    {
+        addPublication(driverProxy, CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> argumentCaptor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy).newNetworkPublication(argumentCaptor.capture());
+
+        final String sessionIdParam =
+            "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + argumentCaptor.getValue().sessionId();
+        final long correlationId = driverProxy.addExclusivePublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+        driverConductor.doWork();
+
+        verify(mockClientProxy).onError(eq(correlationId), eq(GENERIC_ERROR), anyString());
+        verify(mockErrorCounter).increment();
+        verify(mockErrorHandler).onError(any(Throwable.class));
+    }
+
+    @Test
+    public void shouldAddIpcPublicationThenSubscriptionWithSessionId()
+    {
+        final int sessionId = -4097;
+        final String sessionIdParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        final String channelIpcAndSessionId = CHANNEL_IPC + sessionIdParam;
+
+        addPublication(driverProxy, channelIpcAndSessionId, STREAM_ID_1);
+        driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublication.registrationId()), eq(STREAM_ID_1), eq(ipcPublication.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldAddIpcSubscriptionThenPublicationWithSessionId()
+    {
+        final int sessionId = -4097;
+        final String sessionIdParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        final String channelIpcAndSessionId = CHANNEL_IPC + sessionIdParam;
+
+        driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
+        addPublication(driverProxy, channelIpcAndSessionId, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        verify(mockClientProxy).onAvailableImage(
+            eq(ipcPublication.registrationId()), eq(STREAM_ID_1), eq(ipcPublication.sessionId()),
+            anyLong(), anyInt(), eq(ipcPublication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldNotAddIpcPublicationThenSubscriptionWithDifferentSessionId()
+    {
+        final int sessionIdPub = -4097;
+        final int sessionIdSub = -4098;
+        final String sessionIdPubParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdPub;
+        final String sessionIdSubParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdSub;
+
+        addPublication(driverProxy, CHANNEL_IPC + sessionIdPubParam, STREAM_ID_1);
+        driverProxy.addSubscription(CHANNEL_IPC + sessionIdSubParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        verify(mockClientProxy, never()).onAvailableImage(
+            anyLong(), eq(STREAM_ID_1), anyInt(), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldNotAddIpcSubscriptionThenPublicationWithDifferentSessionId()
+    {
+        final int sessionIdPub = -4097;
+        final int sessionIdSub = -4098;
+        final String sessionIdPubParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdPub;
+        final String sessionIdSubParam = "?" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdSub;
+
+        driverProxy.addSubscription(CHANNEL_IPC + sessionIdSubParam, STREAM_ID_1);
+        addPublication(driverProxy, CHANNEL_IPC + sessionIdPubParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
+        assertNotNull(ipcPublication);
+
+        verify(mockClientProxy, never()).onAvailableImage(
+            anyLong(), eq(STREAM_ID_1), anyInt(), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldAddNetworkPublicationThenSingleSpyWithSameSessionId()
+    {
+        final int sessionId = -4097;
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        verify(mockClientProxy).onAvailableImage(
+            eq(networkPublicationCorrelationId(publication)), eq(STREAM_ID_1), eq(publication.sessionId()),
+            anyLong(), anyInt(), eq(publication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldNotAddNetworkPublicationThenSingleSpyWithDifferentSessionId()
+    {
+        final int sessionIdPub = -4097;
+        final int sessionIdSub = -4098;
+        final String sessionIdPubParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdPub;
+        final String sessionIdSubParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdSub;
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdPubParam, STREAM_ID_1);
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdSubParam), STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertFalse(publication.hasSpies());
+
+        verify(mockClientProxy, never()).onAvailableImage(
+            anyLong(), eq(STREAM_ID_1), anyInt(), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldAddSingleSpyThenNetworkPublicationWithSameSessionId()
+    {
+        final int sessionId = -4097;
+        final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertTrue(publication.hasSpies());
+
+        verify(mockClientProxy).onAvailableImage(
+            eq(networkPublicationCorrelationId(publication)), eq(STREAM_ID_1), eq(publication.sessionId()),
+            anyLong(), anyInt(), eq(publication.rawLog().fileName()), anyString());
+    }
+
+    @Test
+    public void shouldNotAddSingleSpyThenNetworkPublicationWithDifferentSessionId()
+    {
+        final int sessionIdPub = -4097;
+        final int sessionIdSub = -4098;
+        final String sessionIdPubParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdPub;
+        final String sessionIdSubParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionIdSub;
+        driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdSubParam), STREAM_ID_1);
+        addPublication(driverProxy, CHANNEL_4000 + sessionIdPubParam, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
+        verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
+        final NetworkPublication publication = captor.getValue();
+
+        assertFalse(publication.hasSpies());
+
+        verify(mockClientProxy, never()).onAvailableImage(
+            anyLong(), eq(STREAM_ID_1), anyInt(), anyLong(), anyInt(), anyString(), anyString());
+    }
+
+    @Test
+    public void shouldUseExistingChannelEndpointOnAddPublicationWithSameTagIdAndSameStreamId()
+    {
+        final long id1 = addPublication(driverProxy, CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
+        final long id2 = addPublication(driverProxy, CHANNEL_TAG_ID_1, STREAM_ID_1);
+
+        driverConductor.doWork();
+        verify(mockErrorHandler, never()).onError(any());
+
+        verify(senderProxy).registerSendChannelEndpoint(any());
+        verify(senderProxy).newNetworkPublication(any());
+
+        driverProxy.removePublication(id1);
+        driverProxy.removePublication(id2);
+
+        doWorkUntil(
+            () -> (PUBLICATION_LINGER_TIMEOUT_NS * 2 + CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(senderProxy).closeSendChannelEndpoint(any());
+    }
+
+    @Test
+    public void shouldUseExistingChannelEndpointOnAddPublicationWithSameTagIdDifferentStreamId()
+    {
+        final long id1 = addPublication(driverProxy, CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
+        final long id2 = addPublication(driverProxy, CHANNEL_TAG_ID_1, STREAM_ID_2);
+
+        driverConductor.doWork();
+        verify(mockErrorHandler, never()).onError(any());
+
+        verify(senderProxy).registerSendChannelEndpoint(any());
+        verify(senderProxy, times(2)).newNetworkPublication(any());
+
+        driverProxy.removePublication(id1);
+        driverProxy.removePublication(id2);
+
+        doWorkUntil(
+            () -> (PUBLICATION_LINGER_TIMEOUT_NS * 2 + CLIENT_LIVENESS_TIMEOUT_NS * 2) - nanoClock.nanoTime() <= 0);
+
+        verify(senderProxy).closeSendChannelEndpoint(any());
+    }
+
+    @Test
+    public void shouldUseExistingChannelEndpointOnAddSubscriptionWithSameTagId()
+    {
+        final long id1 = driverProxy.addSubscription(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
+        final long id2 = driverProxy.addSubscription(CHANNEL_TAG_ID_1, STREAM_ID_1);
+
+        driverConductor.doWork();
+        verify(mockErrorHandler, never()).onError(any());
+
+        verify(receiverProxy).registerReceiveChannelEndpoint(any());
+
+        driverProxy.removeSubscription(id1);
+        driverProxy.removeSubscription(id2);
+
+        driverConductor.doWork();
+
+        verify(receiverProxy).closeReceiveChannelEndpoint(any());
+    }
+
+    @Test
+    public void shouldUseUniqueChannelEndpointOnAddSubscriptionWithNoDistinguishingCharacteristics()
+    {
+        final long id1 = driverProxy.addSubscription(CHANNEL_SUB_CONTROL_MODE_MANUAL, STREAM_ID_1);
+        final long id2 = driverProxy.addSubscription(CHANNEL_SUB_CONTROL_MODE_MANUAL, STREAM_ID_1);
+
+        driverConductor.doWork();
+
+        verify(receiverProxy, times(2)).registerReceiveChannelEndpoint(any());
+
+        driverProxy.removeSubscription(id1);
+        driverProxy.removeSubscription(id2);
+
+        driverConductor.doWork();
+
+        verify(receiverProxy, times(2)).closeReceiveChannelEndpoint(any());
+
+        verify(mockErrorHandler, never()).onError(any());
+    }
+
+    private void doWorkUntil(final BooleanSupplier condition, final LongConsumer timeConsumer)
+    {
+        while (!condition.getAsBoolean())
+        {
+            final long millisecondsToAdvance = 16;
+
+            currentTimeNs += TimeUnit.MILLISECONDS.toNanos(millisecondsToAdvance);
+            currentTimeMs += millisecondsToAdvance;
+            timeConsumer.accept(currentTimeNs);
+            driverConductor.doWork();
+        }
+    }
+
+    private void doWorkUntil(final BooleanSupplier condition)
+    {
+        doWorkUntil(condition, (j) -> {});
+    }
+
+    private static String spyForChannel(final String channel)
+    {
+        return CommonContext.SPY_PREFIX + channel;
+    }
+
+    private static long networkPublicationCorrelationId(final NetworkPublication publication)
+    {
+        return LogBufferDescriptor.correlationId(publication.rawLog().metaData());
+    }
+
+    private long addPublication(final DriverProxy driverProxy, final String channel, final int streamId)
+    {
+        final String newChannel = new ChannelUriStringBuilder(channel).streamId(streamId).build();
+        return driverProxy.addPublication(newChannel);
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -72,6 +72,12 @@ public class ExclusivePublicationTest
     @MethodSource("channels")
     public void shouldPublishFromIndependentExclusivePublications(final String channel, final boolean streamIdInUri)
     {
+        // Stream id not support in C media driver yet.
+        if (streamIdInUri && TestMediaDriver.shouldRunCMediaDriver())
+        {
+            return;
+        }
+
         assertTimeoutPreemptively(ofSeconds(10), () ->
         {
             try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -41,7 +41,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.nio.channels.FileChannel;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -60,10 +60,11 @@ public class PubAndSubTest
 
     private static List<Arguments> channels()
     {
-        final List<Arguments> arguments = Arrays.asList(
-            Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
-            Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
-            Arguments.of("IPC", IPC_URI, false));
+        final List<Arguments> arguments = new ArrayList<>();
+        arguments.add(Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false));
+        arguments.add(Arguments.of(
+            "Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false));
+        arguments.add(Arguments.of("IPC", IPC_URI, false));
 
         // Stream id in uri not supported in C media driver yet.
         if (!TestMediaDriver.shouldRunCMediaDriver())

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -41,8 +41,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.nio.channels.FileChannel;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
@@ -57,9 +58,9 @@ public class PubAndSubTest
 {
     private static final String IPC_URI = "aeron:ipc";
 
-    private static Stream<Arguments> channels()
+    private static List<Arguments> channels()
     {
-        return Stream.of(
+        return Arrays.asList(
             Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
             Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
             Arguments.of("IPC", IPC_URI, false),

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -94,7 +94,8 @@ public class PubAndSubTest
             .errorHandler(Throwable::printStackTrace)
             .dirDeleteOnShutdown(true)
             .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500))
-            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100));
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .dirDeleteOnStart(true);
 
         driver = TestMediaDriver.launch(context, watcher);
         subscribingClient = Aeron.connect();
@@ -102,7 +103,7 @@ public class PubAndSubTest
         if (streamIdInUri)
         {
             final String channelWithStreamId = new ChannelUriStringBuilder(channel).streamId(STREAM_ID).build();
-            subscription = subscribingClient.addSubscription(channel, STREAM_ID);
+            subscription = subscribingClient.addSubscription(channelWithStreamId);
             publication = publishingClient.addPublication(channelWithStreamId);
         }
         else

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -61,9 +61,9 @@ public class PubAndSubTest
     private static List<Arguments> channels()
     {
         return Arrays.asList(
-            Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
-            Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
-            Arguments.of("IPC", IPC_URI, false),
+//            Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
+//            Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
+//            Arguments.of("IPC", IPC_URI, false),
             Arguments.of("Unicast UDP (streamId in URI)", "aeron:udp?endpoint=localhost:54325", true),
             Arguments.of(
                 "Multicast UDP (streamId in URI)", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", true)

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -60,14 +60,22 @@ public class PubAndSubTest
 
     private static List<Arguments> channels()
     {
-        return Arrays.asList(
-//            Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
-//            Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
-//            Arguments.of("IPC", IPC_URI, false),
-            Arguments.of("Unicast UDP (streamId in URI)", "aeron:udp?endpoint=localhost:54325", true),
-            Arguments.of(
-                "Multicast UDP (streamId in URI)", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", true)
-        );
+        final List<Arguments> arguments = Arrays.asList(
+            Arguments.of("Unicast UDP", "aeron:udp?endpoint=localhost:54325", false),
+            Arguments.of("Multicast UDP", "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost", false),
+            Arguments.of("IPC", IPC_URI, false));
+
+        // Stream id in uri not supported in C media driver yet.
+        if (!TestMediaDriver.shouldRunCMediaDriver())
+        {
+            arguments.add(Arguments.of("Unicast UDP (streamId in URI)", "aeron:udp?endpoint=localhost:54325", true));
+            arguments.add(Arguments.of(
+                "Multicast UDP (streamId in URI)",
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost",
+                true));
+        }
+
+        return arguments;
     }
 
     @RegisterExtension


### PR DESCRIPTION
This adds support in the Java media driver and Java client for specifying the stream id in the URI.  There is a common message used for adding subscriptions, publications and exclusive publications (ChannelMessage), which just contains the URI.  There are new control protocol event codes for each of this new events.  I've gone with a naming scheme which appends the version to the name of the event (e.g. `ADD_PUBLICATION_V1`), with the assumption that the existing one is `_V0`, but didn't change the existing names in case users have referenced them.  This did require an additional conductor event SUBSCRIPTION_READY_V1 as the existing event didn't return the streamId (happy to use an alternate naming scheme here if anyone has a better approach). 

When using the new version of the subscription we delay the construction of the `Subscription` object until we get the response.  We stash the channel and availability handlers in the same manner that the publication does.

I've upped the CnC version from 0.0.16 to 0.1.0.

I've included support for the new messages in the event log dissector.

C media driver and C++ client haven't been updated yet, I was going to see if we're happy with this approach before tackling those.

I've also updated the ChannelUriStringBuilder to take in a uri string or constructed ChannelUri which is useful for amending existing URIs.