### PR TITLE
log is not replayed if cluster was shut down and the snapshot is invalid

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1454,17 +1454,21 @@ class ConsensusModuleAgent implements Agent
 
     LogReplay newLogReplay(final long logPosition, final long appendPosition)
     {
-        if (logPosition < appendPosition)
+        if (recoveryPlan.log != null)
         {
-            return new LogReplay(
-                archive,
-                recoveryPlan.log.recordingId,
-                logPosition,
-                appendPosition,
-                recoveryPlan.log.leadershipTermId,
-                recoveryPlan.log.sessionId,
-                logAdapter,
-                ctx);
+            final long startPosition = Math.min(logPosition, recoveryPlan.log.startPosition);
+            if (startPosition < appendPosition)
+            {
+                return new LogReplay(
+                    archive,
+                    recoveryPlan.log.recordingId,
+                    startPosition,
+                    appendPosition,
+                    recoveryPlan.log.leadershipTermId,
+                    recoveryPlan.log.sessionId,
+                    logAdapter,
+                    ctx);
+            }
         }
 
         return null;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1454,21 +1454,17 @@ class ConsensusModuleAgent implements Agent
 
     LogReplay newLogReplay(final long logPosition, final long appendPosition)
     {
-        if (recoveryPlan.log != null)
+        if (logPosition < appendPosition)
         {
-            final long startPosition = Math.min(logPosition, recoveryPlan.log.startPosition);
-            if (startPosition < appendPosition)
-            {
-                return new LogReplay(
-                    archive,
-                    recoveryPlan.log.recordingId,
-                    startPosition,
-                    appendPosition,
-                    recoveryPlan.log.leadershipTermId,
-                    recoveryPlan.log.sessionId,
-                    logAdapter,
-                    ctx);
-            }
+            return new LogReplay(
+                archive,
+                recoveryPlan.log.recordingId,
+                logPosition,
+                appendPosition,
+                recoveryPlan.log.leadershipTermId,
+                recoveryPlan.log.sessionId,
+                logAdapter,
+                ctx);
         }
 
         return null;


### PR DESCRIPTION
If cluster was terminated with the shapshot-and-shutdown operation, and the snapshot is invalidated, then even though the snapshot is invalidated, replay is checked with last commited position, but since snapshot with that position isn't loaded service is restored in incorrect state.

this may be not the optimal fix, but it highlights the problem. happy to apply any review notes.