### PR TITLE
[CPP] fix std::array not initialized bug

### DIFF
--- a/aeron-driver/src/test/c/aeron_receiver_test.h
+++ b/aeron-driver/src/test/c/aeron_receiver_test.h
@@ -55,7 +55,11 @@ void verify_conductor_cmd_function(void *clientd, volatile void *item)
 class ReceiverTestBase : public testing::Test
 {
 public:
-    ReceiverTestBase() : m_conductor_fail_counter(0)
+    ReceiverTestBase() :
+        m_conductor_fail_counter(0),
+        m_error_log_buffer(),
+        m_counter_value_buffer(),
+        m_counter_meta_buffer()
     {}
 
 protected:


### PR DESCRIPTION
std:array<> not zero-initialized without calling the constructor directly.

Refer to https://stackoverflow.com/questions/18295302/default-initialization-of-stdarray

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>