### PR TITLE
[Java] Set field pointing to MappedByteBuffer to null before calling IoUtil#unmap

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -112,9 +112,9 @@ class Catalog implements AutoCloseable
     private final RecordingDescriptorEncoder descriptorEncoder = new RecordingDescriptorEncoder();
     private final RecordingDescriptorDecoder descriptorDecoder = new RecordingDescriptorDecoder();
 
-    private final MappedByteBuffer catalogByteBuffer;
-    private final UnsafeBuffer catalogBuffer;
-    private final UnsafeBuffer fieldAccessBuffer;
+    private MappedByteBuffer catalogByteBuffer;
+    private UnsafeBuffer catalogBuffer;
+    private UnsafeBuffer fieldAccessBuffer;
 
     private final int recordLength;
     private final int maxDescriptorStringsCombinedLength;
@@ -289,6 +289,11 @@ class Catalog implements AutoCloseable
         {
             isClosed = true;
             CloseHelper.quietClose(catalogChannel); // Ignore error so that the rest can be closed
+
+            final MappedByteBuffer catalogByteBuffer = this.catalogByteBuffer;
+            this.catalogByteBuffer = null;
+            catalogBuffer = null;
+            fieldAccessBuffer = null;
             IoUtil.unmap(catalogByteBuffer);
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -112,9 +112,9 @@ class Catalog implements AutoCloseable
     private final RecordingDescriptorEncoder descriptorEncoder = new RecordingDescriptorEncoder();
     private final RecordingDescriptorDecoder descriptorDecoder = new RecordingDescriptorDecoder();
 
-    private MappedByteBuffer catalogByteBuffer;
-    private UnsafeBuffer catalogBuffer;
-    private UnsafeBuffer fieldAccessBuffer;
+    private final MappedByteBuffer catalogByteBuffer;
+    private final UnsafeBuffer catalogBuffer;
+    private final UnsafeBuffer fieldAccessBuffer;
 
     private final int recordLength;
     private final int maxDescriptorStringsCombinedLength;
@@ -289,11 +289,6 @@ class Catalog implements AutoCloseable
         {
             isClosed = true;
             CloseHelper.quietClose(catalogChannel); // Ignore error so that the rest can be closed
-
-            final MappedByteBuffer catalogByteBuffer = this.catalogByteBuffer;
-            this.catalogByteBuffer = null;
-            catalogBuffer = null;
-            fieldAccessBuffer = null;
             IoUtil.unmap(catalogByteBuffer);
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/RecordingReader.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/RecordingReader.java
@@ -197,8 +197,9 @@ class RecordingReader implements AutoCloseable
 
     private void closeRecordingSegment()
     {
+        final MappedByteBuffer mappedSegmentBuffer = this.mappedSegmentBuffer;
+        this.mappedSegmentBuffer = null;
         IoUtil.unmap(mappedSegmentBuffer);
-        mappedSegmentBuffer = null;
     }
 
     private void openRecordingSegment()

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1373,9 +1373,10 @@ public class Aeron implements AutoCloseable
                         throw new DriverTimeoutException("no driver heartbeat detected");
                     }
 
-                    IoUtil.unmap(cncByteBuffer);
-                    cncByteBuffer = null;
+                    final MappedByteBuffer cncByteBuffer = this.cncByteBuffer;
+                    this.cncByteBuffer = null;
                     cncMetaDataBuffer = null;
+                    IoUtil.unmap(cncByteBuffer);
 
                     sleep(100);
                     continue;

--- a/aeron-client/src/main/java/io/aeron/LogBuffers.java
+++ b/aeron-client/src/main/java/io/aeron/LogBuffers.java
@@ -216,23 +216,11 @@ public class LogBuffers implements AutoCloseable, ManagedResource
 
         for (int i = 0, length = mappedByteBuffers.length; i < length; i++)
         {
-            try
-            {
-                IoUtil.unmap(mappedByteBuffers[i]);
-            }
-            catch (final Throwable t)
-            {
-                if (error == null)
-                {
-                    error = t;
-                }
-                else
-                {
-                    error.addSuppressed(t);
-                }
-            }
+            final MappedByteBuffer mappedByteBuffer = mappedByteBuffers[i];
             mappedByteBuffers[i] = null;
+            IoUtil.unmap(mappedByteBuffer);
         }
+
         if (error != null)
         {
             LangUtil.rethrowUnchecked(error);

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -527,16 +527,19 @@ public final class MediaDriver implements AutoCloseable
                 AeronCloseHelper.close(errorHandler, logFactory);
 
                 AeronCloseHelper.close(errorHandler, lossReport);
+
+                final MappedByteBuffer lossReportBuffer = this.lossReportBuffer;
+                this.lossReportBuffer = null;
                 IoUtil.unmap(lossReportBuffer);
-                lossReportBuffer = null;
 
                 if (errorHandler instanceof AutoCloseable)
                 {
                     CloseHelper.quietClose((AutoCloseable)errorHandler); // Ignore error to ensure the rest is closed
                 }
 
+                final MappedByteBuffer cncByteBuffer = this.cncByteBuffer;
+                this.cncByteBuffer = null;
                 IoUtil.unmap(cncByteBuffer);
-                cncByteBuffer = null;
 
                 if (dirDeleteOnShutdown && null != aeronDirectory())
                 {

--- a/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/buffer/MappedRawLog.java
@@ -16,7 +16,8 @@
 package io.aeron.driver.buffer;
 
 import io.aeron.exceptions.AeronException;
-import org.agrona.*;
+import org.agrona.ErrorHandler;
+import org.agrona.IoUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import java.io.File;
@@ -30,8 +31,8 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
 import java.util.EnumSet;
 
-import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static io.aeron.logbuffer.LogBufferDescriptor.*;
+import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.file.StandardOpenOption.*;
 import static org.agrona.BitUtil.align;
 
@@ -137,14 +138,17 @@ class MappedRawLog implements RawLog
 
     public boolean free()
     {
+        final MappedByteBuffer[] mappedBuffers = this.mappedBuffers;
         if (null != mappedBuffers)
         {
-            for (final MappedByteBuffer buffer : mappedBuffers)
+            for (int i = 0; i < mappedBuffers.length; i++)
             {
+                final MappedByteBuffer buffer = mappedBuffers[i];
+                mappedBuffers[i] = null;
                 IoUtil.unmap(buffer);
             }
 
-            mappedBuffers = null;
+            this.mappedBuffers = null;
         }
 
         if (null != logFile)

--- a/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
@@ -39,7 +39,7 @@ public final class CncFileReader implements AutoCloseable
     private boolean isClosed = false;
     private final int cncVersion;
     private final String cncSemanticVersion;
-    private final MappedByteBuffer cncByteBuffer;
+    private MappedByteBuffer cncByteBuffer;
     private final CountersReader countersReader;
     private final UnsafeBuffer toDriverBuffer;
 
@@ -73,8 +73,8 @@ public final class CncFileReader implements AutoCloseable
     /**
      * Map an existing CnC file.
      *
-     * @throws AeronException if the cnc version major version is not compatible.
      * @return the {@link CncFileReader} wrapper for reading useful data from the cnc file.
+     * @throws AeronException if the cnc version major version is not compatible.
      */
     public static CncFileReader map()
     {
@@ -142,6 +142,8 @@ public final class CncFileReader implements AutoCloseable
         if (!isClosed)
         {
             isClosed = true;
+            final MappedByteBuffer cncByteBuffer = this.cncByteBuffer;
+            this.cncByteBuffer = null;
             IoUtil.unmap(cncByteBuffer);
         }
     }


### PR DESCRIPTION
For the symmetry with other places where we free buffers we should null-out the corresponding field reference before freeing/un-mapping the underlying buffer.