### PR TITLE
[Java] Clear the cluster client decoders after use

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -56,6 +56,7 @@ public final class AeronCluster implements AutoCloseable
 
     private static final int SEND_ATTEMPTS = 3;
     private static final int FRAGMENT_LIMIT = 10;
+    private static final DirectBuffer EMPTY_BUFFER = new UnsafeBuffer(new byte[4096]);
 
     private final long clusterSessionId;
     private long leadershipTermId;
@@ -233,6 +234,8 @@ public final class AeronCluster implements AutoCloseable
             .wrapAndApplyHeader(keepaliveMsgBuffer, 0, messageHeaderEncoder)
             .leadershipTermId(leadershipTermId)
             .clusterSessionId(clusterSessionId);
+
+        clearDecoders();
     }
 
     /**
@@ -616,6 +619,8 @@ public final class AeronCluster implements AutoCloseable
                     sessionEventDecoder.detail());
             }
         }
+
+        clearDecoders();
     }
 
     private ControlledFragmentHandler.Action onControlledFragment(
@@ -685,6 +690,7 @@ public final class AeronCluster implements AutoCloseable
             }
         }
 
+        clearDecoders();
         return ControlledFragmentHandler.Action.CONTINUE;
     }
 
@@ -728,6 +734,14 @@ public final class AeronCluster implements AutoCloseable
         {
             return ctx.aeron().addPublication(channel, streamId);
         }
+    }
+
+    private void clearDecoders()
+    {
+        messageHeaderDecoder.wrap(EMPTY_BUFFER, 0);
+        sessionEventDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
+        newLeaderEventDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
+        sessionMessageHeaderDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
     }
 
     /**
@@ -1685,6 +1699,7 @@ public final class AeronCluster implements AutoCloseable
     {
         final int memberId;
         final String endpoint;
+
         Publication publication;
 
         MemberEndpoint(final int memberId, final String endpoint)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
@@ -21,6 +21,7 @@ import io.aeron.cluster.codecs.*;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 import static io.aeron.cluster.client.AeronCluster.SESSION_HEADER_LENGTH;
 
@@ -29,6 +30,8 @@ import static io.aeron.cluster.client.AeronCluster.SESSION_HEADER_LENGTH;
  */
 public class EgressAdapter implements FragmentHandler
 {
+    private static final DirectBuffer EMPTY_BUFFER = new UnsafeBuffer(new byte[4096]);
+
     private final long clusterSessionId;
     private final int fragmentLimit;
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
@@ -49,6 +52,7 @@ public class EgressAdapter implements FragmentHandler
         this.listener = listener;
         this.subscription = subscription;
         this.fragmentLimit = fragmentLimit;
+        clearDecoders();
     }
 
     public int poll()
@@ -87,6 +91,7 @@ public class EgressAdapter implements FragmentHandler
                     header);
             }
 
+            clearDecoders();
             return;
         }
 
@@ -134,5 +139,15 @@ public class EgressAdapter implements FragmentHandler
                 break;
             }
         }
+
+        clearDecoders();
+    }
+
+    private void clearDecoders()
+    {
+        messageHeaderDecoder.wrap(EMPTY_BUFFER, 0);
+        sessionEventDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
+        newLeaderEventDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
+        sessionMessageHeaderDecoder.wrap(EMPTY_BUFFER, 0, 0, 0);
     }
 }


### PR DESCRIPTION
This helps prevent segfaults when using the debugger - the debugger calls toString on the decoder which will try to decode whatever data they happen to be pointing at and can happen at a point where that data is not valid.