### PR TITLE
Parsing required group size from URI

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
@@ -100,12 +100,22 @@ public class TaggedMulticastFlowControl implements FlowControl
                 }
                 else if (arg.startsWith("g:"))
                 {
-                    rtag = AsciiEncoding.parseLongAscii(arg, 2, arg.length() - 2);
+                    final int requiredGroupSizeIndex = arg.indexOf('/');
+
+                    if (2 != requiredGroupSizeIndex)
+                    {
+                        final int lengthToParse = -1 == requiredGroupSizeIndex ?
+                            arg.length() - 2 : requiredGroupSizeIndex - 2;
+                        rtag = AsciiEncoding.parseLongAscii(arg, 2, lengthToParse);
+                    }
+
+                    if (-1 != requiredGroupSizeIndex)
+                    {
+                        requiredGroupSize = AsciiEncoding.parseIntAscii(
+                            arg, requiredGroupSizeIndex + 1, arg.length() - (requiredGroupSizeIndex + 1));
+                    }
                 }
             }
-
-            // TODO: parse out group size
-            requiredGroupSize = 0;
         }
     }
 
@@ -224,5 +234,20 @@ public class TaggedMulticastFlowControl implements FlowControl
         }
 
         return result;
+    }
+
+    long getRtag()
+    {
+        return rtag;
+    }
+
+    long getReceiverTimeoutNs()
+    {
+        return receiverTimeoutNs;
+    }
+
+    long getRequiredGroupSize()
+    {
+        return requiredGroupSize;
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static io.aeron.driver.MinMulticastFlowControl.EMPTY_RECEIVERS;
 import static io.aeron.logbuffer.LogBufferDescriptor.computePosition;
+import static java.lang.Integer.parseInt;
 import static java.lang.System.getProperty;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
@@ -71,6 +72,13 @@ public class TaggedMulticastFlowControl implements FlowControl
     public static final String PREFERRED_ASF_PROP_NAME = "aeron.PreferredMulticastFlowControl.asf";
 
     /**
+     * Property name to set the required group size for tagged multicast flow control.  This is the minimum number
+     * of live channel endpoint required in order for the strategy to consider the publication connected.
+     */
+    public static final String REQUIRED_GROUP_SIZE_PROP_NAME = "aeron.TaggedMulticastFlowControl.requiredGroupSize";
+    private static final int REQUIRED_GROUP_SIZE = parseInt(System.getProperty(REQUIRED_GROUP_SIZE_PROP_NAME, "0"));
+
+    /**
      * Default Application Specific Feedback (ASF) value
      */
     public static final String PREFERRED_ASF_DEFAULT = "FFFFFFFFFFFFFFFF";
@@ -79,7 +87,7 @@ public class TaggedMulticastFlowControl implements FlowControl
     public static final byte[] PREFERRED_ASF_BYTES = BitUtil.fromHex(PREFERRED_ASF);
 
     private volatile MinMulticastFlowControl.Receiver[] receivers = EMPTY_RECEIVERS;
-    private int requiredGroupSize = 0;
+    private int requiredGroupSize = REQUIRED_GROUP_SIZE;
     private long receiverTimeoutNs = RECEIVER_TIMEOUT;
     private long rtag = new UnsafeBuffer(PREFERRED_ASF_BYTES).getLong(0, ByteOrder.LITTLE_ENDIAN);
 
@@ -246,7 +254,7 @@ public class TaggedMulticastFlowControl implements FlowControl
         return receiverTimeoutNs;
     }
 
-    long getRequiredGroupSize()
+    int getRequiredGroupSize()
     {
         return requiredGroupSize;
     }

--- a/aeron-driver/src/test/java/io/aeron/driver/DefaultMulticastFlowControlSupplierTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DefaultMulticastFlowControlSupplierTest.java
@@ -1,14 +1,59 @@
 package io.aeron.driver;
 
-import org.junit.jupiter.api.Test;
+import io.aeron.driver.media.UdpChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultMulticastFlowControlSupplierTest
 {
-    @Test
-    void shouldReturnValidFlowControl()
-    {
+    private final DefaultMulticastFlowControlSupplier supplier = new DefaultMulticastFlowControlSupplier();
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=min",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=min,t:100ms",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=min,t:100ms,g:10",
+    })
+    void shouldReturnMinFlowControl(final String uri)
+    {
+        assertEquals(MinMulticastFlowControl.class, supplier.newInstance(UdpChannel.parse(uri), 0, 0).getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=max",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=max,t:100ms",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=max,t:100ms,g:10",
+    })
+    void shouldReturnMaxFlowControl(final String uri)
+    {
+        assertEquals(MaxMulticastFlowControl.class, supplier.newInstance(UdpChannel.parse(uri), 0, 0).getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms,g:10",
+    })
+    void shouldReturnTaggedFlowControl(final String uri)
+    {
+        assertEquals(TaggedMulticastFlowControl.class, supplier.newInstance(UdpChannel.parse(uri), 0, 0).getClass());
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=minute",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=maximillian",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=taggedalong",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=foobar",
+    })
+    void shouldRejectInvalidFlowControl(final String uri)
+    {
+        assertThrows(IllegalArgumentException.class, () -> supplier.newInstance(UdpChannel.parse(uri), 0, 0));
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/DefaultMulticastFlowControlSupplierTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DefaultMulticastFlowControlSupplierTest.java
@@ -1,0 +1,14 @@
+package io.aeron.driver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultMulticastFlowControlSupplierTest
+{
+    @Test
+    void shouldReturnValidFlowControl()
+    {
+
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
@@ -64,16 +64,14 @@ class TaggedMulticastFlowControlTest
     }
 
     @ParameterizedTest
-    @ValueSource(
-        strings = {
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:",
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100/",
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:/",
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:",
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100,t:",
-            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms,g:100/",
-        }
-    )
+    @ValueSource(strings = {
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100/",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:/",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100,t:",
+        "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms,g:100/",
+    })
     void shouldFailWithInvalidUris(final String uri)
     {
         assertThrows(Exception.class, () -> flowControl.initialize(UdpChannel.parse(uri), 0, 0));

--- a/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
@@ -1,0 +1,81 @@
+package io.aeron.driver;
+
+import io.aeron.driver.media.UdpChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TaggedMulticastFlowControlTest
+{
+    private static final int DEFAULT_GROUP_SIZE = 0;
+    private static final long DEFAULT_RTAG = new TaggedMulticastFlowControl().getRtag();
+    private static final long DEFAULT_TIMEOUT = new TaggedMulticastFlowControl().getReceiverTimeoutNs();
+
+    private final TaggedMulticastFlowControl flowControl = new TaggedMulticastFlowControl();
+
+    private static Stream<Arguments> validUris()
+    {
+        return Stream.of(
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged",
+                DEFAULT_RTAG, DEFAULT_GROUP_SIZE, DEFAULT_TIMEOUT),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms",
+                DEFAULT_RTAG, DEFAULT_GROUP_SIZE, 100_000_000),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:123",
+                123, DEFAULT_GROUP_SIZE, DEFAULT_TIMEOUT),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:3000000000",
+                3_000_000_000L, DEFAULT_GROUP_SIZE, DEFAULT_TIMEOUT),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:123,t:100ms",
+                123, DEFAULT_GROUP_SIZE, 100_000_000),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100/10",
+                100, 10, DEFAULT_TIMEOUT),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:/10",
+                DEFAULT_RTAG, 10, DEFAULT_TIMEOUT),
+            Arguments.of(
+                "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100/10,t:100ms",
+                100, 10, 100_000_000));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validUris")
+    void shouldParseValidFlowControlConfiguration(
+        final String uri,
+        final long rtag,
+        final int groupSize,
+        final long timeout)
+    {
+        flowControl.initialize(UdpChannel.parse(uri), 0, 0);
+
+        assertEquals(rtag, flowControl.getRtag());
+        assertEquals(groupSize, flowControl.getRequiredGroupSize());
+        assertEquals(timeout, flowControl.getReceiverTimeoutNs());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:",
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100/",
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:/",
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:",
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,g:100,t:",
+            "aeron:udp?endpoint=224.20.30.39:54326|interface=localhost|fc=tagged,t:100ms,g:100/",
+        }
+    )
+    void shouldFailWithInvalidUris(final String uri)
+    {
+        assertThrows(Exception.class, () -> flowControl.initialize(UdpChannel.parse(uri), 0, 0));
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/UriSpecifiedFlowControlTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UriSpecifiedFlowControlTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
-public class TaggedUriFlowControlTest
+public class UriSpecifiedFlowControlTest
 {
     private static final String MULTICAST_URI = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost";
     private static final String URI_WITH_MIN_FLOW_CONTROL = MULTICAST_URI + "|fc=min";


### PR DESCRIPTION
- Parses the group size value from the URI.
- Follows the same strict rules applied to the C driver (relies on StringIndexOutOfBounds, IllegalArgumentException for error handling).
- Adds system property configurable default for the required group size.