### PR TITLE
Add backoff period after exception in ClusterBackupAgent - 2nd attempt

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -252,6 +252,16 @@ public final class ClusterBackup implements AutoCloseable
         public static final String CLUSTER_BACKUP_PROGRESS_TIMEOUT_PROP_NAME = "aeron.cluster.backup.progress.timeout";
 
         /**
+         * Interval at which the cluster backup is re-initialised after an exception has been thrown.
+         */
+        public static final String CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME = "aeron.cluster.backup.cooloff.interval";
+
+        /**
+         * Default interval at which the cluster back is re-initialised after an exception has been thrown.
+         */
+        public static final long CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS = TimeUnit.SECONDS.toNanos(30);
+
+        /**
          * Default timeout within which a cluster backup will expect progress.
          */
         public static final long CLUSTER_BACKUP_PROGRESS_TIMEOUT_DEFAULT_NS = TimeUnit.SECONDS.toNanos(10);
@@ -309,6 +319,18 @@ public final class ClusterBackup implements AutoCloseable
             return getDurationInNanos(
                 CLUSTER_BACKUP_PROGRESS_TIMEOUT_PROP_NAME, CLUSTER_BACKUP_PROGRESS_TIMEOUT_DEFAULT_NS);
         }
+
+        /**
+         * Interval at which the cluster backup is re-initialised after an exception has been thrown.
+         *
+         * @return interval at which the cluster backup is re-initialised after an exception has been thrown.
+         * @see #CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
+         */
+        public static long clusterBackupCoolOffIntervalNs()
+        {
+            return getDurationInNanos(
+                CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME, CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS);
+        }
     }
 
     /**
@@ -333,6 +355,7 @@ public final class ClusterBackup implements AutoCloseable
         private long clusterBackupIntervalNs = Configuration.clusterBackupIntervalNs();
         private long clusterBackupResponseTimeoutNs = Configuration.clusterBackupResponseTimeoutNs();
         private long clusterBackupProgressTimeoutNs = Configuration.clusterBackupProgressTimeoutNs();
+        private long clusterBackupCoolOffIntervalNs = Configuration.clusterBackupCoolOffIntervalNs();
         private int errorBufferLength = ConsensusModule.Configuration.errorBufferLength();
 
         private boolean deleteDirOnStart = false;
@@ -1008,6 +1031,32 @@ public final class ClusterBackup implements AutoCloseable
         public long clusterBackupProgressTimeoutNs()
         {
             return clusterBackupProgressTimeoutNs;
+        }
+
+        /**
+         * Interval at which the cluster backup is re-initialised after an exception has been thrown.
+         *
+         * @param clusterBackupCoolOffIntervalNs time before the cluster backup is re-initialised.
+         * @return this for a fluent API.
+         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
+         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS
+         */
+        public Context clusterBackupCoolOffIntervalNs(final long clusterBackupCoolOffIntervalNs)
+        {
+            this.clusterBackupCoolOffIntervalNs = clusterBackupCoolOffIntervalNs;
+            return this;
+        }
+
+        /**
+         * Interval at which the cluster backup is re-initialised after an exception has been thrown.
+         *
+         * @return interval at which the cluster backup is re-initialised after an exception has been thrown.
+         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
+         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS
+         */
+        public long clusterBackupCoolOffIntervalNs()
+        {
+            return clusterBackupCoolOffIntervalNs;
         }
 
         /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -254,12 +254,13 @@ public final class ClusterBackup implements AutoCloseable
         /**
          * Interval at which the cluster backup is re-initialised after an exception has been thrown.
          */
-        public static final String CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME = "aeron.cluster.backup.cooloff.interval";
+        public static final String CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME =
+            "aeron.cluster.backup.cool.down.interval";
 
         /**
          * Default interval at which the cluster back is re-initialised after an exception has been thrown.
          */
-        public static final long CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS = TimeUnit.SECONDS.toNanos(30);
+        public static final long CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS = TimeUnit.SECONDS.toNanos(30);
 
         /**
          * Default timeout within which a cluster backup will expect progress.
@@ -324,12 +325,12 @@ public final class ClusterBackup implements AutoCloseable
          * Interval at which the cluster backup is re-initialised after an exception has been thrown.
          *
          * @return interval at which the cluster backup is re-initialised after an exception has been thrown.
-         * @see #CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
+         * @see #CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME
          */
-        public static long clusterBackupCoolOffIntervalNs()
+        public static long clusterBackupCoolDownIntervalNs()
         {
             return getDurationInNanos(
-                CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME, CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS);
+                CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME, CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS);
         }
     }
 
@@ -355,7 +356,7 @@ public final class ClusterBackup implements AutoCloseable
         private long clusterBackupIntervalNs = Configuration.clusterBackupIntervalNs();
         private long clusterBackupResponseTimeoutNs = Configuration.clusterBackupResponseTimeoutNs();
         private long clusterBackupProgressTimeoutNs = Configuration.clusterBackupProgressTimeoutNs();
-        private long clusterBackupCoolOffIntervalNs = Configuration.clusterBackupCoolOffIntervalNs();
+        private long clusterBackupCoolDownIntervalNs = Configuration.clusterBackupCoolDownIntervalNs();
         private int errorBufferLength = ConsensusModule.Configuration.errorBufferLength();
 
         private boolean deleteDirOnStart = false;
@@ -1036,14 +1037,14 @@ public final class ClusterBackup implements AutoCloseable
         /**
          * Interval at which the cluster backup is re-initialised after an exception has been thrown.
          *
-         * @param clusterBackupCoolOffIntervalNs time before the cluster backup is re-initialised.
+         * @param clusterBackupCoolDownIntervalNs time before the cluster backup is re-initialised.
          * @return this for a fluent API.
-         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
-         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS
+         * @see Configuration#CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME
+         * @see Configuration#CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS
          */
-        public Context clusterBackupCoolOffIntervalNs(final long clusterBackupCoolOffIntervalNs)
+        public Context clusterBackupCoolDownIntervalNs(final long clusterBackupCoolDownIntervalNs)
         {
-            this.clusterBackupCoolOffIntervalNs = clusterBackupCoolOffIntervalNs;
+            this.clusterBackupCoolDownIntervalNs = clusterBackupCoolDownIntervalNs;
             return this;
         }
 
@@ -1051,12 +1052,12 @@ public final class ClusterBackup implements AutoCloseable
          * Interval at which the cluster backup is re-initialised after an exception has been thrown.
          *
          * @return interval at which the cluster backup is re-initialised after an exception has been thrown.
-         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_PROP_NAME
-         * @see Configuration#CLUSTER_BACKUP_COOLOFF_INTERVAL_DEFAULT_NS
+         * @see Configuration#CLUSTER_BACKUP_COOL_DOWN_INTERVAL_PROP_NAME
+         * @see Configuration#CLUSTER_BACKUP_COOL_DOWN_INTERVAL_DEFAULT_NS
          */
-        public long clusterBackupCoolOffIntervalNs()
+        public long clusterBackupCoolDownIntervalNs()
         {
-            return clusterBackupCoolOffIntervalNs;
+            return clusterBackupCoolDownIntervalNs;
         }
 
         /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -74,7 +74,7 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
     private final long backupResponseTimeoutMs;
     private final long backupQueryIntervalMs;
     private final long backupProgressTimeoutMs;
-    private final long coolOffIntervalMs;
+    private final long coolDownIntervalMs;
 
     private ClusterBackup.State state = INIT;
 
@@ -97,7 +97,7 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
     private long timeOfLastTickMs = 0;
     private long timeOfLastBackupQueryMs = 0;
     private long timeOfLastProgressMs = 0;
-    private long coolOffDeadlineMs = NULL_VALUE;
+    private long coolDownDeadlineMs = NULL_VALUE;
     private long correlationId = NULL_VALUE;
     private long leaderLogRecordingId = NULL_VALUE;
     private long liveLogReplaySubscriptionId = NULL_VALUE;
@@ -117,7 +117,7 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
         backupResponseTimeoutMs = TimeUnit.NANOSECONDS.toMillis(ctx.clusterBackupResponseTimeoutNs());
         backupQueryIntervalMs = TimeUnit.NANOSECONDS.toMillis(ctx.clusterBackupIntervalNs());
         backupProgressTimeoutMs = TimeUnit.NANOSECONDS.toMillis(ctx.clusterBackupProgressTimeoutNs());
-        coolOffIntervalMs = TimeUnit.NANOSECONDS.toMillis(ctx.clusterBackupCoolOffIntervalNs());
+        coolDownIntervalMs = TimeUnit.NANOSECONDS.toMillis(ctx.clusterBackupCoolDownIntervalNs());
         markFile = ctx.clusterMarkFile();
         eventsListener = ctx.eventsListener();
 
@@ -452,15 +452,15 @@ public class ClusterBackupAgent implements Agent, UnavailableCounterHandler
     {
         timeOfLastProgressMs = nowMs;
 
-        if (NULL_VALUE == coolOffDeadlineMs)
+        if (NULL_VALUE == coolDownDeadlineMs)
         {
-            coolOffDeadlineMs = nowMs + coolOffIntervalMs;
+            coolDownDeadlineMs = nowMs + coolDownIntervalMs;
             reset();
             return 1;
         }
-        else if (nowMs > coolOffDeadlineMs)
+        else if (nowMs > coolDownDeadlineMs)
         {
-            coolOffDeadlineMs = NULL_VALUE;
+            coolDownDeadlineMs = NULL_VALUE;
             state(INIT, nowMs);
             return 1;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -403,7 +403,7 @@ public class TestCluster implements AutoCloseable
             .errorHandler(ClusterTests.errorHandler(index))
             .clusterConsensusEndpoints(clusterConsensusEndpoints)
             .consensusChannel(consensusChannelUri.toString())
-            .clusterBackupCoolOffIntervalNs(TimeUnit.SECONDS.toNanos(1))
+            .clusterBackupCoolDownIntervalNs(TimeUnit.SECONDS.toNanos(1))
             .catchupEndpoint(clusterBackupCatchupEndpoint(staticMemberCount + dynamicMemberCount))
             .aeronDirectoryName(aeronDirName)
             .clusterDir(new File(baseDirName, "cluster-backup"))

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -403,6 +403,7 @@ public class TestCluster implements AutoCloseable
             .errorHandler(ClusterTests.errorHandler(index))
             .clusterConsensusEndpoints(clusterConsensusEndpoints)
             .consensusChannel(consensusChannelUri.toString())
+            .clusterBackupCoolOffIntervalNs(TimeUnit.SECONDS.toNanos(1))
             .catchupEndpoint(clusterBackupCatchupEndpoint(staticMemberCount + dynamicMemberCount))
             .aeronDirectoryName(aeronDirName)
             .clusterDir(new File(baseDirName, "cluster-backup"))

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -237,7 +237,7 @@ public class Configuration
     public static final int SEND_TO_STATUS_POLL_RATIO_DEFAULT = 6;
 
     /**
-     * Property name for SO_RCVBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Produce (BDP).
+     * Property name for SO_RCVBUF setting on UDP sockets which must be sufficient for Bandwidth Delay Product (BDP).
      */
     public static final String SOCKET_RCVBUF_LENGTH_PROP_NAME = "aeron.socket.so_rcvbuf";
 


### PR DESCRIPTION
Reapplies #939 after test failure and adds an additional parameter to control cool off period.

30 seconds ensures any lingers resources will be closed.