### PR TITLE
Clustertool commands

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
@@ -162,28 +162,37 @@ public class ClusterTool
                 break;
 
             case "snapshot":
-                snapshot(clusterDir, System.out);
+                exitWithErrorOnFailure(snapshot(clusterDir, System.out));
                 break;
 
             case "suspend":
-                suspend(clusterDir, System.out);
+                exitWithErrorOnFailure(suspend(clusterDir, System.out));
                 break;
 
             case "resume":
-                resume(clusterDir, System.out);
+                exitWithErrorOnFailure(resume(clusterDir, System.out));
                 break;
 
             case "shutdown":
-                shutdown(clusterDir, System.out);
+                exitWithErrorOnFailure(shutdown(clusterDir, System.out));
                 break;
 
             case "abort":
-                abort(clusterDir, System.out);
+                exitWithErrorOnFailure(abort(clusterDir, System.out));
                 break;
 
             default:
                 System.out.println("Unknown command: " + args[1]);
                 printHelp(System.out);
+                System.exit(-1);
+        }
+    }
+
+    private static void exitWithErrorOnFailure(final boolean success)
+    {
+        if (!success)
+        {
+            System.exit(-1);
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -303,4 +303,16 @@ public class ClusterMarkFile implements AutoCloseable
     {
         return SERVICE_FILENAME_PREFIX + serviceId + FILE_EXTENSION;
     }
+
+    public ClusterNodeControlProperties loadControlProperties()
+    {
+        final String aeronDirectoryName = decoder().aeronDirectory();
+        final String archiveChannel = decoder().archiveChannel();
+        final String serviceControlChannel = decoder().serviceControlChannel();
+        final int toServiceStreamId = decoder().serviceStreamId();
+        final int toConsensusModuleStreamId = decoder().consensusModuleStreamId();
+
+        return new ClusterNodeControlProperties(
+            aeronDirectoryName, archiveChannel, serviceControlChannel, toServiceStreamId, toConsensusModuleStreamId);
+    }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterNodeControlProperties.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterNodeControlProperties.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.cluster.service;
 
 public class ClusterNodeControlProperties

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterNodeControlProperties.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterNodeControlProperties.java
@@ -1,0 +1,25 @@
+package io.aeron.cluster.service;
+
+public class ClusterNodeControlProperties
+{
+    public final String aeronDirectoryName;
+    public final String archiveChannel;
+    public final String serviceControlChannel;
+    public final int toServiceStreamId;
+    public final int toConsensusModuleStreamId;
+
+    public ClusterNodeControlProperties(
+        final String aeronDirectoryName,
+        final String archiveChannel,
+        final String serviceControlChannel,
+        final int toServiceStreamId,
+        final int toConsensusModuleStreamId)
+    {
+
+        this.aeronDirectoryName = aeronDirectoryName;
+        this.archiveChannel = archiveChannel;
+        this.serviceControlChannel = serviceControlChannel;
+        this.toServiceStreamId = toServiceStreamId;
+        this.toConsensusModuleStreamId = toConsensusModuleStreamId;
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.cluster;
 
 import org.junit.jupiter.api.Test;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.test.SlowTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -31,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SlowTest
 class ClusterToolTest
 {
     private final CapturingPrintStream capturingPrintStream = new CapturingPrintStream();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -1,0 +1,144 @@
+package io.aeron.cluster;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.time.Duration.ofSeconds;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClusterToolTest
+{
+    private final CapturingPrintStream capturingPrintStream = new CapturingPrintStream();
+
+    @Test
+    void shouldHandleSnapshotOnLeaderOnly()
+    {
+        assertTimeoutPreemptively(ofSeconds(30), () ->
+        {
+            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            {
+                final TestNode leader = cluster.awaitLeader();
+
+                final long initialSnapshotCount = cluster.countRecordingLogSnapshots(leader);
+
+                assertTrue(ClusterTool.snapshot(
+                    leader.consensusModule().context().clusterDir(),
+                    capturingPrintStream.resetAndGetPrintStream()));
+
+                assertThat(
+                    capturingPrintStream.flushAndGetContent(US_ASCII),
+                    containsString("SNAPSHOT applied successfully"));
+
+                assertEquals(initialSnapshotCount + 1, cluster.countRecordingLogSnapshots(leader));
+
+                for (final TestNode follower : cluster.followers())
+                {
+                    assertFalse(ClusterTool.snapshot(
+                        follower.consensusModule().context().clusterDir(),
+                        capturingPrintStream.resetAndGetPrintStream()));
+
+                    assertThat(
+                        capturingPrintStream.flushAndGetContent(US_ASCII),
+                        containsString("Current node is not the leader"));
+                }
+            }
+        });
+    }
+
+    @Test
+    void shouldNotSnapshotWhenSuspendedOnly()
+    {
+        assertTimeoutPreemptively(ofSeconds(30), () ->
+        {
+            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            {
+                final TestNode leader = cluster.awaitLeader();
+
+                final long initialSnapshotCount = cluster.countRecordingLogSnapshots(leader);
+
+                assertTrue(ClusterTool.suspend(
+                    leader.consensusModule().context().clusterDir(),
+                    capturingPrintStream.resetAndGetPrintStream()));
+
+                assertThat(
+                    capturingPrintStream.flushAndGetContent(US_ASCII),
+                    containsString("SUSPEND applied successfully"));
+
+                assertFalse(ClusterTool.snapshot(
+                    leader.consensusModule().context().clusterDir(),
+                    capturingPrintStream.resetAndGetPrintStream()));
+
+                final String expectedMessage =
+                    "Unable to SNAPSHOT as the state of the consensus module is SUSPENDED, but needs to be ACTIVE";
+                assertThat(capturingPrintStream.flushAndGetContent(US_ASCII), containsString(expectedMessage));
+
+                assertEquals(initialSnapshotCount, cluster.countRecordingLogSnapshots(leader));
+            }
+        });
+    }
+
+    @Test
+    void shouldSuspendAndResume()
+    {
+        assertTimeoutPreemptively(ofSeconds(30), () ->
+        {
+            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            {
+                final TestNode leader = cluster.awaitLeader();
+
+                assertTrue(ClusterTool.suspend(
+                    leader.consensusModule().context().clusterDir(),
+                    capturingPrintStream.resetAndGetPrintStream()));
+
+                assertThat(
+                    capturingPrintStream.flushAndGetContent(US_ASCII),
+                    containsString("SUSPEND applied successfully"));
+
+                assertTrue(ClusterTool.resume(
+                    leader.consensusModule().context().clusterDir(),
+                    capturingPrintStream.resetAndGetPrintStream()));
+
+                assertThat(
+                    capturingPrintStream.flushAndGetContent(US_ASCII),
+                    containsString("RESUME applied successfully"));
+            }
+        });
+    }
+
+    @Test
+    void failIfMarkFileUnavailable(final @TempDir Path emptyClusterDir) throws IOException
+    {
+        assertFalse(ClusterTool.snapshot(emptyClusterDir.toFile(), capturingPrintStream.resetAndGetPrintStream()));
+        assertThat(
+            capturingPrintStream.flushAndGetContent(US_ASCII),
+            containsString("cluster-mark.dat does not exist"));
+    }
+
+    public static class CapturingPrintStream
+    {
+        private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        private final PrintStream printStream = new PrintStream(byteArrayOutputStream);
+
+        public PrintStream resetAndGetPrintStream()
+        {
+            byteArrayOutputStream.reset();
+            return printStream;
+        }
+
+        public String flushAndGetContent(final Charset charset)
+        {
+            printStream.flush();
+            return new String(byteArrayOutputStream.toByteArray(), charset);
+        }
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -878,6 +878,15 @@ public class TestCluster implements AutoCloseable
         }
     }
 
+    public long countRecordingLogSnapshots(final TestNode node)
+    {
+        final RecordingLog recordingLog = new RecordingLog(node.consensusModule().context().clusterDir());
+        return recordingLog.entries().stream()
+            .filter(e -> RecordingLog.ENTRY_TYPE_SNAPSHOT == e.type &&
+                ConsensusModule.Configuration.SERVICE_ID == e.serviceId)
+            .count();
+    }
+
     public void printRecordingLogEntries(final int nodeId)
     {
         final TestNode node = node(nodeId);


### PR DESCRIPTION
Adds support for snapshot, suspend, resume, shutdown and abort to ClusterTool.  Will only apply the actions if the cluster is in the right state and the toggle is in NEUTRAL.  I.e. it will only apply to master.  Will error out with a useful message (and a non-zero exit code) if the necessary preconditions are not met.