### PR TITLE
[Java] Fix intermittency in DriverNameResolver.

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -278,7 +278,19 @@ class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransport.Ud
 
         byteBuffer.limit(length);
 
-        if (neighborList.size() == 0 && null != bootstrapNeighborAddress)
+        boolean sendToBootstrap = null != bootstrapNeighborAddress;
+        for (int i = 0, size = neighborList.size(); i < size; i++)
+        {
+            final Neighbor neighbor = neighborList.get(i);
+            sendResolutionFrameTo(byteBuffer, neighbor.socketAddress);
+
+            if (neighbor.socketAddress.equals(bootstrapNeighborAddress))
+            {
+                sendToBootstrap = false;
+            }
+        }
+
+        if (sendToBootstrap)
         {
             if (nowMs > (timeOfLastBootstrapNeighborResolveMs + TIMEOUT_MS))
             {
@@ -287,14 +299,6 @@ class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransport.Ud
             }
 
             sendResolutionFrameTo(byteBuffer, bootstrapNeighborAddress);
-        }
-        else
-        {
-            for (int i = 0, size = neighborList.size(); i < size; i++)
-            {
-                final Neighbor neighbor = neighborList.get(i);
-                sendResolutionFrameTo(byteBuffer, neighbor.socketAddress);
-            }
         }
 
         deadlineSelfResolutionMs = nowMs + selfResolutionIntervalMs;

--- a/aeron-system-tests/src/test/java/io/aeron/DriverNameResolverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/DriverNameResolverTest.java
@@ -210,8 +210,8 @@ public class DriverNameResolverTest
         awaitCounterValue("A", aCacheEntriesCounterId, 1);
 
         try (
-            Subscription subscription = clients.get("A").addSubscription("aeron:udp?endpoint=localhost:24325", 1);
-            Publication publication = clients.get("B").addPublication("aeron:udp?endpoint=B:24325", 1))
+            Subscription subscription = clients.get("B").addSubscription("aeron:udp?endpoint=localhost:24325", 1);
+            Publication publication = clients.get("A").addPublication("aeron:udp?endpoint=B:24325", 1))
         {
             while (!publication.isConnected() || !subscription.isConnected())
             {

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -79,7 +79,10 @@ public final class CTestMediaDriver implements TestMediaDriver
                 throw new RuntimeException("Failed to shutdown cleaning, forcing close");
             }
 
-            driverOutputConsumer.exitCode(context.aeronDirectoryName(), aeronMediaDriverProcess.exitValue());
+            if (null != driverOutputConsumer)
+            {
+                driverOutputConsumer.exitCode(context.aeronDirectoryName(), aeronMediaDriverProcess.exitValue());
+            }
         }
         catch (final InterruptedException e)
         {

--- a/aeron-system-tests/src/test/java/io/aeron/test/DriverOutputConsumer.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/DriverOutputConsumer.java
@@ -16,8 +16,13 @@
 package io.aeron.test;
 
 import java.io.File;
+import java.util.Map;
 
 public interface DriverOutputConsumer
 {
     void outputFiles(String aeronDirectoryName, File stdoutFile, File stderrFile);
+
+    void exitCode(String aeronDirectoryName, int exitValue);
+
+    void environmentVariables(String aeronDirectoryName, Map<String, String> environment);
 }

--- a/aeron-system-tests/src/test/java/io/aeron/test/MediaDriverTestWatcher.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/MediaDriverTestWatcher.java
@@ -22,12 +22,15 @@ import org.junit.jupiter.api.extension.TestWatcher;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.Map;
 
 public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer
 {
-    private final Map<String, StdOutputFiles> outputFilesByAeronDirectoryName = new Object2ObjectHashMap<>();
+    private final Map<String, ProcessDetails> outputFilesByAeronDirectoryName = new Object2ObjectHashMap<>();
+    private int exitValue;
+    private Map<String, String> environment;
 
     public void testFailed(final ExtensionContext context, final Throwable cause)
     {
@@ -40,7 +43,8 @@ public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer
                     try
                     {
                         System.out.println();
-                        System.out.println("Media Driver: " + aeronDirectoryName);
+                        System.out.println("Media Driver: " + aeronDirectoryName + ", exit code: " + files.exitValue);
+                        printEnvironment(files.environment, System.out);
                         System.out.println("*** STDOUT ***");
                         Files.copy(files.stdout.toPath(), System.out);
                         System.out.println("*** STDERR ***");
@@ -55,6 +59,17 @@ public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer
 
             deleteFiles();
         }
+    }
+
+    private void printEnvironment(final Map<String, String> environment, final PrintStream ps)
+    {
+        environment.forEach((name, value) ->
+        {
+            ps.print(name);
+            ps.print('=');
+            ps.print(value);
+            ps.println();
+        });
     }
 
     public void testSuccessful(final ExtensionContext context)
@@ -77,18 +92,41 @@ public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer
 
     public void outputFiles(final String aeronDirectoryName, final File stdoutFile, final File stderrFile)
     {
-        outputFilesByAeronDirectoryName.put(aeronDirectoryName, new StdOutputFiles(stdoutFile, stderrFile));
+        outputFilesByAeronDirectoryName.put(aeronDirectoryName, new ProcessDetails(stdoutFile, stderrFile));
     }
 
-    static final class StdOutputFiles
+    public void exitCode(final String aeronDirectoryName, final int exitValue)
+    {
+        outputFilesByAeronDirectoryName.get(aeronDirectoryName).exitValue(exitValue);
+    }
+
+    public void environmentVariables(final String aeronDirectoryName, final Map<String, String> environment)
+    {
+        outputFilesByAeronDirectoryName.get(aeronDirectoryName).environment(environment);
+        this.environment = environment;
+    }
+
+    static final class ProcessDetails
     {
         private final File stderr;
         private final File stdout;
+        private int exitValue;
+        private Map<String, String> environment;
 
-        StdOutputFiles(final File stdout, final File stderr)
+        ProcessDetails(final File stdout, final File stderr)
         {
             this.stderr = stderr;
             this.stdout = stdout;
+        }
+
+        public void exitValue(final int exitValue)
+        {
+            this.exitValue = exitValue;
+        }
+
+        public void environment(final Map<String, String> environment)
+        {
+            this.environment = environment;
         }
     }
 }


### PR DESCRIPTION
Update DriverNameResolverTest to better support C implementation.  Add additional error reporting information for failed C driver tests (environment variables and exit codes).  Update shouldSeeNeighborsViaGossip so that without the fix would fail consistently.