### PR TITLE
[C] '+' and ':' are not valid win32 path symbol. replace them with '-'

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -188,6 +188,15 @@ int aeron_report_existing_errors(aeron_mapped_file_t *cnc_map, const char *aeron
         FILE *saved_errors_file = NULL;
 
         aeron_format_date(datestamp, sizeof(datestamp) - 1, aeron_epoch_clock());
+        while (true)
+        {
+            char* invalid_win_symbol = strstr(datestamp, ":");
+            if (invalid_win_symbol == NULL)
+            {
+                break;
+            }
+            *invalid_win_symbol = '-';
+        }
         snprintf(buffer, sizeof(buffer) - 1, "%s-%s-error.log", aeron_dir, datestamp);
 
         if ((saved_errors_file = fopen(buffer, "w")) != NULL)


### PR DESCRIPTION
Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>