### PR TITLE
[C] Windows fixes, next part

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ elseif (CYGWIN)
 elseif (MSVC)
     add_definitions(-DWIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D_CRT_NONSTDC_NO_WARNINGS)
     add_definitions(-DNOMINMAX)
 
     if (${MSVC_VERSION} GREATER_EQUAL 1915)

--- a/aeron-driver/src/main/c/aeron_agent.c
+++ b/aeron-driver/src/main/c/aeron_agent.c
@@ -418,11 +418,7 @@ static void *agent_main(void *arg)
 {
     aeron_agent_runner_t *runner = (aeron_agent_runner_t *)arg;
 
-#if defined(Darwin)
     aeron_thread_set_name(runner->role_name);
-#else
-    aeron_thread_set_name(aeron_thread_self(), runner->role_name);
-#endif
 
     if (NULL != runner->on_start)
     {

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -40,13 +40,17 @@
     #include <Windows.h>
 
     #define S_IRWXU 0
-    int mkdir(const char *path, int permission)
+    static int aeron_mkdir(const char *path, int permission)
     {
         return _mkdir(path);
     }
 
 #else
-#include <unistd.h>
+
+    #include <unistd.h>
+
+    #define aeron_mkdir mkdir
+
 #endif
 
 #include <inttypes.h>
@@ -281,7 +285,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_t *driver)
         }
     }
 
-    if (mkdir(driver->context->aeron_dir, S_IRWXU) != 0)
+    if (aeron_mkdir(driver->context->aeron_dir, S_IRWXU) != 0)
     {
         int errcode = errno;
         aeron_set_err(errcode, "mkdir %s: %s", driver->context->aeron_dir, strerror(errcode));
@@ -289,7 +293,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_t *driver)
     }
 
     snprintf(buffer, sizeof(buffer) - 1, "%s/%s", dirname, AERON_PUBLICATIONS_DIR);
-    if (mkdir(buffer, S_IRWXU) != 0)
+    if (aeron_mkdir(buffer, S_IRWXU) != 0)
     {
         int errcode = errno;
         aeron_set_err(errcode, "mkdir %s: %s", buffer, strerror(errcode));
@@ -297,7 +301,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_t *driver)
     }
 
     snprintf(buffer, sizeof(buffer) - 1, "%s/%s", dirname, AERON_IMAGES_DIR);
-    if (mkdir(buffer, S_IRWXU) != 0)
+    if (aeron_mkdir(buffer, S_IRWXU) != 0)
     {
         int errcode = errno;
         aeron_set_err(errcode, "mkdir %s: %s", buffer, strerror(errcode));

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -369,7 +369,8 @@ int aeron_driver_create_loss_report_file(aeron_driver_t *driver)
 
 int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *driver)
 {
-    int result = -1, probe_fd;
+    int result = -1;
+    aeron_socket_t probe_fd;
 
     if ((probe_fd = aeron_socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {

--- a/aeron-driver/src/main/c/aeron_socket.c
+++ b/aeron-driver/src/main/c/aeron_socket.c
@@ -27,7 +27,7 @@ void aeron_net_init()
 {
 }
 
-int set_socket_non_blocking(aeron_fd_t fd)
+int set_socket_non_blocking(aeron_socket_t fd)
 {
     int flags;
     if ((flags = fcntl(fd, F_GETFL, 0)) < 0)
@@ -44,12 +44,12 @@ int set_socket_non_blocking(aeron_fd_t fd)
     return 0;
 }
 
-int aeron_socket(int domain, int type, int protocol)
+aeron_socket_t aeron_socket(int domain, int type, int protocol)
 {
     return socket(domain, type, protocol);
 }
 
-void aeron_close_socket(int socket)
+void aeron_close_socket(aeron_socket_t socket)
 {
     close(socket);
 }
@@ -76,7 +76,7 @@ void aeron_net_init()
     }
 }
 
-int set_socket_non_blocking(aeron_fd_t fd)
+int set_socket_non_blocking(aeron_socket_t fd)
 {
     u_long iMode = 1;
     int iResult = ioctlsocket(fd, FIONBIO, &iMode);
@@ -257,7 +257,7 @@ void freeifaddrs(struct ifaddrs *current)
 #include <iphlpapi.h>
 #include <stdio.h>
 
-ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
+ssize_t recvmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags)
 {
     DWORD size = 0;
     const int result = WSARecvFrom(
@@ -285,7 +285,7 @@ ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
     return size;
 }
 
-ssize_t sendmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
+ssize_t sendmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags)
 {
     DWORD size = 0;
     const int result = WSASendTo(
@@ -318,13 +318,14 @@ int poll(struct pollfd* fds, nfds_t nfds, int timeout)
     return WSAPoll(fds, nfds, timeout);
 }
 
-int aeron_socket(int domain, int type, int protocol)
+aeron_socket_t aeron_socket(int domain, int type, int protocol)
 {
     aeron_net_init();
-    return socket(domain, type, protocol);
+    const SOCKET handle = socket(domain, type, protocol);
+    return handle != INVALID_SOCKET ? handle : -1;
 }
 
-void aeron_close_socket(int socket)
+void aeron_close_socket(aeron_socket_t socket)
 {
     closesocket(socket);
 }

--- a/aeron-driver/src/main/c/aeron_socket.h
+++ b/aeron-driver/src/main/c/aeron_socket.h
@@ -20,12 +20,6 @@
 #include <util/aeron_platform.h>
 #include <stdint.h>
 
-typedef int aeron_fd_t;
-int set_socket_non_blocking(aeron_fd_t fd);
-int aeron_socket(int domain, int type, int protocol);
-void aeron_close_socket(int socket);
-void aeron_net_init();
-
 #if defined(AERON_COMPILER_GCC)
     #include <netinet/in.h>
     #include <sys/socket.h>
@@ -35,12 +29,17 @@ void aeron_net_init();
     #include <netdb.h>
     #include <ifaddrs.h>
 
+    typedef int aeron_socket_t;
+
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
     #include <WinSock2.h>
     #include <windows.h>
     #include <Ws2ipdef.h>
     #include <WS2tcpip.h>
     #include <Iphlpapi.h>
+
+    // SOCKET is uint64_t but we need a signed type to match the Linux version
+    typedef int64_t aeron_socket_t;
 
     struct iovec
     {
@@ -89,12 +88,17 @@ void aeron_net_init();
     typedef unsigned long int nfds_t;
     typedef SSIZE_T ssize_t;
 
-    ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags);
-    ssize_t sendmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags);
+    ssize_t recvmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags);
+    ssize_t sendmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags);
     int poll(struct pollfd* fds, nfds_t nfds, int timeout);
 
 #else
 #error Unsupported platform!
 #endif
+
+int set_socket_non_blocking(aeron_socket_t fd);
+aeron_socket_t aeron_socket(int domain, int type, int protocol);
+void aeron_close_socket(aeron_socket_t socket);
+void aeron_net_init();
 
 #endif //AERON_SOCKET_H

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
@@ -76,6 +76,7 @@ void aeron_distinct_error_log_close(aeron_distinct_error_log_t *log)
     }
 
     aeron_free(log->observation_list);
+    aeron_mutex_destroy(&log->mutex);
 }
 
 static aeron_distinct_observation_t *aeron_distinct_error_log_find_observation(

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
@@ -69,7 +69,7 @@ typedef struct aeron_distinct_error_log_stct
     aeron_clock_func_t clock;
     aeron_resource_linger_func_t linger_resource;
     void *linger_resource_clientd;
-    AERON_MUTEX mutex;
+    aeron_mutex_t mutex;
 }
 aeron_distinct_error_log_t;
 

--- a/aeron-driver/src/main/c/concurrent/aeron_thread.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_thread.c
@@ -19,15 +19,15 @@
 void aeron_nano_sleep(uint64_t nanoseconds)
 {
 #ifdef AERON_COMPILER_MSVC
-    HANDLE timer;
-    LARGE_INTEGER li;
-
-    if (!(timer = CreateWaitableTimer(NULL, TRUE, NULL)))
+    HANDLE timer = CreateWaitableTimer(NULL, TRUE, NULL);
+    if (!timer)
     {
         return;
     }
 
-    li.QuadPart = -nanoseconds;
+    LARGE_INTEGER li;
+    li.QuadPart = -(int64_t)(nanoseconds / 100);
+
     if (!SetWaitableTimer(timer, &li, 0, NULL, NULL, FALSE))
     {
         CloseHandle(timer);

--- a/aeron-driver/src/main/c/concurrent/aeron_thread.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_thread.h
@@ -26,7 +26,7 @@ void aeron_thread_set_name(const char* role_name);
 #if defined(AERON_COMPILER_GCC)
 
     #include <pthread.h>
-    #define AERON_MUTEX pthread_mutex_t
+    typedef pthread_mutex_t aeron_mutex_t;
     #define AERON_INIT_ONCE pthread_once_t
     #define AERON_INIT_ONCE_VALUE PTHREAD_ONCE_INIT
 
@@ -34,6 +34,7 @@ void aeron_thread_set_name(const char* role_name);
     #define aeron_mutex_init pthread_mutex_init
     #define aeron_mutex_lock pthread_mutex_lock
     #define aeron_mutex_unlock pthread_mutex_unlock
+    #define aeron_mutex_destroy pthread_mutex_destroy
     #define aeron_thread_once pthread_once
     #define aeron_thread_attr_init pthread_attr_init
     #define aeron_thread_create pthread_create
@@ -49,7 +50,7 @@ void aeron_thread_set_name(const char* role_name);
     #include <windows.h>
     #include <winnt.h>
 
-    #define AERON_MUTEX HANDLE
+    typedef HANDLE aeron_mutex_t;
 
     typedef struct
     {
@@ -68,26 +69,19 @@ void aeron_thread_set_name(const char* role_name);
 
     void aeron_thread_once(AERON_INIT_ONCE* s_init_once, void* callback);
 
-    void aeron_mutex_init(HANDLE* mutex, void* attr);
-
-    void aeron_mutex_lock(HANDLE* mutex);
-
-    void aeron_mutex_unlock(HANDLE* mutex);
+    int aeron_mutex_init(aeron_mutex_t* mutex, void* attr);
+    int aeron_mutex_destroy(aeron_mutex_t* mutex);
+    int aeron_mutex_lock(aeron_mutex_t* mutex);
+    int aeron_mutex_unlock(aeron_mutex_t* mutex);
 
     int aeron_thread_attr_init(pthread_attr_t* attr);
-
     int aeron_thread_create(aeron_thread_t* thread, void* attr, void*(*callback)(void*), void* arg0);
-
     int aeron_thread_join(aeron_thread_t thread, void **value_ptr);
 
     int aeron_thread_key_create(pthread_key_t *key, void(*destr_function) (void *));
-
     int aeron_thread_key_delete(pthread_key_t key);
-
     int aeron_thread_set_specific(pthread_key_t key, const void *pointer);
-
     void* aeron_thread_get_specific(pthread_key_t key);
-
 
 #else
 #error Unsupported platform!

--- a/aeron-driver/src/main/c/concurrent/aeron_thread.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_thread.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 
+void aeron_thread_set_name(const char* role_name);
 
 #if defined(AERON_COMPILER_GCC)
 
@@ -36,8 +37,6 @@
     #define aeron_thread_once pthread_once
     #define aeron_thread_attr_init pthread_attr_init
     #define aeron_thread_create pthread_create
-    #define aeron_thread_set_name pthread_setname_np
-    #define aeron_thread_self pthread_self
     #define aeron_thread_join pthread_join
     #define aeron_thread_key_create pthread_key_create
     #define aeron_thread_key_delete pthread_key_delete
@@ -52,7 +51,13 @@
 
     #define AERON_MUTEX HANDLE
 
-    typedef HANDLE aeron_thread_t;
+    typedef struct
+    {
+        HANDLE handle;
+        void* (*callback)(void*);
+        void* arg0;
+        void* result;
+    } aeron_thread_t;
 
     typedef INIT_ONCE AERON_INIT_ONCE;
 
@@ -73,11 +78,7 @@
 
     int aeron_thread_create(aeron_thread_t* thread, void* attr, void*(*callback)(void*), void* arg0);
 
-    void aeron_thread_set_name(aeron_thread_t self, const char* role_name);
-
-    aeron_thread_t aeron_thread_self();
-
-    DWORD aeron_thread_join(aeron_thread_t thread, void **value_ptr);
+    int aeron_thread_join(aeron_thread_t thread, void **value_ptr);
 
     int aeron_thread_key_create(pthread_key_t *key, void(*destr_function) (void *));
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
@@ -24,7 +24,7 @@
 
 typedef struct aeron_udp_channel_transport_stct
 {
-    aeron_fd_t fd;
+    aeron_socket_t fd;
     aeron_udp_channel_data_paths_t *data_paths;
     void *dispatch_clientd;
     void *bindings_clientd;

--- a/aeron-driver/src/main/c/util/aeron_fileutil.c
+++ b/aeron-driver/src/main/c/util/aeron_fileutil.c
@@ -45,28 +45,6 @@
 
 static int aeron_mmap(aeron_mapped_file_t *mapping, int fd, off_t offset)
 {
-    size_t length = mapping->length;
-    size_t len;
-    struct stat st;
-    const uint32_t l = offset & 0xFFFFFFFF;
-    const uint32_t h = (offset >> 32) & 0xFFFFFFFF;
-
-    if (!fstat(fd, &st))
-    {
-        len = (size_t)st.st_size;
-    }
-    else
-    {
-        fprintf(stderr, "mmap: could not determine file length");
-        close(fd);
-        return -1;
-    }
-
-    if (length + offset > len)
-    {
-        length = len - offset;
-    }
-
     HANDLE hmap = CreateFileMapping((HANDLE)_get_osfhandle(fd), 0, PAGE_READWRITE, 0, 0, 0);
 
     if (!hmap)
@@ -76,7 +54,7 @@ static int aeron_mmap(aeron_mapped_file_t *mapping, int fd, off_t offset)
         return -1;
     }
 
-    mapping->addr = MapViewOfFileEx(hmap, FILE_MAP_WRITE, h, l, length, NULL);
+    mapping->addr = MapViewOfFileEx(hmap, FILE_MAP_WRITE, 0, offset, mapping->length, NULL);
 
     if (!CloseHandle(hmap))
     {

--- a/aeron-driver/src/main/c/util/aeron_http_util.c
+++ b/aeron-driver/src/main/c/util/aeron_http_util.c
@@ -241,7 +241,7 @@ static char aeron_http_request_format[] =
 int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64_t timeout_ns)
 {
     aeron_http_parsed_url_t parsed_url;
-    int sock;
+    aeron_socket_t sock;
     aeron_http_response_t *_response = NULL;
 
     *response = NULL;


### PR DESCRIPTION
These are larger fixes than in my last PR, I recommend reviewing this commit-by-commit.

The remaining warnings that MSVC outputs are:
 - Various assignments of `size_t` values to `int` (I'm surprised GCC doesn't warn about those)
 - `getsockopt` and `setsockopt` have a `char*` type for the value instead of `void*`. It would be nice to have an `aeron_*` version of those to deal with those warnings if you're OK with that.

Also, errors aren't currently logged properly on Windows ([`strerror` is kind of useless](https://docs.microsoft.com/en-us/cpp/c-language/strerror-function?view=vs-2019) and `errno` isn't used by winsock). Fixing that would require replacing calls to `aeron_set_err` that use `strerror` with something similar to what `aeron_set_windows_error` does. I'm not yet sure about the best way to do it, but would you agree to such a change in principle?
