### PR TITLE
Fixes for MDC in the C media driver

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2721,7 +2721,7 @@ int aeron_driver_conductor_on_remove_destination(
             goto error_cleanup;
         }
 
-        if (NULL != endpoint->destination_tracker || !endpoint->destination_tracker->is_manual_control_mode)
+        if (NULL == endpoint->destination_tracker || !endpoint->destination_tracker->is_manual_control_mode)
         {
             aeron_set_err(
                 EINVAL,

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -54,20 +54,12 @@ int aeron_send_channel_endpoint_create(
     _endpoint->destination_tracker = NULL;
     _endpoint->data_paths = &context->sender_proxy->sender->data_paths;
 
-    if (channel->has_explicit_control)
+    const int64_t destination_timeout_ns = channel->is_manual_control_mode ?
+        AERON_UDP_DESTINATION_TRACKER_MANUAL_DESTINATION_TIMEOUT_NS :
+        AERON_UDP_DESTINATION_TRACKER_DESTINATION_TIMEOUT_NS;
+
+    if (channel->has_explicit_control || channel->is_dynamic_control_mode || channel->is_manual_control_mode)
     {
-        const char *control_mode = channel->uri.params.udp.control_mode;
-        int64_t destination_timeout_ns = AERON_UDP_DESTINATION_TRACKER_DESTINATION_TIMEOUT_NS;
-
-        if (NULL != control_mode &&
-            strncmp(
-                control_mode,
-                AERON_UDP_CHANNEL_CONTROL_MODE_MANUAL_VALUE,
-                strlen(AERON_UDP_CHANNEL_CONTROL_MODE_MANUAL_VALUE)) == 0)
-        {
-            destination_timeout_ns = AERON_UDP_DESTINATION_TRACKER_MANUAL_DESTINATION_TIMEOUT_NS;
-        }
-
         if (aeron_alloc((void **)&_endpoint->destination_tracker, sizeof(aeron_udp_destination_tracker_t)) < 0 ||
             aeron_udp_destination_tracker_init(
                 _endpoint->destination_tracker,

--- a/aeron-driver/src/test/c/aeron_driver_conductor_test.h
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_test.h
@@ -62,7 +62,7 @@ using namespace aeron;
 #define CHANNEL_2 "aeron:udp?endpoint=localhost:40002"
 #define CHANNEL_3 "aeron:udp?endpoint=localhost:40003"
 #define CHANNEL_4 "aeron:udp?endpoint=localhost:40004"
-#define CHANNEL_MDC_MANUAL "aeron:udp?control=localhost:40005|control-mode=manual"
+#define CHANNEL_MDC_MANUAL "aeron:udp?control-mode=manual"
 #define INVALID_URI "aeron:udp://"
 
 #define STREAM_ID_1 (101)
@@ -483,6 +483,19 @@ public:
         command.channel(channel);
 
         return writeCommand(AERON_COMMAND_ADD_DESTINATION, command.length());
+    }
+
+    int removeDestination(
+        int64_t client_id, int64_t correlation_id, int64_t publication_registration_id, const char *channel)
+    {
+        command::DestinationMessageFlyweight command(m_command, 0);
+
+        command.clientId(client_id);
+        command.correlationId(correlation_id);
+        command.registrationId(publication_registration_id);
+        command.channel(channel);
+
+        return writeCommand(AERON_COMMAND_REMOVE_DESTINATION, command.length());
     }
 
     int doWork()

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -21,6 +21,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.MediaDriverTestWatcher;
 import io.aeron.test.TestMediaDriver;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
@@ -32,6 +33,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
 import java.util.UUID;
@@ -78,10 +80,11 @@ public class MultiDestinationCastTest
     private final FragmentHandler fragmentHandlerB = mock(FragmentHandler.class);
     private final FragmentHandler fragmentHandlerC = mock(FragmentHandler.class);
 
+    @RegisterExtension
+    public MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+
     private void launch()
     {
-        TestMediaDriver.notSupportedOnCMediaDriverYet("Multi-destination-cast not available");
-
         final String baseDirA = ROOT_DIR + "A";
         final String baseDirB = ROOT_DIR + "B";
 
@@ -98,8 +101,8 @@ public class MultiDestinationCastTest
             .aeronDirectoryName(baseDirB)
             .threadingMode(ThreadingMode.SHARED);
 
-        driverA = TestMediaDriver.launch(driverAContext);
-        driverB = TestMediaDriver.launch(driverBContext);
+        driverA = TestMediaDriver.launch(driverAContext, testWatcher);
+        driverB = TestMediaDriver.launch(driverBContext, testWatcher);
         clientA = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverAContext.aeronDirectoryName()));
         clientB = Aeron.connect(new Aeron.Context().aeronDirectoryName(driverBContext.aeronDirectoryName()));
     }

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -129,7 +129,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         pb.environment().put("AERON_FLOW_CONTROL_GROUP_TAG", String.valueOf(context.flowControlGroupTag()));
         pb.environment().put(
             "AERON_FLOW_CONTROL_GROUP_MIN_SIZE", String.valueOf(context.flowControlGroupMinSize()));
-        pb.environment().put("AERON_PRINT_CONFIGURATION", "true");
+//        pb.environment().put("AERON_PRINT_CONFIGURATION", "true");
         pb.environment().put("AERON_EVENT_LOG", "0xFFFF");
 
         setFlowControlStrategy(pb.environment(), context);
@@ -149,7 +149,8 @@ public final class CTestMediaDriver implements TestMediaDriver
             else
             {
                 stdoutFile = File.createTempFile("CTestMediaDriver-", ".out");
-                stderrFile = File.createTempFile("CTestMediaDriver-", ".err");
+                final String tmpName = stdoutFile.getName().substring(0, stdoutFile.getName().length() - 4) + ".err";
+                stderrFile = new File(stdoutFile.getParent(), tmpName);
                 driverOutputConsumer.outputFiles(context.aeronDirectoryName(), stdoutFile, stderrFile);
             }
 


### PR DESCRIPTION
- Enables system tests
- Removes restriction of having the control address specified when using `control-mode=manual`
- Fixes logic bug when removing destinations.