### PR TITLE
[C] Improve cppbuild/cppbuild-vs.cmd to match cppbuild/cppbuild

### DIFF
--- a/aeron-system-tests/CMakeLists.txt
+++ b/aeron-system-tests/CMakeLists.txt
@@ -1,8 +1,13 @@
+set (AERON_GRADLEW ./gradlew)
+if (WIN32)
+    set (AERON_GRADLEW ./gradlew.bat)
+endif()
+
 if (AERON_SYSTEM_TESTS)
     add_test(
         NAME java_system_tests_c_media_driver
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ./gradlew -Daeron.test.system.aeronmd.path=$<TARGET_FILE:aeronmd> :aeron-system-tests:cleanTest :aeron-system-tests:test --no-daemon)
+        COMMAND ${AERON_GRADLEW} -Daeron.test.system.aeronmd.path=$<TARGET_FILE:aeronmd> :aeron-system-tests:cleanTest :aeron-system-tests:test --no-daemon)
     set_tests_properties(java_system_tests_c_media_driver PROPERTIES RUN_SERIAL ON)
 endif ()
 
@@ -10,6 +15,6 @@ if (AERON_SLOW_SYSTEM_TESTS)
     add_test(
         NAME java_slow_system_tests_c_media_driver
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        COMMAND ./gradlew -Daeron.test.system.aeronmd.path=$<TARGET_FILE:aeronmd> :aeron-system-tests:cleanTest :aeron-system-tests:slowTest --no-daemon)
+        COMMAND ${AERON_GRADLEW} -Daeron.test.system.aeronmd.path=$<TARGET_FILE:aeronmd> :aeron-system-tests:cleanTest :aeron-system-tests:slowTest --no-daemon)
     set_tests_properties(java_slow_system_tests_c_media_driver PROPERTIES RUN_SERIAL ON)
 endif ()

--- a/cppbuild/cppbuild-vs.cmd
+++ b/cppbuild/cppbuild-vs.cmd
@@ -7,7 +7,7 @@ set ZLIB_ZIP=%CD%\cppbuild\zlib1211.zip
 set BUILD_DIR=%CD%\cppbuild\Release
 set ZLIB_BUILD_DIR=%BUILD_DIR%\zlib-build
 set ZLIB_INSTALL_DIR=%BUILD_DIR%\zlib64
-set EXTRA_CMAKE_ARGS=-DAERON_SYSTEM_TESTS=OFF
+set "EXTRA_CMAKE_ARGS="
 
 for %%o in (%*) do (
 
@@ -28,6 +28,23 @@ for %%o in (%*) do (
         set PROCESSED=1
     )
 
+    if "%%o"=="--build-archive-api" (
+        set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DBUILD_AERON_ARCHIVE_API=ON
+        set PROCESSED=1
+    )
+
+    if "%%o"=="--slow-system-tests" (
+        set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DAERON_SLOW_SYSTEM_TESTS=ON
+        set PROCESSED=1
+    )
+
+    if "%%o"=="--debug-build" (
+        set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DCMAKE_BUILD_TYPE=Debug
+        set BUILD_DIR=%CD%\cppbuild\Debug
+        set BUILD_CONFIG=Debug
+        set PROCESSED=1
+    )
+
     if "%%o"=="--build-aeron-driver" (
         set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DBUILD_AERON_DRIVER=ON
         set PROCESSED=1
@@ -35,6 +52,11 @@ for %%o in (%*) do (
 
     if "%%o"=="--link-samples-client-shared" (
         set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DLINK_SAMPLES_CLIENT_SHARED=ON
+        set PROCESSED=1
+    )
+
+    if "%%o"=="--no-system-tests" (
+        set EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DAERON_SYSTEM_TESTS=OFF
         set PROCESSED=1
     )
 )
@@ -63,8 +85,8 @@ pushd %BUILD_DIR%
 cmake %EXTRA_CMAKE_ARGS% %SOURCE_DIR%
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-cmake --build . --config Release
+cmake --build . --config %BUILD_CONFIG%
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-ctest -C Release --output-on-failure
+ctest -C %BUILD_CONFIG% --output-on-failure
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%


### PR DESCRIPTION
Getting cppbuild-vs.cmd to be consistence with cppbuild-vs.
Getting java_system_tests_c_media_driver and java_slow_system_tests_c_media_driver works under win32
Enable system-tests for Win/MSVC CI

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>