### PR TITLE
[Java] Preserve Archive/MediaDriver/Service/ConsensusModule data upon cluster test failure

### DIFF
--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -18,7 +18,10 @@ package io.aeron.cluster;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
@@ -36,11 +39,23 @@ import static org.junit.jupiter.api.Assertions.*;
 @SlowTest
 public class ClusterTest
 {
+    private TestCluster cluster;
+
+    @AfterEach
+    void after()
+    {
+        if (null != cluster)
+        {
+            cluster.close();
+        }
+    }
+
     @Test
     @Timeout(30)
-    public void shouldStopFollowerAndRestartFollower()
+    public void shouldStopFollowerAndRestartFollower(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             cluster.awaitLeader();
             TestNode follower = cluster.followers().get(0);
@@ -55,13 +70,19 @@ public class ClusterTest
             awaitElectionClosed(follower);
             assertEquals(FOLLOWER, follower.role());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldNotifyClientOfNewLeader()
+    public void shouldNotifyClientOfNewLeader(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -71,13 +92,19 @@ public class ClusterTest
             cluster.stopNode(leader);
             cluster.awaitLeadershipEvent(1);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot()
+    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -97,13 +124,19 @@ public class ClusterTest
             cluster.awaitSnapshotLoadedForService(cluster.node(1));
             cluster.awaitSnapshotLoadedForService(cluster.node(2));
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldShutdownClusterAndRestartWithSnapshots()
+    public void shouldShutdownClusterAndRestartWithSnapshots(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -131,13 +164,19 @@ public class ClusterTest
             cluster.awaitSnapshotLoadedForService(cluster.node(1));
             cluster.awaitSnapshotLoadedForService(cluster.node(2));
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldAbortClusterAndRestart()
+    public void shouldAbortClusterAndRestart(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -165,13 +204,19 @@ public class ClusterTest
             assertFalse(cluster.node(1).service().wasSnapshotLoaded());
             assertFalse(cluster.node(2).service().wasSnapshotLoaded());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldAbortClusterOnTerminationTimeout()
+    public void shouldAbortClusterOnTerminationTimeout(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -198,13 +243,19 @@ public class ClusterTest
             cluster.stopNode(leader);
             cluster.stopNode(followerA);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldEchoMessagesThenContinueOnNewLeader()
+    public void shouldEchoMessagesThenContinueOnNewLeader(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode originalLeader = cluster.awaitLeader();
             cluster.connectClient();
@@ -234,13 +285,19 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(newLeader, preFailureMessageCount + postFailureMessageCount);
             cluster.awaitServiceMessageCount(follower, preFailureMessageCount + postFailureMessageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldStopLeaderAndRestartAsFollower()
+    public void shouldStopLeaderAndRestartAsFollower(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode originalLeader = cluster.awaitLeader();
 
@@ -252,13 +309,19 @@ public class ClusterTest
             awaitElectionClosed(follower);
             assertEquals(FOLLOWER, follower.role());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter()
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode originalLeader = cluster.awaitLeader();
 
@@ -276,13 +339,19 @@ public class ClusterTest
             cluster.sendMessages(messageCount);
             cluster.awaitResponseMessageCount(messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(60)
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader()
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode originalLeader = cluster.awaitLeader();
 
@@ -305,13 +374,19 @@ public class ClusterTest
 
             cluster.awaitLeader(leader.index());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldAcceptMessagesAfterSingleNodeCleanRestart()
+    public void shouldAcceptMessagesAfterSingleNodeCleanRestart(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             cluster.awaitLeader();
             TestNode follower = cluster.followers().get(0);
@@ -333,13 +408,19 @@ public class ClusterTest
             cluster.awaitResponseMessageCount(messageCount);
             cluster.awaitServiceMessageCount(follower, messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldReplaySnapshotTakenWhileDown()
+    public void shouldReplaySnapshotTakenWhileDown(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final TestNode followerA = cluster.followers().get(0);
@@ -368,13 +449,19 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(followerB, messageCount);
             assertEquals(0L, followerB.errors());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(50)
-    public void shouldTolerateMultipleLeaderFailures()
+    public void shouldTolerateMultipleLeaderFailures(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode firstLeader = cluster.awaitLeader();
             cluster.stopNode(firstLeader);
@@ -397,13 +484,19 @@ public class ClusterTest
             cluster.sendMessages(messageCount);
             cluster.awaitResponseMessageCount(messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(120)
-    public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime()
+    public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode firstLeader = cluster.awaitLeader();
 
@@ -438,13 +531,19 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(cluster.followers().get(0), messageCount + 10);
             cluster.awaitServiceMessageCount(cluster.followers().get(1), messageCount + 10);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldAcceptMessagesAfterTwoNodeCleanRestart()
+    public void shouldAcceptMessagesAfterTwoNodeCleanRestart(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -475,13 +574,20 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(followerA, messageCount);
             cluster.awaitServiceMessageCount(followerB, messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos()
+    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos(
+        final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -524,13 +630,20 @@ public class ClusterTest
             final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
             cluster.awaitServiceMessageCount(oldLeader, messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos()
+    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos(
+        final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -569,13 +682,19 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(followerB, messageCount);
             cluster.awaitServiceMessageCount(oldLeader, messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldCallOnRoleChangeOnBecomingLeader()
+    public void shouldCallOnRoleChangeOnBecomingLeader(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             TestNode leader = cluster.awaitLeader();
             List<TestNode> followers = cluster.followers();
@@ -595,13 +714,19 @@ public class ClusterTest
             assertEquals(LEADER, leader.service().roleChangedTo());
             assertNull(follower.service().roleChangedTo());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers()
+    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final TestNode.TestService service = leader.service();
@@ -624,13 +749,19 @@ public class ClusterTest
             }
             assertEquals(FOLLOWER, leader.role());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldTerminateLeaderWhenServiceStops()
+    public void shouldTerminateLeaderWhenServiceStops(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -647,13 +778,19 @@ public class ClusterTest
                 Tests.sleep(1);
             }
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(20)
-    public void shouldCloseClientOnTimeout()
+    public void shouldCloseClientOnTimeout(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -672,13 +809,19 @@ public class ClusterTest
 
             assertEquals(1, context.timedOutClientCounter().get());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldRecoverWhileMessagesContinue() throws InterruptedException
+    public void shouldRecoverWhileMessagesContinue(final TestInfo testInfo) throws InterruptedException
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -714,13 +857,19 @@ public class ClusterTest
             assertEquals(0L, followerA.errors());
             assertEquals(0L, followerB.errors());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchupFromEmptyLog()
+    public void shouldCatchupFromEmptyLog(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -739,13 +888,19 @@ public class ClusterTest
             followerB = cluster.startStaticNode(followerB.index(), true);
             cluster.awaitServiceMessageCount(followerB, messageCount);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart()
+    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -788,13 +943,19 @@ public class ClusterTest
             cluster.awaitSnapshotCount(cluster.node(2), 1);
             assertTrue(cluster.node(2).service().wasSnapshotTaken());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpTwoFreshNodesAfterRestart()
+    public void shouldCatchUpTwoFreshNodesAfterRestart(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -832,13 +993,19 @@ public class ClusterTest
             assertEquals(0L, oldFollower1.errors());
             assertEquals(0L, oldFollower2.errors());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog()
+    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final List<TestNode> followers = cluster.followers();
@@ -912,13 +1079,19 @@ public class ClusterTest
             cluster.awaitServiceMessageCount(cluster.node(2), totalMsgCount);
             assertEquals(totalMsgCount, cluster.node(2).service().messageCount());
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne()
+    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader = cluster.awaitLeader();
             final TestNode follower = cluster.followers().get(0);
@@ -939,13 +1112,19 @@ public class ClusterTest
             cluster.startStaticNode(follower2.index(), true);
             cluster.awaitLeader();
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(40)
-    void shouldRecoverWhenLastSnapshotIsMarkedInvalid()
+    void shouldRecoverWhenLastSnapshotIsMarkedInvalid(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader0 = cluster.awaitLeader();
             cluster.connectClient();
@@ -983,13 +1162,19 @@ public class ClusterTest
 
             cluster.awaitServicesMessageCount(numMessages * 2);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(60)
-    void shouldHandleMultipleElections()
+    void shouldHandleMultipleElections(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader0 = cluster.awaitLeader();
             cluster.connectClient();
@@ -1017,13 +1202,19 @@ public class ClusterTest
             cluster.awaitResponseMessageCount(numMessages * 3);
             cluster.awaitServicesMessageCount(numMessages * 3);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(50)
-    void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections()
+    void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections(final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             final TestNode leader0 = cluster.awaitLeader();
             cluster.connectClient();
@@ -1064,25 +1255,31 @@ public class ClusterTest
 
             cluster.awaitServicesMessageCount(numMessages * 2);
         }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpAfterFollowerMissesOneMessage()
+    public void shouldCatchUpAfterFollowerMissesOneMessage(final TestInfo testInfo)
     {
-        shouldCatchUpAfterFollowerMissesMessage(NO_OP_MSG);
+        shouldCatchUpAfterFollowerMissesMessage(NO_OP_MSG, testInfo);
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpAfterFollowerMissesTimerRegistration()
+    public void shouldCatchUpAfterFollowerMissesTimerRegistration(final TestInfo testInfo)
     {
-        shouldCatchUpAfterFollowerMissesMessage(REGISTER_TIMER_MSG);
+        shouldCatchUpAfterFollowerMissesMessage(REGISTER_TIMER_MSG, testInfo);
     }
 
-    private void shouldCatchUpAfterFollowerMissesMessage(final String message)
+    private void shouldCatchUpAfterFollowerMissesMessage(final String message, final TestInfo testInfo)
     {
-        try (TestCluster cluster = startThreeNodeStaticCluster(NULL_VALUE))
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
         {
             cluster.awaitLeader();
             TestNode follower = cluster.followers().get(0);
@@ -1100,6 +1297,11 @@ public class ClusterTest
 
             awaitElectionClosed(follower);
             assertEquals(FOLLOWER, follower.role());
+        }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
         }
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestNode.java
@@ -15,7 +15,9 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.Counter;
+import io.aeron.ExclusivePublication;
+import io.aeron.Image;
 import io.aeron.archive.Archive;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.status.RecordingPos;
@@ -27,7 +29,11 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
-import org.agrona.*;
+import io.aeron.test.DataCollector;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.LangUtil;
 import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.status.CountersReader;
 
@@ -47,7 +53,7 @@ class TestNode implements AutoCloseable
     private final Context context;
     private boolean isClosed = false;
 
-    TestNode(final Context context)
+    TestNode(final Context context, final DataCollector dataCollector)
     {
         clusteredMediaDriver = ClusteredMediaDriver.launch(
             context.mediaDriverContext,
@@ -63,6 +69,11 @@ class TestNode implements AutoCloseable
 
         service = context.service;
         this.context = context;
+
+        dataCollector.add(container.context().clusterDir().toPath());
+        dataCollector.add(clusteredMediaDriver.consensusModule().context().clusterDir().toPath());
+        dataCollector.add(clusteredMediaDriver.archive().context().archiveDir().toPath());
+        dataCollector.add(clusteredMediaDriver.mediaDriver().context().aeronDirectory().toPath());
     }
 
     ConsensusModule consensusModule()

--- a/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.TestInfo;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.nio.file.Files.*;
+import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
+import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.agrona.Strings.isEmpty;
+
+/**
+ * {@code DataCollector} is a helper class to preserve data upon test failure.
+ */
+public final class DataCollector
+{
+    static final AtomicInteger UNIQUE_ID = new AtomicInteger(0);
+    private static final String SEPARATOR = "-";
+    private final Path rootDir;
+    private final Set<Path> locations = new LinkedHashSet<>();
+
+    public DataCollector()
+    {
+        this(Paths.get("build/test-output"));
+    }
+
+    public DataCollector(final Path rootDir)
+    {
+        requireNonNull(rootDir);
+        if (exists(rootDir) && !isDirectory(rootDir))
+        {
+            throw new IllegalArgumentException(rootDir + " is not a directory");
+        }
+        this.rootDir = rootDir;
+    }
+
+    /**
+     * Add a file/directory to be preserved.
+     *
+     * @param location file or directory to preserve.
+     * @see #dumpData(TestInfo)
+     * @see #dumpData(String)
+     */
+    public void add(final Path location)
+    {
+        locations.add(requireNonNull(location));
+    }
+
+    /**
+     * Copy data from all of the added locations to the directory {@code $rootDir/$testClass_$testMethod}, where:
+     * <ul>
+     *     <li>{@code $rootDir} is the root directory specified when {@link #DataCollector} was created.</li>
+     *     <li>{@code $testClass} is the fully qualified class name of the test class.</li>
+     *     <li>{@code $testMethod} is the test method name.</li>
+     * </ul>
+     *
+     * @param testInfo test info from JUnit.
+     * @see #dumpData(String)
+     */
+    public void dumpData(final TestInfo testInfo)
+    {
+        final String testClass = testInfo.getTestClass().map(Class::getName).get();
+        final String testMethod = testInfo.getTestMethod().map(Method::getName).get();
+        copyData(testClass + SEPARATOR + testMethod);
+    }
+
+    /**
+     * Copy data from all of the added locations to the directory {@code $rootDir/$destinationDir}, where:
+     * <ul>
+     *     <li>{@code $rootDir} is the root directory specified when {@link #DataCollector} was created.</li>
+     *     <li>{@code $destinationDir} is the destination directory name.</li>
+     * </ul>
+     * <p>
+     *     <em>
+     *     Note: If the destination directory already exists then a unique ID suffix will be added to the name.
+     *     For example given that root directory is {@code build/test-output} and the destination directory is
+     *     {@code my-dir} the actual directory could be {@code build/test-output/my-dir_5}, where {@code _5} is the
+     *     suffix added.
+     *     </em>
+     * </p>
+     *
+     * @param destinationDir destination directory where the data should be copied into.
+     */
+    public void dumpData(final String destinationDir)
+    {
+        if (isEmpty(destinationDir))
+        {
+            throw new IllegalArgumentException("destination dir is required");
+        }
+
+        copyData(destinationDir);
+    }
+
+    private void copyData(final String destinationDir)
+    {
+        final List<Path> locations = this.locations.stream().filter(Files::exists).collect(toList());
+        if (locations.isEmpty())
+        {
+            return;
+        }
+
+        try
+        {
+            final Path destination = createUniqueDirectory(destinationDir);
+            final Map<Path, Set<Path>> groups = groupByParent(locations);
+            for (final Map.Entry<Path, Set<Path>> group : groups.entrySet())
+            {
+                final Set<Path> files = group.getValue();
+                final Path parent = adjustParentToEnsureUniqueContext(destination, files, group.getKey());
+                for (final Path srcFile : files)
+                {
+                    final Path destFile = destination.resolve(parent.relativize(srcFile));
+                    copyFiles(srcFile, destFile);
+                }
+            }
+        }
+        catch (final IOException e)
+        {
+            LangUtil.rethrowUnchecked(e);
+        }
+    }
+
+    private Path createUniqueDirectory(final String name) throws IOException
+    {
+        Path path = rootDir.resolve(name);
+        while (exists(path))
+        {
+            path = rootDir.resolve(name + SEPARATOR + UNIQUE_ID.incrementAndGet());
+        }
+        return createDirectories(path);
+    }
+
+    private Map<Path, Set<Path>> groupByParent(final List<Path> locations)
+    {
+        final LinkedHashMap<Path, Set<Path>> map = new LinkedHashMap<>();
+        for (final Path p : locations)
+        {
+            map.put(p, singleton(p));
+        }
+
+        removeNestedPaths(locations, map);
+
+        return groupByParent(map);
+    }
+
+    private void removeNestedPaths(final List<Path> locations, final LinkedHashMap<Path, Set<Path>> map)
+    {
+        for (final Path p : locations)
+        {
+            Path parent = p.getParent();
+            while (null != parent)
+            {
+                if (map.containsKey(parent))
+                {
+                    map.remove(p);
+                    break;
+                }
+                parent = parent.getParent();
+            }
+        }
+    }
+
+    private LinkedHashMap<Path, Set<Path>> groupByParent(final LinkedHashMap<Path, Set<Path>> locations)
+    {
+        if (1 == locations.size())
+        {
+            return locations;
+        }
+
+        final LinkedHashMap<Path, Set<Path>> result = new LinkedHashMap<>();
+        final Set<Path> processed = new HashSet<>();
+        boolean recurse = false;
+        for (final Map.Entry<Path, Set<Path>> e1 : locations.entrySet())
+        {
+            final Path path1 = e1.getKey();
+            if (processed.add(path1))
+            {
+                boolean found = false;
+                final Path parent = path1.getParent();
+                if (null != parent && !parent.equals(path1.getRoot()))
+                {
+                    for (final Map.Entry<Path, Set<Path>> e2 : locations.entrySet())
+                    {
+                        final Path path2 = e2.getKey();
+                        if (!processed.contains(path2) && path2.startsWith(parent))
+                        {
+                            found = true;
+                            processed.add(path2);
+                            final Set<Path> children = result.computeIfAbsent(parent, key -> new HashSet<>());
+                            children.addAll(e1.getValue());
+                            children.addAll(e2.getValue());
+                        }
+                    }
+                }
+                if (!found)
+                {
+                    result.put(path1, e1.getValue());
+                }
+                recurse = recurse || found;
+            }
+        }
+
+        if (recurse)
+        {
+            return groupByParent(result);
+        }
+        return locations;
+    }
+
+    private Path adjustParentToEnsureUniqueContext(final Path destination, final Set<Path> files, final Path root)
+    {
+        Path parent = root;
+        for (final Path srcFile : files)
+        {
+            while (true)
+            {
+                final Path dest = destination.resolve(parent.relativize(srcFile));
+                if (!exists(dest))
+                {
+                    break;
+                }
+                parent = parent.getParent();
+            }
+        }
+        return parent;
+    }
+
+    private void copyFiles(final Path src, final Path dest) throws IOException
+    {
+        if (isRegularFile(src))
+        {
+            copy(src, dest, COPY_ATTRIBUTES);
+        }
+        else
+        {
+            walkFileTree(src, new SimpleFileVisitor<Path>()
+            {
+                public FileVisitResult preVisitDirectory(
+                    final Path dir, final BasicFileAttributes attrs) throws IOException
+                {
+                    final Path destDir = dest.resolve(src.relativize(dir));
+                    if (!exists(destDir.getParent()))
+                    {
+                        createDirectories(destDir.getParent());
+                    }
+                    copy(dir, destDir, COPY_ATTRIBUTES);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                public FileVisitResult visitFile(
+                    final Path file, final BasicFileAttributes attrs) throws IOException
+                {
+                    copy(file, dest.resolve(src.relativize(file)), COPY_ATTRIBUTES);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+    }
+
+}

--- a/aeron-test-support/src/test/java/io/aeron/test/DataCollectorTest.java
+++ b/aeron-test-support/src/test/java/io/aeron/test/DataCollectorTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.agrona.IoUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.aeron.test.DataCollector.UNIQUE_ID;
+import static java.nio.file.Files.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataCollectorTest
+{
+    @Test
+    void throwsNullPointerExceptionIfTargetDirectoryIsNull()
+    {
+        assertThrows(NullPointerException.class, () -> new DataCollector(null));
+    }
+
+    @Test
+    void throwsIllegalArgumentExceptionIfTargetDirectoryIsAFile(final @TempDir Path tempDir) throws IOException
+    {
+        final Path file = createFile(tempDir.resolve("my.txt"));
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> new DataCollector(file));
+
+        assertEquals(file + " is not a directory", exception.getMessage());
+    }
+
+    @Test
+    void addFileThrowsNullPointerExceptionIfFileIsNull()
+    {
+        final DataCollector dataCollector = new DataCollector();
+        assertThrows(NullPointerException.class, () -> dataCollector.add(null));
+    }
+
+    @Test
+    void copyUsingTestInfoThrowsNullPointerExceptionIfNull()
+    {
+        final DataCollector dataCollector = new DataCollector();
+        assertThrows(NullPointerException.class, () -> dataCollector.dumpData((TestInfo)null));
+    }
+
+    @Test
+    void copyUsingDirectoryNameThrowsIllegalArgumentExceptionIfNull()
+    {
+        final DataCollector dataCollector = new DataCollector();
+        assertThrows(IllegalArgumentException.class, () -> dataCollector.dumpData((String)null));
+    }
+
+    @Test
+    void copyUsingDirectoryNameThrowsIllegalArgumentExceptionIfEmpty()
+    {
+        final DataCollector testWatcher = new DataCollector();
+        assertThrows(IllegalArgumentException.class, () -> testWatcher.dumpData(""));
+    }
+
+    @Test
+    void copyUsingTestInfo(final @TempDir Path tempDir, final TestInfo testInfo) throws Exception
+    {
+        final Path buildDir = Paths.get("build/test/source").toAbsolutePath();
+        createDirectories(buildDir);
+        try
+        {
+            final Path rootDir = tempDir.resolve("copy-root");
+            final Path my1 = createFile(tempDir.resolve("my.txt"));
+            final Path myDir1 = createDirectories(tempDir.resolve("my-dir"));
+            createFile(myDir1.resolve("some1.txt"));
+            final Path dir11 = createDirectories(tempDir.resolve("path1/dir1"));
+            final Path dir12 = createDirectories(tempDir.resolve("path1/dir2"));
+            final Path dir13 = createDirectories(tempDir.resolve("path1/dir2/dir3"));
+            createFile(tempDir.resolve("path1/do_not_copy.txt"));
+            createFile(dir11.resolve("file11.txt"));
+            createFile(dir12.resolve("file12.txt"));
+            createFile(dir13.resolve("file13.txt"));
+            final Path my2 = createFile(dir13.resolve("my.txt"));
+            final Path dir21 = createDirectories(tempDir.resolve("path2/dir1"));
+            final Path dir22 = createDirectories(tempDir.resolve("path2/dir2"));
+            final Path dir23 = createDirectories(tempDir.resolve("path2/dir3"));
+            createFile(dir21.resolve("file21.txt"));
+            createFile(dir22.resolve("file22.txt"));
+            createFile(dir23.resolve("file23.txt"));
+            final Path dir31 = createDirectories(buildDir.resolve("dir1"));
+            final Path dir32 = createDirectories(buildDir.resolve("dir2"));
+            final Path dir33 = createDirectories(buildDir.resolve("dir2/dir3"));
+            createFile(dir31.resolve("file31.txt"));
+            createFile(dir32.resolve("file32.txt"));
+            createFile(dir33.resolve("file33.txt"));
+            final Path my3 = createFile(buildDir.resolve("my.txt"));
+            final Path myDir2 = createDirectories(buildDir.resolve("my-dir"));
+            createFile(myDir2.resolve("some2.txt"));
+
+            final DataCollector dataCollector = new DataCollector(rootDir);
+            dataCollector.add(my1);
+            dataCollector.add(my1);
+            dataCollector.add(my2);
+            dataCollector.add(dir11);
+            dataCollector.add(dir12);
+            dataCollector.add(dir13);
+            dataCollector.add(dir21);
+            dataCollector.add(dir22);
+            dataCollector.add(dir23);
+            dataCollector.add(dir31);
+            dataCollector.add(dir32);
+            dataCollector.add(dir33);
+            dataCollector.add(my3);
+            dataCollector.add(myDir1);
+            dataCollector.add(myDir2);
+
+            final String testClass = testInfo.getTestClass().map(Class::getName).orElse(null);
+            final String testMethod = testInfo.getTestMethod().map(Method::getName).orElse(null);
+            dataCollector.dumpData(testInfo);
+
+            final Path destination = rootDir.resolve(testClass + "-" + testMethod);
+            assertTrue(exists(destination));
+            assertTrue(exists(destination.resolve("my.txt")));
+            assertTrue(exists(destination.resolve("my-dir/some1.txt")));
+            assertTrue(exists(destination.resolve("path1/dir1/file11.txt")));
+            assertTrue(exists(destination.resolve("path1/dir2/file12.txt")));
+            assertTrue(exists(destination.resolve("path1/dir2/dir3/file13.txt")));
+            assertTrue(exists(destination.resolve("path1/dir2/dir3/my.txt")));
+            assertTrue(exists(destination.resolve("path2/dir1/file21.txt")));
+            assertTrue(exists(destination.resolve("path2/dir2/file22.txt")));
+            assertTrue(exists(destination.resolve("path2/dir3/file23.txt")));
+            assertTrue(exists(destination.resolve("source/dir1/file31.txt")));
+            assertTrue(exists(destination.resolve("source/dir2/file32.txt")));
+            assertTrue(exists(destination.resolve("source/dir2/dir3/file33.txt")));
+            assertTrue(exists(destination.resolve("source/my.txt")));
+            assertTrue(exists(destination.resolve("source/my-dir/some2.txt")));
+            assertFalse(exists(destination.resolve("path1/do_not_copy.txt")));
+        }
+        finally
+        {
+            IoUtil.delete(buildDir.toFile(), false);
+        }
+    }
+
+    @Test
+    void copyUsingDirectoryName(final @TempDir Path tempDir) throws Exception
+    {
+        final Path rootDir = tempDir.resolve("copy-root");
+        createDirectories(rootDir.resolve("destination"));
+
+        final Path file0 = createFile(tempDir.resolve("my.txt"));
+        final Path dir1 = createDirectories(tempDir.resolve("my-dir/nested/again"));
+        final Path dir2 = createDirectories(tempDir.resolve("again"));
+        final Path dir3 = createDirectories(tempDir.resolve("nested/again"));
+        final Path dir4 = createDirectories(tempDir.resolve("level1/level2/level3/again"));
+        createFile(dir1.resolve("file1.txt"));
+        createFile(dir2.resolve("file2.txt"));
+        createFile(dir3.resolve("file3.txt"));
+        createFile(dir4.resolve("file4.txt"));
+
+        final DataCollector dataCollector = new DataCollector(rootDir);
+        dataCollector.add(file0);
+        dataCollector.add(tempDir.resolve("my-dir"));
+        dataCollector.add(tempDir.resolve("again"));
+        dataCollector.add(tempDir.resolve("nested"));
+        dataCollector.add(dir4);
+
+        dataCollector.dumpData("destination");
+
+        final Path destination = rootDir.resolve("destination-" + UNIQUE_ID.get());
+        assertTrue(exists(destination));
+        assertTrue(exists(destination.resolve("my.txt")));
+        assertTrue(exists(destination.resolve("my-dir/nested/again/file1.txt")));
+        assertTrue(exists(destination.resolve("again/file2.txt")));
+        assertTrue(exists(destination.resolve("nested/again/file3.txt")));
+        assertTrue(exists(destination.resolve("level1/level2/level3/again/file4.txt")));
+    }
+
+    @Test
+    void copyUsingTestInfoIsANoOpIfNoFilesRegistered(
+        final @TempDir Path tempDir, final TestInfo testInfo) throws Exception
+    {
+        final Path rootDirectory = tempDir.resolve("no-copy");
+
+        new DataCollector(rootDirectory).dumpData(testInfo);
+
+        assertFalse(exists(rootDirectory));
+    }
+
+    @Test
+    void copyUsingDirectoryNameIsANoOpIfNoFilesRegistered(final @TempDir Path tempDir) throws Exception
+    {
+        final Path rootDirectory = tempDir.resolve("no-copy");
+
+        new DataCollector(rootDirectory).dumpData("some-dir");
+
+        assertFalse(exists(rootDirectory));
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -821,8 +821,10 @@ task testReport(type: TestReport) {
 
 task copyCrashLogs(type: Copy) {
     from '.'
+    include '**/build/test-output/**'
     include '**/hs_err*.log'
     include 'LICENSE'
+    exclude 'build'
     into 'build/crash_logs'
 
     includeEmptyDirs = false


### PR DESCRIPTION
When any test in `ClusterTest` fails all of its data will be preserved and copied into `build/test-output/$test_name[_uniqueId]` directory, where `$test_name` is the name derived from test class plus method name and `_uniqueId` is a unique suffix added if such directory already exists (e.g. from previous tests runs or if it's a parameterized test).

The `build/test-output` folders are added to the `crash_logs` when `copyCrashLogs` Gradle task is executed and hence will be preserved in CI.

Here is an example of data preserved for `ClusterTest` when a test fails:
```
aeron-cluster
└── build
    └── test-output
        └── io.aeron.cluster.ClusterTest-shouldNotifyClientOfNewLeader
            ├── aeron-username-0
            │   ├── archive
            │   │   ├── 0-0.rec
            │   │   ├── archive-mark.dat
            │   │   └── archive.catalog
            │   ├── consensus-module
            │   │   ├── cluster-mark.dat
            │   │   └── recording.log
            │   └── service
            │       └── cluster-mark-service-0.dat
            ├── aeron-username-0-driver
            │   ├── blank.template
            │   ├── cnc.dat
            │   ├── images
            │   │   ├── 32.logbuffer
            │   │   ├── 33.logbuffer
            │   │   └── 39.logbuffer
            │   ├── loss-report.dat
            │   └── publications
            │       ├── 18.logbuffer
            │       ├── 19.logbuffer
            │       ├── 21.logbuffer
            │       ├── 25.logbuffer
            │       ├── 26.logbuffer
            │       └── 28.logbuffer
            ├── aeron-username-1
            │   ├── archive
            │   │   ├── 0-0.rec
            │   │   ├── archive-mark.dat
            │   │   └── archive.catalog
            │   ├── consensus-module
            │   │   ├── cluster-mark.dat
            │   │   └── recording.log
            │   └── service
            │       └── cluster-mark-service-0.dat
            ├── aeron-username-1-driver
            │   ├── blank.template
            │   ├── cnc.dat
            │   ├── images
            │   │   ├── 30.logbuffer
            │   │   └── 31.logbuffer
            │   ├── loss-report.dat
            │   └── publications
            │       ├── 18.logbuffer
            │       ├── 19.logbuffer
            │       ├── 21.logbuffer
            │       ├── 23.logbuffer
            │       ├── 27.logbuffer
            │       ├── 28.logbuffer
            │       └── 36.logbuffer
            ├── aeron-username-2
            │   ├── archive
            │   │   ├── 0-0.rec
            │   │   ├── archive-mark.dat
            │   │   └── archive.catalog
            │   ├── consensus-module
            │   │   ├── cluster-mark.dat
            │   │   └── recording.log
            │   └── service
            │       └── cluster-mark-service-0.dat
            └── aeron-username-2-driver
                ├── blank.template
                ├── cnc.dat
                ├── images
                │   ├── 30.logbuffer
                │   ├── 31.logbuffer
                │   └── 39.logbuffer
                ├── loss-report.dat
                └── publications
                    ├── 18.logbuffer
                    ├── 19.logbuffer
                    ├── 21.logbuffer
                    ├── 23.logbuffer
                    ├── 27.logbuffer
                    └── 28.logbuffer
```

The changes to `ClusterTest` were more involved than expected. This is due to the fact that `TestCluster#close` deletes directories and hence copy needs to be executed before that happens. However I haven't found a way to get test status in the `@AfterEach` method thus the copy logic is invoked in each method in a ugly repeatable block.

I've also tried making `DataCollector` implement `org.junit.jupiter.api.extension.TestWatcher` so that it can be invoked automatically. Unfortunately a `TestWatcher` is invoked after all `@AfterEach` hooks were executed. In the similar vein implementing `org.junit.jupiter.api.extension.AfterEachCallback` does not work as an `Extension` is invoked after methods on the test class plus we don't get the status if test succeeded or failed. 