### PR TITLE
Port for g++ 4.8.5 on centos7 compile

### DIFF
--- a/aeron-client/src/main/cpp/FragmentAssembler.h
+++ b/aeron-client/src/main/cpp/FragmentAssembler.h
@@ -98,7 +98,7 @@ private:
             if ((flags & FrameDescriptor::BEGIN_FRAG) == FrameDescriptor::BEGIN_FRAG)
             {
                 auto result = m_builderBySessionIdMap.emplace(
-                    header.sessionId(), static_cast<std::uint32_t>(m_initialBufferLength));
+                    header.sessionId(), BufferBuilder(static_cast<std::uint32_t>(m_initialBufferLength)));
                 BufferBuilder &builder = result.first->second;
 
                 builder


### PR DESCRIPTION
Old g++ has this error on Centos7:

/usr/include/c++/4.8.2/bits/stl_pair.h:112:26: note:   no known conversion for argument 2 from ‘unsigned int’ to ‘const aeron::BufferBuilder&’
/usr/include/c++/4.8.2/bits/stl_pair.h:108:26: note: constexpr std::pair<_T1, _T2>::pair() [with _T1 = const int; _T2 = aeron::BufferBuilder]
       _GLIBCXX_CONSTEXPR pair()
