### PR TITLE
Replay merge test update

### DIFF
--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -93,7 +93,7 @@ public class ReplayMergeTest
     private ArchivingMediaDriver archivingMediaDriver;
     private Aeron aeron;
     private AeronArchive aeronArchive;
-    private int messagesPublished;
+    private int messagesPublished = 0;
 
     @BeforeEach
     public void before()
@@ -135,7 +135,8 @@ public class ReplayMergeTest
     {
         if (received.get() != MIN_MESSAGES_PER_TERM * 6)
         {
-            System.out.println("received " + received.get() + "/" + (MIN_MESSAGES_PER_TERM * 6));
+            System.out.println(
+                "received " + received.get() + ", sent " + messagesPublished + ", total" + (MIN_MESSAGES_PER_TERM * 6));
         }
 
         CloseHelper.closeAll(aeronArchive, aeron, archivingMediaDriver);
@@ -173,6 +174,7 @@ public class ReplayMergeTest
                 final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 putMessages(publication, initialMessageCount, MESSAGE_PREFIX);
+                messagesPublished += initialMessageCount;
                 awaitPosition(counters, counterId, publication.position());
 
                 try (Subscription subscription = aeron.addSubscription(subscriptionChannel, STREAM_ID);
@@ -188,6 +190,7 @@ public class ReplayMergeTest
                     for (int i = initialMessageCount; i < totalMessageCount; i++)
                     {
                         putMessage(publication, i, MESSAGE_PREFIX);
+                        messagesPublished++;
 
                         if (0 == replayMerge.poll(fragmentHandler, FRAGMENT_LIMIT))
                         {

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -20,7 +20,6 @@ import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.client.ReplayMerge;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
-import io.aeron.driver.MinMulticastFlowControl;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.DataHeaderFlyweight;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.concurrent.TimeUnit;
 
 import static io.aeron.archive.Common.*;
 import static io.aeron.archive.codecs.SourceLocation.REMOTE;
@@ -95,6 +93,7 @@ public class ReplayMergeTest
     private ArchivingMediaDriver archivingMediaDriver;
     private Aeron aeron;
     private AeronArchive aeronArchive;
+    private int messagesPublished;
 
     @BeforeEach
     public void before()
@@ -173,7 +172,7 @@ public class ReplayMergeTest
                 final int counterId = awaitRecordingCounterId(counters, publication.sessionId());
                 final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
-                offerMessages(publication, initialMessageCount, MESSAGE_PREFIX);
+                putMessages(publication, initialMessageCount, MESSAGE_PREFIX);
                 awaitPosition(counters, counterId, publication.position());
 
                 try (Subscription subscription = aeron.addSubscription(subscriptionChannel, STREAM_ID);
@@ -188,7 +187,7 @@ public class ReplayMergeTest
                 {
                     for (int i = initialMessageCount; i < totalMessageCount; i++)
                     {
-                        offer(publication, i, MESSAGE_PREFIX);
+                        putMessage(publication, i, MESSAGE_PREFIX);
 
                         if (0 == replayMerge.poll(fragmentHandler, FRAGMENT_LIMIT))
                         {
@@ -239,7 +238,7 @@ public class ReplayMergeTest
         });
     }
 
-    private void offer(final Publication publication, final int index, final String prefix)
+    private void putMessage(final Publication publication, final int index, final String prefix)
     {
         final int length = buffer.putStringWithoutLengthAscii(0, prefix + index);
 
@@ -250,11 +249,11 @@ public class ReplayMergeTest
         }
     }
 
-    private void offerMessages(final Publication publication, final int count, final String prefix)
+    private void putMessages(final Publication publication, final int count, final String prefix)
     {
         for (int i = 0; i < count; i++)
         {
-            offer(publication, i, prefix);
+            putMessage(publication, i, prefix);
         }
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -16,6 +16,9 @@
 package io.aeron.test;
 
 import org.agrona.LangUtil;
+import org.opentest4j.AssertionFailedError;
+
+import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
@@ -67,5 +70,28 @@ public class Tests
             LangUtil.rethrowUnchecked(exception);
             return null;
         }).when(mock).close();
+    }
+
+    public static void runWithTimeout(final Duration duration, final Runnable r)
+    {
+        final long deadlineMs = System.currentTimeMillis() + duration.toMillis();
+        do
+        {
+            try
+            {
+                r.run();
+                Thread.yield();
+                Tests.checkInterruptedStatus();
+                return;
+            }
+            catch (final AssertionFailedError e)
+            {
+                if (System.currentTimeMillis() >= deadlineMs)
+                {
+                    throw e;
+                }
+            }
+        }
+        while (true);
     }
 }


### PR DESCRIPTION
Changed the ReplayMergeTest to take a different approach with regards to timeouts.  It would be useful to merge in a see whether this provides better feedback on the failures seen from that test.

- Renames test methods for clarity.
- Outputs messages send as well as received.
- Runs loops as lamdbas with separate timeouts using assertions to determine exit conditions.