### PR TITLE
Unique canonical forms for MDS and supporting Wildcard Ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Checkout Agrona
+      - name: Checkout & Build Agrona
         uses: actions/checkout@v2
         with:
           repository: real-logic/agrona

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Checkout Agrona
+        uses: actions/checkout@v2
+        with:
+          repository: real-logic/agrona
+          path: agrona
+        run: ./gradle publishToMavenLocal
       - name: Cache Gradle dependencies
         uses: actions/cache@v1
         with:

--- a/aeron-client/src/main/java/io/aeron/Publication.java
+++ b/aeron-client/src/main/java/io/aeron/Publication.java
@@ -16,12 +16,14 @@
 package io.aeron;
 
 import io.aeron.exceptions.AeronException;
-import io.aeron.logbuffer.*;
+import io.aeron.logbuffer.BufferClaim;
+import io.aeron.logbuffer.FrameDescriptor;
+import io.aeron.logbuffer.HeaderWriter;
+import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.status.ChannelEndStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.agrona.concurrent.status.CountersReader;
 import org.agrona.concurrent.status.ReadablePosition;
 
 import java.util.List;

--- a/aeron-client/src/main/java/io/aeron/Publication.java
+++ b/aeron-client/src/main/java/io/aeron/Publication.java
@@ -17,10 +17,14 @@ package io.aeron;
 
 import io.aeron.exceptions.AeronException;
 import io.aeron.logbuffer.*;
+import io.aeron.status.ChannelEndStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.status.CountersReader;
 import org.agrona.concurrent.status.ReadablePosition;
+
+import java.util.List;
 
 import static io.aeron.logbuffer.LogBufferDescriptor.*;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
@@ -579,6 +583,27 @@ public abstract class Publication implements AutoCloseable
         }
 
         return conductor.asyncRemoveDestination(registrationId, endpointChannel);
+    }
+
+    /**
+     * Fetches the ip addresses and ports that this publication is bound to.  If the channel is not ACTIVE, then this
+     * will return an empty list.  The formatting is as follows:
+     * <br>
+     * <br>
+     * IPv4: <code>ip address:port</code>
+     * <br>
+     * IPv6: <code>[ip6 address]:port</code>
+     * <br>
+     * <br>
+     * This is to match the formatting used in the Aeron URI.  For publications this will be the control address and
+     * is likely to only contain a single entry.
+     *
+     * @return List of the formatted ip addresses and ports that this publication is bound to.
+     */
+    public List<String> bindAddressAndPorts()
+    {
+        return ChannelEndStatus.findChannelEnds(
+            conductor.countersReader(), channelStatus(), ChannelEndStatus.SEND_END_STATUS_TYPE_ID, channelStatusId);
     }
 
     void internalClose()

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -24,7 +24,6 @@ import io.aeron.status.ChannelEndStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.collections.ArrayUtil;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -409,6 +409,33 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
     }
 
     /**
+     * EXPERIMENTAL! (currently uses label which is not yet reliable).
+     *
+     * Fetches the ip address and port that this subscription is bound to.  If the channel is not ACTIVE, then this
+     * will return null.  The formatting is as follows:
+     * <br>
+     * <br>
+     * IPv4: <code>ip address:port</code>
+     * <br>
+     * IPv6: <code>[ip6 address]:port</code>
+     * <br>
+     * <br>
+     * This is to match the formatting used in the Aeron URI
+     *
+     * @return The formatted ip address and port that this subscription is bound to.
+     */
+    public List<String> bindAddressAndPort()
+    {
+        if (channelStatus() != ChannelEndpointStatus.ACTIVE)
+        {
+            return Collections.emptyList();
+        }
+
+        final String[] parts = conductor.countersReader().getCounterLabel(channelStatusId).split(" ");
+        return parts.length > 2 ? Collections.singletonList(parts[2]) : Collections.emptyList();
+    }
+
+    /**
      * Add a destination manually to a multi-destination Subscription.
      *
      * @param endpointChannel for the destination to add.

--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -416,10 +416,8 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
     }
 
     /**
-     * EXPERIMENTAL! (currently uses label which is not yet reliable).
-     *
-     * Fetches the ip address and port that this subscription is bound to.  If the channel is not ACTIVE, then this
-     * will return null.  The formatting is as follows:
+     * Fetches the ip addresses and ports that this subscription is bound to.  If the channel is not ACTIVE, then this
+     * will return an empty list.  The formatting is as follows:
      * <br>
      * <br>
      * IPv4: <code>ip address:port</code>
@@ -429,32 +427,12 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
      * <br>
      * This is to match the formatting used in the Aeron URI
      *
-     * @return The formatted ip address and port that this subscription is bound to.
+     * @return List of the formatted ip addresses and ports that this subscription is bound to.
      */
-    public List<String> bindAddressAndPort()
+    public List<String> bindAddressAndPorts()
     {
-        if (channelStatus() != ChannelEndpointStatus.ACTIVE)
-        {
-            return Collections.emptyList();
-        }
-
-        final List<String> bindings = new ArrayList<>(2);
-
-        conductor.countersReader().forEach((counterId, typeId, keyBuffer, label) ->
-        {
-            if (ChannelEndStatus.RECEIVE_END_STATUS_TYPE_ID == typeId &&
-                channelStatusId == ChannelEndStatus.channelStatusId(keyBuffer, 0) &&
-                ChannelEndpointStatus.ACTIVE == conductor.countersReader().getCounterValue(counterId))
-            {
-                final String bindAddressAndPort = ChannelEndStatus.bindAddressAndPort(keyBuffer, 0);
-                if (null != bindAddressAndPort)
-                {
-                    bindings.add(bindAddressAndPort);
-                }
-            }
-        });
-
-        return bindings;
+        return ChannelEndStatus.findChannelEnds(
+            conductor.countersReader(), channelStatus(), ChannelEndStatus.RECEIVE_END_STATUS_TYPE_ID, channelStatusId);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/status/ChannelEndStatus.java
+++ b/aeron-client/src/main/java/io/aeron/status/ChannelEndStatus.java
@@ -1,0 +1,80 @@
+package io.aeron.status;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.CountersManager;
+
+public class ChannelEndStatus
+{
+    private static final int CHANNEL_STATUS_ID_OFFSET = 0;
+    private static final int BIND_ADDRESS_AND_PORT_OFFSET = CHANNEL_STATUS_ID_OFFSET + BitUtil.SIZE_OF_INT;
+    private static final int BIND_ADDRESS_AND_PORT_STRING_OFFSET = BIND_ADDRESS_AND_PORT_OFFSET + BitUtil.SIZE_OF_INT;
+
+    private static final int MAX_IPV6_LENGTH = "[ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255]:65536".length();
+
+    /**
+     * Maximum possible length for a key, reserve this much space in the key buffer on creation to allow
+     * for updating later.
+     */
+    public static final int KEY_RESERVED_LENGTH = BitUtil.SIZE_OF_INT * 2 + MAX_IPV6_LENGTH;
+
+    public static final int RECEIVE_END_STATUS_TYPE_ID = 14;
+
+    public static final int SEND_END_STATUS_TYPE_ID = 15;
+
+    private static final byte[] RESERVED_KEY_BYTES = new byte[KEY_RESERVED_LENGTH];
+
+    public static AtomicCounter allocate(
+        final MutableDirectBuffer tempBuffer,
+        final CountersManager countersManager,
+        final int channelStatusId,
+        final String name,
+        final int typeId)
+    {
+        tempBuffer.putInt(0, channelStatusId);
+        tempBuffer.putInt(BIND_ADDRESS_AND_PORT_OFFSET, 0); // Zero-length address initially.
+        tempBuffer.putBytes(BIND_ADDRESS_AND_PORT_STRING_OFFSET, RESERVED_KEY_BYTES); // Maybe don't need this.
+
+        final int keyLength = KEY_RESERVED_LENGTH;
+
+        int labelLength = 0;
+        labelLength += tempBuffer.putStringWithoutLengthAscii(keyLength + labelLength, name);
+        labelLength += tempBuffer.putStringWithoutLengthAscii(keyLength + labelLength, ": ");
+        labelLength += tempBuffer.putStringWithoutLengthAscii(keyLength + labelLength, String.valueOf(channelStatusId));
+        labelLength += tempBuffer.putStringWithoutLengthAscii(keyLength + labelLength, " ");
+
+        return countersManager.newCounter(typeId, tempBuffer, 0, keyLength, tempBuffer, keyLength, labelLength);
+    }
+
+    public static void updateWithBindAddress(final AtomicCounter counter, final String bindAddressAndPort)
+    {
+        if (bindAddressAndPort.length() > MAX_IPV6_LENGTH)
+        {
+            throw new IllegalArgumentException(
+                "bindAddressAndPort value too long: " + bindAddressAndPort.length() + " max: " + MAX_IPV6_LENGTH);
+        }
+
+        counter.updateKey((keyBuffer) ->
+        {
+            final int bindingLength = keyBuffer.putStringWithoutLengthAscii(
+                BIND_ADDRESS_AND_PORT_STRING_OFFSET, bindAddressAndPort);
+            keyBuffer.putInt(BIND_ADDRESS_AND_PORT_OFFSET, bindingLength);
+        });
+
+        counter.appendToLabel(bindAddressAndPort);
+    }
+
+    public static int channelStatusId(final DirectBuffer keyBuffer, final int offset)
+    {
+        return keyBuffer.getInt(offset + CHANNEL_STATUS_ID_OFFSET);
+    }
+
+    public static String bindAddressAndPort(final DirectBuffer keyBuffer, final int offset)
+    {
+        final int bindingLength = keyBuffer.getInt(offset + BIND_ADDRESS_AND_PORT_OFFSET);
+        return 0 != bindingLength ?
+            keyBuffer.getStringWithoutLengthAscii(BIND_ADDRESS_AND_PORT_STRING_OFFSET, bindingLength) : null;
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1274,6 +1274,7 @@ public class DriverConductor implements Agent
                 udpChannel,
                 SendChannelStatus.allocate(tempBuffer, countersManager, udpChannel.originalUriString()),
                 ctx);
+            channelEndpoint.allocateChannelEndStatus(tempBuffer, countersManager);
 
             sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
             senderProxy.registerSendChannelEndpoint(channelEndpoint);

--- a/aeron-driver/src/main/java/io/aeron/driver/media/NetworkUtil.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/NetworkUtil.java
@@ -234,4 +234,13 @@ public class NetworkUtil
 
         return buffer.slice();
     }
+
+    public static String formatAddressAndPort(InetAddress address, int port)
+    {
+        final String formattedAddress = address instanceof Inet6Address ?
+            "[" + address.getHostAddress() + "]" :
+            address.getHostAddress();
+
+        return formattedAddress + ":" + port;
+    }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/NetworkUtil.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/NetworkUtil.java
@@ -235,7 +235,7 @@ public class NetworkUtil
         return buffer.slice();
     }
 
-    public static String formatAddressAndPort(InetAddress address, int port)
+    public static String formatAddressAndPort(final InetAddress address, final int port)
     {
         final String formattedAddress = address instanceof Inet6Address ?
             "[" + address.getHostAddress() + "]" :

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -186,14 +186,19 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
             final String bindAddressAndPort = bindAddressAndPort();
             statusIndicator.appendToLabel(bindAddressAndPort);
 
-            if (null != bindingStatus)
-            {
-                ChannelEndStatus.updateWithBindAddress(bindingStatus, bindAddressAndPort);
-                bindingStatus.setOrdered(ChannelEndpointStatus.ACTIVE);
-            }
+            updateChannelEndStatus(bindAddressAndPort);
         }
 
         statusIndicator.setOrdered(ChannelEndpointStatus.ACTIVE);
+    }
+
+    private void updateChannelEndStatus(final String bindAddressAndPort)
+    {
+        if (null != bindingStatus)
+        {
+            ChannelEndStatus.updateWithBindAddress(bindingStatus, bindAddressAndPort);
+            bindingStatus.setOrdered(ChannelEndpointStatus.ACTIVE);
+        }
     }
 
     public void closeStatusIndicator()

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -21,16 +21,21 @@ import io.aeron.driver.DataPacketDispatcher;
 import io.aeron.driver.DriverConductorProxy;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.PublicationImage;
+import io.aeron.driver.status.ReceiveEnd;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.ControlProtocolException;
 import io.aeron.protocol.*;
+import io.aeron.status.ChannelEndStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.AsciiEncoding;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Hashing;
 import org.agrona.collections.Int2IntCounterMap;
 import org.agrona.collections.Long2LongCounterMap;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.CountersManager;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -69,6 +74,7 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
     private final long receiverId;
     private InetSocketAddress currentControlAddress;
     private long timeOfLastActivityNs;
+    private AtomicCounter bindingStatus;
 
     public ReceiveChannelEndpoint(
         final UdpChannel udpChannel,
@@ -103,6 +109,22 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
         multiRcvDestination = udpChannel.isManualControlMode() ?
             new MultiRcvDestination(context.nanoClock(), DESTINATION_ADDRESS_TIMEOUT, errorHandler) : null;
         currentControlAddress = udpChannel.localControl();
+    }
+
+    /**
+     * Allocate a channel binding status counter, if required (no used by control-mode=manual
+     *
+     * @param tempBuffer      to hold transient counter key/label information.
+     * @param countersManager to use to create the counter.
+     */
+    public void allocateChannelBindingStatus(
+        final MutableDirectBuffer tempBuffer,
+        final CountersManager countersManager)
+    {
+        if (null == multiRcvDestination)
+        {
+            bindingStatus = ReceiveEnd.allocate(tempBuffer, countersManager, statusIndicator.id());
+        }
     }
 
     /**
@@ -161,7 +183,14 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
 
         if (null == multiRcvDestination)
         {
-            statusIndicator.appendToLabel(bindAddressAndPort());
+            final String bindAddressAndPort = bindAddressAndPort();
+            statusIndicator.appendToLabel(bindAddressAndPort);
+
+            if (null != bindingStatus)
+            {
+                ChannelEndStatus.updateWithBindAddress(bindingStatus, bindAddressAndPort);
+                bindingStatus.setOrdered(ChannelEndpointStatus.ACTIVE);
+            }
         }
 
         statusIndicator.setOrdered(ChannelEndpointStatus.ACTIVE);
@@ -171,8 +200,18 @@ public class ReceiveChannelEndpoint extends UdpChannelTransport
     {
         if (!statusIndicator.isClosed())
         {
+            closeBindingCounter();
             statusIndicator.setOrdered(ChannelEndpointStatus.CLOSING);
             statusIndicator.close();
+        }
+    }
+
+    private void closeBindingCounter()
+    {
+        if (null != bindingStatus && !bindingStatus.isClosed())
+        {
+            bindingStatus.setOrdered(ChannelEndpointStatus.CLOSING);
+            bindingStatus.close();
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -21,14 +21,15 @@ import io.aeron.ErrorCode;
 import io.aeron.driver.*;
 import io.aeron.driver.status.SendEnd;
 import io.aeron.exceptions.ControlProtocolException;
-import io.aeron.status.ChannelEndStatus;
-import io.aeron.status.ChannelEndpointStatus;
 import io.aeron.protocol.NakFlyweight;
 import io.aeron.protocol.RttMeasurementFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
+import io.aeron.status.ChannelEndStatus;
+import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.BiInt2ObjectMap;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersManager;
 
@@ -36,12 +37,12 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.PortUnreachableException;
 import java.nio.ByteBuffer;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import static io.aeron.status.ChannelEndpointStatus.status;
-import static io.aeron.driver.status.SystemCounterDescriptor.*;
+import static io.aeron.driver.status.SystemCounterDescriptor.NAK_MESSAGES_RECEIVED;
+import static io.aeron.driver.status.SystemCounterDescriptor.STATUS_MESSAGES_RECEIVED;
 import static io.aeron.protocol.StatusMessageFlyweight.SEND_SETUP_FLAG;
+import static io.aeron.status.ChannelEndpointStatus.status;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannelTransport.java
@@ -225,7 +225,7 @@ public abstract class UdpChannelTransport implements AutoCloseable
                 return "";
             }
 
-            return localAddress.getAddress().getHostAddress() + ":" + localAddress.getPort();
+            return NetworkUtil.formatAddressAndPort(localAddress.getAddress(), localAddress.getPort());
         }
         catch (final IOException ex)
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/status/ReceiveEnd.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/ReceiveEnd.java
@@ -1,0 +1,20 @@
+package io.aeron.driver.status;
+
+import io.aeron.status.ChannelEndStatus;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.CountersManager;
+
+public class ReceiveEnd
+{
+    public static final String NAME = "rcv-end";
+
+    public static AtomicCounter allocate(
+        final MutableDirectBuffer tempBuffer,
+        final CountersManager countersManager,
+        final int channelStatusId)
+    {
+        return ChannelEndStatus.allocate(
+            tempBuffer, countersManager, channelStatusId, NAME, ChannelEndStatus.RECEIVE_END_STATUS_TYPE_ID);
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/status/SendEnd.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/SendEnd.java
@@ -1,0 +1,20 @@
+package io.aeron.driver.status;
+
+import io.aeron.status.ChannelEndStatus;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.agrona.concurrent.status.CountersManager;
+
+public class SendEnd
+{
+    public static final String NAME = "send-end";
+
+    public static AtomicCounter allocate(
+        final MutableDirectBuffer tempBuffer,
+        final CountersManager countersManager,
+        final int channelStatusId)
+    {
+        return ChannelEndStatus.allocate(
+            tempBuffer, countersManager, channelStatusId, NAME, ChannelEndStatus.SEND_END_STATUS_TYPE_ID);
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/UdpChannelTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/UdpChannelTest.java
@@ -416,6 +416,25 @@ public class UdpChannelTest
             is("UDP-" + udpChannelLocal.localData().getHostString() + ":54321-224.0.1.1:40456"));
     }
 
+    @Test
+    void shouldUseTagsInCanonicalFormForMdsUris()
+    {
+        assertEquals(
+            "UDP-0.0.0.0:0-0.0.0.0:0#1001",
+            UdpChannel.parse("aeron:udp?control-mode=manual|tags=1001").canonicalForm());
+    }
+
+    @Test
+    void shouldUseTagsInCanonicalFormForWildcardPorts()
+    {
+        assertEquals(
+            "UDP-127.0.0.1:0-127.0.0.1:9999#1001",
+            UdpChannel.parse("aeron:udp?endpoint=127.0.0.1:9999|control=127.0.0.1:0|tags=1001").canonicalForm());
+        assertEquals(
+            "UDP-0.0.0.0:0-127.0.0.1:0#1001",
+            UdpChannel.parse("aeron:udp?endpoint=127.0.0.1:0|tags=1001").canonicalForm());
+    }
+
     @ParameterizedTest
     @CsvSource({
         "NAME_ENDPOINT,192.168.1.1,,,UDP-127.0.0.1:0-NAME_ENDPOINT",

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -117,7 +117,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(100000)
+    @Timeout(10)
     public void subscriptionCloseShouldAlsoCloseMediaDriverPorts()
     {
         launch();
@@ -280,7 +280,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(100000)
+    @Timeout(10)
     public void shouldFindMdsSubscriptionWithTags()
     {
         launch();
@@ -570,7 +570,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(10000000)
     public void shouldMergeStreamsFromMultiplePublicationsWithSameParams()
     {
         final int numMessagesToSend = 30;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -570,7 +570,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10000000)
+    @Timeout(10)
     public void shouldMergeStreamsFromMultiplePublicationsWithSameParams()
     {
         final int numMessagesToSend = 30;

--- a/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
@@ -203,7 +203,7 @@ public class WildcardPortsSystemTest
 
         final String mdcUri = "aeron:udp?control=localhost:0";
 
-        try (final Publication mdcPub = client.addPublication(mdcUri, STREAM_ID))
+        try (Publication mdcPub = client.addPublication(mdcUri, STREAM_ID))
         {
             List<String> bindAddressAndPort1;
             while ((bindAddressAndPort1 = mdcPub.bindAddressAndPorts()).isEmpty())

--- a/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
@@ -1,0 +1,119 @@
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.TestMediaDriver;
+import io.aeron.test.Tests;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.mock;
+
+public class WildcardPortsSystemTest
+{
+    private static final int STREAM_ID = 2002;
+
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[16]);
+    private final FragmentHandler fragmentHandler = mock(FragmentHandler.class);
+
+    private TestMediaDriver driver;
+    private Aeron client;
+
+    @BeforeEach
+    void launch()
+    {
+        buffer.putInt(0, 1);
+
+        final MediaDriver.Context context = new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .threadingMode(ThreadingMode.SHARED);
+
+        driver = TestMediaDriver.launch(context);
+        client = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName()));
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.closeAll(client, driver);
+    }
+
+    @Test
+    @Timeout(5)
+    void shouldSubscribeToWildcardPorts()
+    {
+        final String wildCardUri1 = "aeron:udp?endpoint=[::1]:0|tags=1001";
+        final String wildCardUri2 = "aeron:udp?endpoint=127.0.0.1:0|tags=1002";
+        final String wildCardUri3 = "aeron:udp?endpoint=127.0.0.1:0|tags=1003";
+        final String tagged2 = "aeron:udp?tags=1002";
+
+        try (Subscription sub1 = client.addSubscription(wildCardUri1, STREAM_ID);
+            Subscription sub2 = client.addSubscription(wildCardUri2, STREAM_ID);
+            Subscription sub3 = client.addSubscription(wildCardUri3, STREAM_ID);
+            Subscription sub4 = client.addSubscription(tagged2, STREAM_ID + 1))
+        {
+            String bindAddressAndPort1;
+            while (null == (bindAddressAndPort1 = sub1.bindAddressAndPort().get(0)))
+            {
+                Tests.yieldingWait("No bind address port for sub1");
+            }
+            String bindAddressAndPort2;
+            while (null == (bindAddressAndPort2 = sub2.bindAddressAndPort().get(0)))
+            {
+                Tests.yieldingWait("No bind address port for sub2");
+            }
+            String bindAddressAndPort3;
+            while (null == (bindAddressAndPort3 = sub3.bindAddressAndPort().get(0)))
+            {
+                Tests.yieldingWait("No bind address port for sub3");
+            }
+
+            assertNotEquals(bindAddressAndPort1, bindAddressAndPort2);
+            assertNotEquals(bindAddressAndPort1, bindAddressAndPort3);
+            assertNotEquals(bindAddressAndPort2, bindAddressAndPort3);
+
+            String bindAddressAndPort4;
+            while (null == (bindAddressAndPort4 = sub4.bindAddressAndPort().get(0)))
+            {
+                Tests.yieldingWait("No bind address port for sub4");
+            }
+
+            assertEquals(bindAddressAndPort4, bindAddressAndPort2);
+
+            final String pub1Uri = new ChannelUriStringBuilder().media("udp").endpoint(bindAddressAndPort1).build();
+            final String pub2Uri = new ChannelUriStringBuilder().media("udp").endpoint(bindAddressAndPort2).build();
+
+
+            try (Publication pub1 = client.addPublication(pub1Uri, STREAM_ID);
+                Publication pub2 = client.addPublication(pub2Uri, STREAM_ID))
+            {
+                while (pub1.offer(buffer, 0, buffer.capacity()) < 0)
+                {
+                    Tests.yieldingWait("Failed to publish to pub1");
+                }
+
+                while (sub1.poll(fragmentHandler, 1) < 0)
+                {
+                    Tests.yieldingWait("Failed to receive from sub1");
+                }
+
+                while (pub2.offer(buffer, 0, buffer.capacity()) < 0)
+                {
+                    Tests.yieldingWait("Failed to publish to pub2");
+                }
+
+                while (sub2.poll(fragmentHandler, 1) < 0)
+                {
+                    Tests.yieldingWait("Failed to receive from sub2");
+                }
+            }
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/WildcardPortsSystemTest.java
@@ -49,6 +49,8 @@ public class WildcardPortsSystemTest
     @Timeout(5)
     void shouldSubscribeToWildcardPorts()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet("Wildcard ports not supported yet");
+
         final String wildCardUri1 = "aeron:udp?endpoint=127.0.0.1:0|tags=1002";
         final String wildCardUri2 = "aeron:udp?endpoint=127.0.0.1:0|tags=1003";
         final String tagged1 = "aeron:udp?tags=1002";
@@ -101,6 +103,7 @@ public class WildcardPortsSystemTest
     @Timeout(5)
     void shouldSubscribeToWildcardPortsUsingIPv6()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet("Wildcard ports not supported yet");
         assumeFalse(Boolean.getBoolean("java.net.preferIPv4Stack"));
 
         final String wildCardUri1 = "aeron:udp?endpoint=[::1]:0|tags=1001";
@@ -146,6 +149,8 @@ public class WildcardPortsSystemTest
     @Timeout(5)
     void shouldBindMultipleWildcardsToMultiDestinationSubscription()
     {
+        TestMediaDriver.notSupportedOnCMediaDriverYet("Wildcard ports not supported yet");
+
         final String wildCardUri2 = "aeron:udp?endpoint=127.0.0.1:0";
         final String wildCardUri3 = "aeron:udp?endpoint=127.0.0.1:0";
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ defaultTasks 'clean', 'build'
 def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
-def agronaVersion = '1.4.1'
-def agronaVersionRange = '[1.4,1.5[' // allow any patch release of 1.4.x
+def agronaVersion = '1.5.0-SNAPSHOT'
+def agronaVersionRange = '1.5.+' // allow any patch release of 1.4.x
 def sbeVersion = '1.17.0'
 def checkstyleVersion = '8.28'
 def hamcrestVersion = '2.2'


### PR DESCRIPTION
- Appends unique index or tag to canonical form for udp channels that have wildcard fields.  Specifically this is MDS URIs (`aeron:udp?control-mode=manual`) and URIs that use a wildcard port (i.e. 0) e.g. `aeron:udp?endpoint:192.168.10.2:0`.
- Adds counters for each address/port binding on the sender and receiver side.  The counter will include the string representation in it's key, space is set up such that it won't be truncated.
- Add `bindAddressAndPorts()` method to Subscription and Publication so that clients can retrieve the bind addresses and ports once the channel and destination is active.
- Updates the format of the address/port pair to surround the address in square brackets `[`, `]` when using IPv6 addresses.

Probably some further discussion on naming required.