### PR TITLE
Tagged Flow Controls, renaming and fixing

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -645,10 +645,9 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
     fprintf(fpout, "\n    sm_receiver_tag.is_present=%d",
         context->sm_receiver_tag.is_present);
     fprintf(fpout, "\n    sm_receiver_tag.value=%" PRId64, context->sm_receiver_tag.value);
-    fprintf(fpout, "\n    flow_control_group.required_size=%" PRId32, context->flow_control_group.required_size);
-    fprintf(fpout, "\n    flow_control_group.receiver_tag=%" PRId64, context->flow_control_group.receiver_tag);
-    fprintf(fpout, "\n    min_flow_control_timeout_ns=%" PRIu64, context->min_flow_control_timeout_ns);
-    fprintf(fpout, "\n    tagged_flow_control_timeout_ns=%" PRIu64, context->tagged_flow_control_timeout_ns);
+    fprintf(fpout, "\n    flow_control_receiver_timeout_ns=%" PRIu64, context->flow_control.receiver_timeout_ns);
+    fprintf(fpout, "\n    flow_control.receiver_group_min_size=%" PRId32, context->flow_control.receiver_group_min_size);
+    fprintf(fpout, "\n    flow_control.group_receiver_tag=%" PRId64, context->flow_control.group_receiver_tag);
     fprintf(fpout, "\n    congestion_control_supplier_func=%p%s",
         (void *)context->congestion_control_supplier_func,
         aeron_dlinfo((const void *)context->congestion_control_supplier_func, buffer, sizeof(buffer)));

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -355,9 +355,8 @@ static void aeron_driver_conductor_to_client_interceptor_null(
 #define AERON_SM_RECEIVER_TAG_IS_PRESENT_DEFAULT false
 #define AERON_SM_RECEIVER_TAG_VALUE_DEFAULT (-1)
 #define AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT (-1)
-#define AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT (0)
-#define AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT (2 * 1000 * 1000 * 1000L)
-#define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT (2 * 1000 * 1000 * 1000L)
+#define AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_DEFAULT (0)
+#define AERON_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT (2 * 1000 * 1000 * 1000L)
 #define AERON_SEND_TO_STATUS_POLL_RATIO_DEFAULT (4)
 #define AERON_RCV_STATUS_MESSAGE_TIMEOUT_NS_DEFAULT (200 * 1000 * 1000LL)
 #define AERON_MULTICAST_FLOWCONTROL_SUPPLIER_DEFAULT ("aeron_max_multicast_flow_control_strategy_supplier")
@@ -498,10 +497,9 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->multicast_ttl = AERON_SOCKET_MULTICAST_TTL_DEFAULT;
     _context->sm_receiver_tag.is_present = AERON_SM_RECEIVER_TAG_IS_PRESENT_DEFAULT;
     _context->sm_receiver_tag.value = AERON_SM_RECEIVER_TAG_VALUE_DEFAULT;
-    _context->flow_control_group.receiver_tag = AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
-    _context->flow_control_group.required_size = AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT;
-    _context->min_flow_control_timeout_ns = AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
-    _context->tagged_flow_control_timeout_ns = AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
+    _context->flow_control.group_receiver_tag = AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
+    _context->flow_control.receiver_group_min_size = AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_DEFAULT;
+    _context->flow_control.receiver_timeout_ns = AERON_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
     _context->send_to_sm_poll_ratio = AERON_SEND_TO_STATUS_POLL_RATIO_DEFAULT;
     _context->status_message_timeout_ns = AERON_RCV_STATUS_MESSAGE_TIMEOUT_NS_DEFAULT;
     _context->image_liveness_timeout_ns = AERON_IMAGE_LIVENESS_TIMEOUT_NS_DEFAULT;
@@ -857,31 +855,24 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
             INT64_MAX);
     }
 
-    _context->flow_control_group.receiver_tag = aeron_config_parse_int64(
+    _context->flow_control.group_receiver_tag = aeron_config_parse_int64(
         AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_ENV_VAR,
         getenv(AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_ENV_VAR),
-        _context->flow_control_group.receiver_tag,
+        _context->flow_control.group_receiver_tag,
         INT64_MIN,
         INT64_MAX);
 
-    _context->flow_control_group.required_size = aeron_config_parse_int32(
-        AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_ENV_VAR,
-        getenv(AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_ENV_VAR),
-        _context->flow_control_group.receiver_tag,
+    _context->flow_control.receiver_group_min_size = aeron_config_parse_int32(
+        AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_ENV_VAR,
+        getenv(AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_ENV_VAR),
+        _context->flow_control.receiver_group_min_size,
         0,
         INT32_MAX);
 
-    _context->min_flow_control_timeout_ns = aeron_config_parse_duration_ns(
+    _context->flow_control.receiver_timeout_ns = aeron_config_parse_duration_ns(
         AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR,
         getenv(AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR),
-        _context->min_flow_control_timeout_ns,
-        0,
-        INT64_MAX);
-
-    _context->tagged_flow_control_timeout_ns = aeron_config_parse_duration_ns(
-        AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR,
-        getenv(AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR),
-        _context->tagged_flow_control_timeout_ns,
+        _context->flow_control.receiver_timeout_ns,
         0,
         INT64_MAX);
 
@@ -1932,63 +1923,47 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
     return NULL != context ? context->counter_free_to_reuse_ns : AERON_COUNTERS_FREE_TO_REUSE_TIMEOUT_NS_DEFAULT;
 }
 
-int aeron_driver_context_set_min_multicast_flow_control_receiver_timeout_ns(
+int aeron_driver_context_set_flow_control_receiver_timeout_ns(
     aeron_driver_context_t *context,
     uint64_t value)
 {
     AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
 
-    context->min_flow_control_timeout_ns = value;
+    context->flow_control.receiver_timeout_ns = value;
     return 0;
 }
 
-uint64_t aeron_driver_context_get__min_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context)
+uint64_t aeron_driver_context_get_flow_control_receiver_timeout_ns(aeron_driver_context_t *context)
 {
     return NULL != context ?
-        context->min_flow_control_timeout_ns : AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
+        context->flow_control.receiver_timeout_ns : AERON_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
 }
-
-int aeron_driver_context_set_tagged_multicast_flow_control_receiver_timeout_ns(
-    aeron_driver_context_t *context,
-    uint64_t value)
-{
-    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
-
-    context->tagged_flow_control_timeout_ns = value;
-    return 0;
-}
-
-uint64_t aeron_driver_context_get__tagged_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context)
-{
-    return NULL != context ?
-        context->min_flow_control_timeout_ns : AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_NS_DEFAULT;
-}
-
 
 int aeron_driver_context_set_flow_control_group_receiver_tag(aeron_driver_context_t *context, int64_t value)
 {
     AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
 
-    context->flow_control_group.receiver_tag = value;
+    context->flow_control.group_receiver_tag = value;
     return 0;
 }
 
 int64_t aeron_driver_context_get_flow_control_group_receiver_tag(aeron_driver_context_t *context)
 {
-    return NULL != context ? context->flow_control_group.receiver_tag : AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
+    return NULL != context ? context->flow_control.group_receiver_tag : AERON_FLOW_CONTROL_GROUP_RECEIVER_TAG_DEFAULT;
 }
 
 int aeron_driver_context_set_flow_control_group_required_size(aeron_driver_context_t *context, int32_t value)
 {
     AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
 
-    context->flow_control_group.required_size = value;
+    context->flow_control.receiver_group_min_size = value;
     return 0;
 }
 
 int32_t aeron_driver_context_get_flow_control_group_required_size(aeron_driver_context_t *context)
 {
-    return NULL != context ? context->flow_control_group.required_size : AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_DEFAULT;
+    return NULL != context ? context->flow_control.receiver_group_min_size :
+        AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_DEFAULT;
 }
 
 int aeron_driver_context_set_sm_receiver_tag(aeron_driver_context_t *context, bool is_present, int64_t value)

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -125,12 +125,11 @@ typedef struct aeron_driver_context_stct
     sm_receiver_tag;
     struct
     {
-        int64_t receiver_tag;                               /* aeron.flow.control.group.rtag = -1 */
-        int32_t required_size;                              /* aeron.flow.control.group.required.size = 0 */
+        int32_t receiver_group_min_size;                     /* aeron.flow.control.receiver.group.min.size = 0 */
+        uint64_t receiver_timeout_ns;                        /* aeron.flow.control.receiver.timeout */
+        int64_t group_receiver_tag;                          /* aeron.flow.control.group.rtag = -1 */
     }
-    flow_control_group;
-    uint64_t min_flow_control_timeout_ns;                   /* aeron.min.multicast.flow.control.receiver.timeout */
-    uint64_t tagged_flow_control_timeout_ns;                /* aeron.tagged.multicast.flow.control.receiver.timeout */
+    flow_control;
 
     aeron_mapped_file_t cnc_map;
     aeron_mapped_file_t loss_report;

--- a/aeron-driver/src/main/c/aeron_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_flow_control.c
@@ -253,8 +253,8 @@ int aeron_flow_control_parse_tagged_options(
     flow_control_options->timeout_ns.value = 0;
     flow_control_options->receiver_tag.is_present = false;
     flow_control_options->receiver_tag.value = -1;
-    flow_control_options->required_group_size.is_present = false;
-    flow_control_options->required_group_size.value = -1;
+    flow_control_options->group_min_size.is_present = false;
+    flow_control_options->group_min_size.value = -1;
 
     char number_buffer[AERON_FLOW_CONTROL_NUMBER_BUFFER_LEN];
 
@@ -318,14 +318,14 @@ int aeron_flow_control_parse_tagged_options(
                 errno = 0;
 
                 const long long receiver_tag = strtoll(number_buffer, &end_ptr, 10);
-                const bool has_group_size = '/' == *end_ptr;
+                const bool has_group_min_size = '/' == *end_ptr;
 
-                if (0 == errno && number_buffer != end_ptr && ('\0' == *end_ptr || has_group_size))
+                if (0 == errno && number_buffer != end_ptr && ('\0' == *end_ptr || has_group_min_size))
                 {
                     flow_control_options->receiver_tag.is_present = true;
                     flow_control_options->receiver_tag.value = (int64_t)receiver_tag;
                 }
-                else if (number_buffer != end_ptr && !has_group_size) // Allow empty values if we have a group count
+                else if (number_buffer != end_ptr && !has_group_min_size) // Allow empty values if we have a group count
                 {
                     aeron_set_err(
                         -EINVAL,
@@ -336,21 +336,21 @@ int aeron_flow_control_parse_tagged_options(
                     return -EINVAL;
                 }
 
-                if (has_group_size)
+                if (has_group_min_size)
                 {
-                    const char *group_size_ptr = end_ptr + 1;
+                    const char *group_min_size_ptr = end_ptr + 1;
                     end_ptr = "";
                     errno = 0;
 
-                    const long group_size = strtol(group_size_ptr, &end_ptr, 10);
+                    const long group_min_size = strtol(group_min_size_ptr, &end_ptr, 10);
 
                     if (0 == errno &&
                         '\0' == *end_ptr &&
-                        group_size_ptr != end_ptr &&
-                        0 <= group_size && group_size <= INT32_MAX)
+                        group_min_size_ptr != end_ptr &&
+                        0 <= group_min_size && group_min_size <= INT32_MAX)
                     {
-                        flow_control_options->required_group_size.is_present = true;
-                        flow_control_options->required_group_size.value = (int32_t)group_size;
+                        flow_control_options->group_min_size.is_present = true;
+                        flow_control_options->group_min_size.value = (int32_t)group_min_size;
                     }
                     else
                     {

--- a/aeron-driver/src/main/c/aeron_flow_control.h
+++ b/aeron-driver/src/main/c/aeron_flow_control.h
@@ -80,7 +80,7 @@ typedef struct aeron_flow_control_tagged_options_stct
         bool is_present;
         int32_t value;
     }
-    required_group_size;
+    group_min_size;
 }
 aeron_flow_control_tagged_options_t;
 

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -224,7 +224,7 @@ int aeron_min_flow_control_strategy_supplier(
     state->receivers.length = 0;
 
     state->receiver_timeout_ns = options.timeout_ns.is_present ?
-        options.timeout_ns.value : context->min_flow_control_timeout_ns;
+        options.timeout_ns.value : context->flow_control.receiver_timeout_ns;
 
     *strategy = _strategy;
 
@@ -385,14 +385,14 @@ int aeron_tagged_flow_control_strategy_supplier(
     state->min_flow_control_state.receivers.capacity = 0;
     state->min_flow_control_state.receivers.length = 0;
     state->receiver_tag = options.receiver_tag.is_present ?
-        options.receiver_tag.value : context->flow_control_group.receiver_tag;
+        options.receiver_tag.value : context->flow_control.group_receiver_tag;
     state->required_group_size = options.required_group_size.is_present ?
-        options.required_group_size.value : context->flow_control_group.required_size;
+        options.required_group_size.value : context->flow_control.receiver_group_min_size;
 
     state->error_log = context->error_log;
 
     state->min_flow_control_state.receiver_timeout_ns = options.timeout_ns.is_present ?
-        options.timeout_ns.value : context->tagged_flow_control_timeout_ns;
+        options.timeout_ns.value : context->flow_control.receiver_timeout_ns;
 
     *strategy = _strategy;
 

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -92,61 +92,6 @@ int64_t aeron_min_flow_control_strategy_on_idle(
     return strategy_state->receivers.length > 0 ? min_limit_position : snd_lmt;
 }
 
-static int64_t aeron_tagged_flow_control_apply_position_update(
-    aeron_min_flow_control_strategy_state_t *strategy_state,
-    int64_t position,
-    int64_t window_length,
-    int64_t receiver_id,
-    int64_t snd_lmt,
-    int64_t now_ns,
-    bool is_tagged)
-{
-    bool is_existing = false;
-    int64_t min_position = INT64_MAX;
-
-    for (size_t i = 0; i < strategy_state->receivers.length; i++)
-    {
-        aeron_min_flow_control_strategy_receiver_t *receiver = &strategy_state->receivers.array[i];
-
-        if (is_tagged && receiver_id == receiver->receiver_id)
-        {
-            receiver->last_position = position > receiver->last_position ? position : receiver->last_position;
-            receiver->last_position_plus_window = position + window_length;
-            receiver->time_of_last_status_message = now_ns;
-            is_existing = true;
-        }
-
-        min_position = receiver->last_position_plus_window < min_position ?
-            receiver->last_position_plus_window : min_position;
-    }
-
-    if (is_tagged && !is_existing)
-    {
-        int ensure_capacity_result = 0;
-        AERON_ARRAY_ENSURE_CAPACITY(
-            ensure_capacity_result, strategy_state->receivers, aeron_min_flow_control_strategy_receiver_t);
-
-        if (ensure_capacity_result >= 0)
-        {
-            aeron_min_flow_control_strategy_receiver_t *receiver =
-                &strategy_state->receivers.array[strategy_state->receivers.length++];
-
-            receiver->last_position = position;
-            receiver->last_position_plus_window = position + window_length;
-            receiver->time_of_last_status_message = now_ns;
-            receiver->receiver_id = receiver_id;
-
-            min_position = (position + window_length) < min_position ? (position + window_length) : min_position;
-        }
-        else
-        {
-            min_position = 0 == strategy_state->receivers.length ? snd_lmt : min_position;
-        }
-    }
-
-    return snd_lmt > min_position ? snd_lmt : min_position;
-}
-
 
 int64_t aeron_min_flow_control_strategy_on_sm(
     void *state,
@@ -166,14 +111,52 @@ int64_t aeron_min_flow_control_strategy_on_sm(
         position_bits_to_shift,
         initial_term_id);
 
-    return aeron_tagged_flow_control_apply_position_update(
-        (aeron_min_flow_control_strategy_state_t *)state,
-        position,
-        status_message_header->receiver_window,
-        status_message_header->receiver_id,
-        snd_lmt,
-        now_ns,
-        true);
+    aeron_min_flow_control_strategy_state_t *strategy_state = (aeron_min_flow_control_strategy_state_t *)state;
+    bool is_existing = false;
+    int64_t min_position = INT64_MAX;
+
+    for (size_t i = 0; i < strategy_state->receivers.length; i++)
+    {
+        aeron_min_flow_control_strategy_receiver_t *receiver = &strategy_state->receivers.array[i];
+
+        if (status_message_header->receiver_id == receiver->receiver_id)
+        {
+            receiver->last_position = position > receiver->last_position ? position : receiver->last_position;
+            receiver->last_position_plus_window = position + status_message_header->receiver_window;
+            receiver->time_of_last_status_message = now_ns;
+            is_existing = true;
+        }
+
+        min_position = receiver->last_position_plus_window < min_position ?
+            receiver->last_position_plus_window : min_position;
+    }
+
+    if (!is_existing)
+    {
+        int ensure_capacity_result = 0;
+        AERON_ARRAY_ENSURE_CAPACITY(
+            ensure_capacity_result, strategy_state->receivers, aeron_min_flow_control_strategy_receiver_t);
+
+        if (ensure_capacity_result >= 0)
+        {
+            aeron_min_flow_control_strategy_receiver_t *receiver =
+                &strategy_state->receivers.array[strategy_state->receivers.length++];
+
+            receiver->last_position = position;
+            receiver->last_position_plus_window = position + status_message_header->receiver_window;
+            receiver->time_of_last_status_message = now_ns;
+            receiver->receiver_id = status_message_header->receiver_id;
+
+            min_position = (position + status_message_header->receiver_window) < min_position ?
+                (position + status_message_header->receiver_window) : min_position;
+        }
+        else
+        {
+            min_position = 0 == strategy_state->receivers.length ? snd_lmt : min_position;
+        }
+    }
+
+    return snd_lmt > min_position ? snd_lmt : min_position;
 }
 
 int aeron_min_flow_control_strategy_fini(aeron_flow_control_strategy_t *strategy)
@@ -247,15 +230,33 @@ int64_t aeron_tagged_flow_control_strategy_on_idle(
     int64_t snd_pos,
     bool is_end_of_stream)
 {
-    aeron_tagged_flow_control_strategy_state_t *strategy_state =
-        (aeron_tagged_flow_control_strategy_state_t *)state;
+    aeron_tagged_flow_control_strategy_state_t *strategy_state = (aeron_tagged_flow_control_strategy_state_t *)state;
+    aeron_min_flow_control_strategy_state_t *min_strategy_state = (aeron_min_flow_control_strategy_state_t *)state;
+    int64_t min_limit_position = INT64_MAX;
 
-    return aeron_min_flow_control_strategy_on_idle(
-        &strategy_state->min_flow_control_state,
-        now_ns,
-        snd_lmt,
-        snd_pos,
-        is_end_of_stream);
+    for (int last_index = (int) min_strategy_state->receivers.length - 1, i = last_index; i >= 0; i--)
+    {
+        aeron_min_flow_control_strategy_receiver_t *receiver = &min_strategy_state->receivers.array[i];
+
+        if ((receiver->time_of_last_status_message + min_strategy_state->receiver_timeout_ns) - now_ns < 0)
+        {
+            aeron_array_fast_unordered_remove(
+                (uint8_t *) min_strategy_state->receivers.array,
+                sizeof(aeron_min_flow_control_strategy_receiver_t),
+                (size_t)i,
+                (size_t)last_index);
+            last_index--;
+            min_strategy_state->receivers.length--;
+        }
+        else
+        {
+            min_limit_position = receiver->last_position_plus_window < min_limit_position ?
+                receiver->last_position_plus_window : min_limit_position;
+        }
+    }
+
+    return (int32_t)min_strategy_state->receivers.length < strategy_state->required_group_size ||
+        min_strategy_state->receivers.length == 0 ? snd_lmt : min_limit_position;
 }
 
 int64_t aeron_tagged_flow_control_strategy_on_sm(
@@ -281,8 +282,9 @@ int64_t aeron_tagged_flow_control_strategy_on_sm(
     const int64_t receiver_id = status_message_header->receiver_id;
 
     int64_t sm_receiver_tag;
-    int bytes_read = aeron_udp_protocol_sm_receiver_tag(status_message_header, &sm_receiver_tag);
-    bool was_present = bytes_read == sizeof(sm_receiver_tag);
+    const int bytes_read = aeron_udp_protocol_sm_receiver_tag(status_message_header, &sm_receiver_tag);
+    const bool was_present = bytes_read == sizeof(sm_receiver_tag);
+    int64_t position_plus_window = position + window_length;
 
     if (0 != bytes_read && !was_present)
     {
@@ -293,21 +295,66 @@ int64_t aeron_tagged_flow_control_strategy_on_sm(
             "Received a status message for tagged flow control that did not have 0 or 8 bytes for the receiver_tag");
     }
 
-    bool is_tagged = was_present && sm_receiver_tag == strategy_state->receiver_tag;
-    if (!is_tagged && 0 == strategy_state->min_flow_control_state.receivers.length)
+    const bool is_tagged = was_present && sm_receiver_tag == strategy_state->receiver_tag;
+
+    bool is_existing = false;
+    int64_t min_position = INT64_MAX;
+
+    for (size_t i = 0; i < strategy_state->min_flow_control_state.receivers.length; i++)
     {
-        int64_t position_plus_window = position + window_length;
-        return snd_lmt > position_plus_window ? snd_lmt : position_plus_window;
+        aeron_min_flow_control_strategy_receiver_t *receiver =
+            &strategy_state->min_flow_control_state.receivers.array[i];
+
+        if (is_tagged && receiver_id == receiver->receiver_id)
+        {
+            receiver->last_position = position > receiver->last_position ? position : receiver->last_position;
+            receiver->last_position_plus_window = position + window_length;
+            receiver->time_of_last_status_message = now_ns;
+            is_existing = true;
+        }
+
+        min_position = receiver->last_position_plus_window < min_position ?
+            receiver->last_position_plus_window : min_position;
     }
 
-    return aeron_tagged_flow_control_apply_position_update(
-        &strategy_state->min_flow_control_state,
-        position,
-        window_length,
-        receiver_id,
-        snd_lmt,
-        now_ns,
-        is_tagged);
+    if (is_tagged && !is_existing)
+    {
+        int ensure_capacity_result = 0;
+        AERON_ARRAY_ENSURE_CAPACITY(
+            ensure_capacity_result,
+            strategy_state->min_flow_control_state.receivers,
+            aeron_min_flow_control_strategy_receiver_t);
+
+        if (ensure_capacity_result >= 0)
+        {
+            aeron_min_flow_control_strategy_receiver_t *receiver =
+                &strategy_state->min_flow_control_state.receivers.array[strategy_state->min_flow_control_state.receivers.length++];
+
+            receiver->last_position = position;
+            receiver->last_position_plus_window = position + window_length;
+            receiver->time_of_last_status_message = now_ns;
+            receiver->receiver_id = receiver_id;
+
+            min_position = (position + window_length) < min_position ? (position + window_length) : min_position;
+        }
+        else
+        {
+            min_position = 0 == strategy_state->min_flow_control_state.receivers.length ? snd_lmt : min_position;
+        }
+    }
+
+    if ((int32_t)strategy_state->min_flow_control_state.receivers.length < strategy_state->required_group_size)
+    {
+        return snd_lmt;
+    }
+    else if (strategy_state->min_flow_control_state.receivers.length == 0)
+    {
+        return snd_lmt > position_plus_window ? snd_lmt : position_plus_window;
+    }
+    else
+    {
+        return snd_lmt > min_position ? snd_lmt : min_position;
+    }
 }
 
 int aeron_tagged_flow_control_strategy_fini(aeron_flow_control_strategy_t *strategy)

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -619,10 +619,6 @@ void aeron_network_publication_on_status_message(
         AERON_PUT_ORDERED(publication->has_receivers, true);
     }
 
-    aeron_network_publication_update_connected_status(
-        publication,
-        aeron_network_publication_has_required_receivers(publication));
-
     aeron_counter_set_ordered(
         publication->snd_lmt_position.value_addr,
         publication->flow_control->on_status_message(
@@ -634,6 +630,10 @@ void aeron_network_publication_on_status_message(
             publication->initial_term_id,
             publication->position_bits_to_shift,
             time_ns));
+
+    aeron_network_publication_update_connected_status(
+        publication,
+        aeron_network_publication_has_required_receivers(publication));
 }
 
 void aeron_network_publication_on_rttm(

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -477,22 +477,16 @@ uint64_t aeron_driver_context_get_counters_free_to_reuse_timeout_ns(aeron_driver
  */
 #define AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR "AERON_MIN_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
 
-int aeron_driver_context_set_min_multicast_flow_control_receiver_timeout_ns(
+int aeron_driver_context_set_flow_control_receiver_timeout_ns(
     aeron_driver_context_t *context,
     uint64_t value);
 
-uint64_t aeron_driver_context_get__min_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context);
+uint64_t aeron_driver_context_get_flow_control_receiver_timeout_ns(aeron_driver_context_t *context);
 
 /**
  * Timeout for a tagged receiver to be tracked.
  */
 #define AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT_ENV_VAR "AERON_TAGGED_MULTICAST_FLOW_CONTROL_RECEIVER_TIMEOUT"
-
-int aeron_driver_context_set_tagged_multicast_flow_control_receiver_timeout_ns(
-    aeron_driver_context_t *context,
-    uint64_t value);
-
-uint64_t aeron_driver_context_get__tagged_multicast_flow_control_receiver_timeout_ns(aeron_driver_context_t *context);
 
 /**
  * Default receiver tag for publishers to group endpoints by using tagged flow control.
@@ -505,7 +499,7 @@ int64_t aeron_driver_context_get_flow_control_group_receiver_tag(aeron_driver_co
 /**
  * Default required group size to use in tagged multicast flow control.
  */
-#define AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE_ENV_VAR "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE"
+#define AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_ENV_VAR "AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE"
 
 int aeron_driver_context_set_flow_control_group_required_size(aeron_driver_context_t *context, int32_t value);
 int32_t aeron_driver_context_get_flow_control_group_required_size(aeron_driver_context_t *context);

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -644,22 +644,17 @@ public class Configuration
     public static final String FLOW_CONTROL_GROUP_RECEIVER_TAG_PROP_NAME = "aeron.flow.control.group.rtag";
 
     /**
-     * Property name for default required group size (rtag) used by the tagged flow control strategy to determine
+     * Property name for default minimum group size used by flow control strategies to determine
      * connectivity.
      */
-    public static final String FLOW_CONTROL_GROUP_REQUIRED_SIZE_PROP_NAME = "aeron.flow.control.group.required.size";
+    public static final String FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_PROP_NAME =
+        "aeron.flow.control.receiver.group.min.size";
 
     /**
-     * Property name for tagged flow control timeouts.
+     * Property name for flow control timeouts.
      */
-    public static final String TAGGED_FLOW_CONTROL_TIMEOUT_PROP_NAME =
-        "aeron.tagged.multicast.flow.control.receiver.timeout";
-
-    /**
-     * Property name for min flow control timeouts.
-     */
-    public static final String MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME =
-        "aeron.min.multicast.flow.control.receiver.timeout";
+    public static final String FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME =
+        "aeron.flow.control.receiver.timeout";
 
     private static final String MIN_FLOW_CONTROL_TIMEOUT_OLD_PROP_NAME =
         "aeron.MinMulticastFlowControl.receiverTimeout";
@@ -808,20 +803,15 @@ public class Configuration
         return getLong(FLOW_CONTROL_GROUP_RECEIVER_TAG_PROP_NAME, legacyAsfValue);
     }
 
-    public static int flowControlGroupRequiredSize()
+    public static int flowControlReceiverGroupMinSize()
     {
-        return getInteger(FLOW_CONTROL_GROUP_REQUIRED_SIZE_PROP_NAME, 0);
+        return getInteger(FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_PROP_NAME, 0);
     }
 
-    public static long taggedFlowControlTimeoutNs()
-    {
-        return getDurationInNanos(TAGGED_FLOW_CONTROL_TIMEOUT_PROP_NAME, TimeUnit.SECONDS.toNanos(2));
-    }
-
-    public static long minFlowControlTimeoutNs()
+    public static long flowControlReceiverTimeoutNs()
     {
         return getDurationInNanos(
-            MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME,
+            FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME,
             getDurationInNanos(MIN_FLOW_CONTROL_TIMEOUT_OLD_PROP_NAME, TimeUnit.SECONDS.toNanos(2)));
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -444,12 +444,11 @@ public final class MediaDriver implements AutoCloseable
         private int publicationReservedSessionIdHigh = Configuration.publicationReservedSessionIdHigh();
         private int lossReportBufferLength = Configuration.lossReportBufferLength();
         private int sendToStatusMessagePollRatio = Configuration.sendToStatusMessagePollRatio();
-        private long minFlowControlTimeoutNs = Configuration.minFlowControlTimeoutNs();
-        private long taggedFlowControlTimeoutNs = Configuration.taggedFlowControlTimeoutNs();
+        private long flowControlReceiverTimeoutNs = Configuration.flowControlReceiverTimeoutNs();
 
         private Long receiverTag = Configuration.receiverTag();
         private long flowControlGroupReceiverTag = Configuration.flowControlGroupReceiverTag();
-        private int flowControlGroupRequiredSize = Configuration.flowControlGroupRequiredSize();
+        private int flowControlReceiverGroupMinSize = Configuration.flowControlReceiverGroupMinSize();
         private InferableBoolean receiverGroupConsideration = Configuration.receiverGroupConsideration();
 
         private EpochClock epochClock;
@@ -2279,11 +2278,11 @@ public final class MediaDriver implements AutoCloseable
          * Timeout for min multicast flow control strategy.
          *
          * @return timeout in ns.
-         * @see Configuration#MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME
+         * @see Configuration#FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME
          */
-        public long minFlowControlTimeoutNs()
+        public long flowControlReceiverTimeoutNs()
         {
-            return minFlowControlTimeoutNs;
+            return flowControlReceiverTimeoutNs;
         }
 
         /**
@@ -2291,35 +2290,11 @@ public final class MediaDriver implements AutoCloseable
          *
          * @param timeoutNs in ns.
          * @return this for a fluent API.
-         * @see Configuration#MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME
+         * @see Configuration#FLOW_CONTROL_RECEIVER_TIMEOUT_PROP_NAME
          */
-        public Context minFlowControlTimeoutNs(final long timeoutNs)
+        public Context flowControlReceiverTimeoutNs(final long timeoutNs)
         {
-            this.minFlowControlTimeoutNs = timeoutNs;
-            return this;
-        }
-
-        /**
-         * Timeout for tagged multicast flow control strategy.
-         *
-         * @return timeout in ns.
-         * @see Configuration#MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME
-         */
-        public long taggedFlowControlTimeoutNs()
-        {
-            return taggedFlowControlTimeoutNs;
-        }
-
-        /**
-         * Timeout for tagged multicast flow control strategy.
-         *
-         * @param timeoutNs in ns.
-         * @return this for a fluent API.
-         * @see Configuration#MIN_FLOW_CONTROL_TIMEOUT_PROP_NAME
-         */
-        public Context taggedFlowControlTimeoutNs(final long timeoutNs)
-        {
-            this.taggedFlowControlTimeoutNs = timeoutNs;
+            this.flowControlReceiverTimeoutNs = timeoutNs;
             return this;
         }
 
@@ -2773,26 +2748,26 @@ public final class MediaDriver implements AutoCloseable
         }
 
         /**
-         * Get the default required group size for the tagged flow control strategy to indicate connectivity.
+         * Get the default min group size used by flow control strategies to indicate connectivity.
          *
          * @return required group size.
-         * @see Configuration#FLOW_CONTROL_GROUP_REQUIRED_SIZE_PROP_NAME
+         * @see Configuration#FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_PROP_NAME
          */
-        public int flowControlGroupRequiredSize()
+        public int flowControlReceiverGroupMinSize()
         {
-            return flowControlGroupRequiredSize;
+            return flowControlReceiverGroupMinSize;
         }
 
         /**
-         * Set the default required group size for the tagged flow control strategy to indicate connectivity.
+         * Set the default min group size used by flow control strategies to indicate connectivity.
          *
          * @param groupSize minimum required group size used by the tagged flow control strategy.
          * @return this for fluent API.
-         * @see Configuration#FLOW_CONTROL_GROUP_REQUIRED_SIZE_PROP_NAME
+         * @see Configuration#FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE_PROP_NAME
          */
-        public Context flowControlGroupRequiredSize(final int groupSize)
+        public Context flowControlReceiverGroupMinSize(final int groupSize)
         {
-            this.flowControlGroupRequiredSize = groupSize;
+            this.flowControlReceiverGroupMinSize = groupSize;
             return this;
         }
 
@@ -3277,12 +3252,11 @@ public final class MediaDriver implements AutoCloseable
                 "\n    tempBuffer=" + tempBuffer +
                 "\n    unicastFlowControlSupplier=" + unicastFlowControlSupplier +
                 "\n    multicastFlowControlSupplier=" + multicastFlowControlSupplier +
-                "\n    minFlowControlTimeoutNs=" + minFlowControlTimeoutNs +
-                "\n    taggedFlowControlTimeoutNs=" + taggedFlowControlTimeoutNs +
                 "\n    applicationSpecificFeedback=" + Arrays.toString(applicationSpecificFeedback) +
                 "\n    receiverTag=" + receiverTag +
+                "\n    flowControlReceiverTimeoutNs=" + flowControlReceiverTimeoutNs +
+                "\n    flowControlReceiverGroupMinSize=" + flowControlReceiverGroupMinSize +
                 "\n    flowControlGroupReceiverTag=" + flowControlGroupReceiverTag +
-                "\n    flowControlGroupRequiredSize=" + flowControlGroupRequiredSize +
                 "\n    receiverGroupConsideration=" + receiverGroupConsideration +
                 "\n    congestionControlSupplier=" + congestionControlSupplier +
                 "\n    terminationValidator=" + terminationValidator +

--- a/aeron-driver/src/main/java/io/aeron/driver/MinMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MinMulticastFlowControl.java
@@ -52,7 +52,7 @@ public class MinMulticastFlowControl implements FlowControl
         final int initialTermId,
         final int termBufferLength)
     {
-        receiverTimeoutNs = context.minFlowControlTimeoutNs();
+        receiverTimeoutNs = context.flowControlReceiverTimeoutNs();
         final String fcValue = udpChannel.channelUri().get(CommonContext.FLOW_CONTROL_PARAM_NAME);
         if (null != fcValue)
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
@@ -155,8 +155,18 @@ public class TaggedMulticastFlowControl implements FlowControl
             minPosition = Math.min(minPosition, lastPositionPlusWindow);
         }
 
-        return receivers.length > 0 ?
-            Math.max(senderLimit, minPosition) : Math.max(senderLimit, lastPositionPlusWindow);
+        if (receivers.length < requiredGroupSize)
+        {
+            return senderLimit;
+        }
+        else if (receivers.length == 0)
+        {
+            return Math.max(senderLimit, lastPositionPlusWindow);
+        }
+        else
+        {
+            return Math.max(senderLimit, minPosition);
+        }
     }
 
     /**
@@ -191,7 +201,7 @@ public class TaggedMulticastFlowControl implements FlowControl
             this.receivers = receivers;
         }
 
-        return receivers.length > 0 ? minLimitPosition : senderLimit;
+        return receivers.length < requiredGroupSize || receivers.length == 0 ? senderLimit : minLimitPosition;
     }
 
     public boolean hasRequiredReceivers()

--- a/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TaggedMulticastFlowControl.java
@@ -72,9 +72,9 @@ public class TaggedMulticastFlowControl implements FlowControl
         final int initialTermId,
         final int termBufferLength)
     {
-        receiverTimeoutNs = context.taggedFlowControlTimeoutNs();
+        receiverTimeoutNs = context.flowControlReceiverTimeoutNs();
         receiverTag = context.flowControlGroupReceiverTag();
-        requiredGroupSize = context.flowControlGroupRequiredSize();
+        requiredGroupSize = context.flowControlReceiverGroupMinSize();
 
         final String fcValue = udpChannel.channelUri().get(CommonContext.FLOW_CONTROL_PARAM_NAME);
 

--- a/aeron-driver/src/test/c/aeron_flow_control_test.cpp
+++ b/aeron-driver/src/test/c/aeron_flow_control_test.cpp
@@ -445,8 +445,8 @@ TEST_P(ParameterisedSuccessfulOptionsParsingTest, shouldBeValid)
     ASSERT_EQ(std::get<2>(GetParam()), options.timeout_ns.value);
     ASSERT_EQ(std::get<3>(GetParam()), options.receiver_tag.is_present);
     ASSERT_EQ(std::get<4>(GetParam()), options.receiver_tag.value);
-    ASSERT_EQ(std::get<5>(GetParam()), options.required_group_size.is_present);
-    ASSERT_EQ(std::get<6>(GetParam()), options.required_group_size.value);
+    ASSERT_EQ(std::get<5>(GetParam()), options.group_min_size.is_present);
+    ASSERT_EQ(std::get<6>(GetParam()), options.group_min_size.value);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/aeron-driver/src/test/c/aeron_flow_control_test.cpp
+++ b/aeron-driver/src/test/c/aeron_flow_control_test.cpp
@@ -251,8 +251,8 @@ TEST_F(FlowControlTest, shouldUseFallbackToTaggedStrategy)
     context->multicast_flow_control_supplier_func = aeron_tagged_flow_control_strategy_supplier;
     context->sm_receiver_tag.is_present = true;
     context->sm_receiver_tag.value = 1;
-    context->flow_control_group.receiver_tag = 1;
-    context->flow_control_group.required_size = 0;
+    context->flow_control.group_receiver_tag = 1;
+    context->flow_control.receiver_group_min_size = 0;
 
     ASSERT_EQ(0, aeron_default_multicast_flow_control_strategy_supplier(
         &strategy, context, channel,

--- a/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
@@ -1,6 +1,8 @@
 package io.aeron.driver;
 
 import io.aeron.driver.media.UdpChannel;
+import io.aeron.protocol.StatusMessageFlyweight;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -16,6 +18,9 @@ class TaggedMulticastFlowControlTest
     private static final int DEFAULT_GROUP_SIZE = 0;
     private static final long DEFAULT_RECEIVER_TAG = Configuration.flowControlGroupReceiverTag();
     private static final long DEFAULT_TIMEOUT = Configuration.flowControlReceiverTimeoutNs();
+    private static final int WINDOW_LENGTH = 16 * 1024;
+
+    private final TaggedMulticastFlowControl flowControl = new TaggedMulticastFlowControl();
 
     private static Stream<Arguments> validUris()
     {
@@ -51,7 +56,6 @@ class TaggedMulticastFlowControlTest
     void shouldParseValidFlowControlConfiguration(
         final String uri, final long receiverTag, final int groupSize, final long timeout)
     {
-        final TaggedMulticastFlowControl flowControl = new TaggedMulticastFlowControl();
         flowControl.initialize(new MediaDriver.Context(), UdpChannel.parse(uri), 0, 0);
 
         assertEquals(receiverTag, flowControl.receiverTag());
@@ -70,10 +74,75 @@ class TaggedMulticastFlowControlTest
     })
     void shouldFailWithInvalidUris(final String uri)
     {
-        final TaggedMulticastFlowControl flowControl = new TaggedMulticastFlowControl();
-
         assertThrows(
             Exception.class,
             () -> flowControl.initialize(new MediaDriver.Context(), UdpChannel.parse(uri), 0, 0));
+    }
+
+    @Test
+    void shouldClampToSenderLimitUntilMinimumGroupSizeIsMet()
+    {
+        final UdpChannel channelGroupSizeThree = UdpChannel.parse(
+            "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost|fc=tagged,g:123/3");
+
+        flowControl.initialize(new MediaDriver.Context(), channelGroupSizeThree, 0, 0);
+        final long receiverTag = 123L;
+
+        final long senderLimit = 5000L;
+        final int termOffset = 10_000;
+
+        assertEquals(senderLimit, onStatusMessage(flowControl, 0, termOffset, senderLimit, null));
+        assertEquals(senderLimit, onIdle(flowControl, senderLimit));
+        assertEquals(senderLimit, onStatusMessage(flowControl, 1, termOffset, senderLimit, receiverTag));
+        assertEquals(senderLimit, onIdle(flowControl, senderLimit));
+        assertEquals(senderLimit, onStatusMessage(flowControl, 2, termOffset, senderLimit, receiverTag));
+        assertEquals(senderLimit, onIdle(flowControl, senderLimit));
+        assertEquals(senderLimit, onStatusMessage(flowControl, 3, termOffset, senderLimit, null));
+        assertEquals(senderLimit, onIdle(flowControl, senderLimit));
+        assertEquals(termOffset + WINDOW_LENGTH, onStatusMessage(flowControl, 4, termOffset, senderLimit, receiverTag));
+        assertEquals(termOffset + WINDOW_LENGTH, onIdle(flowControl, senderLimit));
+    }
+
+    @Test
+    void shouldReturnLastWindowWhenUntilReceiversAreInGroupWithNoMinSize()
+    {
+        final UdpChannel channelGroupSizeThree = UdpChannel.parse(
+            "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost|fc=tagged,g:123");
+
+        flowControl.initialize(new MediaDriver.Context(), channelGroupSizeThree, 0, 0);
+        final long receiverTag = 123L;
+
+        final long senderLimit = 5000L;
+        final int termOffset0 = 10_000;
+        final int termOffset1 = 9_999;
+
+        assertEquals(termOffset0 + WINDOW_LENGTH, onStatusMessage(flowControl, 0, termOffset0, senderLimit, null));
+        assertEquals(
+            termOffset1 + WINDOW_LENGTH, onStatusMessage(flowControl, 1, termOffset1, senderLimit, receiverTag));
+        assertEquals(termOffset1 + WINDOW_LENGTH, onStatusMessage(flowControl, 0, termOffset0, senderLimit, null));
+    }
+
+    private long onStatusMessage(
+        TaggedMulticastFlowControl flowControl,
+        long receiverId,
+        int termOffset,
+        long senderLimit,
+        Long receiverTag)
+    {
+        final StatusMessageFlyweight statusMessageFlyweight = new StatusMessageFlyweight();
+        statusMessageFlyweight.wrap(new byte[1024]);
+
+        statusMessageFlyweight.receiverId(receiverId);
+        statusMessageFlyweight.consumptionTermId(0);
+        statusMessageFlyweight.consumptionTermOffset(termOffset);
+        statusMessageFlyweight.receiverTag(receiverTag);
+        statusMessageFlyweight.receiverWindowLength(WINDOW_LENGTH);
+
+        return flowControl.onStatusMessage(statusMessageFlyweight, null, senderLimit, 0, 0, 0);
+    }
+
+    private long onIdle(final TaggedMulticastFlowControl flowControl, final long senderLimit)
+    {
+        return flowControl.onIdle(0, senderLimit, 0, false);
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
@@ -15,7 +15,7 @@ class TaggedMulticastFlowControlTest
 {
     private static final int DEFAULT_GROUP_SIZE = 0;
     private static final long DEFAULT_RECEIVER_TAG = Configuration.flowControlGroupReceiverTag();
-    private static final long DEFAULT_TIMEOUT = Configuration.taggedFlowControlTimeoutNs();
+    private static final long DEFAULT_TIMEOUT = Configuration.flowControlReceiverTimeoutNs();
 
     private static Stream<Arguments> validUris()
     {

--- a/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TaggedMulticastFlowControlTest.java
@@ -59,7 +59,7 @@ class TaggedMulticastFlowControlTest
         flowControl.initialize(new MediaDriver.Context(), UdpChannel.parse(uri), 0, 0);
 
         assertEquals(receiverTag, flowControl.receiverTag());
-        assertEquals(groupSize, flowControl.requiredGroupSize());
+        assertEquals(groupSize, flowControl.groupMinSize());
         assertEquals(timeout, flowControl.receiverTimeoutNs());
     }
 
@@ -123,11 +123,11 @@ class TaggedMulticastFlowControlTest
     }
 
     private long onStatusMessage(
-        TaggedMulticastFlowControl flowControl,
-        long receiverId,
-        int termOffset,
-        long senderLimit,
-        Long receiverTag)
+        final TaggedMulticastFlowControl flowControl,
+        final long receiverId,
+        final int termOffset,
+        final long senderLimit,
+        final Long receiverTag)
     {
         final StatusMessageFlyweight statusMessageFlyweight = new StatusMessageFlyweight();
         statusMessageFlyweight.wrap(new byte[1024]);

--- a/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlTest.java
@@ -141,6 +141,7 @@ public class TaggedFlowControlTest
             {
                 driverBContext.receiverTag(receiverTag);
             }
+            driverAContext.flowControlReceiverGroupMinSize(1);
 
             launch();
 

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -131,7 +131,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         }
         pb.environment().put("AERON_FLOW_CONTROL_GROUP_RTAG", String.valueOf(context.flowControlGroupReceiverTag()));
         pb.environment().put(
-            "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE", String.valueOf(context.flowControlReceiverGroupMinSize()));
+            "AERON_FLOW_CONTROL_RECEIVER_GROUP_MIN_SIZE", String.valueOf(context.flowControlReceiverGroupMinSize()));
         pb.environment().put("AERON_PRINT_CONFIGURATION", "true");
         pb.environment().put("AERON_EVENT_LOG", "0xFFFF");
 

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -131,7 +131,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         }
         pb.environment().put("AERON_FLOW_CONTROL_GROUP_RTAG", String.valueOf(context.flowControlGroupReceiverTag()));
         pb.environment().put(
-            "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE", String.valueOf(context.flowControlGroupRequiredSize()));
+            "AERON_FLOW_CONTROL_GROUP_REQUIRED_SIZE", String.valueOf(context.flowControlReceiverGroupMinSize()));
         pb.environment().put("AERON_PRINT_CONFIGURATION", "true");
         pb.environment().put("AERON_EVENT_LOG", "0xFFFF");
 


### PR DESCRIPTION
- Use groupMinSize and the name to require a group of a particular size to indicate connectivity in tagged multicast flow control.
- Fix bug in C driver around use of flow control to handle connectivity.
- Use senderLimit as the position returned from tagged flow control (onStatusMessage, onIdle) when the group size had not been met.
- Tests.