### PR TITLE
Do not pollute the global state by BUILD_SHARED_LIBS and CMAKE_WINDOW…

### DIFF
--- a/aeron-client/src/main/c/CMakeLists.txt
+++ b/aeron-client/src/main/c/CMakeLists.txt
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 if (MSVC AND "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-    set(BUILD_SHARED_LIBS ON)
-endif ()
-
-if (MSVC AND "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
     set(AERON_LIB_WINSOCK_LIBS wsock32 ws2_32 Iphlpapi)
     set(WSAPOLL_PROTOTYPE_EXISTS True)
 endif ()
@@ -152,6 +147,8 @@ set(HEADERS
 add_library(aeron SHARED ${SOURCE} ${HEADERS})
 target_include_directories(aeron
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(aeron
+    PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(aeron_static STATIC ${SOURCE} ${HEADERS})
 target_include_directories(aeron_static

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 
-if (MSVC AND "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
-    set(BUILD_SHARED_LIBS ON)
-endif ()
-
 SET(SOURCE
     Publication.cpp
     ExclusivePublication.cpp

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -21,11 +21,6 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     add_definitions(-D_DEFAULT_SOURCE)
 endif ()
 
-if (MSVC AND "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-    set(BUILD_SHARED_LIBS ON)
-endif ()
-
 check_include_file("bsd/stdlib.h" BSDSTDLIB_H_EXISTS)
 check_include_file("uuid/uuid.h" UUID_H_EXISTS)
 find_library(LIBBSD_EXISTS NAMES bsd libbsd)
@@ -277,6 +272,8 @@ add_library(aeron_driver SHARED ${SOURCE} ${HEADERS})
 target_include_directories(aeron_driver
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${AERON_C_CLIENT_SOURCE_PATH}
     )
+set_target_properties(aeron_driver
+    PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 add_library(aeron_driver_static STATIC ${SOURCE} ${HEADERS})
 target_include_directories(aeron_driver_static


### PR DESCRIPTION
…S_EXPORT_ALL_SYMBOLS

These two global variable can be set on the target properties.