### PR TITLE
[Java] Use `@org.junit.jupiter.api.Timeout` instead of `org.junit.jupiter.api.Assertions#assertTimeoutPreemptively` for timeout control in tests

### DIFF
--- a/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
+++ b/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
@@ -28,6 +28,7 @@ import org.agrona.concurrent.*;
 import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -38,7 +39,6 @@ import static io.aeron.logbuffer.LogBufferDescriptor.PARTITION_COUNT;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
 import static java.lang.Boolean.TRUE;
 import static java.nio.ByteBuffer.allocateDirect;
-import static java.time.Duration.ofSeconds;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
@@ -217,10 +217,10 @@ public class ClientConductorTest
     }
 
     @Test
+    @Timeout(5)
     public void addPublicationShouldTimeoutWithoutReadyMessage()
     {
-        assertTimeoutPreemptively(ofSeconds(5),
-            () -> assertThrows(DriverTimeoutException.class, () -> conductor.addPublication(CHANNEL, STREAM_ID_1)));
+        assertThrows(DriverTimeoutException.class, () -> conductor.addPublication(CHANNEL, STREAM_ID_1));
     }
 
     @Test
@@ -416,10 +416,10 @@ public class ClientConductorTest
     }
 
     @Test
+    @Timeout(5)
     public void addSubscriptionShouldTimeoutWithoutOperationSuccessful()
     {
-        assertTimeoutPreemptively(ofSeconds(5),
-            () -> assertThrows(DriverTimeoutException.class, () -> conductor.addSubscription(CHANNEL, STREAM_ID_1)));
+        assertThrows(DriverTimeoutException.class, () -> conductor.addSubscription(CHANNEL, STREAM_ID_1));
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -25,6 +25,7 @@ import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +34,6 @@ import java.util.concurrent.locks.LockSupport;
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.cluster.TestCluster.awaitElectionClosed;
 import static io.aeron.cluster.service.CommitPos.COMMIT_POSITION_TYPE_ID;
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -42,900 +42,850 @@ public class ClusterTest
     private static final String MSG = "Hello World!";
 
     @Test
-    public void shouldStopFollowerAndRestartFollower()
+    @Timeout(30)
+    public void shouldStopFollowerAndRestartFollower() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                cluster.awaitLeader();
+            cluster.awaitLeader();
 
-                TestNode follower = cluster.followers().get(0);
+            TestNode follower = cluster.followers().get(0);
 
-                cluster.stopNode(follower);
+            cluster.stopNode(follower);
 
-                Tests.sleep(1_000); // wait until existing replay can be cleaned up by conductor.
+            Tests.sleep(1_000); // wait until existing replay can be cleaned up by conductor.
 
-                follower = cluster.startStaticNode(follower.index(), false);
+            follower = cluster.startStaticNode(follower.index(), false);
 
-                awaitElectionClosed(follower);
-                assertEquals(Cluster.Role.FOLLOWER, follower.role());
-            }
-        });
+            awaitElectionClosed(follower);
+            assertEquals(Cluster.Role.FOLLOWER, follower.role());
+        }
     }
 
     @Test
-    public void shouldNotifyClientOfNewLeader()
+    @Timeout(40)
+    public void shouldNotifyClientOfNewLeader() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
+            final TestNode leader = cluster.awaitLeader();
 
-                cluster.connectClient();
-                cluster.stopNode(leader);
-                cluster.awaitLeadershipEvent(1);
-            }
-        });
+            cluster.connectClient();
+            cluster.stopNode(leader);
+            cluster.awaitLeadershipEvent(1);
+        }
     }
 
     @Test
-    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot()
+    @Timeout(30)
+    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
+            final TestNode leader = cluster.awaitLeader();
 
-                cluster.takeSnapshot(leader);
-                cluster.awaitSnapshotCount(cluster.node(0), 1);
-                cluster.awaitSnapshotCount(cluster.node(1), 1);
-                cluster.awaitSnapshotCount(cluster.node(2), 1);
+            cluster.takeSnapshot(leader);
+            cluster.awaitSnapshotCount(cluster.node(0), 1);
+            cluster.awaitSnapshotCount(cluster.node(1), 1);
+            cluster.awaitSnapshotCount(cluster.node(2), 1);
 
-                cluster.stopAllNodes();
+            cluster.stopAllNodes();
 
-                cluster.restartAllNodes(false);
+            cluster.restartAllNodes(false);
 
-                cluster.awaitLeader();
-                assertEquals(2, cluster.followers().size());
+            cluster.awaitLeader();
+            assertEquals(2, cluster.followers().size());
 
-                cluster.awaitSnapshotLoadedForService(cluster.node(0));
-                cluster.awaitSnapshotLoadedForService(cluster.node(1));
-                cluster.awaitSnapshotLoadedForService(cluster.node(2));
-            }
-        });
+            cluster.awaitSnapshotLoadedForService(cluster.node(0));
+            cluster.awaitSnapshotLoadedForService(cluster.node(1));
+            cluster.awaitSnapshotLoadedForService(cluster.node(2));
+        }
     }
 
     @Test
-    public void shouldShutdownClusterAndRestartWithSnapshots()
+    @Timeout(30)
+    public void shouldShutdownClusterAndRestartWithSnapshots() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
+            final TestNode leader = cluster.awaitLeader();
 
-                cluster.node(0).terminationExpected(true);
-                cluster.node(1).terminationExpected(true);
-                cluster.node(2).terminationExpected(true);
+            cluster.node(0).terminationExpected(true);
+            cluster.node(1).terminationExpected(true);
+            cluster.node(2).terminationExpected(true);
 
-                cluster.shutdownCluster(leader);
-                cluster.awaitNodeTermination(cluster.node(0));
-                cluster.awaitNodeTermination(cluster.node(1));
-                cluster.awaitNodeTermination(cluster.node(2));
+            cluster.shutdownCluster(leader);
+            cluster.awaitNodeTermination(cluster.node(0));
+            cluster.awaitNodeTermination(cluster.node(1));
+            cluster.awaitNodeTermination(cluster.node(2));
 
-                assertTrue(cluster.node(0).service().wasSnapshotTaken());
-                assertTrue(cluster.node(1).service().wasSnapshotTaken());
-                assertTrue(cluster.node(2).service().wasSnapshotTaken());
+            assertTrue(cluster.node(0).service().wasSnapshotTaken());
+            assertTrue(cluster.node(1).service().wasSnapshotTaken());
+            assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
-                cluster.stopAllNodes();
+            cluster.stopAllNodes();
 
-                cluster.restartAllNodes(false);
+            cluster.restartAllNodes(false);
 
-                cluster.awaitLeader();
-                assertEquals(2, cluster.followers().size());
+            cluster.awaitLeader();
+            assertEquals(2, cluster.followers().size());
 
-                cluster.awaitSnapshotLoadedForService(cluster.node(0));
-                cluster.awaitSnapshotLoadedForService(cluster.node(1));
-                cluster.awaitSnapshotLoadedForService(cluster.node(2));
-            }
-        });
+            cluster.awaitSnapshotLoadedForService(cluster.node(0));
+            cluster.awaitSnapshotLoadedForService(cluster.node(1));
+            cluster.awaitSnapshotLoadedForService(cluster.node(2));
+        }
     }
 
     @Test
-    public void shouldAbortClusterAndRestart()
+    @Timeout(30)
+    public void shouldAbortClusterAndRestart() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
+            final TestNode leader = cluster.awaitLeader();
 
-                cluster.node(0).terminationExpected(true);
-                cluster.node(1).terminationExpected(true);
-                cluster.node(2).terminationExpected(true);
+            cluster.node(0).terminationExpected(true);
+            cluster.node(1).terminationExpected(true);
+            cluster.node(2).terminationExpected(true);
 
-                cluster.abortCluster(leader);
-                cluster.awaitNodeTermination(cluster.node(0));
-                cluster.awaitNodeTermination(cluster.node(1));
-                cluster.awaitNodeTermination(cluster.node(2));
+            cluster.abortCluster(leader);
+            cluster.awaitNodeTermination(cluster.node(0));
+            cluster.awaitNodeTermination(cluster.node(1));
+            cluster.awaitNodeTermination(cluster.node(2));
 
-                assertFalse(cluster.node(0).service().wasSnapshotTaken());
-                assertFalse(cluster.node(1).service().wasSnapshotTaken());
-                assertFalse(cluster.node(2).service().wasSnapshotTaken());
+            assertFalse(cluster.node(0).service().wasSnapshotTaken());
+            assertFalse(cluster.node(1).service().wasSnapshotTaken());
+            assertFalse(cluster.node(2).service().wasSnapshotTaken());
 
-                cluster.stopAllNodes();
+            cluster.stopAllNodes();
 
-                cluster.restartAllNodes(false);
+            cluster.restartAllNodes(false);
 
-                cluster.awaitLeader();
-                assertEquals(2, cluster.followers().size());
+            cluster.awaitLeader();
+            assertEquals(2, cluster.followers().size());
 
-                assertFalse(cluster.node(0).service().wasSnapshotLoaded());
-                assertFalse(cluster.node(1).service().wasSnapshotLoaded());
-                assertFalse(cluster.node(2).service().wasSnapshotLoaded());
-            }
-        });
+            assertFalse(cluster.node(0).service().wasSnapshotLoaded());
+            assertFalse(cluster.node(1).service().wasSnapshotLoaded());
+            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+        }
     }
 
     @Test
-    public void shouldAbortClusterOnTerminationTimeout()
+    @Timeout(30)
+    public void shouldAbortClusterOnTerminationTimeout() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            final TestNode leader = cluster.awaitLeader();
+            final List<TestNode> followers = cluster.followers();
+
+            assertEquals(2, followers.size());
+            final TestNode followerA = followers.get(0);
+            final TestNode followerB = followers.get(1);
+
+            leader.terminationExpected(true);
+            followerA.terminationExpected(true);
+
+            cluster.stopNode(followerB);
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+
+            cluster.abortCluster(leader);
+            cluster.awaitNodeTermination(leader);
+            cluster.awaitNodeTermination(followerA);
+
+            cluster.stopNode(leader);
+            cluster.stopNode(followerA);
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldEchoMessagesThenContinueOnNewLeader() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode originalLeader = cluster.awaitLeader();
+            cluster.connectClient();
+
+            final int preFailureMessageCount = 10;
+            final int postFailureMessageCount = 7;
+
+            cluster.sendMessages(preFailureMessageCount);
+            cluster.awaitResponseMessageCount(preFailureMessageCount);
+            cluster.awaitServiceMessageCount(cluster.node(0), preFailureMessageCount);
+            cluster.awaitServiceMessageCount(cluster.node(1), preFailureMessageCount);
+            cluster.awaitServiceMessageCount(cluster.node(2), preFailureMessageCount);
+
+            assertEquals(originalLeader.index(), cluster.client().leaderMemberId());
+
+            cluster.stopNode(originalLeader);
+
+            final TestNode newLeader = cluster.awaitLeader(originalLeader.index());
+
+            cluster.sendMessages(postFailureMessageCount);
+            cluster.awaitResponseMessageCount(preFailureMessageCount + postFailureMessageCount);
+            assertEquals(newLeader.index(), cluster.client().leaderMemberId());
+
+            final TestNode follower = cluster.followers().get(0);
+
+            cluster.awaitServiceMessageCount(newLeader, preFailureMessageCount + postFailureMessageCount);
+            cluster.awaitServiceMessageCount(follower, preFailureMessageCount + postFailureMessageCount);
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldStopLeaderAndRestartAsFollower() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode originalLeader = cluster.awaitLeader();
+
+            cluster.stopNode(originalLeader);
+            cluster.awaitLeader(originalLeader.index());
+
+            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+
+            awaitElectionClosed(follower);
+            assertEquals(Cluster.Role.FOLLOWER, follower.role());
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode originalLeader = cluster.awaitLeader();
+
+            cluster.stopNode(originalLeader);
+            cluster.awaitLeader(originalLeader.index());
+
+            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+
+            awaitElectionClosed(follower);
+            assertEquals(Cluster.Role.FOLLOWER, follower.role());
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+        }
+    }
+
+    @Test
+    @Timeout(60)
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode originalLeader = cluster.awaitLeader();
+
+            cluster.stopNode(originalLeader);
+            cluster.awaitLeader(originalLeader.index());
+
+            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+            awaitElectionClosed(follower);
+
+            assertEquals(Cluster.Role.FOLLOWER, follower.role());
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+
+            final TestNode leader = cluster.awaitLeader();
+
+            cluster.stopNode(leader);
+
+            cluster.awaitLeader(leader.index());
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldAcceptMessagesAfterSingleNodeCleanRestart() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            cluster.awaitLeader();
+
+            TestNode follower = cluster.followers().get(0);
+
+            cluster.stopNode(follower);
+
+            Tests.sleep(10_000);
+
+            follower = cluster.startStaticNode(follower.index(), true);
+
+            awaitElectionClosed(follower);
+            assertEquals(Cluster.Role.FOLLOWER, follower.role());
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+            cluster.awaitServiceMessageCount(follower, messageCount);
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldReplaySnapshotTakenWhileDown() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+            final TestNode followerA = cluster.followers().get(0);
+            TestNode followerB = cluster.followers().get(1);
+
+            cluster.stopNode(followerB);
+
+            Tests.sleep(10_000);
+
+            cluster.takeSnapshot(leader);
+            cluster.awaitSnapshotCount(leader, 1);
+            cluster.awaitSnapshotCount(followerA, 1);
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+
+            followerB = cluster.startStaticNode(followerB.index(), false);
+
+            cluster.awaitSnapshotCount(followerB, 1);
+            assertEquals(Cluster.Role.FOLLOWER, followerB.role());
+
+            cluster.awaitServiceMessageCount(followerB, messageCount);
+            assertEquals(0L, followerB.errors());
+        }
+    }
+
+    @Test
+    @Timeout(50)
+    public void shouldTolerateMultipleLeaderFailures() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode firstLeader = cluster.awaitLeader();
+            cluster.stopNode(firstLeader);
+
+            final TestNode secondLeader = cluster.awaitLeader();
+
+            final long commitPos = secondLeader.commitPosition();
+            final TestNode newFollower = cluster.startStaticNode(firstLeader.index(), false);
+
+            cluster.awaitCommitPosition(newFollower, commitPos);
+            cluster.awaitNotInElection(newFollower);
+
+            cluster.stopNode(secondLeader);
+
+            cluster.awaitLeader();
+
+            cluster.connectClient();
+
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldAcceptMessagesAfterTwoNodeCleanRestart() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            cluster.awaitLeader();
+
+            final List<TestNode> followers = cluster.followers();
+            TestNode followerA = followers.get(0), followerB = followers.get(1);
+
+            cluster.stopNode(followerA);
+            cluster.stopNode(followerB);
+
+            Tests.sleep(1_000); // wait until existing replays can be cleaned up by conductor.
+
+            followerA = cluster.startStaticNode(followerA.index(), true);
+            followerB = cluster.startStaticNode(followerB.index(), true);
+
+            awaitElectionClosed(followerA);
+            awaitElectionClosed(followerB);
+
+            assertEquals(Cluster.Role.FOLLOWER, followerA.role());
+            assertEquals(Cluster.Role.FOLLOWER, followerB.role());
+
+            cluster.connectClient();
+            final int messageCount = 10;
+
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+            cluster.awaitServiceMessageCount(followerA, messageCount);
+            cluster.awaitServiceMessageCount(followerB, messageCount);
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldHaveOnlyOneCommitPositionCounter() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+
+            final List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0), followerB = followers.get(1);
+
+            cluster.stopNode(leader);
+
+            cluster.awaitLeader(leader.index());
+
+            assertEquals(1, countersOfType(followerA.countersReader(), COMMIT_POSITION_TYPE_ID));
+            assertEquals(1, countersOfType(followerB.countersReader(), COMMIT_POSITION_TYPE_ID));
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldCallOnRoleChangeOnBecomingLeader() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            TestNode leader = cluster.awaitLeader();
+
+            List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0);
+            final TestNode followerB = followers.get(1);
+
+            assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
+            assertNull(followerA.service().roleChangedTo());
+            assertNull(followerB.service().roleChangedTo());
+
+            cluster.stopNode(leader);
+
+            leader = cluster.awaitLeader(leader.index());
+            followers = cluster.followers();
+            final TestNode follower = followers.get(0);
+
+            assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
+            assertNull(follower.service().roleChangedTo());
+        }
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+
+            final List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0);
+            final TestNode followerB = followers.get(1);
+
+            assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
+
+            cluster.stopNode(followerA);
+            cluster.stopNode(followerB);
+
+            while (leader.service().roleChangedTo() == Cluster.Role.LEADER)
             {
-                final TestNode leader = cluster.awaitLeader();
-                final List<TestNode> followers = cluster.followers();
+                Thread.yield();
+                Tests.checkInterruptStatus();
+            }
 
-                assertEquals(2, followers.size());
-                final TestNode followerA = followers.get(0);
-                final TestNode followerB = followers.get(1);
+            assertEquals(Cluster.Role.FOLLOWER, leader.service().roleChangedTo());
+        }
+    }
 
-                leader.terminationExpected(true);
-                followerA.terminationExpected(true);
+    @Test
+    @Timeout(70)
+    public void shouldRecoverWhileMessagesContinue() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
 
+            final List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0);
+            TestNode followerB = followers.get(1);
+
+            cluster.connectClient();
+            final Thread messageThread = startMessageThread(cluster, TimeUnit.MICROSECONDS.toNanos(500));
+            try
+            {
                 cluster.stopNode(followerB);
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-
-                cluster.abortCluster(leader);
-                cluster.awaitNodeTermination(leader);
-                cluster.awaitNodeTermination(followerA);
-
-                cluster.stopNode(leader);
-                cluster.stopNode(followerA);
-            }
-        });
-    }
-
-    @Test
-    public void shouldEchoMessagesThenContinueOnNewLeader()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode originalLeader = cluster.awaitLeader();
-                cluster.connectClient();
-
-                final int preFailureMessageCount = 10;
-                final int postFailureMessageCount = 7;
-
-                cluster.sendMessages(preFailureMessageCount);
-                cluster.awaitResponseMessageCount(preFailureMessageCount);
-                cluster.awaitServiceMessageCount(cluster.node(0), preFailureMessageCount);
-                cluster.awaitServiceMessageCount(cluster.node(1), preFailureMessageCount);
-                cluster.awaitServiceMessageCount(cluster.node(2), preFailureMessageCount);
-
-                assertEquals(originalLeader.index(), cluster.client().leaderMemberId());
-
-                cluster.stopNode(originalLeader);
-
-                final TestNode newLeader = cluster.awaitLeader(originalLeader.index());
-
-                cluster.sendMessages(postFailureMessageCount);
-                cluster.awaitResponseMessageCount(preFailureMessageCount + postFailureMessageCount);
-                assertEquals(newLeader.index(), cluster.client().leaderMemberId());
-
-                final TestNode follower = cluster.followers().get(0);
-
-                cluster.awaitServiceMessageCount(newLeader, preFailureMessageCount + postFailureMessageCount);
-                cluster.awaitServiceMessageCount(follower, preFailureMessageCount + postFailureMessageCount);
-            }
-        });
-    }
-
-    @Test
-    public void shouldStopLeaderAndRestartAsFollower()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode originalLeader = cluster.awaitLeader();
-
-                cluster.stopNode(originalLeader);
-                cluster.awaitLeader(originalLeader.index());
-
-                final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
-
-                awaitElectionClosed(follower);
-                assertEquals(Cluster.Role.FOLLOWER, follower.role());
-            }
-        });
-    }
-
-    @Test
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode originalLeader = cluster.awaitLeader();
-
-                cluster.stopNode(originalLeader);
-                cluster.awaitLeader(originalLeader.index());
-
-                final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
-
-                awaitElectionClosed(follower);
-                assertEquals(Cluster.Role.FOLLOWER, follower.role());
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-            }
-        });
-    }
-
-    @Test
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader()
-    {
-        assertTimeoutPreemptively(ofSeconds(60), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode originalLeader = cluster.awaitLeader();
-
-                cluster.stopNode(originalLeader);
-                cluster.awaitLeader(originalLeader.index());
-
-                final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
-                awaitElectionClosed(follower);
-
-                assertEquals(Cluster.Role.FOLLOWER, follower.role());
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-
-                final TestNode leader = cluster.awaitLeader();
-
-                cluster.stopNode(leader);
-
-                cluster.awaitLeader(leader.index());
-            }
-        });
-    }
-
-    @Test
-    public void shouldAcceptMessagesAfterSingleNodeCleanRestart()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                cluster.awaitLeader();
-
-                TestNode follower = cluster.followers().get(0);
-
-                cluster.stopNode(follower);
-
                 Tests.sleep(10_000);
-
-                follower = cluster.startStaticNode(follower.index(), true);
-
-                awaitElectionClosed(follower);
-                assertEquals(Cluster.Role.FOLLOWER, follower.role());
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-                cluster.awaitServiceMessageCount(follower, messageCount);
-            }
-        });
-    }
-
-    @Test
-    public void shouldReplaySnapshotTakenWhileDown()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-                final TestNode followerA = cluster.followers().get(0);
-                TestNode followerB = cluster.followers().get(1);
-
-                cluster.stopNode(followerB);
-
-                Tests.sleep(10_000);
-
-                cluster.takeSnapshot(leader);
-                cluster.awaitSnapshotCount(leader, 1);
-                cluster.awaitSnapshotCount(followerA, 1);
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
 
                 followerB = cluster.startStaticNode(followerB.index(), false);
-
-                cluster.awaitSnapshotCount(followerB, 1);
-                assertEquals(Cluster.Role.FOLLOWER, followerB.role());
-
-                cluster.awaitServiceMessageCount(followerB, messageCount);
-                assertEquals(0L, followerB.errors());
+                Tests.sleep(30_000);
             }
-        });
-    }
-
-    @Test
-    public void shouldTolerateMultipleLeaderFailures()
-    {
-        assertTimeoutPreemptively(ofSeconds(50), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            finally
             {
-                final TestNode firstLeader = cluster.awaitLeader();
-                cluster.stopNode(firstLeader);
-
-                final TestNode secondLeader = cluster.awaitLeader();
-
-                final long commitPos = secondLeader.commitPosition();
-                final TestNode newFollower = cluster.startStaticNode(firstLeader.index(), false);
-
-                cluster.awaitCommitPosition(newFollower, commitPos);
-                cluster.awaitNotInElection(newFollower);
-
-                cluster.stopNode(secondLeader);
-
-                cluster.awaitLeader();
-
-                cluster.connectClient();
-
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
+                messageThread.interrupt();
+                messageThread.join();
             }
-        });
+
+            awaitElectionClosed(followerB);
+            assertEquals(0L, leader.errors());
+            assertEquals(0L, followerA.errors());
+            assertEquals(0L, followerB.errors());
+        }
     }
 
     @Test
-    public void shouldAcceptMessagesAfterTwoNodeCleanRestart()
+    @Timeout(30)
+    public void shouldCatchupFromEmptyLog() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            cluster.awaitLeader();
+
+            final List<TestNode> followers = cluster.followers();
+            TestNode followerB = followers.get(1);
+
+            cluster.stopNode(followerB);
+
+            cluster.connectClient();
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+
+            Tests.sleep(1_000); // wait until existing replay can be cleaned up by conductor.
+
+            followerB = cluster.startStaticNode(followerB.index(), true);
+            cluster.awaitServiceMessageCount(followerB, messageCount);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+            final List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0);
+            final TestNode followerB = followers.get(1);
+
+            cluster.connectClient();
+            final int messageCount = 10;
+            cluster.sendMessages(messageCount);
+            cluster.awaitResponseMessageCount(messageCount);
+
+            leader.terminationExpected(true);
+            followerA.terminationExpected(true);
+            followerB.terminationExpected(true);
+
+            cluster.shutdownCluster(leader);
+            cluster.awaitNodeTermination(cluster.node(0));
+            cluster.awaitNodeTermination(cluster.node(1));
+            cluster.awaitNodeTermination(cluster.node(2));
+
+            assertTrue(cluster.node(0).service().wasSnapshotTaken());
+            assertTrue(cluster.node(1).service().wasSnapshotTaken());
+            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+
+            cluster.stopAllNodes();
+
+            cluster.startStaticNode(0, false);
+            cluster.startStaticNode(1, false);
+            cluster.startStaticNode(2, true);
+
+            final TestNode newLeader = cluster.awaitLeader();
+
+            assertNotEquals(2, newLeader.index());
+
+            assertTrue(cluster.node(0).service().wasSnapshotLoaded());
+            assertTrue(cluster.node(1).service().wasSnapshotLoaded());
+            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+
+            cluster.awaitServiceMessageCount(cluster.node(2), messageCount);
+            cluster.awaitSnapshotCount(cluster.node(2), 1);
+            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldCatchUpAfterFollowerMissesOneMessage() throws InterruptedException
+    {
+        shouldCatchUpAfterFollowerMissesMessage(TestMessages.NO_OP);
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldCatchUpAfterFollowerMissesTimerRegistration() throws InterruptedException
+    {
+        shouldCatchUpAfterFollowerMissesMessage(TestMessages.REGISTER_TIMER);
+    }
+
+    @Test
+    @Timeout(30)
+    public void shouldCatchUpTwoFreshNodesAfterRestart() throws InterruptedException
+    {
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader = cluster.awaitLeader();
+            final List<TestNode> followers = cluster.followers();
+
+            cluster.connectClient();
+            final int messageCount = 50_000;
+            for (int i = 0; i < messageCount; i++)
             {
-                cluster.awaitLeader();
-
-                final List<TestNode> followers = cluster.followers();
-                TestNode followerA = followers.get(0), followerB = followers.get(1);
-
-                cluster.stopNode(followerA);
-                cluster.stopNode(followerB);
-
-                Tests.sleep(1_000); // wait until existing replays can be cleaned up by conductor.
-
-                followerA = cluster.startStaticNode(followerA.index(), true);
-                followerB = cluster.startStaticNode(followerB.index(), true);
-
-                awaitElectionClosed(followerA);
-                awaitElectionClosed(followerB);
-
-                assertEquals(Cluster.Role.FOLLOWER, followerA.role());
-                assertEquals(Cluster.Role.FOLLOWER, followerB.role());
-
-                cluster.connectClient();
-                final int messageCount = 10;
-
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-                cluster.awaitServiceMessageCount(followerA, messageCount);
-                cluster.awaitServiceMessageCount(followerB, messageCount);
+                cluster.msgBuffer().putStringWithoutLengthAscii(0, TestMessages.NO_OP);
+                cluster.sendMessage(TestMessages.NO_OP.length());
             }
-        });
+            cluster.awaitResponseMessageCount(messageCount);
+
+            cluster.node(0).terminationExpected(true);
+            cluster.node(1).terminationExpected(true);
+            cluster.node(2).terminationExpected(true);
+
+            cluster.abortCluster(leader);
+            cluster.awaitNodeTermination(cluster.node(0));
+            cluster.awaitNodeTermination(cluster.node(1));
+            cluster.awaitNodeTermination(cluster.node(2));
+
+            cluster.stopAllNodes();
+
+            final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
+            final TestNode oldFollower1 = cluster.startStaticNode(followers.get(0).index(), true);
+            final TestNode oldFollower2 = cluster.startStaticNode(followers.get(1).index(), true);
+
+            cluster.awaitLeader();
+            awaitElectionClosed(oldFollower1);
+            awaitElectionClosed(oldFollower2);
+
+            assertEquals(0L, oldLeader.errors());
+            assertEquals(0L, oldFollower1.errors());
+            assertEquals(0L, oldFollower2.errors());
+        }
     }
 
     @Test
-    public void shouldHaveOnlyOneCommitPositionCounter()
+    @Timeout(30)
+    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            final TestNode leader = cluster.awaitLeader();
+            final List<TestNode> followers = cluster.followers();
+            final TestNode followerA = followers.get(0);
+            final TestNode followerB = followers.get(1);
+
+            cluster.connectClient();
+
+            cluster.sendMessages(2);
+            cluster.awaitResponseMessageCount(2);
+            cluster.awaitServiceMessageCount(cluster.node(2), 2);
+
+            cluster.takeSnapshot(leader);
+            final int memberCount = 3;
+            for (int memberId = 0; memberId < memberCount; memberId++)
             {
-                final TestNode leader = cluster.awaitLeader();
-
-                final List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0), followerB = followers.get(1);
-
-                cluster.stopNode(leader);
-
-                cluster.awaitLeader(leader.index());
-
-                assertEquals(1, countersOfType(followerA.countersReader(), COMMIT_POSITION_TYPE_ID));
-                assertEquals(1, countersOfType(followerB.countersReader(), COMMIT_POSITION_TYPE_ID));
+                final TestNode node = cluster.node(memberId);
+                cluster.awaitSnapshotCount(node, 1);
+                assertTrue(node.service().wasSnapshotTaken());
+                node.service().resetSnapshotTaken();
             }
-        });
+
+            cluster.sendMessages(1);
+            cluster.awaitResponseMessageCount(3);
+            cluster.awaitServiceMessageCount(cluster.node(2), 3);
+
+            leader.terminationExpected(true);
+            followerA.terminationExpected(true);
+            followerB.terminationExpected(true);
+
+            cluster.awaitNeutralControlToggle(leader);
+            cluster.shutdownCluster(leader);
+            cluster.awaitNodeTermination(cluster.node(0));
+            cluster.awaitNodeTermination(cluster.node(1));
+            cluster.awaitNodeTermination(cluster.node(2));
+
+            assertTrue(cluster.node(0).service().wasSnapshotTaken());
+            assertTrue(cluster.node(1).service().wasSnapshotTaken());
+            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+
+            cluster.stopAllNodes();
+
+            cluster.startStaticNode(0, false);
+            cluster.startStaticNode(1, false);
+            cluster.startStaticNode(2, true);
+
+            final TestNode newLeader = cluster.awaitLeader();
+
+            assertNotEquals(2, newLeader.index());
+
+            assertTrue(cluster.node(0).service().wasSnapshotLoaded());
+            assertTrue(cluster.node(1).service().wasSnapshotLoaded());
+            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+
+            assertEquals(3, cluster.node(0).service().messageCount());
+            assertEquals(3, cluster.node(1).service().messageCount());
+            assertEquals(3, cluster.node(2).service().messageCount());
+
+            cluster.reconnectClient();
+
+            final int msgCountAfterStart = 4;
+            final int totalMsgCount = 2 + 1 + 4;
+            cluster.sendMessages(msgCountAfterStart);
+            cluster.awaitResponseMessageCount(totalMsgCount);
+            cluster.awaitServiceMessageCount(newLeader, totalMsgCount);
+            assertEquals(totalMsgCount, newLeader.service().messageCount());
+
+            cluster.awaitServiceMessageCount(cluster.node(1), totalMsgCount);
+            assertEquals(totalMsgCount, cluster.node(1).service().messageCount());
+
+            cluster.awaitServiceMessageCount(cluster.node(2), totalMsgCount);
+            assertEquals(totalMsgCount, cluster.node(2).service().messageCount());
+        }
     }
 
     @Test
-    public void shouldCallOnRoleChangeOnBecomingLeader()
+    @Timeout(40)
+    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+            cluster.awaitLeader();
+
+            final TestNode leader = cluster.findLeader();
+            final TestNode follower = cluster.followers().get(0);
+            final TestNode follower2 = cluster.followers().get(1);
+
+            cluster.connectClient();
+            cluster.sendMessages(10);
+
+            cluster.stopNode(follower);
+            cluster.stopNode(follower2);
+
+            while (leader.role() != Cluster.Role.FOLLOWER)
             {
-                TestNode leader = cluster.awaitLeader();
-
-                List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0);
-                final TestNode followerB = followers.get(1);
-
-                assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
-                assertNull(followerA.service().roleChangedTo());
-                assertNull(followerB.service().roleChangedTo());
-
-                cluster.stopNode(leader);
-
-                leader = cluster.awaitLeader(leader.index());
-                followers = cluster.followers();
-                final TestNode follower = followers.get(0);
-
-                assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
-                assertNull(follower.service().roleChangedTo());
-            }
-        });
-    }
-
-    @Test
-    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers()
-    {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-
-                final List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0);
-                final TestNode followerB = followers.get(1);
-
-                assertEquals(Cluster.Role.LEADER, leader.service().roleChangedTo());
-
-                cluster.stopNode(followerA);
-                cluster.stopNode(followerB);
-
-                while (leader.service().roleChangedTo() == Cluster.Role.LEADER)
-                {
-                    Thread.yield();
-                    Tests.checkInterruptStatus();
-                }
-
-                assertEquals(Cluster.Role.FOLLOWER, leader.service().roleChangedTo());
-            }
-        });
-    }
-
-    @Test
-    public void shouldRecoverWhileMessagesContinue()
-    {
-        assertTimeoutPreemptively(ofSeconds(70), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-
-                final List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0);
-                TestNode followerB = followers.get(1);
-
-                cluster.connectClient();
-                final Thread messageThread = startMessageThread(cluster, TimeUnit.MICROSECONDS.toNanos(500));
-                try
-                {
-                    cluster.stopNode(followerB);
-                    Tests.sleep(10_000);
-
-                    followerB = cluster.startStaticNode(followerB.index(), false);
-                    Tests.sleep(30_000);
-                }
-                finally
-                {
-                    messageThread.interrupt();
-                    messageThread.join();
-                }
-
-                awaitElectionClosed(followerB);
-                assertEquals(0L, leader.errors());
-                assertEquals(0L, followerA.errors());
-                assertEquals(0L, followerB.errors());
-            }
-        });
-    }
-
-    @Test
-    public void shouldCatchupFromEmptyLog()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                cluster.awaitLeader();
-
-                final List<TestNode> followers = cluster.followers();
-                TestNode followerB = followers.get(1);
-
-                cluster.stopNode(followerB);
-
-                cluster.connectClient();
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-
-                Tests.sleep(1_000); // wait until existing replay can be cleaned up by conductor.
-
-                followerB = cluster.startStaticNode(followerB.index(), true);
-                cluster.awaitServiceMessageCount(followerB, messageCount);
-            }
-        });
-    }
-
-    @Test
-    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-                final List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0);
-                final TestNode followerB = followers.get(1);
-
-                cluster.connectClient();
-                final int messageCount = 10;
-                cluster.sendMessages(messageCount);
-                cluster.awaitResponseMessageCount(messageCount);
-
-                leader.terminationExpected(true);
-                followerA.terminationExpected(true);
-                followerB.terminationExpected(true);
-
-                cluster.shutdownCluster(leader);
-                cluster.awaitNodeTermination(cluster.node(0));
-                cluster.awaitNodeTermination(cluster.node(1));
-                cluster.awaitNodeTermination(cluster.node(2));
-
-                assertTrue(cluster.node(0).service().wasSnapshotTaken());
-                assertTrue(cluster.node(1).service().wasSnapshotTaken());
-                assertTrue(cluster.node(2).service().wasSnapshotTaken());
-
-                cluster.stopAllNodes();
-
-                cluster.startStaticNode(0, false);
-                cluster.startStaticNode(1, false);
-                cluster.startStaticNode(2, true);
-
-                final TestNode newLeader = cluster.awaitLeader();
-
-                assertNotEquals(2, newLeader.index());
-
-                assertTrue(cluster.node(0).service().wasSnapshotLoaded());
-                assertTrue(cluster.node(1).service().wasSnapshotLoaded());
-                assertFalse(cluster.node(2).service().wasSnapshotLoaded());
-
-                cluster.awaitServiceMessageCount(cluster.node(2), messageCount);
-                cluster.awaitSnapshotCount(cluster.node(2), 1);
-                assertTrue(cluster.node(2).service().wasSnapshotTaken());
-            }
-        });
-    }
-
-    @Test
-    public void shouldCatchUpAfterFollowerMissesOneMessage()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-            shouldCatchUpAfterFollowerMissesMessage(TestMessages.NO_OP));
-    }
-
-    @Test
-    public void shouldCatchUpAfterFollowerMissesTimerRegistration()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-            shouldCatchUpAfterFollowerMissesMessage(TestMessages.REGISTER_TIMER));
-    }
-
-    @Test
-    public void shouldCatchUpTwoFreshNodesAfterRestart()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-                final List<TestNode> followers = cluster.followers();
-
-                cluster.connectClient();
-                final int messageCount = 50_000;
-                for (int i = 0; i < messageCount; i++)
-                {
-                    cluster.msgBuffer().putStringWithoutLengthAscii(0, TestMessages.NO_OP);
-                    cluster.sendMessage(TestMessages.NO_OP.length());
-                }
-                cluster.awaitResponseMessageCount(messageCount);
-
-                cluster.node(0).terminationExpected(true);
-                cluster.node(1).terminationExpected(true);
-                cluster.node(2).terminationExpected(true);
-
-                cluster.abortCluster(leader);
-                cluster.awaitNodeTermination(cluster.node(0));
-                cluster.awaitNodeTermination(cluster.node(1));
-                cluster.awaitNodeTermination(cluster.node(2));
-
-                cluster.stopAllNodes();
-
-                final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
-                final TestNode oldFollower1 = cluster.startStaticNode(followers.get(0).index(), true);
-                final TestNode oldFollower2 = cluster.startStaticNode(followers.get(1).index(), true);
-
-                cluster.awaitLeader();
-                awaitElectionClosed(oldFollower1);
-                awaitElectionClosed(oldFollower2);
-
-                assertEquals(0L, oldLeader.errors());
-                assertEquals(0L, oldFollower1.errors());
-                assertEquals(0L, oldFollower2.errors());
-            }
-        });
-    }
-
-    @Test
-    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog()
-    {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                final TestNode leader = cluster.awaitLeader();
-                final List<TestNode> followers = cluster.followers();
-                final TestNode followerA = followers.get(0);
-                final TestNode followerB = followers.get(1);
-
-                cluster.connectClient();
-
-                cluster.sendMessages(2);
-                cluster.awaitResponseMessageCount(2);
-                cluster.awaitServiceMessageCount(cluster.node(2), 2);
-
-                cluster.takeSnapshot(leader);
-                final int memberCount = 3;
-                for (int memberId = 0; memberId < memberCount; memberId++)
-                {
-                    final TestNode node = cluster.node(memberId);
-                    cluster.awaitSnapshotCount(node, 1);
-                    assertTrue(node.service().wasSnapshotTaken());
-                    node.service().resetSnapshotTaken();
-                }
-
+                Tests.sleep(1_000);
                 cluster.sendMessages(1);
-                cluster.awaitResponseMessageCount(3);
-                cluster.awaitServiceMessageCount(cluster.node(2), 3);
-
-                leader.terminationExpected(true);
-                followerA.terminationExpected(true);
-                followerB.terminationExpected(true);
-
-                cluster.awaitNeutralControlToggle(leader);
-                cluster.shutdownCluster(leader);
-                cluster.awaitNodeTermination(cluster.node(0));
-                cluster.awaitNodeTermination(cluster.node(1));
-                cluster.awaitNodeTermination(cluster.node(2));
-
-                assertTrue(cluster.node(0).service().wasSnapshotTaken());
-                assertTrue(cluster.node(1).service().wasSnapshotTaken());
-                assertTrue(cluster.node(2).service().wasSnapshotTaken());
-
-                cluster.stopAllNodes();
-
-                cluster.startStaticNode(0, false);
-                cluster.startStaticNode(1, false);
-                cluster.startStaticNode(2, true);
-
-                final TestNode newLeader = cluster.awaitLeader();
-
-                assertNotEquals(2, newLeader.index());
-
-                assertTrue(cluster.node(0).service().wasSnapshotLoaded());
-                assertTrue(cluster.node(1).service().wasSnapshotLoaded());
-                assertFalse(cluster.node(2).service().wasSnapshotLoaded());
-
-                assertEquals(3, cluster.node(0).service().messageCount());
-                assertEquals(3, cluster.node(1).service().messageCount());
-                assertEquals(3, cluster.node(2).service().messageCount());
-
-                cluster.reconnectClient();
-
-                final int msgCountAfterStart = 4;
-                final int totalMsgCount = 2 + 1 + 4;
-                cluster.sendMessages(msgCountAfterStart);
-                cluster.awaitResponseMessageCount(totalMsgCount);
-                cluster.awaitServiceMessageCount(newLeader, totalMsgCount);
-                assertEquals(totalMsgCount, newLeader.service().messageCount());
-
-                cluster.awaitServiceMessageCount(cluster.node(1), totalMsgCount);
-                assertEquals(totalMsgCount, cluster.node(1).service().messageCount());
-
-                cluster.awaitServiceMessageCount(cluster.node(2), totalMsgCount);
-                assertEquals(totalMsgCount, cluster.node(2).service().messageCount());
             }
-        });
+
+            cluster.startStaticNode(follower2.index(), true);
+            cluster.awaitLeader();
+        }
     }
 
     @Test
-    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne()
+    @Timeout(40)
+    void shouldRecoverWhenLastSnapshotIsMarkedInvalid() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                cluster.awaitLeader();
+            // Leadership Term 0
+            final TestNode leader0 = cluster.awaitLeader();
+            cluster.connectClient();
 
-                final TestNode leader = cluster.findLeader();
-                final TestNode follower = cluster.followers().get(0);
-                final TestNode follower2 = cluster.followers().get(1);
+            final int numMessages = 3;
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages);
 
-                cluster.connectClient();
-                cluster.sendMessages(10);
+            // Snapshot
+            cluster.takeSnapshot(leader0);
+            cluster.awaitSnapshotCount(leader0, 1);
 
-                cluster.stopNode(follower);
-                cluster.stopNode(follower2);
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
 
-                while (leader.role() != Cluster.Role.FOLLOWER)
-                {
-                    Tests.sleep(1_000);
-                    cluster.sendMessages(1);
-                }
+            // Snapshot
+            cluster.takeSnapshot(leader0);
+            cluster.awaitSnapshotCount(leader0, 2);
 
-                cluster.startStaticNode(follower2.index(), true);
-                cluster.awaitLeader();
-            }
-        });
+            // Leadership Term 1
+            cluster.stopNode(leader0);
+            cluster.awaitLeader(leader0.index());
+            cluster.startStaticNode(leader0.index(), false);
+
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 3);
+
+            // Stop without snapshot
+            cluster.node(0).terminationExpected(true);
+            cluster.node(1).terminationExpected(true);
+            cluster.node(2).terminationExpected(true);
+
+            cluster.stopAllNodes();
+
+            // Invalidate snapshot from leadershipTermId = 1
+            cluster.invalidateLatestSnapshots();
+
+            // Start, should replay from snapshot in leadershipTerm = 0.
+            cluster.restartAllNodes(false);
+
+            cluster.awaitLeader();
+        }
     }
 
     @Test
-    void shouldRecoverWhenLastSnapshotIsMarkedInvalid()
+    @Timeout(50)
+    void shouldRecoverWhenLastSnapshotIsInvalidAndWasBetweenTwoElections() throws InterruptedException
     {
-        assertTimeoutPreemptively(ofSeconds(40), () ->
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                // Leadership Term 0
-                final TestNode leader0 = cluster.awaitLeader();
-                cluster.connectClient();
+            // Leadership Term 0
+            final TestNode leader0 = cluster.awaitLeader();
+            cluster.connectClient();
 
-                final int numMessages = 3;
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages);
+            final int numMessages = 3;
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages);
 
-                // Snapshot
-                cluster.takeSnapshot(leader0);
-                cluster.awaitSnapshotCount(leader0, 1);
+            // Leadership Term 1
+            cluster.stopNode(leader0);
+            final TestNode leader1 = cluster.awaitLeader(leader0.index());
+            cluster.startStaticNode(leader0.index(), false);
 
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
 
-                // Snapshot
-                cluster.takeSnapshot(leader0);
-                cluster.awaitSnapshotCount(leader0, 2);
+            // Snapshot
+            cluster.takeSnapshot(leader1);
+            cluster.awaitSnapshotCount(leader1, 1);
 
-                // Leadership Term 1
-                cluster.stopNode(leader0);
-                cluster.awaitLeader(leader0.index());
-                cluster.startStaticNode(leader0.index(), false);
+            // Leadership Term 2
+            cluster.stopNode(leader1);
+            cluster.awaitLeader(leader1.index());
+            cluster.startStaticNode(leader1.index(), false);
 
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages * 3);
+            cluster.sendMessages(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 3);
 
-                // Stop without snapshot
-                cluster.node(0).terminationExpected(true);
-                cluster.node(1).terminationExpected(true);
-                cluster.node(2).terminationExpected(true);
+            // No snapshot for Term 2
 
-                cluster.stopAllNodes();
+            // Stop without snapshot
+            cluster.node(0).terminationExpected(true);
+            cluster.node(1).terminationExpected(true);
+            cluster.node(2).terminationExpected(true);
 
-                // Invalidate snapshot from leadershipTermId = 1
-                cluster.invalidateLatestSnapshots();
+            cluster.stopAllNodes();
 
-                // Start, should replay from snapshot in leadershipTerm = 0.
-                cluster.restartAllNodes(false);
+            // Invalidate snapshot from leadershipTermId = 1
+            cluster.invalidateLatestSnapshots();
 
-                cluster.awaitLeader();
-            }
-        });
-    }
+            // Start, should replay from snapshot in leadershipTerm = 0.
+            cluster.restartAllNodes(false);
 
-    @Test
-    void shouldRecoverWhenLastSnapshotIsInvalidAndWasBetweenTwoElections()
-    {
-        assertTimeoutPreemptively(ofSeconds(50), () ->
-        {
-            try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
-            {
-                // Leadership Term 0
-                final TestNode leader0 = cluster.awaitLeader();
-                cluster.connectClient();
-
-                final int numMessages = 3;
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages);
-
-                // Leadership Term 1
-                cluster.stopNode(leader0);
-                final TestNode leader1 = cluster.awaitLeader(leader0.index());
-                cluster.startStaticNode(leader0.index(), false);
-
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
-
-                // Snapshot
-                cluster.takeSnapshot(leader1);
-                cluster.awaitSnapshotCount(leader1, 1);
-
-                // Leadership Term 2
-                cluster.stopNode(leader1);
-                cluster.awaitLeader(leader1.index());
-                cluster.startStaticNode(leader1.index(), false);
-
-                cluster.sendMessages(numMessages);
-                awaitAllServiceMessageCount(cluster, 3, numMessages * 3);
-
-                // No snapshot for Term 2
-
-                // Stop without snapshot
-                cluster.node(0).terminationExpected(true);
-                cluster.node(1).terminationExpected(true);
-                cluster.node(2).terminationExpected(true);
-
-                cluster.stopAllNodes();
-
-                // Invalidate snapshot from leadershipTermId = 1
-                cluster.invalidateLatestSnapshots();
-
-                // Start, should replay from snapshot in leadershipTerm = 0.
-                cluster.restartAllNodes(false);
-
-                cluster.awaitLeader();
-            }
-        });
+            cluster.awaitLeader();
+        }
     }
 
     private void awaitAllServiceMessageCount(final TestCluster cluster, final int numNodes, final int numMessages)

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
@@ -43,6 +43,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -54,7 +55,6 @@ import java.util.stream.Stream;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.cluster.RecordingLog.RECORDING_LOG_FILE_NAME;
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -129,21 +129,19 @@ public class StartFromTruncatedRecordingLogTest
     }
 
     @Test
-    public void shouldBeAbleToStartClusterFromTruncatedRecordingLog()
+    @Timeout(30)
+    public void shouldBeAbleToStartClusterFromTruncatedRecordingLog() throws IOException
     {
-        assertTimeoutPreemptively(ofSeconds(30), () ->
-        {
-            stopAndStartClusterWithTruncationOfRecordingLog();
-            assertClusterIsFunctioningCorrectly();
+        stopAndStartClusterWithTruncationOfRecordingLog();
+        assertClusterIsFunctioningCorrectly();
 
-            stopAndStartClusterWithTruncationOfRecordingLog();
-            assertClusterIsFunctioningCorrectly();
+        stopAndStartClusterWithTruncationOfRecordingLog();
+        assertClusterIsFunctioningCorrectly();
 
-            stopAndStartClusterWithTruncationOfRecordingLog();
-            assertClusterIsFunctioningCorrectly();
+        stopAndStartClusterWithTruncationOfRecordingLog();
+        assertClusterIsFunctioningCorrectly();
 
-            ClusterTests.failOnClusterError();
-        });
+        ClusterTests.failOnClusterError();
     }
 
     private void stopAndStartClusterWithTruncationOfRecordingLog() throws IOException

--- a/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
@@ -27,6 +27,7 @@ import org.agrona.collections.MutableBoolean;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -34,9 +35,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class BufferClaimMessageTest
 {
@@ -65,93 +64,89 @@ public class BufferClaimMessageTest
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldReceivePublishedMessageWithInterleavedAbort(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final MutableInteger fragmentCount = new MutableInteger();
+        final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> fragmentCount.value++;
+
+        final BufferClaim bufferClaim = new BufferClaim();
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
+
+        try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
+            Publication publication = aeron.addPublication(channel, STREAM_ID))
         {
-            final MutableInteger fragmentCount = new MutableInteger();
-            final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> fragmentCount.value++;
+            publishMessage(srcBuffer, publication);
 
-            final BufferClaim bufferClaim = new BufferClaim();
-            final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
-
-            try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
-                Publication publication = aeron.addPublication(channel, STREAM_ID))
+            while (publication.tryClaim(MESSAGE_LENGTH, bufferClaim) < 0L)
             {
-                publishMessage(srcBuffer, publication);
+                Thread.yield();
+                Tests.checkInterruptStatus();
+            }
 
-                while (publication.tryClaim(MESSAGE_LENGTH, bufferClaim) < 0L)
+            publishMessage(srcBuffer, publication);
+
+            bufferClaim.abort();
+
+            final int expectedNumberOfFragments = 2;
+            int numFragments = 0;
+            do
+            {
+                final int fragments = subscription.poll(fragmentHandler, FRAGMENT_COUNT_LIMIT);
+                if (0 == fragments)
                 {
                     Thread.yield();
                     Tests.checkInterruptStatus();
                 }
 
-                publishMessage(srcBuffer, publication);
-
-                bufferClaim.abort();
-
-                final int expectedNumberOfFragments = 2;
-                int numFragments = 0;
-                do
-                {
-                    final int fragments = subscription.poll(fragmentHandler, FRAGMENT_COUNT_LIMIT);
-                    if (0 == fragments)
-                    {
-                        Thread.yield();
-                        Tests.checkInterruptStatus();
-                    }
-
-                    numFragments += fragments;
-                }
-                while (numFragments < expectedNumberOfFragments);
-
-                assertEquals(expectedNumberOfFragments, fragmentCount.value);
+                numFragments += fragments;
             }
-        });
+            while (numFragments < expectedNumberOfFragments);
+
+            assertEquals(expectedNumberOfFragments, fragmentCount.value);
+        }
     }
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldTransferReservedValue(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
-        {
-            final BufferClaim bufferClaim = new BufferClaim();
+        final BufferClaim bufferClaim = new BufferClaim();
 
-            try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
-                Publication publication = aeron.addPublication(channel, STREAM_ID))
+        try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
+            Publication publication = aeron.addPublication(channel, STREAM_ID))
+        {
+            while (publication.tryClaim(MESSAGE_LENGTH, bufferClaim) < 0L)
             {
-                while (publication.tryClaim(MESSAGE_LENGTH, bufferClaim) < 0L)
+                Thread.yield();
+                Tests.checkInterruptStatus();
+            }
+
+            final long reservedValue = System.currentTimeMillis();
+            bufferClaim.reservedValue(reservedValue);
+            bufferClaim.commit();
+
+            final MutableBoolean done = new MutableBoolean();
+            while (!done.get())
+            {
+                final int fragments = subscription.poll(
+                    (buffer, offset, length, header) ->
+                    {
+                        assertEquals(MESSAGE_LENGTH, length);
+                        assertEquals(reservedValue, header.reservedValue());
+
+                        done.value = true;
+                    },
+                    FRAGMENT_COUNT_LIMIT);
+
+                if (0 == fragments)
                 {
                     Thread.yield();
                     Tests.checkInterruptStatus();
                 }
-
-                final long reservedValue = System.currentTimeMillis();
-                bufferClaim.reservedValue(reservedValue);
-                bufferClaim.commit();
-
-                final MutableBoolean done = new MutableBoolean();
-                while (!done.get())
-                {
-                    final int fragments = subscription.poll(
-                        (buffer, offset, length, header) ->
-                        {
-                            assertEquals(MESSAGE_LENGTH, length);
-                            assertEquals(reservedValue, header.reservedValue());
-
-                            done.value = true;
-                        },
-                        FRAGMENT_COUNT_LIMIT);
-
-                    if (0 == fragments)
-                    {
-                        Thread.yield();
-                        Tests.checkInterruptStatus();
-                    }
-                }
             }
-        });
+        }
     }
 
     private static void publishMessage(final UnsafeBuffer srcBuffer, final Publication publication)

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -26,6 +26,7 @@ import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -37,9 +38,9 @@ import static io.aeron.Publication.CLOSED;
 import static io.aeron.logbuffer.FrameDescriptor.*;
 import static io.aeron.protocol.DataHeaderFlyweight.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ExclusivePublicationTest
 {
@@ -72,193 +73,181 @@ public class ExclusivePublicationTest
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldPublishFromIndependentExclusivePublications(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
+            ExclusivePublication publicationOne = aeron.addExclusivePublication(channel, STREAM_ID);
+            ExclusivePublication publicationTwo = aeron.addExclusivePublication(channel, STREAM_ID))
         {
-            try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
-                ExclusivePublication publicationOne = aeron.addExclusivePublication(channel, STREAM_ID);
-                ExclusivePublication publicationTwo = aeron.addExclusivePublication(channel, STREAM_ID))
+            awaitConnection(subscription, 2);
+
+            final int expectedNumberOfFragments = 778;
+            int totalFragmentsRead = 0;
+            final MutableInteger messageCount = new MutableInteger();
+            final FragmentHandler fragmentHandler =
+                (buffer, offset, length, header) ->
+                {
+                    assertEquals(MESSAGE_LENGTH, length);
+                    messageCount.value++;
+                };
+
+            for (int i = 0; i < expectedNumberOfFragments; i += 2)
             {
-                awaitConnection(subscription, 2);
-
-                final int expectedNumberOfFragments = 778;
-                int totalFragmentsRead = 0;
-                final MutableInteger messageCount = new MutableInteger();
-                final FragmentHandler fragmentHandler =
-                    (buffer, offset, length, header) ->
-                    {
-                        assertEquals(MESSAGE_LENGTH, length);
-                        messageCount.value++;
-                    };
-
-                for (int i = 0; i < expectedNumberOfFragments; i += 2)
-                {
-                    publishMessage(srcBuffer, publicationOne);
-                    publishMessage(srcBuffer, publicationTwo);
-                    totalFragmentsRead += pollFragments(subscription, fragmentHandler);
-                }
-
-                do
-                {
-                    totalFragmentsRead += pollFragments(subscription, fragmentHandler);
-                }
-                while (totalFragmentsRead < expectedNumberOfFragments);
-
-                assertEquals(expectedNumberOfFragments, messageCount.value);
+                publishMessage(srcBuffer, publicationOne);
+                publishMessage(srcBuffer, publicationTwo);
+                totalFragmentsRead += pollFragments(subscription, fragmentHandler);
             }
-        });
+
+            do
+            {
+                totalFragmentsRead += pollFragments(subscription, fragmentHandler);
+            }
+            while (totalFragmentsRead < expectedNumberOfFragments);
+
+            assertEquals(expectedNumberOfFragments, messageCount.value);
+        }
     }
 
     @Test
+    @Timeout(10)
     void offerBlockThrowsIllegalArgumentExceptionIfLengthExceedsAvailableSpaceWithinTheTerm()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
         {
-            try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
-                ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
-            {
-                awaitConnection(subscription, 1);
+            awaitConnection(subscription, 1);
 
-                publishMessage(srcBuffer, publication);
+            publishMessage(srcBuffer, publication);
 
-                final int termBufferLength = publication.termBufferLength();
-                final int termOffset = publication.termOffset();
-                final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                    () -> publication.offerBlock(srcBuffer, 0, termBufferLength));
+            final int termBufferLength = publication.termBufferLength();
+            final int termOffset = publication.termOffset();
+            final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> publication.offerBlock(srcBuffer, 0, termBufferLength));
 
-                assertEquals("invalid block length " + termBufferLength +
-                    ", remaining space in term " + (termBufferLength - termOffset), exception.getMessage());
-            }
-        });
+            assertEquals("invalid block length " + termBufferLength +
+                ", remaining space in term " + (termBufferLength - termOffset), exception.getMessage());
+        }
     }
 
     @Test
+    @Timeout(10)
     void offerBlockReturnsClosedWhenPublicationIsClosed()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
         {
-            try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
-                ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
-            {
-                awaitConnection(subscription, 1);
-                publication.close();
+            awaitConnection(subscription, 1);
+            publication.close();
 
-                final long result = publication.offerBlock(srcBuffer, 0, MESSAGE_LENGTH);
-                assertEquals(CLOSED, result);
-            }
-        });
+            final long result = publication.offerBlock(srcBuffer, 0, MESSAGE_LENGTH);
+            assertEquals(CLOSED, result);
+        }
     }
 
     @Test
+    @Timeout(10)
     void offerBlockThrowsIllegalArgumentExceptionUponInvalidFirstFrame()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
         {
-            try (Subscription subscription = aeron.addSubscription(IPC_CHANNEL, STREAM_ID);
-                ExclusivePublication publication = aeron.addExclusivePublication(IPC_CHANNEL, STREAM_ID))
-            {
-                awaitConnection(subscription, 1);
+            awaitConnection(subscription, 1);
 
-                final int sessionId = publication.sessionId();
-                final int streamId = publication.streamId();
-                final int termId = publication.termId();
-                final int offset = 128;
+            final int sessionId = publication.sessionId();
+            final int streamId = publication.streamId();
+            final int termId = publication.termId();
+            final int offset = 128;
 
-                frameType(srcBuffer, offset, HDR_TYPE_NAK);
-                frameSessionId(srcBuffer, offset, -19);
-                srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, 42, LITTLE_ENDIAN);
+            frameType(srcBuffer, offset, HDR_TYPE_NAK);
+            frameSessionId(srcBuffer, offset, -19);
+            srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, 42, LITTLE_ENDIAN);
 
-                final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                    () -> publication.offerBlock(srcBuffer, offset, 1000));
+            final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> publication.offerBlock(srcBuffer, offset, 1000));
 
-                assertEquals("improperly formatted block:" +
-                    " termOffset=0" + " (expected=0)," +
-                    " sessionId=-19" + " (expected=" + sessionId + ")," +
-                    " streamId=42 (expected=" + streamId + ")," +
-                    " termId=0 (expected=" + termId + ")," +
-                    " frameType=" + HDR_TYPE_NAK + " (expected=" + HDR_TYPE_DATA + ")",
-                    ex.getMessage());
-            }
-        });
+            assertEquals("improperly formatted block:" +
+                " termOffset=0" + " (expected=0)," +
+                " sessionId=-19" + " (expected=" + sessionId + ")," +
+                " streamId=42 (expected=" + streamId + ")," +
+                " termId=0 (expected=" + termId + ")," +
+                " frameType=" + HDR_TYPE_NAK + " (expected=" + HDR_TYPE_DATA + ")",
+                ex.getMessage());
+        }
     }
 
     @Test
+    @Timeout(10)
     void offerBlockAcceptsUpToAnEntireTermOfData()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final String channel = IPC_CHANNEL + "?term-length=64k";
+        try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(channel, STREAM_ID))
         {
-            final String channel = IPC_CHANNEL + "?term-length=64k";
-            try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
-                ExclusivePublication publication = aeron.addExclusivePublication(channel, STREAM_ID))
-            {
-                awaitConnection(subscription, 1);
+            awaitConnection(subscription, 1);
 
-                final int sessionId = publication.sessionId();
-                final int streamId = publication.streamId();
-                final int currentTermId = publication.termId();
-                final int termBufferLength = publication.termBufferLength();
-                final int offset = 1024;
+            final int sessionId = publication.sessionId();
+            final int streamId = publication.streamId();
+            final int currentTermId = publication.termId();
+            final int termBufferLength = publication.termBufferLength();
+            final int offset = 1024;
 
-                frameType(srcBuffer, offset, HDR_TYPE_DATA);
-                frameLengthOrdered(srcBuffer, offset, termBufferLength);
-                frameSessionId(srcBuffer, offset, sessionId);
-                srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, streamId, LITTLE_ENDIAN);
-                srcBuffer.putInt(offset + TERM_ID_FIELD_OFFSET, currentTermId, LITTLE_ENDIAN);
-                srcBuffer.setMemory(offset + DATA_OFFSET, termBufferLength - HEADER_LENGTH, (byte)13);
+            frameType(srcBuffer, offset, HDR_TYPE_DATA);
+            frameLengthOrdered(srcBuffer, offset, termBufferLength);
+            frameSessionId(srcBuffer, offset, sessionId);
+            srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, streamId, LITTLE_ENDIAN);
+            srcBuffer.putInt(offset + TERM_ID_FIELD_OFFSET, currentTermId, LITTLE_ENDIAN);
+            srcBuffer.setMemory(offset + DATA_OFFSET, termBufferLength - HEADER_LENGTH, (byte)13);
 
-                final long position = publication.position();
-                final long result = publication.offerBlock(srcBuffer, offset, termBufferLength);
-                assertEquals(position + termBufferLength, result);
+            final long position = publication.position();
+            final long result = publication.offerBlock(srcBuffer, offset, termBufferLength);
+            assertEquals(position + termBufferLength, result);
 
-                final RawBlockHandler rawBlockHandler =
-                    (fileChannel, fileOffset, termBuffer, termOffset, length, pollSessionId, termId) ->
-                    {
-                        assertEquals(HDR_TYPE_DATA, frameType(termBuffer, termOffset));
-                        assertEquals(termBufferLength, frameLength(termBuffer, termOffset));
-                        assertEquals(sessionId, frameSessionId(termBuffer, termOffset));
-                        assertEquals(streamId, termBuffer.getInt(termOffset + STREAM_ID_FIELD_OFFSET, LITTLE_ENDIAN));
-                    };
+            final RawBlockHandler rawBlockHandler =
+                (fileChannel, fileOffset, termBuffer, termOffset, length, pollSessionId, termId) ->
+                {
+                    assertEquals(HDR_TYPE_DATA, frameType(termBuffer, termOffset));
+                    assertEquals(termBufferLength, frameLength(termBuffer, termOffset));
+                    assertEquals(sessionId, frameSessionId(termBuffer, termOffset));
+                    assertEquals(streamId, termBuffer.getInt(termOffset + STREAM_ID_FIELD_OFFSET, LITTLE_ENDIAN));
+                };
 
-                final long pollBytes = subscription.rawPoll(rawBlockHandler, termBufferLength);
-                assertEquals(termBufferLength, pollBytes);
-                assertEquals(publication.termBufferLength(), publication.termOffset());
-                assertEquals(currentTermId, publication.termId());
-            }
-        });
+            final long pollBytes = subscription.rawPoll(rawBlockHandler, termBufferLength);
+            assertEquals(termBufferLength, pollBytes);
+            assertEquals(publication.termBufferLength(), publication.termOffset());
+            assertEquals(currentTermId, publication.termId());
+        }
     }
 
     @Test
+    @Timeout(10)
     void offerBlockReturnsBackPressuredStatus()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final String channel = IPC_CHANNEL + "?term-length=64k";
+        try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
+            ExclusivePublication publication = aeron.addExclusivePublication(channel, STREAM_ID))
         {
-            final String channel = IPC_CHANNEL + "?term-length=64k";
-            try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
-                ExclusivePublication publication = aeron.addExclusivePublication(channel, STREAM_ID))
-            {
-                awaitConnection(subscription, 1);
+            awaitConnection(subscription, 1);
 
-                final int length = publication.termBufferLength() / 2;
-                final int sessionId = publication.sessionId();
-                final int streamId = publication.streamId();
-                final int termId = publication.termId();
-                final int dataLength = length - HEADER_LENGTH;
-                final int offset = 2048;
+            final int length = publication.termBufferLength() / 2;
+            final int sessionId = publication.sessionId();
+            final int streamId = publication.streamId();
+            final int termId = publication.termId();
+            final int dataLength = length - HEADER_LENGTH;
+            final int offset = 2048;
 
-                frameType(srcBuffer, offset, HDR_TYPE_DATA);
-                frameLengthOrdered(srcBuffer, offset, dataLength);
-                frameSessionId(srcBuffer, offset, sessionId);
-                srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, streamId, LITTLE_ENDIAN);
-                srcBuffer.putInt(offset + TERM_ID_FIELD_OFFSET, termId, LITTLE_ENDIAN);
-                srcBuffer.setMemory(offset + DATA_OFFSET, dataLength, (byte)6);
-                publication.offerBlock(srcBuffer, offset, length);
+            frameType(srcBuffer, offset, HDR_TYPE_DATA);
+            frameLengthOrdered(srcBuffer, offset, dataLength);
+            frameSessionId(srcBuffer, offset, sessionId);
+            srcBuffer.putInt(offset + STREAM_ID_FIELD_OFFSET, streamId, LITTLE_ENDIAN);
+            srcBuffer.putInt(offset + TERM_ID_FIELD_OFFSET, termId, LITTLE_ENDIAN);
+            srcBuffer.setMemory(offset + DATA_OFFSET, dataLength, (byte)6);
+            publication.offerBlock(srcBuffer, offset, length);
 
-                final long result = publication.offerBlock(srcBuffer, 0, offset);
+            final long result = publication.offerBlock(srcBuffer, 0, offset);
 
-                assertEquals(BACK_PRESSURED, result);
-            }
-        });
+            assertEquals(BACK_PRESSURED, result);
+        }
     }
 
     private static void awaitConnection(final Subscription subscription, final int imageCount)

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -27,6 +27,7 @@ import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,9 +36,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.SystemTests.spyForChannel;
-import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
 public class SpySimulatedConnectionTest
@@ -95,183 +96,175 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldNotSimulateConnectionWhenNotConfiguredTo(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        launch();
+
+        spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
+        publication = client.addPublication(channel, STREAM_ID);
+
+        while (!spy.isConnected())
         {
-            launch();
+            Thread.yield();
+            Tests.checkInterruptStatus();
+        }
 
-            spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
-            publication = client.addPublication(channel, STREAM_ID);
-
-            while (!spy.isConnected())
-            {
-                Thread.yield();
-                Tests.checkInterruptStatus();
-            }
-
-            assertFalse(publication.isConnected());
-        });
+        assertFalse(publication.isConnected());
     }
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldSimulateConnectionWithNoNetworkSubscriptions(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
+
+        driverContext
+            .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .spiesSimulateConnection(true);
+
+        launch();
+
+        spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
+        publication = client.addPublication(channel, STREAM_ID);
+
+        while (!spy.isConnected() || !publication.isConnected())
         {
-            final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
+            Thread.yield();
+            Tests.checkInterruptStatus();
+        }
 
-            driverContext
-                .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
-                .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
-                .spiesSimulateConnection(true);
-
-            launch();
-
-            spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
-            publication = client.addPublication(channel, STREAM_ID);
-
-            while (!spy.isConnected() || !publication.isConnected())
+        for (int i = 0; i < messagesToSend; i++)
+        {
+            while (publication.offer(buffer, 0, buffer.capacity()) < 0L)
             {
                 Thread.yield();
                 Tests.checkInterruptStatus();
             }
 
-            for (int i = 0; i < messagesToSend; i++)
-            {
-                while (publication.offer(buffer, 0, buffer.capacity()) < 0L)
+            final MutableInteger fragmentsRead = new MutableInteger();
+            SystemTests.executeUntil(
+                () -> fragmentsRead.get() > 0,
+                (j) ->
                 {
-                    Thread.yield();
-                    Tests.checkInterruptStatus();
-                }
-
-                final MutableInteger fragmentsRead = new MutableInteger();
-                SystemTests.executeUntil(
-                    () -> fragmentsRead.get() > 0,
-                    (j) ->
+                    final int fragments = spy.poll(fragmentHandlerSpy, 10);
+                    if (0 == fragments)
                     {
-                        final int fragments = spy.poll(fragmentHandlerSpy, 10);
-                        if (0 == fragments)
-                        {
-                            Thread.yield();
-                        }
-                        fragmentsRead.value += fragments;
-                    },
-                    Integer.MAX_VALUE,
-                    TimeUnit.MILLISECONDS.toNanos(500));
-            }
+                        Thread.yield();
+                    }
+                    fragmentsRead.value += fragments;
+                },
+                Integer.MAX_VALUE,
+                TimeUnit.MILLISECONDS.toNanos(500));
+        }
 
-            assertEquals(messagesToSend, fragmentCountSpy.value);
-        });
+        assertEquals(messagesToSend, fragmentCountSpy.value);
     }
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldSimulateConnectionWithSlowNetworkSubscription(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
+        int messagesLeftToSend = messagesToSend;
+        int fragmentsFromSpy = 0;
+        int fragmentsFromSubscription = 0;
+
+        driverContext
+            .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .spiesSimulateConnection(true);
+
+        launch();
+
+        spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
+        subscription = client.addSubscription(channel, STREAM_ID);
+        publication = client.addPublication(channel, STREAM_ID);
+
+        waitUntilFullConnectivity();
+
+        for (int i = 0; fragmentsFromSpy < messagesToSend || fragmentsFromSubscription < messagesToSend; i++)
         {
-            final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
-            int messagesLeftToSend = messagesToSend;
-            int fragmentsFromSpy = 0;
-            int fragmentsFromSubscription = 0;
-
-            driverContext
-                .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
-                .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
-                .spiesSimulateConnection(true);
-
-            launch();
-
-            spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
-            subscription = client.addSubscription(channel, STREAM_ID);
-            publication = client.addPublication(channel, STREAM_ID);
-
-            waitUntilFullConnectivity();
-
-            for (int i = 0; fragmentsFromSpy < messagesToSend || fragmentsFromSubscription < messagesToSend; i++)
+            if (messagesLeftToSend > 0)
             {
-                if (messagesLeftToSend > 0)
+                if (publication.offer(buffer, 0, buffer.capacity()) >= 0L)
                 {
-                    if (publication.offer(buffer, 0, buffer.capacity()) >= 0L)
-                    {
-                        messagesLeftToSend--;
-                    }
-                }
-
-                Thread.yield();
-                Tests.checkInterruptStatus();
-
-                fragmentsFromSpy += spy.poll(fragmentHandlerSpy, 10);
-
-                // subscription receives slowly
-                if ((i % 2) == 0)
-                {
-                    fragmentsFromSubscription += subscription.poll(fragmentHandlerSub, 1);
+                    messagesLeftToSend--;
                 }
             }
 
-            assertEquals(messagesToSend, fragmentCountSpy.value);
-            assertEquals(messagesToSend, fragmentCountSub.value);
-        });
+            Thread.yield();
+            Tests.checkInterruptStatus();
+
+            fragmentsFromSpy += spy.poll(fragmentHandlerSpy, 10);
+
+            // subscription receives slowly
+            if ((i % 2) == 0)
+            {
+                fragmentsFromSubscription += subscription.poll(fragmentHandlerSub, 1);
+            }
+        }
+
+        assertEquals(messagesToSend, fragmentCountSpy.value);
+        assertEquals(messagesToSend, fragmentCountSub.value);
     }
 
     @ParameterizedTest
     @MethodSource("channels")
+    @Timeout(10)
     public void shouldSimulateConnectionWithLeavingNetworkSubscription(final String channel)
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
+        int messagesLeftToSend = messagesToSend;
+        int fragmentsReadFromSpy = 0;
+        int fragmentsReadFromSubscription = 0;
+        boolean isSubscriptionClosed = false;
+
+        driverContext
+            .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
+            .spiesSimulateConnection(true);
+
+        launch();
+
+        spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
+        subscription = client.addSubscription(channel, STREAM_ID);
+        publication = client.addPublication(channel, STREAM_ID);
+
+        waitUntilFullConnectivity();
+
+        while (fragmentsReadFromSpy < messagesToSend)
         {
-            final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
-            int messagesLeftToSend = messagesToSend;
-            int fragmentsReadFromSpy = 0;
-            int fragmentsReadFromSubscription = 0;
-            boolean isSubscriptionClosed = false;
-
-            driverContext
-                .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(250))
-                .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
-                .spiesSimulateConnection(true);
-
-            launch();
-
-            spy = client.addSubscription(spyForChannel(channel), STREAM_ID);
-            subscription = client.addSubscription(channel, STREAM_ID);
-            publication = client.addPublication(channel, STREAM_ID);
-
-            waitUntilFullConnectivity();
-
-            while (fragmentsReadFromSpy < messagesToSend)
+            if (messagesLeftToSend > 0)
             {
-                if (messagesLeftToSend > 0)
+                if (publication.offer(buffer, 0, buffer.capacity()) >= 0L)
                 {
-                    if (publication.offer(buffer, 0, buffer.capacity()) >= 0L)
-                    {
-                        messagesLeftToSend--;
-                    }
-                    else
-                    {
-                        Tests.checkInterruptStatus();
-                    }
+                    messagesLeftToSend--;
                 }
-
-                fragmentsReadFromSpy += spy.poll(fragmentHandlerSpy, 10);
-
-                // subscription receives up to 1/8 of the messages, then stops
-                if (fragmentsReadFromSubscription < (messagesToSend / 8))
+                else
                 {
-                    fragmentsReadFromSubscription += subscription.poll(fragmentHandlerSub, 10);
-                }
-                else if (!isSubscriptionClosed)
-                {
-                    subscription.close();
-                    isSubscriptionClosed = true;
+                    Tests.checkInterruptStatus();
                 }
             }
 
-            assertEquals(messagesToSend, fragmentCountSpy.value);
-        });
+            fragmentsReadFromSpy += spy.poll(fragmentHandlerSpy, 10);
+
+            // subscription receives up to 1/8 of the messages, then stops
+            if (fragmentsReadFromSubscription < (messagesToSend / 8))
+            {
+                fragmentsReadFromSubscription += subscription.poll(fragmentHandlerSub, 10);
+            }
+            else if (!isSubscriptionClosed)
+            {
+                subscription.close();
+                isSubscriptionClosed = true;
+            }
+        }
+
+        assertEquals(messagesToSend, fragmentCountSpy.value);
     }
 
     private void waitUntilFullConnectivity()

--- a/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
@@ -25,10 +25,9 @@ import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static java.time.Duration.ofSeconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class TwoBufferOfferMessageTest
 {
@@ -51,79 +50,75 @@ public class TwoBufferOfferMessageTest
     }
 
     @Test
+    @Timeout(10)
     public void shouldTransferUnfragmentedTwoPartMessage()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[256]);
+        final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);
+        final UnsafeBuffer bufferTwo = new UnsafeBuffer(expectedBuffer, 32, expectedBuffer.capacity() - 32);
+
+        bufferOne.setMemory(0, bufferOne.capacity(), (byte)'a');
+        bufferTwo.setMemory(0, bufferTwo.capacity(), (byte)'b');
+        final String expectedMessage = expectedBuffer.getStringWithoutLengthAscii(0, expectedBuffer.capacity());
+
+        final MutableReference<String> receivedMessage = new MutableReference<>();
+        final FragmentHandler fragmentHandler = (buffer, offset, length, header) ->
+            receivedMessage.set(buffer.getStringWithoutLengthAscii(offset, length));
+
+        try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID))
         {
-            final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[256]);
-            final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);
-            final UnsafeBuffer bufferTwo = new UnsafeBuffer(expectedBuffer, 32, expectedBuffer.capacity() - 32);
-
-            bufferOne.setMemory(0, bufferOne.capacity(), (byte)'a');
-            bufferTwo.setMemory(0, bufferTwo.capacity(), (byte)'b');
-            final String expectedMessage = expectedBuffer.getStringWithoutLengthAscii(0, expectedBuffer.capacity());
-
-            final MutableReference<String> receivedMessage = new MutableReference<>();
-            final FragmentHandler fragmentHandler = (buffer, offset, length, header) ->
-                receivedMessage.set(buffer.getStringWithoutLengthAscii(offset, length));
-
-            try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID))
+            try (Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))
             {
-                try (Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))
-                {
-                    publishMessage(bufferOne, bufferTwo, publication);
-                    pollForMessage(subscription, receivedMessage, fragmentHandler);
+                publishMessage(bufferOne, bufferTwo, publication);
+                pollForMessage(subscription, receivedMessage, fragmentHandler);
 
-                    assertEquals(expectedMessage, receivedMessage.get());
-                }
-
-                try (Publication publication = aeron.addExclusivePublication(CHANNEL, STREAM_ID))
-                {
-                    publishMessage(bufferOne, bufferTwo, publication);
-                    pollForMessage(subscription, receivedMessage, fragmentHandler);
-
-                    assertEquals(expectedMessage, receivedMessage.get());
-                }
+                assertEquals(expectedMessage, receivedMessage.get());
             }
-        });
+
+            try (Publication publication = aeron.addExclusivePublication(CHANNEL, STREAM_ID))
+            {
+                publishMessage(bufferOne, bufferTwo, publication);
+                pollForMessage(subscription, receivedMessage, fragmentHandler);
+
+                assertEquals(expectedMessage, receivedMessage.get());
+            }
+        }
     }
 
     @Test
+    @Timeout(10)
     public void shouldTransferFragmentedTwoPartMessage()
     {
-        assertTimeoutPreemptively(ofSeconds(10), () ->
+        final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[32 + driver.context().mtuLength()]);
+        final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);
+        final UnsafeBuffer bufferTwo = new UnsafeBuffer(expectedBuffer, 32, expectedBuffer.capacity() - 32);
+
+        bufferOne.setMemory(0, bufferOne.capacity(), (byte)'a');
+        bufferTwo.setMemory(0, bufferTwo.capacity(), (byte)'b');
+        final String expectedMessage = expectedBuffer.getStringWithoutLengthAscii(0, expectedBuffer.capacity());
+
+        final MutableReference<String> receivedMessage = new MutableReference<>();
+        final FragmentHandler fragmentHandler = new FragmentAssembler((buffer, offset, length, header) ->
+            receivedMessage.set(buffer.getStringWithoutLengthAscii(offset, length)));
+
+        try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID))
         {
-            final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[32 + driver.context().mtuLength()]);
-            final UnsafeBuffer bufferOne = new UnsafeBuffer(expectedBuffer, 0, 32);
-            final UnsafeBuffer bufferTwo = new UnsafeBuffer(expectedBuffer, 32, expectedBuffer.capacity() - 32);
-
-            bufferOne.setMemory(0, bufferOne.capacity(), (byte)'a');
-            bufferTwo.setMemory(0, bufferTwo.capacity(), (byte)'b');
-            final String expectedMessage = expectedBuffer.getStringWithoutLengthAscii(0, expectedBuffer.capacity());
-
-            final MutableReference<String> receivedMessage = new MutableReference<>();
-            final FragmentHandler fragmentHandler = new FragmentAssembler((buffer, offset, length, header) ->
-                receivedMessage.set(buffer.getStringWithoutLengthAscii(offset, length)));
-
-            try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID))
+            try (Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))
             {
-                try (Publication publication = aeron.addPublication(CHANNEL, STREAM_ID))
-                {
-                    publishMessage(bufferOne, bufferTwo, publication);
-                    pollForMessage(subscription, receivedMessage, fragmentHandler);
+                publishMessage(bufferOne, bufferTwo, publication);
+                pollForMessage(subscription, receivedMessage, fragmentHandler);
 
-                    assertEquals(expectedMessage, receivedMessage.get());
-                }
-
-                try (Publication publication = aeron.addExclusivePublication(CHANNEL, STREAM_ID))
-                {
-                    publishMessage(bufferOne, bufferTwo, publication);
-                    pollForMessage(subscription, receivedMessage, fragmentHandler);
-
-                    assertEquals(expectedMessage, receivedMessage.get());
-                }
+                assertEquals(expectedMessage, receivedMessage.get());
             }
-        });
+
+            try (Publication publication = aeron.addExclusivePublication(CHANNEL, STREAM_ID))
+            {
+                publishMessage(bufferOne, bufferTwo, publication);
+                pollForMessage(subscription, receivedMessage, fragmentHandler);
+
+                assertEquals(expectedMessage, receivedMessage.get());
+            }
+        }
     }
 
     private static void publishMessage(


### PR DESCRIPTION
Pros:
- All tests are executed on the same thread
- Clearer stacktraces in case of error
- No races between tests, i.e. next test will not run before the previous fully terminates
- Less nesting
- Timeouts can be defined at a class-level

Cons:
- Does not handle hanging tests