### PR TITLE
[C++] Use WARN error category when encountering temporary failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
 name: Continuous Integration
+
+javadoc-config:
+  ubuntu-latest: ''
+  windows-latest: '-x javadoc'
+
 on:
   repository_dispatch:
     types: run-commit-tests
@@ -42,7 +47,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        run: ./gradlew
+        run: ./gradlew {{ javadoc-config[matrix.os] }}
       - name: Copy crash logs
         id: copy_crash_logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,4 @@
 name: Continuous Integration
-
-javadoc-config:
-  ubuntu-latest: ''
-  windows-latest: '-x javadoc'
-
 on:
   repository_dispatch:
     types: run-commit-tests
@@ -47,7 +42,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        run: ./gradlew {{ javadoc-config[matrix.os] }}
+        run: ./gradlew
       - name: Copy crash logs
         id: copy_crash_logs
         if: failure()

--- a/aeron-client/src/main/cpp/ClientConductor.cpp
+++ b/aeron-client/src/main/cpp/ClientConductor.cpp
@@ -30,6 +30,12 @@ static size_t getAddress(const std::function<T(U...)> &f)
     return (size_t)*fnPointer;
 }
 
+static ExceptionCategory getCategory(std::int32_t errorCode)
+{
+    return errorCode == ERROR_CODE_RESOURCE_TEMPORARILY_UNAVAILABLE ?
+        ExceptionCategory::EXCEPTION_CATEGORY_WARN : ExceptionCategory::EXCEPTION_CATEGORY_ERROR;
+}
+
 ClientConductor::~ClientConductor()
 {
     std::for_each(m_lingeringImageLists.begin(), m_lingeringImageLists.end(),
@@ -134,7 +140,7 @@ std::shared_ptr<Publication> ClientConductor::findPublication(std::int64_t regis
 
                 m_publicationByRegistrationId.erase(it);
 
-                throw RegistrationException(errorCode, errorMessage, SOURCEINFO);
+                throw RegistrationException(errorCode, getCategory(errorCode), errorMessage, SOURCEINFO);
             }
         }
     }
@@ -223,7 +229,7 @@ std::shared_ptr<ExclusivePublication> ClientConductor::findExclusivePublication(
 
                 m_exclusivePublicationByRegistrationId.erase(it);
 
-                throw RegistrationException(errorCode, errorMessage, SOURCEINFO);
+                throw RegistrationException(errorCode, getCategory(errorCode), errorMessage, SOURCEINFO);
             }
         }
     }
@@ -300,7 +306,7 @@ std::shared_ptr<Subscription> ClientConductor::findSubscription(std::int64_t reg
 
         m_subscriptionByRegistrationId.erase(it);
 
-        throw RegistrationException(errorCode, errorMessage, SOURCEINFO);
+        throw RegistrationException(errorCode, getCategory(errorCode), errorMessage, SOURCEINFO);
     }
 
     return sub;
@@ -395,7 +401,7 @@ std::shared_ptr<Counter> ClientConductor::findCounter(std::int64_t registrationI
 
         m_counterByRegistrationId.erase(it);
 
-        throw RegistrationException(errorCode, errorMessage, SOURCEINFO);
+        throw RegistrationException(errorCode, getCategory(errorCode), errorMessage, SOURCEINFO);
     }
 
     return counter;
@@ -523,7 +529,7 @@ bool ClientConductor::findDestinationResponse(std::int64_t correlationId)
 
             m_destinationStateByCorrelationId.erase(it);
 
-            throw RegistrationException(errorCode, errorMessage, SOURCEINFO);
+            throw RegistrationException(errorCode, getCategory(errorCode), errorMessage, SOURCEINFO);
         }
     }
 

--- a/aeron-client/src/main/cpp/command/ErrorResponseFlyweight.h
+++ b/aeron-client/src/main/cpp/command/ErrorResponseFlyweight.h
@@ -65,6 +65,8 @@ static const std::int32_t ERROR_CODE_UNKNOWN_COUNTER = 5;
 static const std::int32_t ERROR_CODE_UNKNOWN_COMMAND_TYPE_ID = 6;
 static const std::int32_t ERROR_CODE_MALFORMED_COMMAND = 7;
 static const std::int32_t ERROR_CODE_NOT_SUPPORTED = 8;
+static const std::int32_t ERROR_CODE_UNKNOWN_HOST = 9;
+static const std::int32_t ERROR_CODE_RESOURCE_TEMPORARILY_UNAVAILABLE = 10;
 
 class ErrorResponseFlyweight : public Flyweight<ErrorResponseDefn>
 {

--- a/aeron-client/src/main/cpp/util/Exceptions.h
+++ b/aeron-client/src/main/cpp/util/Exceptions.h
@@ -132,11 +132,12 @@ private:
 public:
     RegistrationException(
         std::int32_t errorCode,
+        ExceptionCategory exceptionCategory,
         const std::string &what,
         const std::string &function,
         const std::string &file,
         const int line) :
-        SourcedException(what, function, file, line),
+        SourcedException(exceptionCategory, what, function, file, line),
         m_errorCode(errorCode)
     {
     }

--- a/aeron-client/src/test/cpp/ClientConductorTest.cpp
+++ b/aeron-client/src/test/cpp/ClientConductorTest.cpp
@@ -380,6 +380,24 @@ TEST_F(ClientConductorTest, shouldExceptionOnFindWhenReceivingErrorResponseOnAdd
         util::RegistrationException);
 }
 
+TEST_F(ClientConductorTest, shouldExceptionOnFindWhenReceivingErrorResponseOnAddSubscriptionAsWarning)
+{
+    std::int64_t id = m_conductor.addSubscription(
+        CHANNEL, STREAM_ID, m_onAvailableImageHandler, m_onUnavailableImageHandler);
+
+    m_conductor.onErrorResponse(id, ERROR_CODE_RESOURCE_TEMPORARILY_UNAVAILABLE, "resource unavailable");
+
+    try
+    {
+        std::shared_ptr<Subscription> sub = m_conductor.findSubscription(id);
+        FAIL() << "Exception should be thrown";
+    }
+    catch (util::RegistrationException &e)
+    {
+        ASSERT_EQ(ExceptionCategory::EXCEPTION_CATEGORY_WARN, e.category());
+    }
+}
+
 TEST_F(ClientConductorTest, shouldReturnNullForUnknownSubscription)
 {
     std::shared_ptr<Subscription> sub = m_conductor.findSubscription(100);


### PR DESCRIPTION
To support the changes in the C driver for handling rapid remove/add subscriptions.