### PR TITLE
[C] Fix sockets on Windows

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -369,7 +369,8 @@ int aeron_driver_create_loss_report_file(aeron_driver_t *driver)
 
 int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *driver)
 {
-    int result = -1, probe_fd;
+    int result = -1;
+    aeron_socket_t probe_fd;
 
     if ((probe_fd = aeron_socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {

--- a/aeron-driver/src/main/c/aeron_socket.c
+++ b/aeron-driver/src/main/c/aeron_socket.c
@@ -27,7 +27,7 @@ void aeron_net_init()
 {
 }
 
-int set_socket_non_blocking(aeron_fd_t fd)
+int set_socket_non_blocking(aeron_socket_t fd)
 {
     int flags;
     if ((flags = fcntl(fd, F_GETFL, 0)) < 0)
@@ -44,12 +44,12 @@ int set_socket_non_blocking(aeron_fd_t fd)
     return 0;
 }
 
-int aeron_socket(int domain, int type, int protocol)
+aeron_socket_t aeron_socket(int domain, int type, int protocol)
 {
     return socket(domain, type, protocol);
 }
 
-void aeron_close_socket(int socket)
+void aeron_close_socket(aeron_socket_t socket)
 {
     close(socket);
 }
@@ -76,7 +76,7 @@ void aeron_net_init()
     }
 }
 
-int set_socket_non_blocking(aeron_fd_t fd)
+int set_socket_non_blocking(aeron_socket_t fd)
 {
     u_long iMode = 1;
     int iResult = ioctlsocket(fd, FIONBIO, &iMode);
@@ -257,7 +257,7 @@ void freeifaddrs(struct ifaddrs *current)
 #include <iphlpapi.h>
 #include <stdio.h>
 
-ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
+ssize_t recvmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags)
 {
     DWORD size = 0;
     const int result = WSARecvFrom(
@@ -285,7 +285,7 @@ ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
     return size;
 }
 
-ssize_t sendmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags)
+ssize_t sendmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags)
 {
     DWORD size = 0;
     const int result = WSASendTo(
@@ -318,13 +318,14 @@ int poll(struct pollfd* fds, nfds_t nfds, int timeout)
     return WSAPoll(fds, nfds, timeout);
 }
 
-int aeron_socket(int domain, int type, int protocol)
+aeron_socket_t aeron_socket(int domain, int type, int protocol)
 {
     aeron_net_init();
-    return socket(domain, type, protocol);
+    const SOCKET handle = socket(domain, type, protocol);
+    return handle != INVALID_SOCKET ? handle : -1;
 }
 
-void aeron_close_socket(int socket)
+void aeron_close_socket(aeron_socket_t socket)
 {
     closesocket(socket);
 }

--- a/aeron-driver/src/main/c/aeron_socket.h
+++ b/aeron-driver/src/main/c/aeron_socket.h
@@ -20,12 +20,6 @@
 #include <util/aeron_platform.h>
 #include <stdint.h>
 
-typedef int aeron_fd_t;
-int set_socket_non_blocking(aeron_fd_t fd);
-int aeron_socket(int domain, int type, int protocol);
-void aeron_close_socket(int socket);
-void aeron_net_init();
-
 #if defined(AERON_COMPILER_GCC)
     #include <netinet/in.h>
     #include <sys/socket.h>
@@ -35,12 +29,17 @@ void aeron_net_init();
     #include <netdb.h>
     #include <ifaddrs.h>
 
+    typedef int aeron_socket_t;
+
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
     #include <WinSock2.h>
     #include <windows.h>
     #include <Ws2ipdef.h>
     #include <WS2tcpip.h>
     #include <Iphlpapi.h>
+
+    // SOCKET is uint64_t but we need a signed type to match the Linux version
+    typedef int64_t aeron_socket_t;
 
     struct iovec
     {
@@ -89,12 +88,17 @@ void aeron_net_init();
     typedef unsigned long int nfds_t;
     typedef SSIZE_T ssize_t;
 
-    ssize_t recvmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags);
-    ssize_t sendmsg(aeron_fd_t fd, struct msghdr* msghdr, int flags);
+    ssize_t recvmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags);
+    ssize_t sendmsg(aeron_socket_t fd, struct msghdr* msghdr, int flags);
     int poll(struct pollfd* fds, nfds_t nfds, int timeout);
 
 #else
 #error Unsupported platform!
 #endif
+
+int set_socket_non_blocking(aeron_socket_t fd);
+aeron_socket_t aeron_socket(int domain, int type, int protocol);
+void aeron_close_socket(aeron_socket_t socket);
+void aeron_net_init();
 
 #endif //AERON_SOCKET_H

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
@@ -24,7 +24,7 @@
 
 typedef struct aeron_udp_channel_transport_stct
 {
-    aeron_fd_t fd;
+    aeron_socket_t fd;
     aeron_udp_channel_data_paths_t *data_paths;
     void *dispatch_clientd;
     void *bindings_clientd;

--- a/aeron-driver/src/main/c/util/aeron_http_util.c
+++ b/aeron-driver/src/main/c/util/aeron_http_util.c
@@ -241,7 +241,7 @@ static char aeron_http_request_format[] =
 int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64_t timeout_ns)
 {
     aeron_http_parsed_url_t parsed_url;
-    int sock;
+    aeron_socket_t sock;
     aeron_http_response_t *_response = NULL;
 
     *response = NULL;


### PR DESCRIPTION
 - The `SOCKET` type was incorrectly cast to `int`, even though it's larger
 - Renamed `aeron_fd_t` to `aeron_socket_t` as a socket handle is not a file descriptor on Windows

Part of #863 