### PR TITLE
[Java] Use `AeronCloseHelper` with the `ErrorHandler` to close resources

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -156,6 +156,11 @@ abstract class ArchiveConductor
         return new UnsafeBuffer(allocateDirectAligned(MAX_BLOCK_LENGTH, BitUtil.CACHE_LINE_LENGTH));
     }
 
+    Archive.Context context()
+    {
+        return ctx;
+    }
+
     public void onStart()
     {
         replayer = newReplayer();

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchivingMediaDriver.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchivingMediaDriver.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.archive;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import org.agrona.CloseHelper;
@@ -125,6 +126,7 @@ public class ArchivingMediaDriver implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.closeAll(archive, driver);
+        AeronCloseHelper.close(driver.context().errorHandler(), archive);
+        CloseHelper.close(driver);
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -288,7 +288,7 @@ class Catalog implements AutoCloseable
         if (!isClosed)
         {
             isClosed = true;
-            CloseHelper.close(catalogChannel);
+            CloseHelper.quietClose(catalogChannel); // Ignore error so that the rest can be closed
             IoUtil.unmap(catalogByteBuffer);
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplaySession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplaySession.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.archive;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.Counter;
 import io.aeron.ExclusivePublication;
 import io.aeron.Publication;
@@ -25,6 +26,7 @@ import io.aeron.logbuffer.LogBufferDescriptor;
 import org.agrona.CloseHelper;
 import org.agrona.LangUtil;
 import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CountedErrorHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import java.io.File;
@@ -175,8 +177,11 @@ class ReplaySession implements Session, AutoCloseable
 
     public void close()
     {
-        closeRecordingSegment();
-        CloseHelper.close(publication);
+        final CountedErrorHandler errorHandler = controlSession.archiveConductor().context().countedErrorHandler();
+        AeronCloseHelper.close(errorHandler, fileChannel);
+        fileChannel = null;
+        segmentFile = null;
+        AeronCloseHelper.close(errorHandler, publication);
     }
 
     public long sessionId()

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -139,15 +139,17 @@ public class AeronArchive implements AutoCloseable
             if (!isClosed)
             {
                 isClosed = true;
+                final ErrorHandler errorHandler = context.errorHandler();
+
                 if (archiveProxy.publication().isConnected())
                 {
-                    archiveProxy.closeSession(controlSessionId);
+                    AeronCloseHelper.close(errorHandler, () -> archiveProxy.closeSession(controlSessionId));
                 }
 
                 if (!context.ownsAeronClient())
                 {
-                    CloseHelper.close(archiveProxy.publication());
-                    CloseHelper.close(controlResponsePoller.subscription());
+                    AeronCloseHelper.close(errorHandler, archiveProxy.publication());
+                    AeronCloseHelper.close(errorHandler, controlResponsePoller.subscription());
                 }
 
                 context.close();
@@ -2625,8 +2627,9 @@ public class AeronArchive implements AutoCloseable
         {
             if (5 != step)
             {
-                CloseHelper.close(controlResponsePoller.subscription());
-                CloseHelper.close(archiveProxy.publication());
+                final ErrorHandler errorHandler = ctx.errorHandler();
+                AeronCloseHelper.close(errorHandler, controlResponsePoller.subscription());
+                AeronCloseHelper.close(errorHandler, archiveProxy.publication());
                 ctx.close();
             }
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchivingMediaDriverTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchivingMediaDriverTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.driver.MediaDriver;
+import org.agrona.ErrorHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class ArchivingMediaDriverTest
+{
+    @Test
+    void close() throws Exception
+    {
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final MediaDriver mediaDriver = mock(MediaDriver.class);
+        when(mediaDriver.context()).thenReturn(new MediaDriver.Context().errorHandler(errorHandler));
+        final IllegalArgumentException driverException = new IllegalArgumentException("driver");
+        throwOnClose(mediaDriver, driverException);
+
+        final Archive archive = mock(Archive.class);
+        final AbstractMethodError archiveException = new AbstractMethodError("archive");
+        throwOnClose(archive, archiveException);
+
+        final ArchivingMediaDriver archivingMediaDriver = new ArchivingMediaDriver(mediaDriver, archive);
+
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, archivingMediaDriver::close);
+
+        assertSame(driverException, ex);
+        final InOrder inOrder = inOrder(archive, mediaDriver, errorHandler);
+        inOrder.verify(archive).close();
+        inOrder.verify(errorHandler).onError(archiveException);
+        inOrder.verify(mediaDriver).close();
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/ControlSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ControlSessionTest.java
@@ -1,20 +1,39 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.archive;
 
 import io.aeron.Publication;
 import io.aeron.security.Authenticator;
 import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CountedErrorHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ControlSessionTest
 {
     private static final long CONNECT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(5);
 
+    private final CountedErrorHandler errorHandler = mock(CountedErrorHandler.class);
+    private final Archive.Context context = mock(Archive.Context.class);
     private final ControlSessionDemuxer mockDemuxer = mock(ControlSessionDemuxer.class);
     private final ArchiveConductor mockConductor = mock(ArchiveConductor.class);
     private final Publication mockControlPublication = mock(Publication.class);
@@ -68,5 +87,32 @@ public class ControlSessionTest
         cachedEpochClock.update(CONNECT_TIMEOUT_MS + 1L);
         session.doWork();
         assertTrue(session.isDone());
+    }
+
+    @Test
+    void closeErrorHandling()
+    {
+        when(mockConductor.context()).thenReturn(context);
+        when(context.countedErrorHandler()).thenReturn(errorHandler);
+
+        final Session activeListing = mock(Session.class);
+        final IllegalStateException activeListingException = new IllegalStateException("can't abort me");
+        doThrow(activeListingException).when(activeListing).abort();
+        session.activeListing(activeListing);
+
+        final NullPointerException publicationException = new NullPointerException("pub");
+        doThrow(publicationException).when(mockControlPublication).close();
+
+        final AssertionError demuxerException = new AssertionError("demouxer");
+        doThrow(demuxerException).when(mockDemuxer).removeControlSession(session);
+
+        final AssertionError ex = assertThrows(AssertionError.class, session::close);
+
+        assertSame(demuxerException, ex);
+        assertEquals(ControlSession.State.CLOSED, session.state());
+        final InOrder inOrder = inOrder(errorHandler);
+        inOrder.verify(errorHandler).onError(activeListingException);
+        inOrder.verify(errorHandler).onError(publicationException);
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/aeron-archive/src/test/java/io/aeron/archive/client/AeronArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/client/AeronArchiveTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014-2020 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive.client;
+
+import io.aeron.Aeron;
+import io.aeron.Publication;
+import io.aeron.Subscription;
+import io.aeron.archive.client.AeronArchive.Context;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.NoOpIdleStrategy;
+import org.agrona.concurrent.NoOpLock;
+import org.agrona.concurrent.SystemNanoClock;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class AeronArchiveTest
+{
+    private final Aeron aeron = mock(Aeron.class);
+    private final ControlResponsePoller controlResponsePoller = mock(ControlResponsePoller.class);
+    private final ArchiveProxy archiveProxy = mock(ArchiveProxy.class);
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class);
+
+    @Test
+    void closeNotOwningAeronClient()
+    {
+        final long controlSessionId = 42;
+
+        final Aeron.Context aeronContext = mock(Aeron.Context.class);
+        when(aeronContext.nanoClock()).thenReturn(SystemNanoClock.INSTANCE);
+        when(aeron.context()).thenReturn(aeronContext);
+        doThrow(new IllegalMonitorStateException("aeron closed")).when(aeron).close();
+
+        final Publication publication = mock(Publication.class);
+        when(publication.isConnected()).thenReturn(true);
+        final IllegalAccessError publicationException = new IllegalAccessError("publication is closed");
+        doThrow(publicationException).when(publication).close();
+
+        final Subscription subscription = mock(Subscription.class);
+        when(controlResponsePoller.subscription()).thenReturn(subscription);
+        final NoClassDefFoundError subscriptionException = new NoClassDefFoundError("subscription");
+        doThrow(subscriptionException).when(subscription).close();
+
+        when(archiveProxy.publication()).thenReturn(publication);
+        final IndexOutOfBoundsException closeSessionException = new IndexOutOfBoundsException();
+        when(archiveProxy.closeSession(controlSessionId)).thenThrow(closeSessionException);
+
+        final Context context = new Context()
+            .aeron(aeron)
+            .idleStrategy(NoOpIdleStrategy.INSTANCE)
+            .messageTimeoutNs(100)
+            .lock(NoOpLock.INSTANCE)
+            .errorHandler(errorHandler)
+            .ownsAeronClient(false);
+        final AeronArchive aeronArchive =
+            new AeronArchive(context, controlResponsePoller, archiveProxy, controlSessionId);
+
+        aeronArchive.close();
+
+        final InOrder inOrder = inOrder(errorHandler);
+        inOrder.verify(errorHandler).onError(closeSessionException);
+        inOrder.verify(errorHandler).onError(publicationException);
+        inOrder.verify(errorHandler).onError(subscriptionException);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void closeOwningAeronClient()
+    {
+        final long controlSessionId = 42;
+
+        final Aeron.Context aeronContext = mock(Aeron.Context.class);
+        when(aeronContext.nanoClock()).thenReturn(SystemNanoClock.INSTANCE);
+        when(aeron.context()).thenReturn(aeronContext);
+        final IllegalMonitorStateException aeronException = new IllegalMonitorStateException("aeron closed");
+        doThrow(aeronException).when(aeron).close();
+
+        final Publication publication = mock(Publication.class);
+        when(publication.isConnected()).thenReturn(true);
+        doThrow(new IllegalAccessError("publication is closed")).when(publication).close();
+
+        final Subscription subscription = mock(Subscription.class);
+        when(controlResponsePoller.subscription()).thenReturn(subscription);
+        doThrow(new NoClassDefFoundError("subscription")).when(subscription).close();
+
+        when(archiveProxy.publication()).thenReturn(publication);
+        final IndexOutOfBoundsException closeSessionException = new IndexOutOfBoundsException();
+        when(archiveProxy.closeSession(controlSessionId)).thenThrow(closeSessionException);
+
+        final Context context = new Context()
+            .aeron(aeron)
+            .idleStrategy(NoOpIdleStrategy.INSTANCE)
+            .messageTimeoutNs(100)
+            .lock(NoOpLock.INSTANCE)
+            .errorHandler(errorHandler)
+            .ownsAeronClient(true);
+        final AeronArchive aeronArchive =
+            new AeronArchive(context, controlResponsePoller, archiveProxy, controlSessionId);
+
+        final IllegalMonitorStateException ex = assertThrows(IllegalMonitorStateException.class, aeronArchive::close);
+
+        assertSame(aeronException, ex);
+        final InOrder inOrder = inOrder(errorHandler);
+        inOrder.verify(errorHandler).onError(closeSessionException);
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -153,7 +153,7 @@ public class Aeron implements AutoCloseable
     /**
      * Print out the values from {@link #countersReader()} which can be useful for debugging.
      *
-     *  @param out to where the counters get printed.
+     * @param out to where the counters get printed.
      */
     public void printCounters(final PrintStream out)
     {
@@ -225,13 +225,14 @@ public class Aeron implements AutoCloseable
     {
         if (IS_CLOSED_UPDATER.compareAndSet(this, 0, 1))
         {
+            final ErrorHandler errorHandler = ctx.errorHandler();
             if (null != conductorRunner)
             {
-                conductorRunner.close();
+                AeronCloseHelper.close(errorHandler, conductorRunner);
             }
             else
             {
-                conductorInvoker.close();
+                AeronCloseHelper.close(errorHandler, conductorInvoker);
             }
         }
     }
@@ -1128,7 +1129,7 @@ public class Aeron implements AutoCloseable
 
         /**
          * Set a {@link Runnable} that is called when the client is closed by timeout or normal means.
-         *
+         * <p>
          * It is not safe to call any API functions from any threads after this hook is called. In addition any
          * in flight calls may still cause faults. It is thus recommended to treat this as a hard error and
          * terminate the process in this hook as soon as possible.

--- a/aeron-client/src/main/java/io/aeron/AeronCloseHelper.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCloseHelper.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import org.agrona.ErrorHandler;
+import org.agrona.IoUtil;
+import org.agrona.LangUtil;
+
+import java.io.File;
+import java.util.Collection;
+
+// FIXME: Temporary class until next Agrona release
+public final class AeronCloseHelper
+{
+    private AeronCloseHelper()
+    {
+    }
+
+    // FIXME: Use Agrona version of this method
+    public static void close(final ErrorHandler errorHandler, final AutoCloseable closeable)
+    {
+        try
+        {
+            if (null != closeable)
+            {
+                closeable.close();
+            }
+        }
+        catch (final Throwable ex)
+        {
+            errorHandler.onError(ex);
+        }
+    }
+
+    // FIXME: Use Agrona version of this method
+    public static void closeAll(final ErrorHandler errorHandler, final Collection<? extends AutoCloseable> closeables)
+    {
+        if (closeables == null || closeables.isEmpty())
+        {
+            return;
+        }
+
+        for (final AutoCloseable closeable : closeables)
+        {
+            if (closeable != null)
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (final Throwable ex)
+                {
+                    errorHandler.onError(ex);
+                }
+            }
+        }
+    }
+
+    // FIXME: Use Agrona version of this method
+    public static void closeAll(final ErrorHandler errorHandler, final AutoCloseable... closeables)
+    {
+        if (closeables == null || closeables.length == 0)
+        {
+            return;
+        }
+
+        for (final AutoCloseable closeable : closeables)
+        {
+            if (closeable != null)
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (final Throwable ex)
+                {
+                    errorHandler.onError(ex);
+                }
+            }
+        }
+    }
+
+    // FIXME: Use Agrona version of this method
+    public static void closeAll(final Collection<? extends AutoCloseable> closeables)
+    {
+        if (closeables == null || closeables.isEmpty())
+        {
+            return;
+        }
+
+        Throwable error = null;
+        for (final AutoCloseable closeable : closeables)
+        {
+            if (closeable != null)
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (final Throwable ex)
+                {
+                    if (error == null)
+                    {
+                        error = ex;
+                    }
+                    else
+                    {
+                        error.addSuppressed(ex);
+                    }
+                }
+            }
+        }
+
+        if (error != null)
+        {
+            LangUtil.rethrowUnchecked(error);
+        }
+    }
+
+    // FIXME: Use Agrona version of this method
+    public static void closeAll(final AutoCloseable... closeables)
+    {
+        if (closeables == null || closeables.length == 0)
+        {
+            return;
+        }
+
+        Throwable error = null;
+        for (final AutoCloseable closeable : closeables)
+        {
+            if (closeable != null)
+            {
+                try
+                {
+                    closeable.close();
+                }
+                catch (final Throwable ex)
+                {
+                    if (error == null)
+                    {
+                        error = ex;
+                    }
+                    else
+                    {
+                        error.addSuppressed(ex);
+                    }
+                }
+            }
+        }
+
+        if (error != null)
+        {
+            LangUtil.rethrowUnchecked(error);
+        }
+    }
+
+    public static void delete(final File file, final boolean ignoreFailures)
+    {
+        if (!file.exists())
+        {
+            return;
+        }
+
+        IoUtil.delete(file, ignoreFailures);
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupMediaDriver.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupMediaDriver.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.archive.Archive;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
@@ -69,9 +70,9 @@ public class ClusterBackupMediaDriver implements AutoCloseable
     /**
      * Launch a new {@link ClusterBackupMediaDriver} with provided contexts.
      *
-     * @param driverCtx          for configuring the {@link MediaDriver}.
-     * @param archiveCtx         for configuring the {@link Archive}.
-     * @param clusterBackupCtx   for the configuration of the {@link ClusterBackup}.
+     * @param driverCtx        for configuring the {@link MediaDriver}.
+     * @param archiveCtx       for configuring the {@link Archive}.
+     * @param clusterBackupCtx for the configuration of the {@link ClusterBackup}.
      * @return a new {@link ClusterBackupMediaDriver} with the provided contexts.
      */
     public static ClusterBackupMediaDriver launch(
@@ -124,8 +125,8 @@ public class ClusterBackupMediaDriver implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(clusterBackup);
-        CloseHelper.close(archive);
+        AeronCloseHelper.close(archive.context().countedErrorHandler(), clusterBackup);
+        AeronCloseHelper.close(driver.context().errorHandler(), archive);
         CloseHelper.close(driver);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterSession.java
@@ -90,9 +90,10 @@ class ClusterSession
 
     public void close()
     {
-        CloseHelper.close(responsePublication);
-        responsePublication = null;
+        final Publication responsePublication = this.responsePublication;
+        this.responsePublication = null;
         state = State.CLOSED;
+        CloseHelper.close(responsePublication);
     }
 
     long id()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusteredMediaDriver.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusteredMediaDriver.java
@@ -15,8 +15,9 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.driver.MediaDriver;
+import io.aeron.AeronCloseHelper;
 import io.aeron.archive.Archive;
+import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.status.AtomicCounter;
@@ -141,6 +142,8 @@ public class ClusteredMediaDriver implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.closeAll(consensusModule, archive, driver);
+        AeronCloseHelper.close(archive.context().countedErrorHandler(), consensusModule);
+        AeronCloseHelper.close(driver.context().errorHandler(), archive);
+        CloseHelper.close(driver);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.ControlledFragmentAssembler;
 import io.aeron.Subscription;
 import io.aeron.cluster.client.AeronCluster;
@@ -22,14 +23,15 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.*;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.logbuffer.Header;
-import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.CountedErrorHandler;
 
 final class ConsensusModuleAdapter implements AutoCloseable
 {
     private static final int FRAGMENT_LIMIT = 10;
     private final Subscription subscription;
     private final ConsensusModuleAgent consensusModuleAgent;
+    private final CountedErrorHandler countedErrorHandler;
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     private final SessionMessageHeaderDecoder sessionMessageHeaderDecoder = new SessionMessageHeaderDecoder();
     private final ScheduleTimerDecoder scheduleTimerDecoder = new ScheduleTimerDecoder();
@@ -40,15 +42,19 @@ final class ConsensusModuleAdapter implements AutoCloseable
     private final RemoveMemberDecoder removeMemberDecoder = new RemoveMemberDecoder();
     private final ControlledFragmentAssembler fragmentAssembler = new ControlledFragmentAssembler(this::onFragment);
 
-    ConsensusModuleAdapter(final Subscription subscription, final ConsensusModuleAgent consensusModuleAgent)
+    ConsensusModuleAdapter(
+        final Subscription subscription,
+        final ConsensusModuleAgent consensusModuleAgent,
+        final CountedErrorHandler countedErrorHandler)
     {
         this.subscription = subscription;
         this.consensusModuleAgent = consensusModuleAgent;
+        this.countedErrorHandler = countedErrorHandler;
     }
 
     public void close()
     {
-        CloseHelper.close(subscription);
+        AeronCloseHelper.close(countedErrorHandler, subscription);
     }
 
     int poll()
@@ -56,7 +62,7 @@ final class ConsensusModuleAdapter implements AutoCloseable
         return subscription.controlledPoll(fragmentAssembler, FRAGMENT_LIMIT);
     }
 
-    @SuppressWarnings({"unused", "MethodLength"})
+    @SuppressWarnings({ "unused", "MethodLength" })
     private ControlledFragmentHandler.Action onFragment(
         final DirectBuffer buffer, final int offset, final int length, final Header header)
     {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/DynamicJoin.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/DynamicJoin.java
@@ -31,6 +31,7 @@ import io.aeron.logbuffer.Header;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Long2LongHashMap;
+import org.agrona.concurrent.CountedErrorHandler;
 import org.agrona.concurrent.status.CountersReader;
 
 import java.util.ArrayList;
@@ -108,10 +109,11 @@ class DynamicJoin implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(memberStatusPublication);
-        CloseHelper.close(snapshotRetrieveSubscription);
-        CloseHelper.close(leaderArchive);
-        CloseHelper.close(leaderArchiveAsyncConnect);
+        final CountedErrorHandler countedErrorHandler = ctx.countedErrorHandler();
+        AeronCloseHelper.close(countedErrorHandler, memberStatusPublication);
+        AeronCloseHelper.close(countedErrorHandler, snapshotRetrieveSubscription);
+        AeronCloseHelper.close(countedErrorHandler, leaderArchive);
+        AeronCloseHelper.close(countedErrorHandler, leaderArchiveAsyncConnect);
     }
 
     ClusterMember[] clusterMembers()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -18,7 +18,6 @@ package io.aeron.cluster;
 import io.aeron.*;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.service.Cluster;
-import org.agrona.CloseHelper;
 import org.agrona.collections.Int2ObjectHashMap;
 
 import java.util.Random;
@@ -158,7 +157,7 @@ public class Election implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(stateCounter);
+        AeronCloseHelper.close(ctx.countedErrorHandler(), stateCounter);
     }
 
     public ClusterMember leader()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/SingleNodeCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/SingleNodeCluster.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.CommonContext;
 import io.aeron.ExclusivePublication;
 import io.aeron.Image;
@@ -32,8 +33,8 @@ import io.aeron.driver.MinMulticastFlowControlSupplier;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
-import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.YieldingIdleStrategy;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Single Node Cluster that includes everything needed to run all in one place. Includes a simple service to show
  * event processing. And also includes a cluster client.
- *
+ * <p>
  * Perfect for playing around with the cluster
  */
 public class SingleNodeCluster implements AutoCloseable
@@ -246,10 +247,11 @@ public class SingleNodeCluster implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.quietClose(client);
-        CloseHelper.quietClose(container);
-        CloseHelper.quietClose(clusteredMediaDriver);
-        CloseHelper.quietClose(clientMediaDriver);
+        final ErrorHandler errorHandler = clientMediaDriver.context().errorHandler();
+        AeronCloseHelper.close(errorHandler, client);
+        AeronCloseHelper.close(errorHandler, container);
+        AeronCloseHelper.close(errorHandler, clusteredMediaDriver);
+        AeronCloseHelper.close(errorHandler, clientMediaDriver);
     }
 
     void connectClientToCluster()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -16,6 +16,7 @@
 package io.aeron.cluster.service;
 
 import io.aeron.Aeron;
+import io.aeron.AeronCloseHelper;
 import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.client.ClusterException;
@@ -37,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
 
-import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.*;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.CLUSTERED_SERVICE_ERROR_COUNT_TYPE_ID;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 import static org.agrona.SystemUtil.getSizeAsInt;
@@ -138,7 +139,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(serviceAgentRunner);
+        AeronCloseHelper.close(ctx.errorHandler(), serviceAgentRunner);
     }
 
     /**
@@ -1399,7 +1400,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
         {
             if (null != clusterDir)
             {
-                IoUtil.delete(clusterDir, false);
+                AeronCloseHelper.delete(clusterDir, false);
             }
         }
 
@@ -1410,7 +1411,8 @@ public final class ClusteredServiceContainer implements AutoCloseable
          */
         public void close()
         {
-            CloseHelper.close(markFile);
+            final ErrorHandler errorHandler = errorHandler();
+            AeronCloseHelper.close(errorHandler, markFile);
 
             if (ownsAeronClient)
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupContextCloseTests.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupContextCloseTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.Counter;
+import io.aeron.cluster.ClusterBackup.Context;
+import io.aeron.cluster.service.ClusterMarkFile;
+import io.aeron.exceptions.AeronException;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.io.IOException;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+class ClusterBackupContextCloseTests
+{
+    private final CountedErrorHandler countedErrorHandler = mock(CountedErrorHandler.class);
+    private final Aeron aeron = mock(Aeron.class);
+    private final Counter stateCounter = mock(Counter.class);
+    private final Counter liveLogPositionCounter = mock(Counter.class);
+    private final ClusterMarkFile markFile = mock(ClusterMarkFile.class);
+    private final AeronException aeronException = new AeronException("client is dead");
+    private final IOException markFileException = new IOException("file");
+    private final IllegalStateException stateCounterException = new IllegalStateException("stateCounter");
+    private final LinkageError liveLogPositionCounterException = new LinkageError("live log position");
+    private Context context;
+
+    @BeforeEach
+    void before() throws Exception
+    {
+        throwOnClose(aeron, aeronException);
+        throwOnClose(stateCounter, stateCounterException);
+        throwOnClose(liveLogPositionCounter, liveLogPositionCounterException);
+        throwOnClose(markFile, markFileException);
+
+        context = new Context()
+            .countedErrorHandler(countedErrorHandler)
+            .aeron(aeron)
+            .stateCounter(stateCounter)
+            .liveLogPositionCounter(liveLogPositionCounter)
+            .clusterMarkFile(markFile);
+    }
+
+    @Test
+    void closeOwnsAeronClient()
+    {
+        context.ownsAeronClient(true);
+
+        context.close();
+
+        final InOrder inOrder = inOrder(countedErrorHandler);
+        inOrder.verify(countedErrorHandler).onError(aeronException);
+        inOrder.verify(countedErrorHandler).onError(markFileException);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void closeDoesNotOwnAeronClient()
+    {
+        context.ownsAeronClient(false);
+
+        context.close();
+
+        final InOrder inOrder = inOrder(countedErrorHandler);
+        inOrder.verify(countedErrorHandler).onError(stateCounterException);
+        inOrder.verify(countedErrorHandler).onError(liveLogPositionCounterException);
+        inOrder.verify(countedErrorHandler).onError(markFileException);
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupMediaDriverTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterBackupMediaDriverTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.archive.Archive;
+import io.aeron.driver.MediaDriver;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class ClusterBackupMediaDriverTest
+{
+    @Test
+    void close() throws Exception
+    {
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final CountedErrorHandler countedErrorHandler = mock(CountedErrorHandler.class);
+
+        final MediaDriver driver = mock(MediaDriver.class);
+        when(driver.context()).thenReturn(new MediaDriver.Context().errorHandler(errorHandler));
+        final AssertionError driverException = new AssertionError("driver");
+        throwOnClose(driver, driverException);
+
+        final Archive archive = mock(Archive.class);
+        when(archive.context()).thenReturn(new Archive.Context().countedErrorHandler(countedErrorHandler));
+        final ArithmeticException archiveException = new ArithmeticException("archive");
+        throwOnClose(archive, archiveException);
+
+        final ClusterBackup clusterBackup = mock(ClusterBackup.class);
+        final IllegalStateException clusterBackupException = new IllegalStateException();
+        throwOnClose(clusterBackup, clusterBackupException);
+
+        final ClusterBackupMediaDriver clusterBackupMediaDriver =
+            new ClusterBackupMediaDriver(driver, archive, clusterBackup);
+
+        final AssertionError ex = assertThrows(AssertionError.class, clusterBackupMediaDriver::close);
+
+        assertSame(driverException, ex);
+        final InOrder inOrder = inOrder(errorHandler, countedErrorHandler);
+        inOrder.verify(countedErrorHandler).onError(clusterBackupException);
+        inOrder.verify(errorHandler).onError(archiveException);
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusteredMediaDriverTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusteredMediaDriverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.archive.Archive;
+import io.aeron.driver.MediaDriver;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.sql.BatchUpdateException;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class ClusteredMediaDriverTest
+{
+    @Test
+    void close() throws Exception
+    {
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final CountedErrorHandler countedErrorHandler = mock(CountedErrorHandler.class);
+
+        final MediaDriver driver = mock(MediaDriver.class);
+        when(driver.context()).thenReturn(new MediaDriver.Context().errorHandler(errorHandler));
+        final AssertionError driverException = new AssertionError("driver");
+        throwOnClose(driver, driverException);
+
+        final Archive archive = mock(Archive.class);
+        when(archive.context()).thenReturn(new Archive.Context().countedErrorHandler(countedErrorHandler));
+        final ArithmeticException archiveException = new ArithmeticException("archive");
+        throwOnClose(archive, archiveException);
+
+        final ConsensusModule consensusModule = mock(ConsensusModule.class);
+        final BatchUpdateException consensusModuleException = new BatchUpdateException();
+        throwOnClose(consensusModule, consensusModuleException);
+
+        final ClusteredMediaDriver clusteredMediaDriver =
+            new ClusteredMediaDriver(driver, archive, consensusModule);
+
+        final AssertionError ex = assertThrows(AssertionError.class, clusteredMediaDriver::close);
+
+        assertSame(driverException, ex);
+        final InOrder inOrder = inOrder(errorHandler, countedErrorHandler);
+        inOrder.verify(countedErrorHandler).onError(consensusModuleException);
+        inOrder.verify(errorHandler).onError(archiveException);
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextCloseTests.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextCloseTests.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.Counter;
+import io.aeron.cluster.service.ClusterMarkFile;
+import io.aeron.exceptions.AeronException;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import javax.naming.InvalidNameException;
+import java.io.IOException;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ConsensusModuleContextCloseTests
+{
+    private final CountedErrorHandler countedErrorHandler = mock(CountedErrorHandler.class);
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class,
+        withSettings().extraInterfaces(AutoCloseable.class));
+    private final RecordingLog recordingLog = mock(RecordingLog.class);
+    private final ReflectiveOperationException recodingLogException = new ReflectiveOperationException();
+    private final ClusterMarkFile markFile = mock(ClusterMarkFile.class);
+    private final IOException markFileException = new IOException();
+    private final Aeron aeron = mock(Aeron.class);
+    private final AeronException aeronException = new AeronException();
+    private final Counter moduleState = mock(Counter.class);
+    private final IllegalStateException moduleStateException = new IllegalStateException();
+    private final Counter commitPosition = mock(Counter.class);
+    private final InvalidNameException commitPositionException = new InvalidNameException();
+    private final Counter clusterNodeRole = mock(Counter.class);
+    private final AssertionError clusterNodeRoleException = new AssertionError();
+    private final Counter controlToggle = mock(Counter.class);
+    private final IllegalArgumentException controlToggleException = new IllegalArgumentException();
+    private final Counter snapshotCounter = mock(Counter.class);
+    private final IndexOutOfBoundsException snapshotCounterException = new IndexOutOfBoundsException();
+    private final Counter invalidRequestCounter = mock(Counter.class);
+    private final UnsupportedOperationException invalidRequestCounterException = new UnsupportedOperationException();
+    private final Counter timedOutClientCounter = mock(Counter.class);
+    private final UnknownError timedOutClientCounterException = new UnknownError();
+    private ConsensusModule.Context context;
+
+
+    @BeforeEach
+    void before() throws Exception
+    {
+        throwOnClose(recordingLog, recodingLogException);
+        throwOnClose(markFile, markFileException);
+        throwOnClose(aeron, aeronException);
+        throwOnClose(moduleState, moduleStateException);
+        throwOnClose(commitPosition, commitPositionException);
+        throwOnClose(clusterNodeRole, clusterNodeRoleException);
+        throwOnClose(controlToggle, controlToggleException);
+        throwOnClose(snapshotCounter, snapshotCounterException);
+        throwOnClose(invalidRequestCounter, invalidRequestCounterException);
+        throwOnClose(timedOutClientCounter, timedOutClientCounterException);
+
+        context = new ConsensusModule.Context()
+            .countedErrorHandler(countedErrorHandler)
+            .errorHandler(errorHandler)
+            .recordingLog(recordingLog)
+            .clusterMarkFile(markFile)
+            .aeron(aeron)
+            .moduleStateCounter(moduleState)
+            .clusterNodeCounter(clusterNodeRole)
+            .commitPositionCounter(commitPosition)
+            .controlToggleCounter(controlToggle)
+            .snapshotCounter(snapshotCounter)
+            .invalidRequestCounter(invalidRequestCounter)
+            .timedOutClientCounter(timedOutClientCounter);
+    }
+
+    @Test
+    void ownsAeronClient() throws Exception
+    {
+        context.ownsAeronClient(true);
+
+        final AeronException ex = assertThrows(AeronException.class, context::close);
+
+        assertSame(aeronException, ex);
+        final InOrder inOrder = inOrder(countedErrorHandler, errorHandler, aeron);
+        inOrder.verify(countedErrorHandler).onError(recodingLogException);
+        inOrder.verify(countedErrorHandler).onError(markFileException);
+        inOrder.verify((AutoCloseable)errorHandler).close();
+        inOrder.verify(aeron).close();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void doesNotOwnAeronClientAndClientIsNotClosed() throws Exception
+    {
+        context.ownsAeronClient(false);
+        when(aeron.isClosed()).thenReturn(false);
+
+        final IllegalStateException ex = assertThrows(IllegalStateException.class, context::close);
+
+        assertSame(moduleStateException, ex);
+        assertArrayEquals(new Throwable[]
+            {
+            clusterNodeRoleException,
+            commitPositionException,
+            controlToggleException,
+            snapshotCounterException,
+            invalidRequestCounterException,
+            timedOutClientCounterException
+            }, ex.getSuppressed());
+        final InOrder inOrder = inOrder(countedErrorHandler, errorHandler, aeron);
+        inOrder.verify(countedErrorHandler).onError(recodingLogException);
+        inOrder.verify(countedErrorHandler).onError(markFileException);
+        inOrder.verify((AutoCloseable)errorHandler).close();
+        inOrder.verify(aeron).isClosed();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void doesNotOwnAeronClientAndClientIsClosed() throws Exception
+    {
+        context.ownsAeronClient(false);
+        when(aeron.isClosed()).thenReturn(true);
+
+        context.close();
+
+        final InOrder inOrder = inOrder(countedErrorHandler, errorHandler, aeron);
+        inOrder.verify(countedErrorHandler).onError(recodingLogException);
+        inOrder.verify(countedErrorHandler).onError(markFileException);
+        inOrder.verify((AutoCloseable)errorHandler).close();
+        inOrder.verify(aeron).isClosed();
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.ExclusivePublication;
 import io.aeron.Image;
 import io.aeron.archive.Archive;
@@ -27,8 +28,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
-import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableLong;
@@ -82,8 +83,9 @@ class TestNode implements AutoCloseable
         if (!isClosed)
         {
             isClosed = true;
-            CloseHelper.close(container);
-            CloseHelper.close(clusteredMediaDriver);
+            final ErrorHandler errorHandler = context.mediaDriverContext.errorHandler();
+            AeronCloseHelper.close(errorHandler, container);
+            AeronCloseHelper.close(errorHandler, clusteredMediaDriver);
         }
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterCloseTests.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/client/AeronClusterCloseTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster.client;
+
+import io.aeron.Aeron;
+import io.aeron.Publication;
+import io.aeron.Subscription;
+import io.aeron.cluster.client.AeronCluster.Context;
+import io.aeron.cluster.codecs.MessageHeaderEncoder;
+import io.aeron.logbuffer.BufferClaim;
+import org.agrona.ErrorHandler;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.concurrent.NoOpIdleStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+class AeronClusterCloseTests
+{
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class);
+    private final Context context = new Context();
+    private final Publication publication = mock(Publication.class);
+    private final IllegalArgumentException publicationException = new IllegalArgumentException();
+    private final Subscription subscription = mock(Subscription.class);
+    private final OutOfMemoryError subscriptionException = new OutOfMemoryError();
+    private final Aeron aeron = mock(Aeron.class);
+    private final AssertionError aeronException = new AssertionError();
+    private String tryClaimExceptionMessage;
+    private AeronCluster aeronCluster;
+
+    @BeforeEach
+    void before() throws Exception
+    {
+        context
+            .errorHandler(errorHandler)
+            .idleStrategy(NoOpIdleStrategy.INSTANCE)
+            .aeron(aeron);
+
+        when(publication.isConnected()).thenReturn(true);
+
+        throwOnClose(publication, publicationException);
+        throwOnClose(subscription, subscriptionException);
+        throwOnClose(aeron, aeronException);
+
+        aeronCluster = new AeronCluster(
+            context,
+            new MessageHeaderEncoder(),
+            publication,
+            subscription,
+            new Int2ObjectHashMap<>(),
+            42L,
+            21L,
+            1);
+    }
+
+    @Test
+    void ownsAeronClient()
+    {
+        mockTryClaim(Publication.MAX_POSITION_EXCEEDED);
+        context.ownsAeronClient(true);
+
+        final AssertionError ex = assertThrows(AssertionError.class, aeronCluster::close);
+
+        assertSame(aeronException, ex);
+        final InOrder inOrder = inOrder(aeron, errorHandler);
+        inOrder.verify(errorHandler).onError(argThat(t -> tryClaimExceptionMessage.equals(t.getMessage())));
+        inOrder.verify(aeron).close();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void doesNotOwnAeronClient()
+    {
+        mockTryClaim(Publication.NOT_CONNECTED);
+        context.ownsAeronClient(false);
+
+        aeronCluster.close();
+
+        final InOrder inOrder = inOrder(errorHandler);
+        inOrder.verify(errorHandler).onError(argThat(t -> tryClaimExceptionMessage.equals(t.getMessage())));
+        inOrder.verify(errorHandler).onError(subscriptionException);
+        inOrder.verify(errorHandler).onError(publicationException);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    private void mockTryClaim(final long result)
+    {
+        when(publication.tryClaim(anyInt(), any(BufferClaim.class))).thenReturn(result);
+        tryClaimExceptionMessage = "unexpected publication state: " + result;
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/buffer/FileStoreLogFactory.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/buffer/FileStoreLogFactory.java
@@ -15,8 +15,8 @@
  */
 package io.aeron.driver.buffer;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.exceptions.AeronException;
-import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.IoUtil;
 import org.agrona.LangUtil;
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
-import java.nio.file.*;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
 
 import static io.aeron.logbuffer.LogBufferDescriptor.computeLogLength;
 
@@ -83,7 +84,7 @@ public class FileStoreLogFactory implements LogFactory
 
     public void close()
     {
-        CloseHelper.close(blankChannel);
+        AeronCloseHelper.close(errorHandler, blankChannel);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ControlTransportPoller.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ControlTransportPoller.java
@@ -15,11 +15,13 @@
  */
 package io.aeron.driver.media;
 
+import io.aeron.AeronCloseHelper;
 import io.aeron.driver.Configuration;
 import io.aeron.protocol.NakFlyweight;
 import io.aeron.protocol.RttMeasurementFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
 import org.agrona.BufferUtil;
+import org.agrona.ErrorHandler;
 import org.agrona.LangUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -31,9 +33,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 
 import static io.aeron.logbuffer.FrameDescriptor.frameType;
-import static io.aeron.protocol.HeaderFlyweight.HDR_TYPE_NAK;
-import static io.aeron.protocol.HeaderFlyweight.HDR_TYPE_RTTM;
-import static io.aeron.protocol.HeaderFlyweight.HDR_TYPE_SM;
+import static io.aeron.protocol.HeaderFlyweight.*;
 import static org.agrona.BitUtil.CACHE_LINE_LENGTH;
 
 /**
@@ -49,12 +49,14 @@ public class ControlTransportPoller extends UdpTransportPoller
     private final RttMeasurementFlyweight rttMeasurement = new RttMeasurementFlyweight(unsafeBuffer);
     private SendChannelEndpoint[] transports = new SendChannelEndpoint[0];
 
+    public ControlTransportPoller(final ErrorHandler errorHandler)
+    {
+        super(errorHandler);
+    }
+
     public void close()
     {
-        for (final SendChannelEndpoint channelEndpoint : transports)
-        {
-            channelEndpoint.close();
-        }
+        AeronCloseHelper.closeAll(errorHandler, transports);
 
         super.close();
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -96,7 +96,7 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
             Long.valueOf(AsciiEncoding.parseLongAscii(rtagStr, 0, rtagStr.length()));
 
         multiRcvDestination = udpChannel.isManualControlMode() ?
-            new MultiRcvDestination(context.nanoClock(), DESTINATION_ADDRESS_TIMEOUT) : null;
+            new MultiRcvDestination(context.nanoClock(), DESTINATION_ADDRESS_TIMEOUT, errorHandler) : null;
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpTransportPoller.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpTransportPoller.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.driver.media;
 
+import org.agrona.ErrorHandler;
 import org.agrona.nio.TransportPoller;
 
 import java.nio.channels.SelectionKey;
@@ -24,6 +25,13 @@ import java.nio.channels.SelectionKey;
  */
 public abstract class UdpTransportPoller extends TransportPoller
 {
+    protected final ErrorHandler errorHandler;
+
+    public UdpTransportPoller(final ErrorHandler errorHandler)
+    {
+        this.errorHandler = errorHandler;
+    }
+
     /**
      * Explicit event loop processing as a poll
      *

--- a/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounters.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounters.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.driver.status;
 
+import io.aeron.AeronCloseHelper;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersManager;
 
@@ -57,9 +58,6 @@ public class SystemCounters implements AutoCloseable
      */
     public void close()
     {
-        for (final AtomicCounter counter : counterByDescriptorMap.values())
-        {
-            counter.close();
-        }
+        AeronCloseHelper.closeAll(counterByDescriptorMap.values());
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
@@ -1,11 +1,22 @@
 package io.aeron.driver;
 
 import io.aeron.driver.MediaDriver.Context;
+import io.aeron.driver.buffer.LogFactory;
+import org.agrona.ErrorHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+
+import java.io.IOError;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
 
 import static io.aeron.driver.Configuration.NAK_MAX_BACKOFF_DEFAULT_NS;
 import static io.aeron.driver.Configuration.NAK_MULTICAST_MAX_BACKOFF_PROP_NAME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static io.aeron.test.Tests.throwOnClose;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class MediaDriverContextTest
 {
@@ -37,5 +48,32 @@ public class MediaDriverContextTest
         final Context context = new Context();
         context.nakMulticastMaxBackoffNs(Long.MIN_VALUE);
         assertEquals(Long.MIN_VALUE, context.nakMulticastMaxBackoffNs());
+    }
+
+    @Test
+    void closeErrorHandling(final @TempDir Path tempDir) throws Exception
+    {
+        final ErrorHandler errorHandler = mock(ErrorHandler.class, withSettings().extraInterfaces(AutoCloseable.class));
+        throwOnClose((AutoCloseable)errorHandler, new UncheckedIOException(new IOException("You won't see me!")));
+
+        final LogFactory logFactory = mock(LogFactory.class);
+        final IOError logFactoryException = new IOError(new IncompatibleClassChangeError("logging failed"));
+        throwOnClose(logFactory, logFactoryException);
+
+        final Context context = new Context()
+            .errorHandler(errorHandler)
+            .logFactory(logFactory)
+            .dirDeleteOnShutdown(true)
+            .aeronDirectoryName(tempDir.toAbsolutePath().resolve("test-aerondir").toString());
+        context.concludeAeronDirectory();
+
+        context.close();
+
+        assertNotNull(context.aeronDirectory());
+        assertFalse(context.aeronDirectory().exists());
+        final InOrder inOrder = inOrder(errorHandler);
+        inOrder.verify(errorHandler).onError(logFactoryException);
+        inOrder.verify((AutoCloseable)errorHandler).close();
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -109,9 +109,9 @@ public class ReceiverTest
     private ReceiverProxy receiverProxy;
     private final ManyToOneConcurrentArrayQueue<Runnable> toConductorQueue =
         new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final CongestionControl congestionControl = mock(CongestionControl.class);
 
     private ReceiveChannelEndpoint receiveChannelEndpoint;
-    private final CongestionControl congestionControl = mock(CongestionControl.class);
 
     @BeforeEach
     public void setUp() throws Exception
@@ -218,7 +218,8 @@ public class ReceiverTest
                 mockSystemCounters,
                 SOURCE_ADDRESS,
                 congestionControl,
-                lossReport);
+                lossReport,
+                mockErrorHandler);
 
             final int messagesRead = toConductorQueue.drain((e) ->
             {
@@ -292,7 +293,8 @@ public class ReceiverTest
                     mockSystemCounters,
                     SOURCE_ADDRESS,
                     congestionControl,
-                    lossReport);
+                    lossReport,
+                    mockErrorHandler);
 
                 receiverProxy.newPublicationImage(receiveChannelEndpoint, image);
             });
@@ -363,7 +365,8 @@ public class ReceiverTest
                     mockSystemCounters,
                     SOURCE_ADDRESS,
                     congestionControl,
-                    lossReport);
+                    lossReport,
+                    mockErrorHandler);
 
                 receiverProxy.newPublicationImage(receiveChannelEndpoint, image);
             });
@@ -437,7 +440,8 @@ public class ReceiverTest
                     mockSystemCounters,
                     SOURCE_ADDRESS,
                     congestionControl,
-                    lossReport);
+                    lossReport,
+                    mockErrorHandler);
 
                 receiverProxy.newPublicationImage(receiveChannelEndpoint, image);
             });
@@ -515,7 +519,8 @@ public class ReceiverTest
                     mockSystemCounters,
                     SOURCE_ADDRESS,
                     congestionControl,
-                    lossReport);
+                    lossReport,
+                    mockErrorHandler);
 
                 receiverProxy.newPublicationImage(receiveChannelEndpoint, image);
             });

--- a/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
@@ -22,6 +22,7 @@ import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
 import org.agrona.BitUtil;
+import org.agrona.ErrorHandler;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
@@ -65,9 +66,10 @@ public class SelectorAndTransportTest
 
     private final DataPacketDispatcher mockDispatcher = mock(DataPacketDispatcher.class);
     private final NetworkPublication mockPublication = mock(NetworkPublication.class);
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class);
 
-    private final DataTransportPoller dataTransportPoller = new DataTransportPoller();
-    private final ControlTransportPoller controlTransportPoller = new ControlTransportPoller();
+    private final DataTransportPoller dataTransportPoller = new DataTransportPoller(errorHandler);
+    private final ControlTransportPoller controlTransportPoller = new ControlTransportPoller(errorHandler);
     private SendChannelEndpoint sendChannelEndpoint;
     private ReceiveChannelEndpoint receiveChannelEndpoint;
 

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -28,6 +28,7 @@ import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.protocol.SetupFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
+import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
 import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
@@ -105,6 +106,8 @@ public class SenderTest
             return length;
         };
 
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class);
+
     @BeforeEach
     public void setUp()
     {
@@ -120,7 +123,8 @@ public class SenderTest
                 .controlTransportPoller(mockTransportPoller)
                 .systemCounters(mockSystemCounters)
                 .senderCommandQueue(senderCommandQueue)
-                .nanoClock(nanoClock));
+                .nanoClock(nanoClock)
+                .errorHandler(errorHandler));
 
         LogBufferDescriptor.initialiseTailWithTermId(rawLog.metaData(), 0, INITIAL_TERM_ID);
 
@@ -160,7 +164,8 @@ public class SenderTest
             Configuration.untetheredWindowLimitTimeoutNs(),
             Configuration.untetheredRestingTimeoutNs(),
             false,
-            false);
+            false,
+            errorHandler);
 
         senderCommandQueue.offer(() -> sender.onNewNetworkPublication(publication));
     }

--- a/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
@@ -20,6 +20,7 @@ import io.aeron.driver.buffer.RawLog;
 import io.aeron.driver.buffer.TestLogFactory;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import org.agrona.ErrorHandler;
 import org.agrona.concurrent.status.AtomicLongPosition;
 import org.agrona.concurrent.status.Position;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,7 @@ public class UntetheredSubscriptionTest
 
     private final RawLog rawLog = TestLogFactory.newLogBuffers(TERM_BUFFER_LENGTH);
     private final AtomicLongPosition publisherLimit = new AtomicLongPosition();
+    private final ErrorHandler errorHandler = mock(ErrorHandler.class);
     private IpcPublication ipcPublication;
 
     @BeforeEach
@@ -62,7 +64,8 @@ public class UntetheredSubscriptionTest
             UNTETHERED_RESTING_TIMEOUT_NS,
             TIME_NS,
             mock(SystemCounters.class),
-            true);
+            true,
+            errorHandler);
     }
 
     @Test
@@ -115,6 +118,6 @@ public class UntetheredSubscriptionTest
         final SubscriptionParams params = new SubscriptionParams();
         params.isTether = isTether;
 
-        return new IpcSubscriptionLink(registrationId, STREAM_ID, CHANNEL, null, params);
+        return new IpcSubscriptionLink(registrationId, STREAM_ID, CHANNEL, null, params, errorHandler);
     }
 }

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedRecordingThroughput.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedRecordingThroughput.java
@@ -25,7 +25,9 @@ import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.samples.SampleConfiguration;
 import org.agrona.CloseHelper;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.status.CountersReader;
 import org.agrona.console.ContinueBarrier;
 
@@ -99,12 +101,12 @@ public class EmbeddedRecordingThroughput implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(aeronArchive);
-        CloseHelper.close(aeron);
-        CloseHelper.close(archivingMediaDriver);
-
-        archivingMediaDriver.archive().context().deleteArchiveDirectory();
-        archivingMediaDriver.mediaDriver().context().deleteAeronDirectory();
+        CloseHelper.closeAll(
+            aeronArchive,
+            aeron,
+            archivingMediaDriver,
+            () -> archivingMediaDriver.archive().context().deleteArchiveDirectory(),
+            () -> archivingMediaDriver.mediaDriver().context().deleteAeronDirectory());
     }
 
     public long streamMessagesForRecording()

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedReplayThroughput.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedReplayThroughput.java
@@ -121,12 +121,12 @@ public class EmbeddedReplayThroughput implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(aeronArchive);
-        CloseHelper.close(aeron);
-        CloseHelper.close(archivingMediaDriver);
-
-        archivingMediaDriver.archive().context().deleteArchiveDirectory();
-        archivingMediaDriver.mediaDriver().context().deleteAeronDirectory();
+        CloseHelper.closeAll(
+            aeronArchive,
+            aeron,
+            archivingMediaDriver,
+            () -> archivingMediaDriver.archive().context().deleteArchiveDirectory(),
+            () -> archivingMediaDriver.mediaDriver().context().deleteAeronDirectory());
     }
 
     void onMessage(final DirectBuffer buffer, final int offset, final int length, final Header header)

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
@@ -166,15 +166,15 @@ public class IndexedReplicatedRecording implements AutoCloseable
 
     public void close()
     {
-        CloseHelper.close(srcAeronArchive);
-        CloseHelper.close(dstAeronArchive);
-        CloseHelper.close(srcAeron);
-        CloseHelper.close(dstAeron);
-        CloseHelper.close(srcArchivingMediaDriver);
-        CloseHelper.close(dstArchivingMediaDriver);
-
-        srcArchivingMediaDriver.archive().context().deleteArchiveDirectory();
-        dstArchivingMediaDriver.archive().context().deleteArchiveDirectory();
+        CloseHelper.closeAll(
+            srcAeronArchive,
+            dstAeronArchive,
+            srcAeron,
+            dstAeron,
+            srcArchivingMediaDriver,
+            dstArchivingMediaDriver,
+            () -> srcArchivingMediaDriver.archive().context().deleteArchiveDirectory(),
+            () -> dstArchivingMediaDriver.archive().context().deleteArchiveDirectory());
     }
 
     public static void main(final String[] args) throws Exception

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -18,6 +18,7 @@ package io.aeron.test;
 import org.agrona.LangUtil;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.doAnswer;
 
 public class Tests
 {
@@ -50,5 +51,21 @@ public class Tests
         {
             LangUtil.rethrowUnchecked(ex);
         }
+    }
+
+    /**
+     * Helper method to mock {@link AutoCloseable#close()} method to throw exception.
+     *
+     * @param mock      to have it's method mocked
+     * @param exception exception to be thrown
+     * @throws Exception to make compiler happy
+     */
+    public static void throwOnClose(final AutoCloseable mock, final Throwable exception) throws Exception
+    {
+        doAnswer((invocation) ->
+        {
+            LangUtil.rethrowUnchecked(exception);
+            return null;
+        }).when(mock).close();
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ subprojects {
     dependencies {
         testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
         testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+        testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
         testImplementation "org.junit.jupiter:junit-jupiter-params:${junitVersion}"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     }
@@ -311,7 +312,6 @@ project(':aeron-client') {
 
     dependencies {
         api "org.agrona:agrona:${agronaVersion}"
-        testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
     }
 
     uploadArchives {
@@ -375,7 +375,7 @@ project(':aeron-driver') {
 
     dependencies {
         api project(':aeron-client')
-        testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
+        testImplementation project(':aeron-test-support')
     }
 
     uploadArchives {
@@ -871,6 +871,7 @@ project(':aeron-test-support') {
     dependencies {
         api "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
         api "org.agrona:agrona:${agronaVersion}"
+        implementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     }
 }
 


### PR DESCRIPTION
Ensure proper closure of the resources by using new helper API that uses `ErrorHandler` which consumes
any error generated by the resource being closed. In cases where there is no `ErrorHandler` around or if
it was already closed use variants of the `CloseHelper#closeAll` methods and if not possible
`CloseHelper#quiteClose` as the final resort.

Because not all of the resource being closed implement the `AutoCloseable` interface we are forced to use
lambda expressions in several places. This might be a potential performance issues, however given the fact
that we are dealing with `close` methods that should never be on the fast path.

Closes #818 