### PR TITLE
C driver flow control configuration

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -58,6 +58,7 @@
 #include "aeron_driver.h"
 #include "aeron_socket.h"
 #include "util/aeron_dlopen.h"
+#include "aeron_driver_context.h"
 
 const char aeron_version_full_str[] = "aeron version " AERON_VERSION_TXT " built " __DATE__ " " __TIME__;
 int aeron_major_version = AERON_VERSION_MAJOR;
@@ -631,6 +632,11 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
     fprintf(fpout, "\n    multicast_flow_control_supplier_func=%p%s",
         (void *)context->multicast_flow_control_supplier_func,
         aeron_dlinfo((const void *)context->multicast_flow_control_supplier_func, buffer, sizeof(buffer)));
+    fprintf(fpout, "\n    sm_receiver_tag.is_present=%d",
+        context->sm_receiver_tag.is_present);
+    fprintf(fpout, "\n    sm_receiver_tag.value=%" PRId64, context->sm_receiver_tag.value);
+    fprintf(fpout, "\n    flow_control_group.required_size=%" PRId32, context->flow_control_group.required_size);
+    fprintf(fpout, "\n    flow_control_group.receiver_tag=%" PRId64, context->flow_control_group.receiver_tag);
     /* applicationSpecificFeedback */
     fprintf(fpout, "\n    congestion_control_supplier_func=%p%s",
         (void *)context->congestion_control_supplier_func,

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -637,7 +637,8 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
     fprintf(fpout, "\n    sm_receiver_tag.value=%" PRId64, context->sm_receiver_tag.value);
     fprintf(fpout, "\n    flow_control_group.required_size=%" PRId32, context->flow_control_group.required_size);
     fprintf(fpout, "\n    flow_control_group.receiver_tag=%" PRId64, context->flow_control_group.receiver_tag);
-    /* applicationSpecificFeedback */
+    fprintf(fpout, "\n    min_flow_control_timeout_ns=%" PRIu64, context->min_flow_control_timeout_ns);
+    fprintf(fpout, "\n    tagged_flow_control_timeout_ns=%" PRIu64, context->tagged_flow_control_timeout_ns);
     fprintf(fpout, "\n    congestion_control_supplier_func=%p%s",
         (void *)context->congestion_control_supplier_func,
         aeron_dlinfo((const void *)context->congestion_control_supplier_func, buffer, sizeof(buffer)));

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -1914,6 +1914,50 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
     return NULL != context ? context->counter_free_to_reuse_ns : AERON_COUNTERS_FREE_TO_REUSE_TIMEOUT_NS_DEFAULT;
 }
 
+int aeron_driver_context_set_flow_control_group_receiver_tag(aeron_driver_context_t *context, int64_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->flow_control_group.receiver_tag = value;
+    return 0;
+}
+
+int64_t aeron_driver_context_get_flow_control_group_receiver_tag(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->flow_control_group.receiver_tag : AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
+}
+
+int aeron_driver_context_set_flow_control_group_required_size(aeron_driver_context_t *context, int32_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->flow_control_group.required_size = value;
+    return 0;
+}
+
+int32_t aeron_driver_context_get_flow_control_group_required_size(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->flow_control_group.required_size : AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT;
+}
+
+int aeron_driver_context_set_sm_receiver_tag(aeron_driver_context_t *context, bool is_present, int64_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->sm_receiver_tag.is_present = is_present;
+    context->sm_receiver_tag.value = value;
+}
+
+bool aeron_driver_context_get_sm_receiver_tag_is_present(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->sm_receiver_tag.is_present : AERON_SM_RECEIVER_TAG_IS_PRESENT_DEFAULT;
+}
+
+int64_t aeron_driver_context_get_sm_receiver_tag_value(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->sm_receiver_tag.value : AERON_SM_RECEIVER_TAG_VALUE_DEFAULT;
+}
+
 int aeron_driver_context_set_driver_termination_validator(
     aeron_driver_context_t *context, aeron_driver_termination_validator_func_t value, void *state)
 {

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -1997,6 +1997,7 @@ int aeron_driver_context_set_sm_receiver_tag(aeron_driver_context_t *context, bo
 
     context->sm_receiver_tag.is_present = is_present;
     context->sm_receiver_tag.value = value;
+    return 0;
 }
 
 bool aeron_driver_context_get_sm_receiver_tag_is_present(aeron_driver_context_t *context)

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -356,6 +356,8 @@ static void aeron_driver_conductor_to_client_interceptor_null(
 #define AERON_SM_RECEIVER_TAG_VALUE_DEFAULT (-1)
 #define AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT (-1)
 #define AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT (0)
+#define AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT (2 * 1000 * 1000 * 1000L)
+#define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT (2 * 1000 * 1000 * 1000L)
 #define AERON_SEND_TO_STATUS_POLL_RATIO_DEFAULT (4)
 #define AERON_RCV_STATUS_MESSAGE_TIMEOUT_NS_DEFAULT (200 * 1000 * 1000LL)
 #define AERON_MULTICAST_FLOWCONTROL_SUPPLIER_DEFAULT ("aeron_max_multicast_flow_control_strategy_supplier")
@@ -498,6 +500,8 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->sm_receiver_tag.value = AERON_SM_RECEIVER_TAG_VALUE_DEFAULT;
     _context->flow_control_group.receiver_tag = AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
     _context->flow_control_group.required_size = AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT;
+    _context->min_flow_control_timeout_ns = AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
+    _context->tagged_flow_control_timeout_ns = AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
     _context->send_to_sm_poll_ratio = AERON_SEND_TO_STATUS_POLL_RATIO_DEFAULT;
     _context->status_message_timeout_ns = AERON_RCV_STATUS_MESSAGE_TIMEOUT_NS_DEFAULT;
     _context->image_liveness_timeout_ns = AERON_IMAGE_LIVENESS_TIMEOUT_NS_DEFAULT;
@@ -866,6 +870,20 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         _context->flow_control_group.receiver_tag,
         0,
         INT32_MAX);
+
+    _context->min_flow_control_timeout_ns = aeron_config_parse_duration_ns(
+        AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR,
+        getenv(AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR),
+        _context->min_flow_control_timeout_ns,
+        0,
+        INT64_MAX);
+
+    _context->tagged_flow_control_timeout_ns = aeron_config_parse_duration_ns(
+        AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR,
+        getenv(AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR),
+        _context->tagged_flow_control_timeout_ns,
+        0,
+        INT64_MAX);
 
     _context->to_driver_buffer = NULL;
     _context->to_clients_buffer = NULL;
@@ -1913,6 +1931,39 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
 {
     return NULL != context ? context->counter_free_to_reuse_ns : AERON_COUNTERS_FREE_TO_REUSE_TIMEOUT_NS_DEFAULT;
 }
+
+int aeron_driver_context_set_min_multicast_flow_control_receiver_timeout_ns(
+    aeron_driver_context_t *context,
+    uint64_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->min_flow_control_timeout_ns = value;
+    return 0;
+}
+
+uint64_t aeron_driver_context_get__min_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context)
+{
+    return NULL != context ?
+        context->min_flow_control_timeout_ns : AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
+}
+
+int aeron_driver_context_set_tagged_multicast_flow_control_receiver_timeout_ns(
+    aeron_driver_context_t *context,
+    uint64_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->tagged_flow_control_timeout_ns = value;
+    return 0;
+}
+
+uint64_t aeron_driver_context_get__tagged_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context)
+{
+    return NULL != context ?
+        context->min_flow_control_timeout_ns : AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
+}
+
 
 int aeron_driver_context_set_flow_control_group_receiver_tag(aeron_driver_context_t *context, int64_t value)
 {

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -116,7 +116,8 @@ typedef struct aeron_driver_context_stct
     int32_t publication_reserved_session_id_low;            /* aeron.publication.reserved.session.id.low = -1 */
     int32_t publication_reserved_session_id_high;           /* aeron.publication.reserved.session.id.high = 10000 */
     uint8_t multicast_ttl;                                  /* aeron.socket.multicast.ttl = 0 */
-    struct                                                  /* aeron.flow.control.sm.receiver.tag = <unset> */
+
+    struct                                                  /* aeron.sm.receiver.tag = <unset> */
     {
         bool is_present;
         int64_t value;
@@ -128,6 +129,8 @@ typedef struct aeron_driver_context_stct
         int32_t required_size;                              /* aeron.flow.control.group.required.size = 0 */
     }
     flow_control_group;
+    uint64_t min_flow_control_timeout_ns;                   /* aeron.min.multicast.flow.control.receiver.timeout */
+    uint64_t tagged_flow_control_timeout_ns;                /* aeron.tagged.multicast.flow.control.receiver.timeout */
 
     aeron_mapped_file_t cnc_map;
     aeron_mapped_file_t loss_report;

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -116,12 +116,18 @@ typedef struct aeron_driver_context_stct
     int32_t publication_reserved_session_id_low;            /* aeron.publication.reserved.session.id.low = -1 */
     int32_t publication_reserved_session_id_high;           /* aeron.publication.reserved.session.id.high = 10000 */
     uint8_t multicast_ttl;                                  /* aeron.socket.multicast.ttl = 0 */
-    struct                                                  /* aeron.tagged.multicast.flow.control.rtag = <unset> */
+    struct                                                  /* aeron.flow.control.sm.receiver.tag = <unset> */
     {
-        bool is_present;                                    /* default: false */
-        int64_t value;                                      /* default: -1 */
+        bool is_present;
+        int64_t value;
     }
-    receiver_tag;
+    sm_receiver_tag;
+    struct
+    {
+        int64_t receiver_tag;                               /* aeron.flow.control.group.rtag = -1 */
+        int32_t required_size;                              /* aeron.flow.control.group.required.size = 0 */
+    }
+    flow_control_group;
 
     aeron_mapped_file_t cnc_map;
     aeron_mapped_file_t loss_report;

--- a/aeron-driver/src/main/c/aeron_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_flow_control.c
@@ -129,7 +129,8 @@ aeron_flow_control_strategy_supplier_func_table_entry_t aeron_flow_control_strat
 {
     { AERON_UNICAST_MAX_FLOW_CONTROL_STRATEGY_NAME, aeron_unicast_flow_control_strategy_supplier },
     { AERON_MULTICAST_MAX_FLOW_CONTROL_STRATEGY_NAME, aeron_max_multicast_flow_control_strategy_supplier },
-    { AERON_MULTICAST_MIN_FLOW_CONTROL_STRATEGY_NAME, aeron_min_flow_control_strategy_supplier }
+    { AERON_MULTICAST_MIN_FLOW_CONTROL_STRATEGY_NAME, aeron_min_flow_control_strategy_supplier },
+    { AERON_MULTICAST_TAGGED_FLOW_CONTROL_STRATEGY_NAME, aeron_tagged_flow_control_strategy_supplier }
 };
 
 aeron_flow_control_strategy_supplier_func_t aeron_flow_control_strategy_supplier_by_name(const char *name)

--- a/aeron-driver/src/main/c/aeron_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_flow_control.c
@@ -240,8 +240,8 @@ int aeron_flow_control_parse_tagged_options(
     flow_control_options->timeout_ns.value = 0;
     flow_control_options->receiver_tag.is_present = false;
     flow_control_options->receiver_tag.value = -1;
-    flow_control_options->group_count.is_present = false;
-    flow_control_options->group_count.value = -1;
+    flow_control_options->required_group_size.is_present = false;
+    flow_control_options->required_group_size.value = -1;
 
     char number_buffer[AERON_FLOW_CONTROL_NUMBER_BUFFER_LEN];
 
@@ -305,14 +305,14 @@ int aeron_flow_control_parse_tagged_options(
                 errno = 0;
 
                 const long long receiver_tag = strtoll(number_buffer, &end_ptr, 10);
-                const bool has_group_count = '/' == *end_ptr;
+                const bool has_group_size = '/' == *end_ptr;
 
-                if (0 == errno && number_buffer != end_ptr && ('\0' == *end_ptr || has_group_count))
+                if (0 == errno && number_buffer != end_ptr && ('\0' == *end_ptr || has_group_size))
                 {
                     flow_control_options->receiver_tag.is_present = true;
                     flow_control_options->receiver_tag.value = (int64_t)receiver_tag;
                 }
-                else if (number_buffer != end_ptr && !has_group_count) // Allow empty values if we have a group count
+                else if (number_buffer != end_ptr && !has_group_size) // Allow empty values if we have a group count
                 {
                     aeron_set_err(
                         -EINVAL,
@@ -323,21 +323,21 @@ int aeron_flow_control_parse_tagged_options(
                     return -EINVAL;
                 }
 
-                if (has_group_count)
+                if (has_group_size)
                 {
-                    const char *count_ptr = end_ptr + 1;
+                    const char *group_size_ptr = end_ptr + 1;
                     end_ptr = "";
                     errno = 0;
 
-                    const long group_count = strtol(count_ptr, &end_ptr, 10);
+                    const long group_size = strtol(group_size_ptr, &end_ptr, 10);
 
                     if (0 == errno &&
                         '\0' == *end_ptr &&
-                        count_ptr != end_ptr &&
-                        0 <= group_count && group_count <= INT32_MAX)
+                        group_size_ptr != end_ptr &&
+                        0 <= group_size && group_size <= INT32_MAX)
                     {
-                        flow_control_options->group_count.is_present = true;
-                        flow_control_options->group_count.value = (int32_t)group_count;
+                        flow_control_options->required_group_size.is_present = true;
+                        flow_control_options->required_group_size.value = (int32_t)group_size;
                     }
                     else
                     {

--- a/aeron-driver/src/main/c/aeron_flow_control.h
+++ b/aeron-driver/src/main/c/aeron_flow_control.h
@@ -75,7 +75,7 @@ typedef struct aeron_flow_control_tagged_options_stct
         bool is_present;
         int32_t value;
     }
-    group_count;
+    required_group_size;
 }
 aeron_flow_control_tagged_options_t;
 

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -486,15 +486,25 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
  */
 #define AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_ENV_VAR "AERON_FLOW_CONTROL_GROUP_RTAG"
 
+int aeron_driver_context_set_flow_control_group_receiver_tag(aeron_driver_context_t *context, int64_t value);
+int64_t aeron_driver_context_get_flow_control_group_receiver_tag(aeron_driver_context_t *context);
+
 /**
  * Default required group size to use in tagged multicast flow control.
  */
 #define AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_ENV_VAR "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE"
 
+int aeron_driver_context_set_flow_control_group_required_size(aeron_driver_context_t *context, int32_t value);
+int32_t aeron_driver_context_get_flow_control_group_required_size(aeron_driver_context_t *context);
+
 /**
  * Default receiver tag to be sent on status messages from channel to handle tagged flow control.
  */
 #define AERON_SM_RECEIVER_TAG_ENV_VAR "AERON_SM_RTAG"
+
+int aeron_driver_context_set_sm_receiver_tag(aeron_driver_context_t *context, bool is_present, int64_t value);
+bool aeron_driver_context_get_sm_receiver_tag_is_present(aeron_driver_context_t *context);
+int64_t aeron_driver_context_get_sm_receiver_tag_value(aeron_driver_context_t *context);
 
 /**
  * Function name to call for termination validation.

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -476,10 +476,22 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
  */
 #define AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR "AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
 
+int aeron_driver_context_set_min_multicast_flow_control_receiver_timeout_ns(
+    aeron_driver_context_t *context,
+    uint64_t value);
+
+uint64_t aeron_driver_context_get__min_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context);
+
 /**
- * Timeout for a preferred receiver to be tracked.
+ * Timeout for a tagged receiver to be tracked.
  */
 #define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR "AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
+
+int aeron_driver_context_set_tagged_multicast_flow_control_receiver_timeout_ns(
+    aeron_driver_context_t *context,
+    uint64_t value);
+
+uint64_t aeron_driver_context_get__tagged_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context);
 
 /**
  * Default receiver tag for publishers to group endpoints by using tagged flow control.

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -482,9 +482,19 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
 #define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR "AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
 
 /**
- * Timeout for a tagged receiver to be tracked.
+ * Default receiver tag for publishers to group endpoints by using tagged flow control.
  */
-#define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RTAG_ENV_VAR "AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
+#define AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_ENV_VAR "AERON_FLOW_CONTROL_GROUP_RTAG"
+
+/**
+ * Default required group size to use in tagged multicast flow control.
+ */
+#define AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_ENV_VAR "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE"
+
+/**
+ * Default receiver tag to be sent on status messages from channel to handle tagged flow control.
+ */
+#define AERON_SM_RECEIVER_TAG_ENV_VAR "AERON_SM_RTAG"
 
 /**
  * Function name to call for termination validation.

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -264,6 +264,7 @@ typedef int (*aeron_flow_control_strategy_supplier_func_t)(
 
 #define AERON_MULTICAST_MIN_FLOW_CONTROL_STRATEGY_NAME "multicast_min"
 #define AERON_MULTICAST_MAX_FLOW_CONTROL_STRATEGY_NAME "multicast_max"
+#define AERON_MULTICAST_TAGGED_FLOW_CONTROL_STRATEGY_NAME "multicast_tagged"
 #define AERON_UNICAST_MAX_FLOW_CONTROL_STRATEGY_NAME "unicast_max"
 
 /**

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -43,8 +43,8 @@ int aeron_receive_channel_endpoint_set_receiver_tag(
 
     if (0 == rc)
     {
-        endpoint->receiver_tag.is_present = context->receiver_tag.is_present;
-        endpoint->receiver_tag.value = context->receiver_tag.value;
+        endpoint->receiver_tag.is_present = context->sm_receiver_tag.is_present;
+        endpoint->receiver_tag.value = context->sm_receiver_tag.value;
     }
     else
     {

--- a/aeron-driver/src/test/c/aeron_driver_configuration_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_configuration_test.cpp
@@ -48,6 +48,7 @@ TEST_F(DriverConfigurationTest, shouldFindAllBuiltinFlowControlStrategies)
     EXPECT_NE(aeron_flow_control_strategy_supplier_by_name(AERON_MULTICAST_MIN_FLOW_CONTROL_STRATEGY_NAME), nullptr);
     EXPECT_NE(aeron_flow_control_strategy_supplier_by_name(AERON_MULTICAST_MAX_FLOW_CONTROL_STRATEGY_NAME), nullptr);
     EXPECT_NE(aeron_flow_control_strategy_supplier_by_name(AERON_UNICAST_MAX_FLOW_CONTROL_STRATEGY_NAME), nullptr);
+    EXPECT_NE(aeron_flow_control_strategy_supplier_by_name(AERON_MULTICAST_TAGGED_FLOW_CONTROL_STRATEGY_NAME), nullptr);
 }
 
 TEST_F(DriverConfigurationTest, shouldNotFindNonBuiltinFlowControlStrategies)


### PR DESCRIPTION
Adds lots of configuration environment var/property/programmatic configuration on the c driver for:
- Tagged flow control strategy supplier (including by name).
- Min/Tagged flow control timeouts.
- Default group rtag.
- Default group required size.
Removes thread_once configuration for min/tagged timeouts.
Renaming for consistency.

With the exception of handling the require group size, this bring parity with the Java driver.