### PR TITLE
[C] Refactor error handling to improve error messages on Windows

### DIFF
--- a/aeron-driver/src/main/c/aeron_agent.c
+++ b/aeron-driver/src/main/c/aeron_agent.c
@@ -47,9 +47,7 @@ int aeron_idle_strategy_sleeping_init_args(void **state, const char *env_var, co
 {
     if (aeron_alloc((void **)state, sizeof(uint64_t)) < 0)
     {
-        int err_code = errno;
-
-        aeron_set_err(err_code, "%s:%d: %s", __FILE__, __LINE__, strerror(err_code));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -168,9 +166,7 @@ int aeron_idle_strategy_backoff_state_init(
 {
     if (aeron_alloc((void **)state, sizeof(aeron_idle_strategy_backoff_state_t)) < 0)
     {
-        int err_code = errno;
-
-        aeron_set_err(err_code, "%s:%d: %s", __FILE__, __LINE__, strerror(err_code));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -399,9 +395,7 @@ int aeron_agent_init(
     runner->on_close = on_close;
     if (aeron_alloc((void **)&runner->role_name, role_name_length + 1) < 0)
     {
-        int err_code = errno;
-
-        aeron_set_err(err_code, "%s:%d: %s", __FILE__, __LINE__, strerror(err_code));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
     memcpy((char *)runner->role_name, role_name, role_name_length);

--- a/aeron-driver/src/main/c/aeron_alloc.c
+++ b/aeron-driver/src/main/c/aeron_alloc.c
@@ -20,6 +20,10 @@
 #include "util/aeron_bitutil.h"
 #include "aeron_alloc.h"
 
+#if defined(AERON_COMPILER_MSVC)
+#include <windows.h>
+#endif
+
 int aeron_alloc_no_err(void **ptr, size_t size)
 {
     *ptr = malloc(size);
@@ -41,6 +45,9 @@ int aeron_alloc(void **ptr, size_t size)
     if (NULL == *ptr)
     {
         errno = ENOMEM;
+#if defined(AERON_COMPILER_MSVC)
+        SetLastError(ERROR_OUTOFMEMORY);
+#endif
         return -1;
     }
 
@@ -54,6 +61,9 @@ int aeron_alloc_aligned(void **ptr, size_t *offset, size_t size, size_t alignmen
     if (!(AERON_IS_POWER_OF_TWO(alignment)))
     {
         errno = EINVAL;
+#if defined(AERON_COMPILER_MSVC)
+        SetLastError(ERROR_INCORRECT_SIZE);
+#endif
         return -1;
     }
 
@@ -83,6 +93,9 @@ int aeron_reallocf(void **ptr, size_t size)
         {
             free(*ptr);
             errno = ENOMEM;
+#if defined(AERON_COMPILER_MSVC)
+            SetLastError(ERROR_OUTOFMEMORY);
+#endif
             return -1;
         }
     }

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -27,18 +27,14 @@ int aeron_data_packet_dispatcher_init(
     if (aeron_int64_to_ptr_hash_map_init(
         &dispatcher->ignored_sessions_map, 16, AERON_INT64_TO_PTR_HASH_MAP_DEFAULT_LOAD_FACTOR) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not init ignored_session_map: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not init ignored_session_map");
         return -1;
     }
 
     if (aeron_int64_to_ptr_hash_map_init(
         &dispatcher->session_by_stream_id_map, 16, AERON_INT64_TO_PTR_HASH_MAP_DEFAULT_LOAD_FACTOR) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not init session_by_stream_id_map: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not init session_by_stream_id_map");
         return -1;
     }
 
@@ -75,9 +71,7 @@ int aeron_data_packet_dispatcher_add_subscription(aeron_data_packet_dispatcher_t
             aeron_int64_to_ptr_hash_map_init(session_map, 16, AERON_INT64_TO_PTR_HASH_MAP_DEFAULT_LOAD_FACTOR) < 0 ||
             aeron_int64_to_ptr_hash_map_put(&dispatcher->session_by_stream_id_map, stream_id, session_map) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "could not aeron_data_packet_dispatcher_add_subscription: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("could not aeron_data_packet_dispatcher_add_subscription");
             return -1;
         }
     }
@@ -108,9 +102,7 @@ int aeron_data_packet_dispatcher_add_publication_image(
     {
         if (aeron_int64_to_ptr_hash_map_put(session_map, image->session_id, image) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "could not aeron_data_packet_dispatcher_add_publication_image: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("could not aeron_data_packet_dispatcher_add_publication_image");
             return -1;
         }
 
@@ -147,9 +139,7 @@ int aeron_data_packet_dispatcher_remove_publication_image(
         aeron_int64_to_ptr_hash_map_compound_key(image->session_id, image->stream_id),
         &dispatcher->tokens.on_cool_down) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not aeron_data_packet_dispatcher_remove_publication_image: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not aeron_data_packet_dispatcher_remove_publication_image");
         return -1;
     }
 
@@ -218,9 +208,7 @@ int aeron_data_packet_dispatcher_on_setup(
                 aeron_int64_to_ptr_hash_map_compound_key(header->session_id, header->stream_id),
                 &dispatcher->tokens.init_in_progress) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "could not aeron_data_packet_dispatcher_on_setup: %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("could not aeron_data_packet_dispatcher_on_setup");
                 return -1;
             }
 
@@ -295,9 +283,7 @@ int aeron_data_packet_dispatcher_elicit_setup_from_source(
         aeron_int64_to_ptr_hash_map_compound_key(session_id, stream_id),
         &dispatcher->tokens.pending_setup_frame) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not aeron_data_packet_dispatcher_remove_publication_image: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not aeron_data_packet_dispatcher_remove_publication_image");
         return -1;
     }
 

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -223,9 +223,7 @@ int aeron_report_existing_errors(aeron_mapped_file_t *cnc_map, const char *aeron
         }
         else
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             result = -1;
         }
     }
@@ -287,24 +285,21 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_t *driver)
 
     if (aeron_mkdir(driver->context->aeron_dir, S_IRWXU) != 0)
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "mkdir %s: %s", driver->context->aeron_dir, strerror(errcode));
+        aeron_set_err_from_last_err_code("mkdir %s", driver->context->aeron_dir);
         return -1;
     }
 
     snprintf(buffer, sizeof(buffer) - 1, "%s/%s", dirname, AERON_PUBLICATIONS_DIR);
     if (aeron_mkdir(buffer, S_IRWXU) != 0)
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "mkdir %s: %s", buffer, strerror(errcode));
+        aeron_set_err_from_last_err_code("mkdir %s", buffer);
         return -1;
     }
 
     snprintf(buffer, sizeof(buffer) - 1, "%s/%s", dirname, AERON_IMAGES_DIR);
     if (aeron_mkdir(buffer, S_IRWXU) != 0)
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "mkdir %s: %s", buffer, strerror(errcode));
+        aeron_set_err_from_last_err_code("mkdir %s", buffer);
         return -1;
     }
 
@@ -378,9 +373,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
 
     if ((probe_fd = aeron_socket(AF_INET, SOCK_DGRAM, 0)) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "socket %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("socket %s:%d", __FILE__, __LINE__);
         goto cleanup;
     }
 
@@ -388,9 +381,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     socklen_t len = sizeof(default_sndbuf);
     if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("getsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
         goto cleanup;
     }
 
@@ -398,9 +389,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     len = sizeof(default_rcvbuf);
     if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
         goto cleanup;
     }
 
@@ -413,18 +402,14 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
 
         if (setsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
         len = sizeof(socket_sndbuf);
         if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, &len) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "getsockopt(SO_SNDBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("getsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
@@ -447,18 +432,14 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
 
         if (setsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
         len = sizeof(socket_rcvbuf);
         if (getsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, &len) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
@@ -769,9 +750,7 @@ int aeron_driver_init(aeron_driver_t **driver, aeron_driver_context_t *context)
 
     if (aeron_alloc((void **)&_driver, sizeof(aeron_driver_t)) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         goto error;
     }
 

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -55,9 +55,7 @@ int aeron_driver_receiver_init(
             AERON_DRIVER_RECEIVER_MAX_UDP_PACKET_LENGTH,
             AERON_CACHE_LINE_LENGTH) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             return -1;
         }
 
@@ -407,9 +405,7 @@ int aeron_driver_receiver_add_pending_setup(
 
     if (ensure_capacity_result < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "receiver add_pending_setup: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("receiver add_pending_setup");
         return ensure_capacity_result;
     }
 

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -56,9 +56,7 @@ int aeron_driver_sender_init(
             context->mtu_length,
             AERON_CACHE_LINE_LENGTH) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             return -1;
         }
 

--- a/aeron-driver/src/main/c/aeron_retransmit_handler.c
+++ b/aeron-driver/src/main/c/aeron_retransmit_handler.c
@@ -29,9 +29,7 @@ int aeron_retransmit_handler_init(
     if (aeron_int64_to_ptr_hash_map_init(
         &handler->active_retransmits_map, 8, AERON_INT64_TO_PTR_HASH_MAP_DEFAULT_LOAD_FACTOR) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not init retransmit handler map: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not init retransmit handler map");
         return -1;
     }
 
@@ -125,9 +123,7 @@ int aeron_retransmit_handler_on_nak(
 
             if (aeron_int64_to_ptr_hash_map_put(&handler->active_retransmits_map, key, action) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "could not put retransmit handler map: %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("could not put retransmit handler map");
                 return -1;
             }
         }

--- a/aeron-driver/src/main/c/aeron_system_counters.c
+++ b/aeron-driver/src/main/c/aeron_system_counters.c
@@ -62,9 +62,7 @@ int aeron_system_counters_init(aeron_system_counters_t *counters, aeron_counters
     counters->manager = manager;
     if (aeron_alloc((void **)&counters->counter_ids, sizeof(int32_t) * num_system_counters) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 

--- a/aeron-driver/src/main/c/collections/aeron_int64_to_ptr_hash_map.h
+++ b/aeron-driver/src/main/c/collections/aeron_int64_to_ptr_hash_map.h
@@ -21,6 +21,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
+
+#include "util/aeron_platform.h"
+
+#if defined(AERON_COMPILER_MSVC)
+#include <WinSock2.h>
+#include <windows.h>
+#endif
+
 #include "util/aeron_bitutil.h"
 #include "aeron_alloc.h"
 
@@ -136,6 +144,9 @@ inline int aeron_int64_to_ptr_hash_map_put(aeron_int64_to_ptr_hash_map_t *map, c
     if (NULL == value)
     {
         errno = EINVAL;
+#if defined(AERON_COMPILER_MSVC)
+        SetLastError(ERROR_BAD_ARGUMENTS);
+#endif
         return -1;
     }
 

--- a/aeron-driver/src/main/c/collections/aeron_str_to_ptr_hash_map.h
+++ b/aeron-driver/src/main/c/collections/aeron_str_to_ptr_hash_map.h
@@ -21,6 +21,14 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
+
+#include "util/aeron_platform.h"
+
+#if defined(AERON_COMPILER_MSVC)
+#include <WinSock2.h>
+#include <windows.h>
+#endif
+
 #include "aeron_alloc.h"
 #include "util/aeron_bitutil.h"
 #include "util/aeron_strutil.h"
@@ -74,17 +82,13 @@ inline int aeron_str_to_ptr_hash_map_init(
 
     if (aeron_alloc((void **)&map->keys, (capacity * sizeof(aeron_str_to_ptr_hash_map_key_t))) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
     if (aeron_alloc((void **)&map->values, (capacity * sizeof(void *))) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -114,17 +118,13 @@ inline int aeron_str_to_ptr_hash_map_rehash(aeron_str_to_ptr_hash_map_t *map, si
 
     if (aeron_alloc((void **)&tmp_keys, (new_capacity * sizeof(aeron_str_to_ptr_hash_map_key_t))) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
     if (aeron_alloc((void **)&tmp_values, (new_capacity * sizeof(void *))) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -164,6 +164,9 @@ inline int aeron_str_to_ptr_hash_map_put(aeron_str_to_ptr_hash_map_t *map, const
     if (NULL == value)
     {
         errno = EINVAL;
+#if defined(AERON_COMPILER_MSVC)
+        SetLastError(ERROR_BAD_ARGUMENTS);
+#endif
         return -1;
     }
 

--- a/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
+++ b/aeron-driver/src/main/c/concurrent/aeron_distinct_error_log.c
@@ -45,9 +45,7 @@ int aeron_distinct_error_log_init(
 
     if (aeron_alloc((void **)&log->observation_list, sizeof(aeron_distinct_error_log_observation_list_t)) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -200,6 +198,9 @@ int aeron_distinct_error_log_record(
             aeron_format_date(buffer, sizeof(buffer), timestamp);
             fprintf(stderr, "%s - unrecordable error %d: %s %s\n", buffer, error_code, description, message);
             errno = ENOMEM;
+#if defined(AERON_COMPILER_MSVC)
+            SetLastError(ERROR_OUTOFMEMORY);
+#endif
             return -1;
         }
     }

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -66,9 +66,7 @@ int aeron_receive_channel_endpoint_create(
 
     if (aeron_alloc((void **)&_endpoint, sizeof(aeron_receive_channel_endpoint_t)) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not allocate receive_channel_endpoint: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not allocate receive_channel_endpoint");
         return -1;
     }
 
@@ -81,9 +79,7 @@ int aeron_receive_channel_endpoint_create(
     if (aeron_int64_to_ptr_hash_map_init(
         &_endpoint->stream_id_to_refcnt_map, 16, AERON_INT64_TO_PTR_HASH_MAP_DEFAULT_LOAD_FACTOR) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "could not init stream_id_to_refcnt_map: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("could not init stream_id_to_refcnt_map");
         return -1;
     }
 
@@ -431,18 +427,14 @@ int32_t aeron_receive_channel_endpoint_incref_to_stream(
 
         if (aeron_alloc((void **)&count, sizeof(aeron_stream_id_refcnt_t)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "could not allocate aeron_stream_id_refcnt: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("could not allocate aeron_stream_id_refcnt");
             return -1;
         }
 
         count->refcnt = 0;
         if (aeron_int64_to_ptr_hash_map_put(&endpoint->stream_id_to_refcnt_map, stream_id, count) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "could not put aeron_stream_id_refcnt: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("could not put aeron_stream_id_refcnt");
             return -1;
         }
 

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -218,7 +218,7 @@ int aeron_send_channel_endpoint_add_publication(
     int result = aeron_int64_to_ptr_hash_map_put(&endpoint->publication_dispatch_map, key_value, publication);
     if (result < 0)
     {
-        aeron_set_err(errno, "send_channel_endpoint_add(hash_map): %s", strerror(errno));
+        aeron_set_err_from_last_err_code("send_channel_endpoint_add(hash_map)");
     }
 
     return result;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -74,9 +74,7 @@ int aeron_udp_channel_transport_init(
     {
         if (bind(transport->fd, (struct sockaddr *)bind_addr, bind_addr_len) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "unicast bind: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("unicast bind");
             goto error;
         }
     }
@@ -87,9 +85,7 @@ int aeron_udp_channel_transport_init(
 #if defined(SO_REUSEADDR)
         if (setsockopt(transport->fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_REUSEADDR): %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_REUSEADDR)");
             goto error;
         }
 #endif
@@ -97,9 +93,7 @@ int aeron_udp_channel_transport_init(
 #if defined(SO_REUSEPORT)
         if (setsockopt(transport->fd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_REUSEPORT): %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_REUSEPORT)");
             goto error;
         }
 #endif
@@ -112,9 +106,7 @@ int aeron_udp_channel_transport_init(
 
             if (bind(transport->fd, (struct sockaddr *) &addr, bind_addr_len) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "multicast IPv6 bind: %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("multicast IPv6 bind");
                 goto error;
             }
 
@@ -125,18 +117,14 @@ int aeron_udp_channel_transport_init(
 
             if (setsockopt(transport->fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq, sizeof(mreq)) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "setsockopt(IPV6_JOIN_GROUP): %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("setsockopt(IPV6_JOIN_GROUP)");
                 goto error;
             }
 
             if (setsockopt(
                 transport->fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &multicast_if_index, sizeof(multicast_if_index)) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "setsockopt(IPV6_MULTICAST_IF): %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("setsockopt(IPV6_MULTICAST_IF)");
                 goto error;
             }
 
@@ -144,9 +132,7 @@ int aeron_udp_channel_transport_init(
             {
                 if (setsockopt(transport->fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &ttl, sizeof(ttl)) < 0)
                 {
-                    int errcode = errno;
-
-                    aeron_set_err(errcode, "setsockopt(IPV6_MULTICAST_HOPS): %s", strerror(errcode));
+                    aeron_set_err_from_last_err_code("setsockopt(IPV6_MULTICAST_HOPS)");
                     goto error;
                 }
             }
@@ -159,9 +145,7 @@ int aeron_udp_channel_transport_init(
 
             if (bind(transport->fd, (struct sockaddr *) &addr, bind_addr_len) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "multicast IPv4 bind: %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("multicast IPv4 bind");
                 goto error;
             }
 
@@ -173,17 +157,13 @@ int aeron_udp_channel_transport_init(
 
             if (setsockopt(transport->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "setsockopt(IP_ADD_MEMBERSHIP): %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("setsockopt(IP_ADD_MEMBERSHIP)");
                 goto error;
             }
 
             if (setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_IF, &interface_addr->sin_addr, sizeof(struct in_addr)) < 0)
             {
-                int errcode = errno;
-
-                aeron_set_err(errcode, "setsockopt(IP_MULTICAST_IF): %s", strerror(errcode));
+                aeron_set_err_from_last_err_code("setsockopt(IP_MULTICAST_IF)");
                 goto error;
             }
 
@@ -191,9 +171,7 @@ int aeron_udp_channel_transport_init(
             {
                 if (setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
                 {
-                    int errcode = errno;
-
-                    aeron_set_err(errcode, "setsockopt(IP_MULTICAST_TTL): %s", strerror(errcode));
+                    aeron_set_err_from_last_err_code("setsockopt(IP_MULTICAST_TTL)");
                     goto error;
                 }
             }
@@ -204,9 +182,7 @@ int aeron_udp_channel_transport_init(
     {
         if (setsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_RCVBUF): %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_RCVBUF)");
             goto error;
         }
     }
@@ -215,9 +191,7 @@ int aeron_udp_channel_transport_init(
     {
         if (setsockopt(transport->fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
         {
-            int errcode = errno;
-
-            aeron_set_err(errcode, "setsockopt(SO_SNDBUF): %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("setsockopt(SO_SNDBUF)");
             goto error;
         }
     }
@@ -225,9 +199,7 @@ int aeron_udp_channel_transport_init(
 
     if (set_socket_non_blocking(transport->fd) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "set_socket_non_blocking: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("set_socket_non_blocking");
         goto error;
     }
 
@@ -274,7 +246,7 @@ int aeron_udp_channel_transport_recvmmsg(
             return 0;
         }
 
-        aeron_set_err(err, "recvmmsg: %s", strerror(err));
+        aeron_set_err_from_last_err_code("recvmmsg");
         return -1;
     }
     else if (0 == result)
@@ -313,7 +285,7 @@ int aeron_udp_channel_transport_recvmmsg(
                 break;
             }
 
-            aeron_set_err(err, "recvmsg: %s", strerror(err));
+            aeron_set_err_from_last_err_code("recvmsg");
             return -1;
         }
 
@@ -348,7 +320,7 @@ int aeron_udp_channel_transport_sendmmsg(
     int sendmmsg_result = sendmmsg(transport->fd, msgvec, vlen, 0);
     if (sendmmsg_result < 0)
     {
-        aeron_set_err(errno, "sendmmsg: %s", strerror(errno));
+        aeron_set_err_from_last_err_code("sendmmsg");
         return -1;
     }
 
@@ -361,7 +333,7 @@ int aeron_udp_channel_transport_sendmmsg(
         ssize_t sendmsg_result = sendmsg(transport->fd, &msgvec[i].msg_hdr, 0);
         if (sendmsg_result < 0)
         {
-            aeron_set_err(errno, "sendmsg: %s", strerror(errno));
+            aeron_set_err_from_last_err_code("sendmsg");
             return -1;
         }
 
@@ -387,7 +359,7 @@ int aeron_udp_channel_transport_sendmsg(
     ssize_t sendmsg_result = sendmsg(transport->fd, message, 0);
     if (sendmsg_result < 0)
     {
-        aeron_set_err(errno, "sendmsg: %s", strerror(errno));
+        aeron_set_err_from_last_err_code("sendmsg");
         return -1;
     }
 
@@ -400,9 +372,7 @@ int aeron_udp_channel_transport_get_so_rcvbuf(aeron_udp_channel_transport_t *tra
 
     if (getsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, so_rcvbuf, &len) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "getsockopt(SO_RCVBUF) %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
         return -1;
     }
 
@@ -417,9 +387,7 @@ int aeron_udp_channel_transport_bind_addr_and_port(
 
     if (getsockname(transport->fd, (struct sockaddr *)&addr, &addr_len) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "getsockname %s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("getsockname %s:%d", __FILE__, __LINE__);
         return -1;
     }
 

--- a/aeron-driver/src/main/c/media/aeron_udp_transport_poller.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_transport_poller.c
@@ -37,7 +37,7 @@ int aeron_udp_transport_poller_init(
 #if defined(HAVE_EPOLL)
     if ((poller->epoll_fd = epoll_create1(0)) < 0)
     {
-        aeron_set_err(errno, "epoll_create1: %s", strerror(errno));
+        aeron_set_err_from_last_err_code("epoll_create1");
         return -1;
     }
     poller->epoll_events = NULL;
@@ -93,7 +93,7 @@ int aeron_udp_transport_poller_add(aeron_udp_transport_poller_t *poller, aeron_u
     int result = epoll_ctl(poller->epoll_fd, EPOLL_CTL_ADD, transport->fd, &event);
     if (result < 0)
     {
-        aeron_set_err(errno, "epoll_ctl(EPOLL_CTL_ADD): %s", strerror(errno));
+        aeron_set_err_from_last_err_code("epoll_ctl(EPOLL_CTL_ADD)");
         return -1;
     }
 
@@ -154,7 +154,7 @@ int aeron_udp_transport_poller_remove(aeron_udp_transport_poller_t *poller, aero
         int result = epoll_ctl(poller->epoll_fd, EPOLL_CTL_DEL, transport->fd, &event);
         if (result < 0)
         {
-            aeron_set_err(errno, "epoll_ctl(EPOLL_CTL_DEL): %s", strerror(errno));
+            aeron_set_err_from_last_err_code("epoll_ctl(EPOLL_CTL_DEL)");
             return -1;
         }
 
@@ -210,7 +210,7 @@ int aeron_udp_transport_poller_poll(
                 return 0;
             }
 
-            aeron_set_err(err, "epoll_wait: %s", strerror(err));
+            aeron_set_err_from_last_err_code("epoll_wait");
             return -1;
         }
         else if (0 == result)
@@ -250,7 +250,7 @@ int aeron_udp_transport_poller_poll(
                 return 0;
             }
 
-            aeron_set_err(err, "poll: %s", strerror(err));
+            aeron_set_err_from_last_err_code("poll");
             return -1;
         }
         else if (0 == result)

--- a/aeron-driver/src/main/c/util/aeron_error.h
+++ b/aeron-driver/src/main/c/util/aeron_error.h
@@ -29,11 +29,11 @@ aeron_per_thread_error_t;
 int aeron_errcode();
 const char *aeron_errmsg();
 void aeron_set_err(int errcode, const char *format, ...);
+void aeron_set_err_from_last_err_code(const char* format, ...);
 
 const char *aeron_error_code_str(int errcode);
 
 #if defined(AERON_COMPILER_MSVC)
-void aeron_set_windows_error();
 bool aeron_error_dll_process_attach();
 void aeron_error_dll_thread_detach();
 void aeron_error_dll_process_detach();

--- a/aeron-driver/src/main/c/util/aeron_fileutil.c
+++ b/aeron-driver/src/main/c/util/aeron_fileutil.c
@@ -49,7 +49,7 @@ static int aeron_mmap(aeron_mapped_file_t *mapping, int fd, off_t offset)
 
     if (!hmap)
     {
-        aeron_set_windows_error();
+        aeron_set_err_from_last_err_code("CreateFileMapping");
         close(fd);
         return -1;
     }
@@ -176,8 +176,7 @@ static int unlink_func(const char *path, const struct stat *sb, int type_flag, s
 {
     if (remove(path) != 0)
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "could not remove %s: %s", path, strerror(errcode));
+        aeron_set_err_from_last_err_code("could not remove %s", path);
     }
 
     return 0;
@@ -250,20 +249,17 @@ int aeron_map_new_file(aeron_mapped_file_t *mapped_file, const char *path, bool 
             }
             else
             {
-                int errcode = errno;
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             }
         }
         else
         {
-            int errcode = errno;
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         }
     }
     else
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
     }
 
     return result;
@@ -286,20 +282,17 @@ int aeron_map_existing_file(aeron_mapped_file_t *mapped_file, const char *path)
             }
             else
             {
-                int errcode = errno;
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             }
         }
         else
         {
-            int errcode = errno;
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         }
     }
     else
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
     }
 
     return result;
@@ -369,8 +362,7 @@ int aeron_map_raw_log(
 
             if (aeron_mmap(&mapped_raw_log->mapped_file, fd, 0) < 0)
             {
-                int errcode = errno;
-                aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+                aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
                 return -1;
             }
 
@@ -394,14 +386,12 @@ int aeron_map_raw_log(
         }
         else
         {
-            int errcode = errno;
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
         }
     }
     else
     {
-        int errcode = errno;
-        aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+        aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
     }
 
     return result;
@@ -420,8 +410,7 @@ int aeron_map_raw_log_close(aeron_mapped_raw_log_t *mapped_raw_log, const char *
 
         if (NULL != filename && remove(filename) < 0)
         {
-            int errcode = errno;
-            aeron_set_err(errcode, "%s:%d: %s", __FILE__, __LINE__, strerror(errcode));
+            aeron_set_err_from_last_err_code("%s:%d", __FILE__, __LINE__);
             return -1;
         }
 

--- a/aeron-driver/src/main/c/util/aeron_http_util.c
+++ b/aeron-driver/src/main/c/util/aeron_http_util.c
@@ -260,9 +260,7 @@ int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64
 
     if (connect(sock, (struct sockaddr *)&parsed_url.address, addr_len) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "http connect: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("http connect");
         goto error;
     }
 
@@ -273,25 +271,19 @@ int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64
 
     if (length < 0 || (sent_length = send(sock, request, (size_t)length, 0)) < length)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "http sent %" PRId64 "/%d bytes: %s", (uint64_t)sent_length, length, strerror(errcode));
+        aeron_set_err_from_last_err_code("http sent %" PRId64 "/%d bytes", (uint64_t)sent_length, length);
         goto error;
     }
 
     if (set_socket_non_blocking(sock) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "http set_socket_non_blocking: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("http set_socket_non_blocking");
         goto error;
     }
 
     if (aeron_alloc((void **)&_response, sizeof(aeron_http_response_t)) < 0)
     {
-        int errcode = errno;
-
-        aeron_set_err(errcode, "http alloc response: %s", strerror(errcode));
+        aeron_set_err_from_last_err_code("http alloc response");
         goto error;
     }
 
@@ -333,7 +325,7 @@ int aeron_http_retrieve(aeron_http_response_t **response, const char *url, int64
                 continue;
             }
 
-            aeron_set_err(errcode, "http recv: %s", strerror(errcode));
+            aeron_set_err_from_last_err_code("http recv");
             goto error;
         }
 

--- a/aeron-driver/src/main/c/util/aeron_properties_util.c
+++ b/aeron-driver/src/main/c/util/aeron_properties_util.c
@@ -241,9 +241,7 @@ int aeron_properties_file_load(const char *filename)
 
     if (!feof(fpin))
     {
-        int err_code = errno;
-
-        aeron_set_err(err_code, "error reading file: %s", strerror(err_code));
+        aeron_set_err_from_last_err_code("error reading file");
         goto cleanup;
     }
     else


### PR DESCRIPTION
The issue I'm trying to solve:

 - WinAPI functions return error codes through `GetLastError()`, not through `errno`
 - `strerror` is [not very useful](https://docs.microsoft.com/en-us/cpp/c-language/strerror-function?view=vs-2019) on Windows, so mapping error codes wouldn't work

I came up with this refactor which I hope you'll find acceptable. It ends up simplifying the `aeron_set_err` calls.

I've added an `aeron_set_err_from_last_err_code` function which will act the same way as `aeron_set_err`, except it will automatically append an error message based on the last error code. This will use `GetLastError` and `FormatMessage` on Windows, and `strerror(errno)` on other platforms.

 - This will still work on Windows with the C library file I/O calls, since they call WinAPI
 - WinSock returns errors through `WSAGetLastError`, but this is an alias to `GetLastError`
 - I added a couple `SetLastError` calls in a few places which set `errno` themselves
 - Some places like the `strto*` calls continue to use `errno`
