### PR TITLE
Use required group size in tagged flow control to affect publication connected status

### DIFF
--- a/aeron-driver/src/main/c/aeron_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_flow_control.c
@@ -47,6 +47,11 @@ aeron_flow_control_strategy_supplier_func_t aeron_flow_control_strategy_supplier
     return func;
 }
 
+bool aeron_flow_control_strategy_has_required_receivers_default(aeron_flow_control_strategy_t *strategy)
+{
+    return true;
+}
+
 int64_t aeron_max_flow_control_strategy_on_idle(
     void *state,
     int64_t now_ns,
@@ -224,8 +229,15 @@ int aeron_default_multicast_flow_control_strategy_supplier(
         flow_control_strategy_supplier_func = context->unicast_flow_control_supplier_func;
     }
 
-    return flow_control_strategy_supplier_func(
+    int rc = flow_control_strategy_supplier_func(
         strategy, context, channel, stream_id, registration_id, initial_term_id, term_length);
+
+    if (0 <= rc && NULL != *strategy && NULL == (*strategy)->has_required_receivers)
+    {
+        (*strategy)->has_required_receivers = aeron_flow_control_strategy_has_required_receivers_default;
+    }
+
+    return rc;
 }
 
 #define AERON_FLOW_CONTROL_NUMBER_BUFFER_LEN (64)

--- a/aeron-driver/src/main/c/aeron_flow_control.h
+++ b/aeron-driver/src/main/c/aeron_flow_control.h
@@ -45,14 +45,19 @@ typedef int64_t (*aeron_flow_control_strategy_on_sm_func_t)(
 
 typedef int (*aeron_flow_control_strategy_fini_func_t)(aeron_flow_control_strategy_t *strategy);
 
+typedef bool (*aeron_flow_control_strategy_has_required_receivers)(aeron_flow_control_strategy_t *strategy);
+
 typedef struct aeron_flow_control_strategy_stct
 {
     aeron_flow_control_strategy_on_sm_func_t on_status_message;
     aeron_flow_control_strategy_on_idle_func_t on_idle;
     aeron_flow_control_strategy_fini_func_t fini;
+    aeron_flow_control_strategy_has_required_receivers has_required_receivers;
     void *state;
 }
 aeron_flow_control_strategy_t;
+
+bool aeron_flow_control_strategy_has_required_receivers_default(aeron_flow_control_strategy_t *strategy);
 
 typedef struct aeron_flow_control_tagged_options_stct
 {

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -326,17 +326,7 @@ bool aeron_tagged_flow_control_strategy_has_required_receivers(aeron_flow_contro
     aeron_tagged_flow_control_strategy_state_t *strategy_state =
         (aeron_tagged_flow_control_strategy_state_t *)strategy->state;
 
-
-    bool result = strategy_state->required_group_size <= (int32_t)strategy_state->min_flow_control_state.receivers
-        .length;
-
-    fprintf(
-        stdout,
-        "required: %d, currently: %zu, result: %s\n",
-        strategy_state->required_group_size,
-        strategy_state->min_flow_control_state.receivers.length,
-        result ? "true" : "false");
-    return result;
+    return strategy_state->required_group_size <= (int32_t)strategy_state->min_flow_control_state.receivers.length;
 }
 
 int aeron_tagged_flow_control_strategy_supplier(

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -321,6 +321,24 @@ int aeron_tagged_flow_control_strategy_fini(aeron_flow_control_strategy_t *strat
     return 0;
 }
 
+bool aeron_tagged_flow_control_strategy_has_required_receivers(aeron_flow_control_strategy_t *strategy)
+{
+    aeron_tagged_flow_control_strategy_state_t *strategy_state =
+        (aeron_tagged_flow_control_strategy_state_t *)strategy->state;
+
+
+    bool result = strategy_state->required_group_size <= (int32_t)strategy_state->min_flow_control_state.receivers
+        .length;
+
+    fprintf(
+        stdout,
+        "required: %d, currently: %zu, result: %s\n",
+        strategy_state->required_group_size,
+        strategy_state->min_flow_control_state.receivers.length,
+        result ? "true" : "false");
+    return result;
+}
+
 int aeron_tagged_flow_control_strategy_supplier(
     aeron_flow_control_strategy_t **strategy,
     aeron_driver_context_t *context,
@@ -348,6 +366,7 @@ int aeron_tagged_flow_control_strategy_supplier(
     _strategy->on_idle = aeron_tagged_flow_control_strategy_on_idle;
     _strategy->on_status_message = aeron_tagged_flow_control_strategy_on_sm;
     _strategy->fini = aeron_tagged_flow_control_strategy_fini;
+    _strategy->has_required_receivers = aeron_tagged_flow_control_strategy_has_required_receivers;
 
     aeron_tagged_flow_control_strategy_state_t *state =
         (aeron_tagged_flow_control_strategy_state_t *)_strategy->state;


### PR DESCRIPTION
Follows the Java implementation, unit test provided.

I have a system test for the Java side, but it is dependent on #849 being merged first.