### PR TITLE
[C] Fix mutexes on Windows

### DIFF
--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
@@ -76,6 +76,7 @@ void aeron_distinct_error_log_close(aeron_distinct_error_log_t *log)
     }
 
     aeron_free(log->observation_list);
+    aeron_mutex_destroy(&log->mutex);
 }
 
 static aeron_distinct_observation_t *aeron_distinct_error_log_find_observation(

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.h
@@ -69,7 +69,7 @@ typedef struct aeron_distinct_error_log_stct
     aeron_clock_func_t clock;
     aeron_resource_linger_func_t linger_resource;
     void *linger_resource_clientd;
-    AERON_MUTEX mutex;
+    aeron_mutex_t mutex;
 }
 aeron_distinct_error_log_t;
 

--- a/aeron-driver/src/main/c/concurrent/aeron_thread.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_thread.c
@@ -55,19 +55,32 @@ void aeron_thread_once(AERON_INIT_ONCE* s_init_once, void* callback)
     InitOnceExecuteOnce(s_init_once, aeron_thread_once_callback, callback, NULL);
 }
 
-void aeron_mutex_init(HANDLE* mutex, void* attr)
+int aeron_mutex_init(aeron_mutex_t* mutex, void* attr)
 {
     *mutex = CreateMutexA(NULL, FALSE, NULL);
+    return *mutex ? 0 : -1;
 }
 
-void aeron_mutex_lock(HANDLE* mutex)
+int aeron_mutex_lock(aeron_mutex_t* mutex)
 {
-    WaitForSingleObject(mutex, INFINITE);
+    return WaitForSingleObject(*mutex, INFINITE) == WAIT_OBJECT_0 ? 0 : EINVAL;
 }
 
-void aeron_mutex_unlock(HANDLE* mutex)
+int aeron_mutex_unlock(aeron_mutex_t* mutex)
 {
-    ReleaseMutex(mutex);
+    return ReleaseMutex(*mutex) ? 0 : EINVAL;
+}
+
+int aeron_mutex_destroy(aeron_mutex_t* mutex)
+{
+    if (*mutex)
+    {
+        CloseHandle(*mutex);
+        *mutex = 0;
+        return 0;
+    }
+
+    return EINVAL;
 }
 
 int aeron_thread_attr_init(pthread_attr_t* attr)

--- a/aeron-driver/src/main/c/concurrent/aeron_thread.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_thread.h
@@ -25,7 +25,7 @@
 #if defined(AERON_COMPILER_GCC)
 
     #include <pthread.h>
-    #define AERON_MUTEX pthread_mutex_t
+    typedef pthread_mutex_t aeron_mutex_t;
     #define AERON_INIT_ONCE pthread_once_t
     #define AERON_INIT_ONCE_VALUE PTHREAD_ONCE_INIT
 
@@ -33,6 +33,7 @@
     #define aeron_mutex_init pthread_mutex_init
     #define aeron_mutex_lock pthread_mutex_lock
     #define aeron_mutex_unlock pthread_mutex_unlock
+    #define aeron_mutex_destroy pthread_mutex_destroy
     #define aeron_thread_once pthread_once
     #define aeron_thread_attr_init pthread_attr_init
     #define aeron_thread_create pthread_create
@@ -50,7 +51,7 @@
     #include <windows.h>
     #include <winnt.h>
 
-    #define AERON_MUTEX HANDLE
+    typedef HANDLE aeron_mutex_t;
 
     typedef HANDLE aeron_thread_t;
 
@@ -63,11 +64,10 @@
 
     void aeron_thread_once(AERON_INIT_ONCE* s_init_once, void* callback);
 
-    void aeron_mutex_init(HANDLE* mutex, void* attr);
-
-    void aeron_mutex_lock(HANDLE* mutex);
-
-    void aeron_mutex_unlock(HANDLE* mutex);
+    int aeron_mutex_init(aeron_mutex_t* mutex, void* attr);
+    int aeron_mutex_destroy(aeron_mutex_t* mutex);
+    int aeron_mutex_lock(aeron_mutex_t* mutex);
+    int aeron_mutex_unlock(aeron_mutex_t* mutex);
 
     int aeron_thread_attr_init(pthread_attr_t* attr);
 


### PR DESCRIPTION
 - Lock/unlock did not work as an indirection was missing
 - Made the function prototypes match the Linux version
 - Added `aeron_mutex_destroy`

Part of #863 