### PR TITLE
[Java] Page straddle recovery

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -898,7 +898,7 @@ public class Archive implements AutoCloseable
             if (null == catalog)
             {
                 catalog = new Catalog(
-                    archiveDir, archiveDirChannel, catalogFileSyncLevel, maxCatalogEntries, epochClock);
+                    archiveDir, archiveDirChannel, catalogFileSyncLevel, maxCatalogEntries, epochClock, recordChecksum);
             }
 
             if (null == archiveClientContext)

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -834,6 +834,7 @@ public class ArchiveTool
                 startPosition,
                 termLength,
                 segmentLength,
+                checksum,
                 truncateFileOnPageStraddle::confirm);
         }
         catch (final Exception ex)

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -291,7 +291,7 @@ public class ArchiveTool
      */
     public static int maxEntries(final File archiveDir, final long newMaxEntries)
     {
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, INSTANCE))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, INSTANCE, null))
         {
             return catalog.maxEntries();
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -874,6 +874,8 @@ class Catalog implements AutoCloseable
                 !isValidFragment(buffer, lastFragmentOffset, lastFrameLength, checksum) &&
                 truncateFileOnPageStraddle.test(file))
             {
+                IoUtil.unmap(mappedByteBuffer); // unmap buffer before the truncate for Windows interop
+
                 segment.truncate(lastFragmentOffset);
                 final ByteBuffer tmp = ByteBuffer.allocate(1);
                 tmp.put((byte)0).position(0);

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -126,6 +126,7 @@ class Catalog implements AutoCloseable
     private boolean isClosed;
     private final File archiveDir;
     private final EpochClock epochClock;
+    private final Checksum checksum;
     private final FileChannel catalogChannel;
     private long nextRecordingId = 0;
 
@@ -134,12 +135,14 @@ class Catalog implements AutoCloseable
         final FileChannel archiveDirChannel,
         final int fileSyncLevel,
         final long maxNumEntries,
-        final EpochClock epochClock)
+        final EpochClock epochClock,
+        final Checksum checksum)
     {
         this.archiveDir = archiveDir;
         this.forceWrites = fileSyncLevel > 0;
         this.forceMetadata = fileSyncLevel > 1;
         this.epochClock = epochClock;
+        this.checksum = checksum;
 
         validateMaxEntries(maxNumEntries);
 
@@ -227,6 +230,7 @@ class Catalog implements AutoCloseable
         this.forceWrites = false;
         this.forceMetadata = false;
         this.epochClock = epochClock;
+        this.checksum = null;
         this.catalogChannel = null;
 
         try
@@ -723,7 +727,7 @@ class Catalog implements AutoCloseable
                 decoder.startPosition(),
                 decoder.termBufferLength(),
                 decoder.segmentFileLength(),
-                null,
+                checksum,
                 (segmentFile) ->
                 {
                     throw new ArchiveException(

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -456,7 +456,7 @@ class ArchiveToolTests
                 byteBuffer.clear();
                 dataHeaderFlyweight.frameLength(3 * PAGE_SIZE);
                 dataHeaderFlyweight.termOffset(64);
-                dataHeaderFlyweight.setMemory(HEADER_LENGTH, 2 * PAGE_SIZE - HEADER_LENGTH, (byte)111);
+                dataHeaderFlyweight.setMemory(PAGE_SIZE - 64, PAGE_SIZE, (byte)111);
                 dataHeaderFlyweight.setMemory(3 * PAGE_SIZE - 64, 64, (byte)-128);
                 fileChannel.write(byteBuffer, dataHeaderFlyweight.termOffset());
             });
@@ -772,7 +772,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, NULL_TIMESTAMP,
+            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, 100,
                 0, 52, "ch2", "src2");
         }
     }
@@ -930,11 +930,11 @@ class ArchiveToolTests
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
             assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
-            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, 777,
+            assertRecording(catalog, validRecording52, INVALID, 0, NULL_POSITION, 21, NULL_TIMESTAMP,
                 0, 52, "ch2", "src2");
-            assertRecording(catalog, validRecording53, VALID, 0, 64, 22, 777,
+            assertRecording(catalog, validRecording53, INVALID, 0, NULL_POSITION, 22, NULL_TIMESTAMP,
                 0, 53, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 21, 500, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 400, 0, 6, "ch2", "src2");
         }
 
         Mockito.verify(out, times(24)).println(any(String.class));

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -417,7 +417,7 @@ class ArchiveToolTests
                 byteBuffer.clear();
                 dataHeaderFlyweight.frameLength(PAGE_SIZE);
                 dataHeaderFlyweight.termOffset(64);
-                dataHeaderFlyweight.sessionId(790663674);
+                dataHeaderFlyweight.sessionId(2057703623);
                 fileChannel.write(byteBuffer, dataHeaderFlyweight.termOffset());
             });
 
@@ -756,22 +756,24 @@ class ArchiveToolTests
     @Test
     void verifyRecordingValidRecordingTruncateSegmentFileOnPageStraddleValidChecksum()
     {
-        verifyRecording(out, archiveDir, validRecording51, emptySet(), null, epochClock, (file) -> true);
+        verifyRecording(out, archiveDir, validRecording51, emptySet(), crc32(), epochClock, (file) -> true);
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777, 0, 20, "ch2", "src2");
+            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+                0, 20, "ch2", "src2");
         }
     }
 
     @Test
     void verifyRecordingValidRecordingTruncateSegmentFileOnPageStraddleNonZeroBytesInEveryPageAfterTheStraddle()
     {
-        verifyRecording(out, archiveDir, validRecording52, emptySet(), null, epochClock, (file) -> true);
+        verifyRecording(out, archiveDir, validRecording52, emptySet(), crc32(), epochClock, (file) -> true);
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, NULL_TIMESTAMP, 0, 52, "ch2", "src2");
+            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, NULL_TIMESTAMP,
+                0, 52, "ch2", "src2");
         }
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -114,7 +114,7 @@ class ArchiveToolTests
     {
         archiveDir = ArchiveTests.makeTestDirectory();
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, 128, epochClock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, 128, epochClock, null))
         {
             invalidRecording0 = catalog.addNewRecording(NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP, 0,
                 SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 1, 1, "ch1", "ch1?tag=ERR", "src1");

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -448,7 +448,7 @@ class CatalogTest
 
     @ParameterizedTest(name = "fragmentCrossesPageBoundary({0}, {1}, {2})")
     @MethodSource("pageBoundaryTestData")
-    void detectPageBoundaryStraddle(final long fragmentOffset, final long fragmentLength, final boolean expected)
+    void detectPageBoundaryStraddle(final int fragmentOffset, final int fragmentLength, final boolean expected)
     {
         assertEquals(expected, fragmentStraddlesPageBoundary(fragmentOffset, fragmentLength));
     }

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 import static io.aeron.archive.Archive.segmentFileName;
 import static io.aeron.archive.Catalog.PAGE_SIZE;
 import static io.aeron.archive.Catalog.fragmentStraddlesPageBoundary;
+import static io.aeron.archive.checksum.Checksums.crc32;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
@@ -71,7 +72,7 @@ class CatalogTest
     @BeforeEach
     void before()
     {
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             recordingOneId = catalog.addNewRecording(
                 0L, 0L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 6, 1, "channelG", "channelG?tag=f", "sourceA");
@@ -127,7 +128,7 @@ class CatalogTest
     void shouldAppendToExistingIndex()
     {
         final long newRecordingId;
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, () -> 3L))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, () -> 3L, null))
         {
             newRecordingId = catalog.addNewRecording(
                 0L, 0L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 9, 4, "channelJ", "channelJ?tag=f", "sourceN");
@@ -155,7 +156,7 @@ class CatalogTest
     {
         final long newMaxEntries = MAX_ENTRIES * 2;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, clock, null))
         {
             assertEquals(newMaxEntries, catalog.maxEntries());
         }
@@ -166,7 +167,7 @@ class CatalogTest
     {
         final long newMaxEntries = 1;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, clock, null))
         {
             assertEquals(MAX_ENTRIES, catalog.maxEntries());
         }
@@ -188,7 +189,7 @@ class CatalogTest
 
         currentTimeMs = 42L;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             final Catalog.CatalogEntryProcessor entryProcessor =
                 (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
@@ -238,7 +239,7 @@ class CatalogTest
 
         currentTimeMs = 42L;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             assertTrue(catalog.forEntry(
                 newRecordingId,
@@ -275,16 +276,53 @@ class CatalogTest
             ArchiveException.class,
             () ->
             {
-                final Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock);
-                catalog.close();
+                try (Catalog ignore = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
+                {
+                }
             });
         assertThat(exception.getMessage(), containsString(segmentFile.getAbsolutePath()));
+    }
+
+    @Test
+    void shouldUseChecksumToVerifyLastFragmentAfterPageStraddle() throws Exception
+    {
+        final long newRecordingId = newRecording();
+        final File segmentFile = new File(archiveDir, segmentFileName(newRecordingId, 0));
+        try (FileChannel log = FileChannel.open(segmentFile.toPath(), READ, WRITE, CREATE))
+        {
+            final ByteBuffer bb = allocate(HEADER_LENGTH);
+            final DataHeaderFlyweight flyweight = new DataHeaderFlyweight(bb);
+            flyweight.frameLength(PAGE_SIZE - 128);
+            log.write(bb);
+
+            bb.clear();
+            flyweight.frameLength(256);
+            flyweight.sessionId(1025596259);
+            log.write(bb, PAGE_SIZE - 128);
+
+            bb.clear();
+            bb.put(0, (byte)0).limit(1).position(0);
+            log.write(bb, PAGE_SIZE + 127);
+        }
+
+        currentTimeMs = 42L;
+
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, crc32()))
+        {
+            assertTrue(catalog.forEntry(
+                newRecordingId,
+                (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                {
+                    assertEquals(42L, descriptorDecoder.stopTimestamp());
+                    assertEquals(PAGE_SIZE + 128, descriptorDecoder.stopPosition());
+                }));
+        }
     }
 
     private long newRecording()
     {
         final long newRecordingId;
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             newRecordingId = catalog.addNewRecording(
                 0L,
@@ -335,7 +373,7 @@ class CatalogTest
 
         currentTimeMs = 42L;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             assertTrue(catalog.forEntry(
                 newRecordingId,
@@ -354,7 +392,7 @@ class CatalogTest
         final File archiveDir = ArchiveTests.makeTestDirectory();
         final long maxEntries = 2;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, maxEntries, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, maxEntries, clock, null))
         {
             for (int i = 0; i < maxEntries; i++)
             {
@@ -373,7 +411,7 @@ class CatalogTest
             }
         }
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, maxEntries, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, maxEntries, clock, null))
         {
             assertEquals(maxEntries, catalog.countEntries());
         }
@@ -391,14 +429,14 @@ class CatalogTest
             log.write(bb);
         }
 
-        final Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock);
+        final Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null);
         catalog.close();
     }
 
     @Test
     void shouldContainChannelFragment()
     {
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             final String originalChannel = "aeron:udp?endpoint=localhost:7777|tags=777|alias=TestString";
             final String strippedChannel = "strippedChannelUri";

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogViewTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogViewTest.java
@@ -49,7 +49,7 @@ public class CatalogViewTest
     {
         clock.update(1);
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null))
         {
             recordingOneId = catalog.addNewRecording(
                 10L, 4L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 7, 1, "channelG", "channelG?tag=f", "sourceA");

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
@@ -37,7 +37,7 @@ public class ListRecordingsForUriSessionTest
     @BeforeEach
     public void before()
     {
-        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock);
+        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null);
         matchingRecordingIds[0] = catalog.addNewRecording(
             0L, 0L, 0, SEGMENT_FILE_SIZE, 4096, 1024, 6, 1, "localhost", "localhost?tag=f", "sourceA");
         catalog.addNewRecording(

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
@@ -35,7 +35,7 @@ public class ListRecordingsSessionTest
     @BeforeEach
     public void before()
     {
-        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock);
+        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null);
         recordingIds[0] = catalog.addNewRecording(
             0L, 0L, 0, SEGMENT_FILE_SIZE, 4096, 1024, 6, 1, "channelG", "channelG?tag=f", "sourceA");
         recordingIds[1] = catalog.addNewRecording(


### PR DESCRIPTION
When the last fragment in the segment file straddle page boundaries Aeron will attempt to verify if it was persisted correctly by looking at the following:
- if `Checksum` was configured either on the Archive via `io.aeron.archive.Archive.Context#recordChecksum()` or specified as a parameter to the `ArchiveTool` then it will be used to verify the checksum of the last fragment. Upon match fragment will be considered complete.
- if `Checksum` was not configured or if the check failed then Aeron will look for non-zero bytes in every page since the straddle offset. If all pages have at least one non-zero byte then the fragment is considered complete. 
_Note: In case if zeroes are the valid data only the `Checksum` can be used to recover such fragments._