### PR TITLE
static const std::int32_t PAGE_SIZE are conflict with macro PAGE_SIZE…

### DIFF
--- a/aeron-client/src/test/cpp/ClientConductorFixture.h
+++ b/aeron-client/src/test/cpp/ClientConductorFixture.h
@@ -36,6 +36,10 @@ using namespace aeron;
 
 using namespace std::placeholders;
 
+#ifdef PAGE_SIZE
+#undef PAGE_SIZE
+#endif
+
 #define CAPACITY (1024)
 #define MANY_TO_ONE_RING_BUFFER_LENGTH (CAPACITY + RingBufferDescriptor::TRAILER_LENGTH)
 #define BROADCAST_BUFFER_LENGTH (CAPACITY + BroadcastBufferDescriptor::TRAILER_LENGTH)

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <time.h>
 #include "util/aeron_error.h"
 #include "util/aeron_netutil.h"
 #include "aeron_udp_channel_transport.h"


### PR DESCRIPTION
…, undefine it in ClientConductorFixture.h

/root/shared/work/aeron/aeron/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp:25: warning: "PAGE_SIZE" redefined
   25 | #define PAGE_SIZE (LogBufferDescriptor::AERON_PAGE_MIN_SIZE)
      |
In file included from /usr/include/fortify/wchar.h:22,
                 from /usr/include/c++/9.2.0/cwchar:44,
                 from /usr/include/c++/9.2.0/bits/postypes.h:40,
                 from /usr/include/c++/9.2.0/iosfwd:40,
                 from /usr/include/c++/9.2.0/memory:72,
                 from /root/shared/work/aeron/aeron/cppbuild/googletest/googletest/include/gtest/gtest.h:57,
                 from /root/shared/work/aeron/aeron/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp:17:
/usr/include/limits.h:89: note: this is the location of the previous definition
   89 | #define PAGE_SIZE PAGESIZE
      |
In file included from /usr/include/limits.h:8,
                 from /usr/include/fortify/wchar.h:22,
                 from /usr/include/c++/9.2.0/cwchar:44,
                 from /usr/include/c++/9.2.0/bits/postypes.h:40,
                 from /usr/include/c++/9.2.0/iosfwd:40,
                 from /usr/include/c++/9.2.0/memory:72,
                 from /root/shared/work/aeron/aeron/cppbuild/googletest/googletest/include/gtest/gtest.h:57,
                 from /root/shared/work/aeron/aeron/aeron-client/src/test/cpp/ClientConductorTest.cpp:17:
/root/shared/work/aeron/aeron/aeron-client/src/test/cpp/ClientConductorTest.cpp:32:27: error: expected unqualified-id before numeric constant
   32 | static const std::int32_t PAGE_SIZE = LogBufferDescriptor::AERON_PAGE_MIN_SIZE;
      |                           ^~~~~~~~~

Should include <time.h> for struct timespec