### PR TITLE
[Java] Change the use of the isStartup flag for closing existing sessions.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
@@ -53,13 +53,17 @@ final class ClusterEventDissector
         absoluteOffset += SIZE_OF_INT;
 
         final int logSessionId = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_INT;
+
+        final boolean isStartup = 1 == buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId)
             .append(", leadershipTermId=").append(leadershipTermId)
             .append(", logPosition=").append(logPosition)
             .append(", timestamp=").append(timestamp)
             .append(", leaderMemberId=").append(leaderMemberId)
-            .append(", logSessionId=").append(logSessionId);
+            .append(", logSessionId=").append(logSessionId)
+            .append(", isStartup=").append(isStartup);
     }
 
     static void dissectStateChange(

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventEncoder.java
@@ -40,7 +40,8 @@ final class ClusterEventEncoder
         final long logPosition,
         final long timestamp,
         final int leaderMemberId,
-        final int logSessionId)
+        final int logSessionId,
+        final boolean isStartup)
     {
         int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
@@ -62,12 +63,15 @@ final class ClusterEventEncoder
         encodingBuffer.putInt(offset + relativeOffset, logSessionId, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_INT;
 
+        encodingBuffer.putInt(offset + relativeOffset, isStartup ? 1 : 0, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
         return relativeOffset;
     }
 
     static int newLeaderShipTermLength()
     {
-        return SIZE_OF_LONG * 4 + SIZE_OF_INT * 2;
+        return SIZE_OF_LONG * 4 + SIZE_OF_INT * 3;
     }
 
     static <T extends Enum<T>> int encodeStateChange(

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventLogger.java
@@ -48,7 +48,8 @@ public final class ClusterEventLogger
         final long logPosition,
         final long timestamp,
         final int leaderMemberId,
-        final int logSessionId)
+        final int logSessionId,
+        final boolean isStartup)
     {
         final int length = newLeaderShipTermLength();
         final int captureLength = captureLength(length);
@@ -69,7 +70,8 @@ public final class ClusterEventLogger
                     logPosition,
                     timestamp,
                     leaderMemberId,
-                    logSessionId);
+                    logSessionId,
+                    isStartup);
             }
             finally
             {

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterInterceptor.java
@@ -46,7 +46,8 @@ class ClusterInterceptor
             final long logPosition,
             final long timestamp,
             final int leaderMemberId,
-            final int logSessionId)
+            final int logSessionId,
+            final boolean isStartup)
         {
             LOGGER.logNewLeadershipTerm(
                 logLeadershipTermId,
@@ -54,7 +55,8 @@ class ClusterInterceptor
                 logPosition,
                 timestamp,
                 leaderMemberId,
-                logSessionId);
+                logSessionId,
+                isStartup);
         }
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
@@ -44,11 +44,12 @@ class ClusterEventDissectorTest
         buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_LONG * 3, 4, LITTLE_ENDIAN);
         buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4, 100, LITTLE_ENDIAN);
         buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4 + SIZE_OF_INT, 200, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_LONG * 4 + SIZE_OF_INT + SIZE_OF_INT, 1, LITTLE_ENDIAN);
 
         ClusterEventDissector.dissectNewLeadershipTerm(buffer, 0, builder);
 
         assertEquals("[33.0] " + CONTEXT + ": " + NEW_LEADERSHIP_TERM.name() + " [8/9]: logLeadershipTermId=1" +
-            ", leadershipTermId=2, logPosition=3, timestamp=4, leaderMemberId=100, logSessionId=200",
+            ", leadershipTermId=2, logPosition=3, timestamp=4, leaderMemberId=100, logSessionId=200, isStartup=true",
             builder.toString());
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventEncoderTest.java
@@ -67,6 +67,7 @@ class ClusterEventEncoderTest
         final int timestamp = 32423436;
         final int leaderMemberId = 42;
         final int logSessionId = 18;
+        final boolean isStartup = true;
 
         final int encodedLength = encodeNewLeadershipTerm(
             buffer,
@@ -78,7 +79,8 @@ class ClusterEventEncoderTest
             logPosition,
             timestamp,
             leaderMemberId,
-            logSessionId);
+            logSessionId,
+            isStartup);
 
         assertEquals(encodedLength(newLeaderShipTermLength()), encodedLength);
         int relativeOffset = 0;
@@ -99,12 +101,14 @@ class ClusterEventEncoderTest
         assertEquals(leaderMemberId, buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN));
         relativeOffset += SIZE_OF_INT;
         assertEquals(logSessionId, buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_INT;
+        assertEquals(isStartup, 1 == buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN));
     }
 
     @Test
     void testNewLeaderShipTermLength()
     {
-        assertEquals(SIZE_OF_LONG * 4 + SIZE_OF_INT * 2, newLeaderShipTermLength());
+        assertEquals(SIZE_OF_LONG * 4 + SIZE_OF_INT * 3, newLeaderShipTermLength());
     }
 
     @Test

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventLoggerTest.java
@@ -65,26 +65,27 @@ class ClusterEventLoggerTest
         final long timestamp = 2;
         final int leaderMemberId = 0;
         final int logSessionId = 3;
-        final int captureLength = SIZE_OF_LONG * 4 + SIZE_OF_INT * 2;
+        final int captureLength = SIZE_OF_LONG * 4 + SIZE_OF_INT * 3;
+        final boolean isStartup = true;
 
         logger.logNewLeadershipTerm(
-            logLeadershipTermId, leadershipTermId, logPosition, timestamp, leaderMemberId, logSessionId);
+            logLeadershipTermId, leadershipTermId, logPosition, timestamp, leaderMemberId, logSessionId, isStartup);
 
-        verifyLogHeader(
-            logBuffer, offset, toEventCodeId(NEW_LEADERSHIP_TERM), captureLength, captureLength);
-        assertEquals(logLeadershipTermId,
-            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH), LITTLE_ENDIAN));
-        assertEquals(leadershipTermId,
-            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG), LITTLE_ENDIAN));
-        assertEquals(logPosition,
-            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG * 2), LITTLE_ENDIAN));
-        assertEquals(timestamp,
-            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG * 3), LITTLE_ENDIAN));
-        assertEquals(leaderMemberId,
-            logBuffer.getInt(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG * 4), LITTLE_ENDIAN));
-        assertEquals(logSessionId,
-            logBuffer.getInt(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG * 4 + SIZE_OF_INT),
-            LITTLE_ENDIAN));
+        verifyLogHeader(logBuffer, offset, toEventCodeId(NEW_LEADERSHIP_TERM), captureLength, captureLength);
+        int relativeOffset = LOG_HEADER_LENGTH;
+        assertEquals(logLeadershipTermId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_LONG;
+        assertEquals(leadershipTermId, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_LONG;
+        assertEquals(logPosition, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_LONG;
+        assertEquals(timestamp, logBuffer.getLong(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_LONG;
+        assertEquals(leaderMemberId, logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_INT;
+        assertEquals(logSessionId, logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
+        relativeOffset += SIZE_OF_INT;
+        assertEquals(isStartup, 1 == logBuffer.getInt(encodedMsgOffset(offset + relativeOffset), LITTLE_ENDIAN));
     }
 
     @Test

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -459,7 +459,8 @@ class ConsensusModuleAgent implements Agent
                     logPublisher.position(),
                     recordingLog.getTermTimestamp(leadershipTermId),
                     thisMember.id(),
-                    logPublisher.sessionId());
+                    logPublisher.sessionId(),
+                    false);
             }
         }
     }
@@ -501,12 +502,13 @@ class ConsensusModuleAgent implements Agent
         final long logPosition,
         final long timestamp,
         final int leaderId,
-        final int logSessionId)
+        final int logSessionId,
+        final boolean isStartup)
     {
         if (null != election)
         {
             election.onNewLeadershipTerm(
-                logLeadershipTermId, leadershipTermId, logPosition, timestamp, leaderId, logSessionId);
+                logLeadershipTermId, leadershipTermId, logPosition, timestamp, leaderId, logSessionId, isStartup);
         }
         else if (leadershipTermId > this.leadershipTermId)
         {
@@ -1161,7 +1163,8 @@ class ConsensusModuleAgent implements Agent
         @SuppressWarnings("unused") final int leaderMemberId,
         @SuppressWarnings("unused") final int logSessionId,
         final TimeUnit timeUnit,
-        final int appVersion)
+        final int appVersion,
+        final boolean isStartup)
     {
         if (timeUnit != clusterTimeUnit)
         {
@@ -1188,7 +1191,7 @@ class ConsensusModuleAgent implements Agent
         {
             final long recordingId = RecordingPos.getRecordingId(aeron.countersReader(), appendPosition.counterId());
             election.onReplayNewLeadershipTermEvent(
-                recordingId, leadershipTermId, logPosition, timestamp, termBaseLogPosition);
+                recordingId, leadershipTermId, logPosition, timestamp, termBaseLogPosition, isStartup);
         }
     }
 
@@ -1501,7 +1504,7 @@ class ConsensusModuleAgent implements Agent
             {
                 if (session.state() == OPEN)
                 {
-                    session.close(CloseReason.TIMEOUT);
+//                    session.close(CloseReason.TIMEOUT);
                 }
             }
         }
@@ -1637,7 +1640,8 @@ class ConsensusModuleAgent implements Agent
                 memberId,
                 logPublisher.sessionId(),
                 clusterTimeUnit,
-                ctx.appVersion()))
+                ctx.appVersion(),
+                election.isLeaderStartup()))
             {
                 return false;
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1163,8 +1163,7 @@ class ConsensusModuleAgent implements Agent
         @SuppressWarnings("unused") final int leaderMemberId,
         @SuppressWarnings("unused") final int logSessionId,
         final TimeUnit timeUnit,
-        final int appVersion,
-        final boolean isStartup)
+        final int appVersion)
     {
         if (timeUnit != clusterTimeUnit)
         {
@@ -1191,7 +1190,7 @@ class ConsensusModuleAgent implements Agent
         {
             final long recordingId = RecordingPos.getRecordingId(aeron.countersReader(), appendPosition.counterId());
             election.onReplayNewLeadershipTermEvent(
-                recordingId, leadershipTermId, logPosition, timestamp, termBaseLogPosition, isStartup);
+                recordingId, leadershipTermId, logPosition, timestamp, termBaseLogPosition);
         }
     }
 
@@ -1504,7 +1503,7 @@ class ConsensusModuleAgent implements Agent
             {
                 if (session.state() == OPEN)
                 {
-//                    session.close(CloseReason.TIMEOUT);
+                    session.close(CloseReason.TIMEOUT);
                 }
             }
         }
@@ -1640,8 +1639,8 @@ class ConsensusModuleAgent implements Agent
                 memberId,
                 logPublisher.sessionId(),
                 clusterTimeUnit,
-                ctx.appVersion(),
-                election.isLeaderStartup()))
+                ctx.appVersion()
+            ))
             {
                 return false;
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -100,7 +100,8 @@ public class Election
         }
     }
 
-    private boolean isStartup;
+    private boolean isNodeStartup;
+    private boolean isLeaderStartup;
     private boolean isExtendedCanvass;
     private boolean shouldReplay;
     private final ClusterMember[] clusterMembers;
@@ -129,7 +130,7 @@ public class Election
     private LogReplay logReplay = null;
 
     public Election(
-        final boolean isStartup,
+        final boolean isNodeStartup,
         final long leadershipTermId,
         final long logPosition,
         final ClusterMember[] clusterMembers,
@@ -140,9 +141,9 @@ public class Election
         final ConsensusModule.Context ctx,
         final ConsensusModuleAgent consensusModuleAgent)
     {
-        this.isStartup = isStartup;
-        this.shouldReplay = isStartup;
-        this.isExtendedCanvass = isStartup;
+        this.isNodeStartup = isNodeStartup;
+        this.shouldReplay = isNodeStartup;
+        this.isExtendedCanvass = isNodeStartup;
         this.logPosition = logPosition;
         this.logLeadershipTermId = leadershipTermId;
         this.leadershipTermId = leadershipTermId;
@@ -171,6 +172,11 @@ public class Election
     public long logPosition()
     {
         return logPosition;
+    }
+
+    public boolean isLeaderStartup()
+    {
+        return isLeaderStartup;
     }
 
     int doWork(final long nowNs)
@@ -271,7 +277,8 @@ public class Election
                         this.logPosition,
                         timestamp,
                         thisMember.id(),
-                        logSessionId);
+                        logSessionId,
+                        isLeaderStartup);
                 }
             }
             else if (State.CANVASS != state && logLeadershipTermId > leadershipTermId)
@@ -340,7 +347,8 @@ public class Election
         final long logPosition,
         final long timestamp,
         final int leaderMemberId,
-        final int logSessionId)
+        final int logSessionId,
+        final boolean isStartup)
     {
         final ClusterMember leader = clusterMemberByIdMap.get(leaderMemberId);
         if (null == leader)
@@ -349,6 +357,7 @@ public class Election
         }
 
         leaderMember = leader;
+        this.isLeaderStartup = isStartup;
 
         if (this.logPosition > logPosition && logLeadershipTermId == this.logLeadershipTermId)
         {
@@ -424,7 +433,8 @@ public class Election
         final long leadershipTermId,
         final long logPosition,
         final long timestamp,
-        final long termBaseLogPosition)
+        final long termBaseLogPosition,
+        final boolean isStartup)
     {
         if (State.FOLLOWER_CATCHUP == state)
         {
@@ -453,12 +463,13 @@ public class Election
 
             logLeadershipTermId = leadershipTermId;
             this.logPosition = logPosition;
+            isLeaderStartup = isStartup;
         }
     }
 
     private int init()
     {
-        if (!isStartup)
+        if (!isNodeStartup)
         {
             cleanupReplay();
             consensusModuleAgent.prepareForNewLeadership(logPosition);
@@ -636,7 +647,8 @@ public class Election
 
     private int leaderTransition(final long nowNs)
     {
-        consensusModuleAgent.becomeLeader(candidateTermId, logPosition, logSessionId, isStartup);
+        isLeaderStartup = isNodeStartup;
+        consensusModuleAgent.becomeLeader(candidateTermId, logPosition, logSessionId, isLeaderStartup);
 
         final long recordingId = consensusModuleAgent.logRecordingId();
         final long timestamp = ctx.clusterClock().timeUnit().convert(nowNs, TimeUnit.NANOSECONDS);
@@ -725,7 +737,7 @@ public class Election
                 ctx.logChannel(), logSessionId, consensusModuleAgent.logSubscriptionTags());
 
             logSubscription = consensusModuleAgent.createAndRecordLogSubscriptionAsFollower(logChannelUri.toString());
-            consensusModuleAgent.awaitServicesReady(logChannelUri, logSessionId, logPosition, isStartup);
+            consensusModuleAgent.awaitServicesReady(logChannelUri, logSessionId, logPosition, isLeaderStartup);
 
             final String replayDestination = new ChannelUriStringBuilder()
                 .media(CommonContext.UDP_MEDIA)
@@ -792,7 +804,7 @@ public class Election
                 ctx.logChannel(), logSessionId, consensusModuleAgent.logSubscriptionTags());
 
             logSubscription = consensusModuleAgent.createAndRecordLogSubscriptionAsFollower(logChannelUri.toString());
-            consensusModuleAgent.awaitServicesReady(logChannelUri, logSessionId, logPosition, isStartup);
+            consensusModuleAgent.awaitServicesReady(logChannelUri, logSessionId, logPosition, isLeaderStartup);
         }
 
         if (null == liveLogDestination)
@@ -878,7 +890,8 @@ public class Election
             logPosition,
             timestamp,
             thisMember.id(),
-            logSessionId);
+            logSessionId,
+            isLeaderStartup);
     }
 
     private boolean catchupPosition(final long leadershipTermId, final long logPosition)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -433,8 +433,7 @@ public class Election
         final long leadershipTermId,
         final long logPosition,
         final long timestamp,
-        final long termBaseLogPosition,
-        final boolean isStartup)
+        final long termBaseLogPosition)
     {
         if (State.FOLLOWER_CATCHUP == state)
         {
@@ -463,7 +462,6 @@ public class Election
 
             logLeadershipTermId = leadershipTermId;
             this.logPosition = logPosition;
-            isLeaderStartup = isStartup;
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
@@ -170,7 +170,8 @@ final class LogAdapter implements ControlledFragmentHandler, AutoCloseable
                     newLeadershipTermEventDecoder.leaderMemberId(),
                     newLeadershipTermEventDecoder.logSessionId(),
                     ClusterClock.map(newLeadershipTermEventDecoder.timeUnit()),
-                    newLeadershipTermEventDecoder.appVersion());
+                    newLeadershipTermEventDecoder.appVersion(),
+                    newLeadershipTermEventDecoder.isStartup() == BooleanType.TRUE);
                 break;
 
             case MembershipChangeEventDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
@@ -170,8 +170,8 @@ final class LogAdapter implements ControlledFragmentHandler, AutoCloseable
                     newLeadershipTermEventDecoder.leaderMemberId(),
                     newLeadershipTermEventDecoder.logSessionId(),
                     ClusterClock.map(newLeadershipTermEventDecoder.timeUnit()),
-                    newLeadershipTermEventDecoder.appVersion(),
-                    newLeadershipTermEventDecoder.isStartup() == BooleanType.TRUE);
+                    newLeadershipTermEventDecoder.appVersion()
+                );
                 break;
 
             case MembershipChangeEventDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
@@ -260,8 +260,7 @@ class LogPublisher
         final int leaderMemberId,
         final int logSessionId,
         final TimeUnit timeUnit,
-        final int appVersion,
-        final boolean isStartup)
+        final int appVersion)
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + NewLeadershipTermEventEncoder.BLOCK_LENGTH;
         final int fragmentLength = DataHeaderFlyweight.HEADER_LENGTH +
@@ -284,8 +283,7 @@ class LogPublisher
                     .leaderMemberId(leaderMemberId)
                     .logSessionId(logSessionId)
                     .timeUnit(ClusterClock.map(timeUnit))
-                    .appVersion(appVersion)
-                    .isStartup(isStartup ? BooleanType.TRUE : BooleanType.FALSE);
+                    .appVersion(appVersion);
 
                 bufferClaim.commit();
                 return true;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
@@ -260,7 +260,8 @@ class LogPublisher
         final int leaderMemberId,
         final int logSessionId,
         final TimeUnit timeUnit,
-        final int appVersion)
+        final int appVersion,
+        final boolean isStartup)
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + NewLeadershipTermEventEncoder.BLOCK_LENGTH;
         final int fragmentLength = DataHeaderFlyweight.HEADER_LENGTH +
@@ -283,7 +284,8 @@ class LogPublisher
                     .leaderMemberId(leaderMemberId)
                     .logSessionId(logSessionId)
                     .timeUnit(ClusterClock.map(timeUnit))
-                    .appVersion(appVersion);
+                    .appVersion(appVersion)
+                    .isStartup(isStartup ? BooleanType.TRUE : BooleanType.FALSE);
 
                 bufferClaim.commit();
                 return true;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/MemberStatusAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/MemberStatusAdapter.java
@@ -142,7 +142,8 @@ class MemberStatusAdapter implements FragmentHandler, AutoCloseable
                     newLeadershipTermDecoder.logPosition(),
                     newLeadershipTermDecoder.timestamp(),
                     newLeadershipTermDecoder.leaderMemberId(),
-                    newLeadershipTermDecoder.logSessionId());
+                    newLeadershipTermDecoder.logSessionId(),
+                    newLeadershipTermDecoder.isStartup() == BooleanType.TRUE);
                 break;
 
             case AppendPositionDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/java/io/aeron/cluster/MemberStatusPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/MemberStatusPublisher.java
@@ -154,7 +154,8 @@ class MemberStatusPublisher
         final long logPosition,
         final long timestamp,
         final int leaderMemberId,
-        final int logSessionId)
+        final int logSessionId,
+        final boolean isStartup)
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + NewLeadershipTermEncoder.BLOCK_LENGTH;
 
@@ -171,7 +172,8 @@ class MemberStatusPublisher
                     .logPosition(logPosition)
                     .timestamp(timestamp)
                     .leaderMemberId(leaderMemberId)
-                    .logSessionId(logSessionId);
+                    .logSessionId(logSessionId)
+                    .isStartup(isStartup ? BooleanType.TRUE : BooleanType.FALSE);
 
                 bufferClaim.commit();
 

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.cluster.codecs"
                    id="111"
-                   version="7"
+                   version="6"
                    semanticVersion="5.2"
                    description="Message Codecs for communicating with, and within, an Aeron Cluster."
                    byteOrder="littleEndian">
@@ -39,7 +39,6 @@
             <validValue name="CLIENT_ACTION" description="Client closed the session.">0</validValue>
             <validValue name="SERVICE_ACTION" description="Service closed the session.">1</validValue>
             <validValue name="TIMEOUT" description="Session timed out due to inactivity.">2</validValue>
-            <validValue name="TIMEOUT_ONSTART" description="Session timed out due to cluster restart.">3</validValue>
         </enum>
         <enum name="ClusterAction" encodingType="int32" description="Action to be taken by cluster nodes.">
             <validValue name="SUSPEND" description="Suspend ingress to the cluster.">0</validValue>
@@ -247,7 +246,6 @@
         <field name="logSessionId"             id="6" type="int32"/>
         <field name="timeUnit"                 id="7" type="ClusterTimeUnit" sinceVersion="4" presence="optional"/>
         <field name="appVersion"               id="8" type="version_t" sinceVersion="4" presence="optional"/>
-        <field name="isStartup"                id="9" type="BooleanType" sinceVersion="7" presence="optional"/>
     </sbe:message>
 
     <sbe:message name="MembershipChangeEvent"
@@ -431,7 +429,7 @@
         <field name="leaderMemberId"            id="5" type="int32"/>
         <field name="logSessionId"              id="6" type="int32"/>
         <field name="appVersion"                id="7" type="version_t"/>
-        <field name="isStartup"                 id="8" type="BooleanType" sinceVersion="7" presence="optional"/>
+        <field name="isStartup"                 id="8" type="BooleanType"/>
     </sbe:message>
 
     <!-- keep this under 32 - 8 = 24 bytes for efficiency -->

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.cluster.codecs"
                    id="111"
-                   version="6"
+                   version="7"
                    semanticVersion="5.2"
                    description="Message Codecs for communicating with, and within, an Aeron Cluster."
                    byteOrder="littleEndian">
@@ -39,6 +39,7 @@
             <validValue name="CLIENT_ACTION" description="Client closed the session.">0</validValue>
             <validValue name="SERVICE_ACTION" description="Service closed the session.">1</validValue>
             <validValue name="TIMEOUT" description="Session timed out due to inactivity.">2</validValue>
+            <validValue name="TIMEOUT_ONSTART" description="Session timed out due to cluster restart.">3</validValue>
         </enum>
         <enum name="ClusterAction" encodingType="int32" description="Action to be taken by cluster nodes.">
             <validValue name="SUSPEND" description="Suspend ingress to the cluster.">0</validValue>
@@ -246,6 +247,7 @@
         <field name="logSessionId"             id="6" type="int32"/>
         <field name="timeUnit"                 id="7" type="ClusterTimeUnit" sinceVersion="4" presence="optional"/>
         <field name="appVersion"               id="8" type="version_t" sinceVersion="4" presence="optional"/>
+        <field name="isStartup"                id="9" type="BooleanType" sinceVersion="7" presence="optional"/>
     </sbe:message>
 
     <sbe:message name="MembershipChangeEvent"
@@ -429,6 +431,7 @@
         <field name="leaderMemberId"            id="5" type="int32"/>
         <field name="logSessionId"              id="6" type="int32"/>
         <field name="appVersion"                id="7" type="version_t"/>
+        <field name="isStartup"                 id="8" type="BooleanType" sinceVersion="7" presence="optional"/>
     </sbe:message>
 
     <!-- keep this under 32 - 8 = 24 bytes for efficiency -->

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -839,7 +839,6 @@ public class ClusterTest
     @Timeout(60)
     void shouldHandleMultipleElections() throws InterruptedException
     {
-        long t0 = System.currentTimeMillis();
         try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
         {
             final TestNode leader0 = cluster.awaitLeader();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -859,7 +859,7 @@ public class ClusterTest
             awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
 
             cluster.stopNode(leader1);
-            final TestNode leader2 = cluster.awaitLeader(leader1.index());
+            cluster.awaitLeader(leader1.index());
             cluster.awaitLeadershipEvent(2);
             cluster.startStaticNode(leader1.index(), false);
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -836,6 +836,41 @@ public class ClusterTest
     }
 
     @Test
+    @Timeout(60)
+    void shouldHandleMultipleElections() throws InterruptedException
+    {
+        long t0 = System.currentTimeMillis();
+        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        {
+            final TestNode leader0 = cluster.awaitLeader();
+            cluster.connectClient();
+
+            final int numMessages = 3;
+            cluster.sendMessages(numMessages);
+            cluster.awaitResponseMessageCount(numMessages);
+            awaitAllServiceMessageCount(cluster, 3, numMessages);
+
+            cluster.stopNode(leader0);
+            final TestNode leader1 = cluster.awaitLeader(leader0.index());
+            cluster.awaitLeadershipEvent(1);
+            cluster.startStaticNode(leader0.index(), false);
+
+            cluster.sendMessages(numMessages);
+            cluster.awaitResponseMessageCount(numMessages * 2);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 2);
+
+            cluster.stopNode(leader1);
+            final TestNode leader2 = cluster.awaitLeader(leader1.index());
+            cluster.awaitLeadershipEvent(2);
+            cluster.startStaticNode(leader1.index(), false);
+
+            cluster.sendMessages(numMessages);
+            cluster.awaitResponseMessageCount(numMessages * 3);
+            awaitAllServiceMessageCount(cluster, 3, numMessages * 3);
+        }
+    }
+
+    @Test
     @Timeout(50)
     void shouldRecoverWhenLastSnapshotIsInvalidAndWasBetweenTwoElections() throws InterruptedException
     {


### PR DESCRIPTION
This causes a bug where a node that that dies and leaves that cluster and is then restarted and rejoins the cluster may end up having differing state from the leader as it's own isStartup flag gets used to determine if any sessions should be closed.  This records the isStartup flag from the leader in the leadership term event and uses that value to determine is session should be closed.

This can cause some strange behaviour around sessions and visibility of events from the cluster.  It was causing `ClusterTest::shouldRecoverWhenLastSnapshotIsInvalidAndWasBetweenTwoElections` to be intermittent.