### PR TITLE
[Java] Re-implement replay using new `offerBlock` API

### DIFF
--- a/aeron-client/src/main/java/io/aeron/logbuffer/ExclusiveTermAppender.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/ExclusiveTermAppender.java
@@ -18,6 +18,7 @@ package io.aeron.logbuffer;
 import io.aeron.DirectBufferVector;
 import io.aeron.ReservedValueSupplier;
 import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.UnsafeAccess;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -597,6 +598,40 @@ public final class ExclusiveTermAppender
 
         return resultingOffset;
     }
+
+
+    /**
+     * Append pre-formatted block of messages into the term buffer.
+     * <p>
+     * <em>WARNING: This is internal API used by {@code ExclusivePublication#offerBlock} method.</em>
+     * </p>
+     *
+     * @param termId     for the current term.
+     * @param termOffset in the term at which to append.
+     * @param buffer     which contains block of messages.
+     * @param offset     within the buffer at which the block begins.
+     * @param length     of the block in bytes (always aligned).
+     * @return the resulting offset of the term after success otherwise {@link #FAILED}.
+     */
+    public int appendBlock(
+        final int termId,
+        final int termOffset,
+        final MutableDirectBuffer buffer,
+        final int offset,
+        final int length)
+    {
+        final UnsafeBuffer termBuffer = this.termBuffer;
+        final int resultingOffset = termOffset + length;
+
+        final int lengthOfFirstFrame = buffer.getInt(offset, LITTLE_ENDIAN);
+        buffer.putInt(offset, 0, LITTLE_ENDIAN);
+        termBuffer.putBytes(termOffset, buffer, offset, length);
+        frameLengthOrdered(termBuffer, termOffset, lengthOfFirstFrame);
+        putRawTailOrdered(termId, resultingOffset);
+
+        return resultingOffset;
+    }
+
 
     private static int handleEndOfLogCondition(
         final UnsafeBuffer termBuffer,

--- a/aeron-client/src/test/java/io/aeron/logbuffer/ExclusiveTermAppenderTest.java
+++ b/aeron-client/src/test/java/io/aeron/logbuffer/ExclusiveTermAppenderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.logbuffer;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static io.aeron.logbuffer.LogBufferDescriptor.*;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BufferUtil.allocateDirectAligned;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ExclusiveTermAppenderTest
+{
+    private final UnsafeBuffer metadataBuffer = new UnsafeBuffer(allocateDirectAligned(1024, 64));
+    private final UnsafeBuffer termBuffer = mock(UnsafeBuffer.class);
+    private final ExclusiveTermAppender termAppender = new ExclusiveTermAppender(termBuffer, metadataBuffer, 0);
+
+    @Test
+    void appendBlock()
+    {
+        final int termId = 43;
+        final int termOffset = 128;
+        final MutableDirectBuffer buffer = mock(MutableDirectBuffer.class);
+        final int offset = 16;
+        final int length = 1024;
+        final int lengthOfFirstFrame = 148;
+        when(buffer.getInt(offset, LITTLE_ENDIAN)).thenReturn(lengthOfFirstFrame);
+
+        final int resultOffset = termAppender.appendBlock(termId, termOffset, buffer, offset, length);
+
+        assertEquals(termOffset + length, resultOffset);
+        final long rawTail = rawTail(metadataBuffer, 0);
+        assertEquals(termId, termId(rawTail));
+        assertEquals(termOffset + length, termOffset(rawTail));
+        final InOrder inOrder = inOrder(termBuffer, buffer);
+        inOrder.verify(buffer).getInt(offset, LITTLE_ENDIAN);
+        inOrder.verify(buffer).putInt(offset, 0, LITTLE_ENDIAN);
+        inOrder.verify(termBuffer).putBytes(termOffset, buffer, offset, length);
+        inOrder.verify(termBuffer).putIntOrdered(termOffset, lengthOfFirstFrame);
+        inOrder.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
In order to apply some batching for the replay a new method `ExclusivePublication#offerBlock` was added. It is a low-level API intended for offering pre-formatted block of messages directly into publication. This method then copies provided block verbatim into the underlying term.
Preliminary performance tests showed a 50% increase in message throughput for the replay.