### PR TITLE
[C] Fix remaining MSVC warnings in the media driver

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -379,7 +379,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
 
     size_t default_sndbuf = 0;
     socklen_t len = sizeof(default_sndbuf);
-    if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
+    if (aeron_getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
     {
         aeron_set_err_from_last_err_code("getsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
         goto cleanup;
@@ -387,7 +387,7 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
 
     size_t default_rcvbuf = 0;
     len = sizeof(default_rcvbuf);
-    if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
+    if (aeron_getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &default_sndbuf, &len) < 0)
     {
         aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
         goto cleanup;
@@ -400,14 +400,14 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     {
         size_t socket_sndbuf = driver->context->socket_sndbuf;
 
-        if (setsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
+        if (aeron_setsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
         len = sizeof(socket_sndbuf);
-        if (getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, &len) < 0)
+        if (aeron_getsockopt(probe_fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, &len) < 0)
         {
             aeron_set_err_from_last_err_code("getsockopt(SO_SNDBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
@@ -430,14 +430,14 @@ int aeron_driver_validate_sufficient_socket_buffer_lengths(aeron_driver_t *drive
     {
         size_t socket_rcvbuf = driver->context->socket_rcvbuf;
 
-        if (setsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
+        if (aeron_setsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;
         }
 
         len = sizeof(socket_rcvbuf);
-        if (getsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, &len) < 0)
+        if (aeron_getsockopt(probe_fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, &len) < 0)
         {
             aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
             goto cleanup;

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -900,8 +900,8 @@ aeron_ipc_publication_t *aeron_driver_conductor_get_or_add_ipc_publication(
                 {
                     int64_t position = aeron_logbuffer_compute_position(
                         params->term_id,
-                        params->term_offset,
-                        (size_t)aeron_number_of_trailing_zeroes(params->term_length),
+                        (int32_t)params->term_offset,
+                        (size_t)aeron_number_of_trailing_zeroes((int32_t)params->term_length),
                         initial_term_id);
 
                     aeron_counter_set_ordered(pub_pos_position.value_addr, position);
@@ -1081,8 +1081,8 @@ aeron_network_publication_t *aeron_driver_conductor_get_or_add_network_publicati
                 {
                     int64_t position = aeron_logbuffer_compute_position(
                         params->term_id,
-                        params->term_offset,
-                        (size_t)aeron_number_of_trailing_zeroes(params->term_length),
+                        (int32_t)params->term_offset,
+                        (size_t)aeron_number_of_trailing_zeroes((int32_t)params->term_length),
                         initial_term_id);
 
                     aeron_counter_set_ordered(pub_pos_position.value_addr, position);
@@ -2018,7 +2018,7 @@ int aeron_driver_conductor_link_subscribable(
 
 void aeron_driver_conductor_unlink_subscribable(aeron_subscription_link_t *link, aeron_subscribable_t *subscribable)
 {
-    for (int last_index = link->subscribable_list.length - 1, i = last_index; i >= 0; i--)
+    for (int last_index = (int32_t)link->subscribable_list.length - 1, i = last_index; i >= 0; i--)
     {
         if (subscribable == link->subscribable_list.array[i].subscribable)
         {

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -61,7 +61,7 @@ int aeron_driver_sender_init(
         }
 
         sender->recv_buffers.iov[i].iov_base = sender->recv_buffers.buffers[i] + offset;
-        sender->recv_buffers.iov[i].iov_len = context->mtu_length;
+        sender->recv_buffers.iov[i].iov_len = (uint32_t)context->mtu_length;
     }
 
     if (aeron_udp_channel_data_paths_init(

--- a/aeron-driver/src/main/c/aeron_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_flow_control.c
@@ -166,7 +166,7 @@ void aeron_flow_control_extract_strategy_name_length(
     size_t *strategy_length)
 {
     const char *next_option = (const char *)memchr(options, ',', options_length);
-    *strategy_length = NULL == next_option ? options_length : labs(next_option - options);
+    *strategy_length = NULL == next_option ? options_length : labs((long)(next_option - options));
 }
 
 int aeron_default_multicast_flow_control_strategy_supplier(

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -392,7 +392,7 @@ int aeron_network_publication_send_data(
         if (available > 0)
         {
             iov[i].iov_base = ptr;
-            iov[i].iov_len = available;
+            iov[i].iov_len = (uint32_t)available;
             mmsghdr[i].msg_hdr.msg_iov = &iov[i];
             mmsghdr[i].msg_hdr.msg_iovlen = 1;
             mmsghdr[i].msg_hdr.msg_flags = 0;
@@ -540,7 +540,7 @@ int aeron_network_publication_resend(void *clientd, int32_t term_id, int32_t ter
             struct msghdr msghdr;
 
             iov[0].iov_base = ptr;
-            iov[0].iov_len = available;
+            iov[0].iov_len = (uint32_t)available;
             msghdr.msg_iov = iov;
             msghdr.msg_iovlen = 1;
             msghdr.msg_control = NULL;

--- a/aeron-driver/src/main/c/aeron_position.c
+++ b/aeron-driver/src/main/c/aeron_position.c
@@ -68,7 +68,7 @@ int32_t aeron_stream_counter_allocate(
             .registration_id = registration_id,
             .session_id = session_id,
             .stream_id = stream_id,
-            .channel_length = channel_length
+            .channel_length = (int32_t)channel_length
         };
 
     strncpy(layout.channel, channel, sizeof(layout.channel) - 1);
@@ -213,7 +213,7 @@ int32_t aeron_channel_endpoint_status_allocate(
     int label_length = snprintf(label, sizeof(label), "%s: %.*s", name, (int)channel_length, channel);
     aeron_channel_endpoint_status_key_layout_t layout =
         {
-            .channel_length = channel_length
+            .channel_length = (int32_t)channel_length
         };
 
     strncpy(layout.channel, channel, sizeof(layout.channel) - 1);

--- a/aeron-driver/src/main/c/aeron_socket.c
+++ b/aeron-driver/src/main/c/aeron_socket.c
@@ -333,3 +333,16 @@ void aeron_close_socket(aeron_socket_t socket)
 #else
 #error Unsupported platform!
 #endif
+
+/* aeron_getsockopt and aeron_setsockopt ensure a consistent signature between platforms
+ * (MSVC uses char* instead of void* for optval, which causes warnings)
+ */
+int aeron_getsockopt(aeron_socket_t fd, int level, int optname, void* optval, socklen_t* optlen)
+{
+    return getsockopt(fd, level, optname, optval, optlen);
+}
+
+int aeron_setsockopt(aeron_socket_t fd, int level, int optname, const void* optval, socklen_t optlen)
+{
+    return setsockopt(fd, level, optname, optval, optlen);
+}

--- a/aeron-driver/src/main/c/aeron_socket.h
+++ b/aeron-driver/src/main/c/aeron_socket.h
@@ -101,4 +101,7 @@ aeron_socket_t aeron_socket(int domain, int type, int protocol);
 void aeron_close_socket(aeron_socket_t socket);
 void aeron_net_init();
 
+int aeron_getsockopt(aeron_socket_t fd, int level, int optname, void* optval, socklen_t* optlen);
+int aeron_setsockopt(aeron_socket_t fd, int level, int optname, const void* optval, socklen_t optlen);
+
 #endif //AERON_SOCKET_H

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -295,7 +295,7 @@ void aeron_driver_agent_incoming_msg(
     struct iovec iov;
 
     iov.iov_base = buffer;
-    iov.iov_len = length;
+    iov.iov_len = (uint32_t)length;
     message.msg_iovlen = 1;
     message.msg_iov = &iov;
     message.msg_name = addr;
@@ -303,7 +303,7 @@ void aeron_driver_agent_incoming_msg(
     message.msg_controllen = 0;
     message.msg_namelen = sizeof(struct sockaddr_storage);
 
-    aeron_driver_agent_log_frame(AERON_FRAME_IN, &message, length, length);
+    aeron_driver_agent_log_frame(AERON_FRAME_IN, &message, (int32_t)length, (int32_t)length);
 
     delegate->incoming_func(
         delegate->interceptor_state,

--- a/aeron-driver/src/main/c/concurrent/aeron_atomic64_msvc.h
+++ b/aeron-driver/src/main/c/concurrent/aeron_atomic64_msvc.h
@@ -82,7 +82,7 @@ inline bool aeron_cmpxchgu64(volatile uint64_t* destination, uint64_t expected, 
 
 inline bool aeron_cmpxchg32(volatile int32_t* destination, int32_t expected, int32_t desired)
 {
-    uint32_t original = _InterlockedCompareExchange(
+    int32_t original = _InterlockedCompareExchange(
         (long volatile*)destination, (long)desired, (long)expected);
 
     return original == expected;
@@ -99,7 +99,10 @@ inline void aeron_acquire()
 /* storeFence */
 inline void aeron_release()
 {
+#pragma warning(push)
+#pragma warning(disable: 4189) // 'dummy': local variable is initialized but not referenced
     volatile int64_t dummy = 0;
+#pragma warning(pop)
 }
 
 #define AERON_CMPXCHG32(original, dst, expected, desired) \

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -83,7 +83,7 @@ int aeron_udp_channel_transport_init(
         int reuse = 1;
 
 #if defined(SO_REUSEADDR)
-        if (setsockopt(transport->fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
+        if (aeron_setsockopt(transport->fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_REUSEADDR)");
             goto error;
@@ -91,7 +91,7 @@ int aeron_udp_channel_transport_init(
 #endif
 
 #if defined(SO_REUSEPORT)
-        if (setsockopt(transport->fd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
+        if (aeron_setsockopt(transport->fd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_REUSEPORT)");
             goto error;
@@ -115,13 +115,13 @@ int aeron_udp_channel_transport_init(
             memcpy(&mreq.ipv6mr_multiaddr, &in6->sin6_addr, sizeof(in6->sin6_addr));
             mreq.ipv6mr_interface = multicast_if_index;
 
-            if (setsockopt(transport->fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq, sizeof(mreq)) < 0)
+            if (aeron_setsockopt(transport->fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq, sizeof(mreq)) < 0)
             {
                 aeron_set_err_from_last_err_code("setsockopt(IPV6_JOIN_GROUP)");
                 goto error;
             }
 
-            if (setsockopt(
+            if (aeron_setsockopt(
                 transport->fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &multicast_if_index, sizeof(multicast_if_index)) < 0)
             {
                 aeron_set_err_from_last_err_code("setsockopt(IPV6_MULTICAST_IF)");
@@ -130,7 +130,7 @@ int aeron_udp_channel_transport_init(
 
             if (ttl > 0)
             {
-                if (setsockopt(transport->fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &ttl, sizeof(ttl)) < 0)
+                if (aeron_setsockopt(transport->fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &ttl, sizeof(ttl)) < 0)
                 {
                     aeron_set_err_from_last_err_code("setsockopt(IPV6_MULTICAST_HOPS)");
                     goto error;
@@ -155,13 +155,13 @@ int aeron_udp_channel_transport_init(
             mreq.imr_multiaddr.s_addr = in4->sin_addr.s_addr;
             mreq.imr_interface.s_addr = interface_addr->sin_addr.s_addr;
 
-            if (setsockopt(transport->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0)
+            if (aeron_setsockopt(transport->fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0)
             {
                 aeron_set_err_from_last_err_code("setsockopt(IP_ADD_MEMBERSHIP)");
                 goto error;
             }
 
-            if (setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_IF, &interface_addr->sin_addr, sizeof(struct in_addr)) < 0)
+            if (aeron_setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_IF, &interface_addr->sin_addr, sizeof(struct in_addr)) < 0)
             {
                 aeron_set_err_from_last_err_code("setsockopt(IP_MULTICAST_IF)");
                 goto error;
@@ -169,7 +169,7 @@ int aeron_udp_channel_transport_init(
 
             if (ttl > 0)
             {
-                if (setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
+                if (aeron_setsockopt(transport->fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0)
                 {
                     aeron_set_err_from_last_err_code("setsockopt(IP_MULTICAST_TTL)");
                     goto error;
@@ -180,7 +180,7 @@ int aeron_udp_channel_transport_init(
 
     if (socket_rcvbuf > 0)
     {
-        if (setsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
+        if (aeron_setsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, &socket_rcvbuf, sizeof(socket_rcvbuf)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_RCVBUF)");
             goto error;
@@ -189,7 +189,7 @@ int aeron_udp_channel_transport_init(
 
     if (socket_sndbuf > 0)
     {
-        if (setsockopt(transport->fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
+        if (aeron_setsockopt(transport->fd, SOL_SOCKET, SO_SNDBUF, &socket_sndbuf, sizeof(socket_sndbuf)) < 0)
         {
             aeron_set_err_from_last_err_code("setsockopt(SO_SNDBUF)");
             goto error;
@@ -370,7 +370,7 @@ int aeron_udp_channel_transport_get_so_rcvbuf(aeron_udp_channel_transport_t *tra
 {
     socklen_t len = sizeof(size_t);
 
-    if (getsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, so_rcvbuf, &len) < 0)
+    if (aeron_getsockopt(transport->fd, SOL_SOCKET, SO_RCVBUF, so_rcvbuf, &len) < 0)
     {
         aeron_set_err_from_last_err_code("getsockopt(SO_RCVBUF) %s:%d", __FILE__, __LINE__);
         return -1;


### PR DESCRIPTION
This fixes all remaining level 3 MSVC warnings in the media driver.

 - Added `aeron_getsockopt`/`aeron_setsockopt` as the Windows version declares `optval` as `char*` instead of `void*`, which causes warnings.
 - Added various casts:
   - Term offsets and lengths need to fit in an `int32_t`, they are declared as `size_t` in `aeron_uri_publication_params_stct` but their value is then checked to fit inside the valid range.
   - Unfortunately, `iovec.iov_len` is `uint32_t` on Windows. I inserted casts because of that but I could compile them conditionally if you prefer.
