### PR TITLE
[C] Add logging for the untethered subscription state change

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_common.h
+++ b/aeron-driver/src/main/c/aeron_driver_common.h
@@ -67,6 +67,20 @@ typedef struct aeron_tetherable_position_stct
 }
 aeron_tetherable_position_t;
 
+typedef void (*aeron_untethered_subscription_state_change_func_t)(
+        aeron_tetherable_position_t *,
+        int64_t now_ns,
+        aeron_subscription_tether_state_t new_state,
+        int32_t stream_id,
+        int32_t session_id);
+
+void aeron_untethered_subscription_state_change(
+        aeron_tetherable_position_t *tetherable_position,
+        int64_t now_ns,
+        aeron_subscription_tether_state_t new_state,
+        int32_t stream_id,
+        int32_t session_id);
+
 typedef struct aeron_subscribable_stct
 {
     size_t length;

--- a/aeron-driver/src/main/c/aeron_driver_common.h
+++ b/aeron-driver/src/main/c/aeron_driver_common.h
@@ -74,12 +74,16 @@ typedef void (*aeron_untethered_subscription_state_change_func_t)(
         int32_t stream_id,
         int32_t session_id);
 
-void aeron_untethered_subscription_state_change(
+inline static void aeron_untethered_subscription_state_change(
         aeron_tetherable_position_t *tetherable_position,
         int64_t now_ns,
         aeron_subscription_tether_state_t new_state,
         int32_t stream_id,
-        int32_t session_id);
+        int32_t session_id)
+{
+    tetherable_position->state = new_state;
+    tetherable_position->time_of_last_update_ns = now_ns;
+}
 
 typedef struct aeron_subscribable_stct
 {

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -2393,14 +2393,3 @@ uint64_t aeron_driver_context_get_re_resolution_check_interval_ns(aeron_driver_c
     return NULL != context ?
         context->re_resolution_check_interval_ns : AERON_DRIVER_RERESOLUTION_CHECK_INTERVAL_NS_DEFAULT;
 }
-
-void aeron_untethered_subscription_state_change(
-        aeron_tetherable_position_t *tetherable_position,
-        int64_t now_ns,
-        aeron_subscription_tether_state_t new_state,
-        int32_t stream_id,
-        int32_t session_id)
-{
-    tetherable_position->state = new_state;
-    tetherable_position->time_of_last_update_ns = now_ns;
-}

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -998,6 +998,8 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->to_driver_interceptor_func = aeron_driver_conductor_to_driver_interceptor_null;
     _context->to_client_interceptor_func = aeron_driver_conductor_to_client_interceptor_null;
 
+    _context->untethered_subscription_state_change_func = aeron_untethered_subscription_state_change;
+
     if ((_context->termination_validator_func = aeron_driver_termination_validator_load(
         AERON_CONFIG_GETENV_OR_DEFAULT(AERON_DRIVER_TERMINATION_VALIDATOR_ENV_VAR, "deny"))) == NULL)
     {
@@ -2392,3 +2394,13 @@ uint64_t aeron_driver_context_get_re_resolution_check_interval_ns(aeron_driver_c
         context->re_resolution_check_interval_ns : AERON_DRIVER_RERESOLUTION_CHECK_INTERVAL_NS_DEFAULT;
 }
 
+void aeron_untethered_subscription_state_change(
+        aeron_tetherable_position_t *tetherable_position,
+        int64_t now_ns,
+        aeron_subscription_tether_state_t new_state,
+        int32_t stream_id,
+        int32_t session_id)
+{
+    tetherable_position->state = new_state;
+    tetherable_position->time_of_last_update_ns = now_ns;
+}

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -180,6 +180,8 @@ typedef struct aeron_driver_context_stct
     aeron_driver_conductor_to_driver_interceptor_func_t to_driver_interceptor_func;
     aeron_driver_conductor_to_client_interceptor_func_t to_client_interceptor_func;
 
+    aeron_untethered_subscription_state_change_func_t untethered_subscription_state_change_func;
+
     aeron_driver_termination_validator_func_t termination_validator_func;
     void *termination_validator_state;
 

--- a/aeron-driver/src/main/c/aeron_ipc_publication.h
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.h
@@ -67,6 +67,7 @@ typedef struct aeron_ipc_publication_stct
     size_t position_bits_to_shift;
     bool is_exclusive;
     aeron_map_raw_log_close_func_t map_raw_log_close_func;
+    aeron_untethered_subscription_state_change_func_t untethered_subscription_state_change_func;
 
     int64_t *unblocked_publications_counter;
 }

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -111,6 +111,7 @@ int aeron_network_publication_create(
         return -1;
     }
     _pub->map_raw_log_close_func = context->map_raw_log_close_func;
+    _pub->untethered_subscription_state_change_func = context->untethered_subscription_state_change_func;
 
     strncpy(_pub->log_file_name, path, (size_t)path_length);
     _pub->log_file_name[path_length] = '\0';
@@ -870,16 +871,24 @@ void aeron_network_publication_check_untethered_subscriptions(
                             AERON_IPC_CHANNEL,
                             AERON_IPC_CHANNEL_LEN);
 
-                        tetherable_position->state = AERON_SUBSCRIPTION_TETHER_LINGER;
-                        tetherable_position->time_of_last_update_ns = now_ns;
+                        publication->untethered_subscription_state_change_func(
+                                tetherable_position,
+                                now_ns,
+                                AERON_SUBSCRIPTION_TETHER_LINGER,
+                                publication->stream_id,
+                                publication->session_id);
                     }
                     break;
 
                 case AERON_SUBSCRIPTION_TETHER_LINGER:
                     if (now_ns > (tetherable_position->time_of_last_update_ns + window_limit_timeout_ns))
                     {
-                        tetherable_position->state = AERON_SUBSCRIPTION_TETHER_RESTING;
-                        tetherable_position->time_of_last_update_ns = now_ns;
+                        publication->untethered_subscription_state_change_func(
+                                tetherable_position,
+                                now_ns,
+                                AERON_SUBSCRIPTION_TETHER_RESTING,
+                                publication->stream_id,
+                                publication->session_id);
                     }
                     break;
 
@@ -899,8 +908,13 @@ void aeron_network_publication_check_untethered_subscriptions(
                             tetherable_position->subscription_registration_id,
                             AERON_IPC_CHANNEL,
                             AERON_IPC_CHANNEL_LEN);
-                        tetherable_position->state = AERON_SUBSCRIPTION_TETHER_ACTIVE;
-                        tetherable_position->time_of_last_update_ns = now_ns;
+
+                        publication->untethered_subscription_state_change_func(
+                                tetherable_position,
+                                now_ns,
+                                AERON_SUBSCRIPTION_TETHER_ACTIVE,
+                                publication->stream_id,
+                                publication->session_id);
                     }
                     break;
             }

--- a/aeron-driver/src/main/c/aeron_network_publication.h
+++ b/aeron-driver/src/main/c/aeron_network_publication.h
@@ -102,6 +102,7 @@ typedef struct aeron_network_publication_stct
     bool track_sender_limits;
     bool has_sender_released;
     aeron_map_raw_log_close_func_t map_raw_log_close_func;
+    aeron_untethered_subscription_state_change_func_t untethered_subscription_state_change_func;
 
     int64_t *short_sends_counter;
     int64_t *heartbeats_sent_counter;

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -97,6 +97,7 @@ typedef struct aeron_publication_image_stct
     size_t log_file_name_length;
     size_t position_bits_to_shift;
     aeron_map_raw_log_close_func_t map_raw_log_close_func;
+    aeron_untethered_subscription_state_change_func_t untethered_subscription_state_change_func;
 
     volatile int64_t begin_loss_change;
     volatile int64_t end_loss_change;

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -118,7 +118,7 @@ static void init_logging_ring_buffer()
     }
 }
 
-static void free_logging_ring_buffer()
+static void aeron_free_logging_ring_buffer()
 {
     if (NULL != rb_buffer)
     {
@@ -127,7 +127,7 @@ static void free_logging_ring_buffer()
     }
 }
 
-static void set_logging_mask(uint64_t new_mask)
+static void aeron_set_logging_mask(uint64_t new_mask)
 {
     mask = new_mask;
 }
@@ -367,7 +367,7 @@ int aeron_driver_agent_interceptor_init(void **interceptor_state, aeron_udp_chan
     return 0;
 }
 
-static int init_logging_events_interceptors(aeron_driver_context_t *context)
+static int aeron_init_logging_events_interceptors(aeron_driver_context_t *context)
 {
     if (mask & AERON_FRAME_IN)
     {
@@ -463,7 +463,7 @@ int aeron_driver_agent_context_init(aeron_driver_context_t *context)
 {
     (void)aeron_thread_once(&agent_is_initialized, initialize_agent_logging);
 
-    return init_logging_events_interceptors(context);
+    return aeron_init_logging_events_interceptors(context);
 }
 
 static const char *dissect_msg_type_id(int32_t id)

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -52,7 +52,7 @@ static aeron_mpsc_rb_t logging_mpsc_rb;
 static uint8_t *rb_buffer = NULL;
 static uint64_t mask = 0;
 static FILE *logfp = NULL;
-static aeron_thread_t log_reader_thread = NULL;
+static aeron_thread_t log_reader_thread;
 volatile bool log_reader_running = true;
 
 int64_t aeron_agent_epoch_clock()

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -53,7 +53,7 @@ static uint8_t *rb_buffer = NULL;
 static uint64_t mask = 0;
 static FILE *logfp = NULL;
 static aeron_thread_t log_reader_thread = NULL;
-volatile bool log_reader_running;
+volatile bool log_reader_running = true;
 
 int64_t aeron_agent_epoch_clock()
 {

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -100,7 +100,7 @@ static void *aeron_driver_agent_log_reader(void *arg)
     return NULL;
 }
 
-static void init_logging_ring_buffer()
+void aeron_init_logging_ring_buffer()
 {
     size_t rb_length = RING_BUFFER_LENGTH + AERON_RB_TRAILER_LENGTH;
 
@@ -118,7 +118,7 @@ static void init_logging_ring_buffer()
     }
 }
 
-static void aeron_free_logging_ring_buffer()
+void aeron_free_logging_ring_buffer()
 {
     if (NULL != rb_buffer)
     {
@@ -127,7 +127,7 @@ static void aeron_free_logging_ring_buffer()
     }
 }
 
-static void aeron_set_logging_mask(uint64_t new_mask)
+void aeron_set_logging_mask(uint64_t new_mask)
 {
     mask = new_mask;
 }
@@ -157,7 +157,7 @@ static void initialize_agent_logging()
             }
         }
 
-        init_logging_ring_buffer();
+        aeron_init_logging_ring_buffer();
 
         if (aeron_thread_create(&log_reader_thread, NULL, aeron_driver_agent_log_reader, NULL) != 0)
         {
@@ -367,7 +367,7 @@ int aeron_driver_agent_interceptor_init(void **interceptor_state, aeron_udp_chan
     return 0;
 }
 
-static int aeron_init_logging_events_interceptors(aeron_driver_context_t *context)
+int aeron_init_logging_events_interceptors(aeron_driver_context_t *context)
 {
     if (mask & AERON_FRAME_IN)
     {

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -96,4 +96,12 @@ const char *dissect_log_start(int64_t time_ms);
 
 void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, size_t length, void *clientd);
 
+int aeron_init_logging_events_interceptors(aeron_driver_context_t *context);
+
+void aeron_init_logging_ring_buffer();
+
+void aeron_free_logging_ring_buffer();
+
+void aeron_set_logging_mask(uint64_t new_mask);
+
 #endif //AERON_DRIVER_AGENT_H

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -29,11 +29,10 @@
 #define AERON_CMD_IN (0x01)
 #define AERON_CMD_OUT (0x02)
 #define AERON_FRAME_IN (0x04)
-#define AERON_FRAME_IN_DROPPED (0x05)
-#define AERON_FRAME_OUT (0x08)
-#define AERON_MAP_RAW_LOG_OP (0x10)
-
-#define AERON_MAP_RAW_LOG_OP_CLOSE (0x11)
+#define AERON_FRAME_IN_DROPPED (0x08)
+#define AERON_FRAME_OUT (0x10)
+#define AERON_MAP_RAW_LOG_OP (0x20)
+#define AERON_MAP_RAW_LOG_OP_CLOSE (0x40)
 
 typedef struct aeron_driver_agent_cmd_log_header_stct
 {

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -33,6 +33,7 @@
 #define AERON_FRAME_OUT (0x10)
 #define AERON_MAP_RAW_LOG_OP (0x20)
 #define AERON_MAP_RAW_LOG_OP_CLOSE (0x40)
+#define AERON_UNTETHERED_SUBSCRIPTION_STATE_CHANGE (0x80)
 
 typedef struct aeron_driver_agent_cmd_log_header_stct
 {
@@ -75,6 +76,17 @@ typedef struct aeron_driver_agent_map_raw_log_op_header_stct
     map_raw;
 }
 aeron_driver_agent_map_raw_log_op_header_t;
+
+typedef struct aeron_driver_agent_untethered_subscription_state_change_log_header_stct
+{
+    int64_t time_ms;
+    int64_t subscription_id;
+    int32_t stream_id;
+    int32_t session_id;
+    aeron_subscription_tether_state_t old_state;
+    aeron_subscription_tether_state_t new_state;
+}
+aeron_driver_agent_untethered_subscription_state_change_log_header_t;
 
 typedef int (*aeron_driver_context_init_t)(aeron_driver_context_t **);
 

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -82,6 +82,7 @@ aeron_driver_test(term_gap_filler_test aeron_term_gap_filler_test.cpp)
 aeron_driver_test(parse_util_test aeron_parse_util_test.cpp)
 aeron_driver_test(properties_test aeron_properties_test.cpp)
 aeron_driver_test(driver_configuration_test aeron_driver_configuration_test.cpp)
+aeron_driver_test(driver_agent_test aeron_driver_agent_test.cpp)
 
 aeron_driver_test(system_test aeron_system_test.cpp)
 set_tests_properties(system_test PROPERTIES TIMEOUT 10)

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -82,7 +82,7 @@ aeron_driver_test(term_gap_filler_test aeron_term_gap_filler_test.cpp)
 aeron_driver_test(parse_util_test aeron_parse_util_test.cpp)
 aeron_driver_test(properties_test aeron_properties_test.cpp)
 aeron_driver_test(driver_configuration_test aeron_driver_configuration_test.cpp)
-aeron_driver_test(driver_agent_test aeron_driver_agent_test.cpp)
+aeron_driver_test(driver_agent_test agent/aeron_driver_agent_test.cpp)
 
 aeron_driver_test(system_test aeron_system_test.cpp)
 set_tests_properties(system_test PROPERTIES TIMEOUT 10)

--- a/aeron-driver/src/test/c/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_agent_test.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <functional>
+
+#include <gtest/gtest.h>
+#include <inttypes.h>
+
+extern "C"
+{
+#include "aeron_driver_context.h"
+#include "agent/aeron_driver_agent.c"
+}
+
+class DriverAgentTest : public testing::Test
+{
+public:
+    DriverAgentTest()
+    {
+        agent_is_initialized = AERON_INIT_ONCE_VALUE;
+        mask = 0;
+        rb_buffer = NULL;
+        logfp = NULL;
+        log_reader_running = false;
+        log_reader_thread = NULL;
+
+        if (aeron_driver_context_init(&m_context) < 0)
+        {
+            throw std::runtime_error("could not init context: " + std::string(aeron_errmsg()));
+        }
+    }
+
+    ~DriverAgentTest() override
+    {
+        aeron_driver_context_close(m_context);
+        unsetenv(AERON_AGENT_MASK_ENV_VAR);
+
+        log_reader_running = false;
+        int pthread_result = aeron_thread_join(log_reader_thread, NULL);
+        if (0 != pthread_result && ESRCH != pthread_result)
+        {
+            printf("*** [WARNING] Could not stop logger thread: result=%d\n", pthread_result);
+        }
+
+        if (NULL != rb_buffer)
+        {
+            aeron_free(rb_buffer);
+        }
+    }
+
+    static char *to_mask(uint64_t value)
+    {
+        static char buffer[256];
+
+        snprintf(buffer, sizeof(buffer) - 1, "%" PRIu64, value);
+        return buffer;
+    }
+
+protected:
+    aeron_driver_context_t *m_context = nullptr;
+};
+
+TEST_F(DriverAgentTest, shouldInitializeUntetheredStateChangeInterceptor)
+{
+    setenv(AERON_AGENT_MASK_ENV_VAR, to_mask(AERON_UNTETHERED_SUBSCRIPTION_STATE_CHANGE), 1);
+
+    aeron_driver_agent_context_init(m_context);
+
+    EXPECT_EQ(m_context->untethered_subscription_state_change_func, &aeron_driver_agent_untethered_subscription_state_change_interceptor);
+}
+
+TEST_F(DriverAgentTest, shouldKeepOriginalUntetheredStateChangeFunctionIfEventNotEnabled)
+{
+    aeron_driver_agent_context_init(m_context);
+
+    EXPECT_EQ(m_context->untethered_subscription_state_change_func, &aeron_untethered_subscription_state_change);
+}
+
+TEST_F(DriverAgentTest, shouldLogUntetheredSubscriptionStateChange)
+{
+    init_logging_ring_buffer();
+
+    aeron_subscription_tether_state_t old_state = AERON_SUBSCRIPTION_TETHER_RESTING;
+    aeron_subscription_tether_state_t new_state = AERON_SUBSCRIPTION_TETHER_ACTIVE;
+    int64_t now_ns = -432482364273648;
+    int32_t stream_id = 777;
+    int32_t session_id = 21;
+    int64_t subscription_id = 56;
+    aeron_tetherable_position_t tetherable_position = {};
+    tetherable_position.state = old_state;
+    tetherable_position.subscription_registration_id = subscription_id;
+
+    aeron_driver_agent_untethered_subscription_state_change_interceptor(
+            &tetherable_position,
+            now_ns,
+            new_state,
+            stream_id,
+            session_id);
+
+    EXPECT_EQ(tetherable_position.state, new_state);
+    EXPECT_EQ(tetherable_position.time_of_last_update_ns, now_ns);
+
+    auto message_handler = [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+    {
+        size_t *count = (size_t *)clientd;
+        (*count)++;
+
+        EXPECT_EQ(msg_type_id, AERON_UNTETHERED_SUBSCRIPTION_STATE_CHANGE);
+
+        aeron_driver_agent_untethered_subscription_state_change_log_header_t *data =
+                (aeron_driver_agent_untethered_subscription_state_change_log_header_t *)msg;
+        EXPECT_EQ(data->new_state, AERON_SUBSCRIPTION_TETHER_ACTIVE);
+        EXPECT_EQ(data->old_state, AERON_SUBSCRIPTION_TETHER_RESTING);
+        EXPECT_EQ(data->subscription_id, 56);
+        EXPECT_EQ(data->stream_id, 777);
+        EXPECT_EQ(data->session_id, 21);
+    };
+
+    size_t timesCalled = 0;
+    const size_t messagesRead = aeron_mpsc_rb_read(&logging_mpsc_rb, message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -80,7 +80,7 @@ public:
     static int clear_env(const char *name)
     {
         #if defined(AERON_COMPILER_MSVC)
-            return _put_env_s(name, "");
+            return _putenv_s(name, "");
         #else
             return unsetenv(name);
         #endif

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 extern "C"
 {

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -39,8 +39,8 @@ public:
     ~DriverAgentTest() override
     {
         aeron_driver_context_close(m_context);
-        free_logging_ring_buffer();
-        set_logging_mask(0);
+        aeron_free_logging_ring_buffer();
+        aeron_set_logging_mask(0);
     }
 
 protected:
@@ -49,10 +49,10 @@ protected:
 
 TEST_F(DriverAgentTest, shouldInitializeUntetheredStateChangeInterceptor)
 {
-    set_logging_mask(AERON_UNTETHERED_SUBSCRIPTION_STATE_CHANGE);
+    aeron_set_logging_mask(AERON_UNTETHERED_SUBSCRIPTION_STATE_CHANGE);
     aeron_untethered_subscription_state_change_func_t func = m_context->untethered_subscription_state_change_func;
 
-    init_logging_events_interceptors(m_context);
+    aeron_init_logging_events_interceptors(m_context);
 
     EXPECT_EQ(m_context->untethered_subscription_state_change_func, &aeron_driver_agent_untethered_subscription_state_change_interceptor);
     EXPECT_NE(m_context->untethered_subscription_state_change_func, func);
@@ -62,7 +62,7 @@ TEST_F(DriverAgentTest, shouldKeepOriginalUntetheredStateChangeFunctionIfEventNo
 {
     aeron_untethered_subscription_state_change_func_t func = m_context->untethered_subscription_state_change_func;
 
-    init_logging_events_interceptors(m_context);
+    aeron_init_logging_events_interceptors(m_context);
 
     EXPECT_EQ(m_context->untethered_subscription_state_change_func, func);
     EXPECT_NE(m_context->untethered_subscription_state_change_func, &aeron_driver_agent_untethered_subscription_state_change_interceptor);

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -35,7 +35,6 @@ public:
         rb_buffer = NULL;
         logfp = NULL;
         log_reader_running = false;
-        log_reader_thread = NULL;
 
         if (aeron_driver_context_init(&m_context) < 0)
         {

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -70,7 +70,7 @@ TEST_F(DriverAgentTest, shouldKeepOriginalUntetheredStateChangeFunctionIfEventNo
 
 TEST_F(DriverAgentTest, shouldLogUntetheredSubscriptionStateChange)
 {
-    init_logging_ring_buffer();
+    aeron_init_logging_ring_buffer();
 
     aeron_subscription_tether_state_t old_state = AERON_SUBSCRIPTION_TETHER_RESTING;
     aeron_subscription_tether_state_t new_state = AERON_SUBSCRIPTION_TETHER_ACTIVE;

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -18,7 +18,6 @@
 
 #include <gtest/gtest.h>
 #include <inttypes.h>
-#include <stdlib.h>
 
 extern "C"
 {
@@ -72,7 +71,7 @@ public:
     static int set_env(const char *name, const char *value)
     {
         #if defined(AERON_COMPILER_MSVC)
-            return _put_env_s(name, value);
+            return _putenv_s(name, value);
         #else
             return setenv(name, value, 1);
         #endif

--- a/cppbuild/cppbuild
+++ b/cppbuild/cppbuild
@@ -73,7 +73,7 @@ do
       shift
       ;;
     -h|--help)
-      echo "$0 [--c-warnings-as-errors] [--cxx-warnings-as-errors] [--debug-build] [--build-aeron-driver] [--sanitise-build] [--coverage-build] [--no-parallel]"
+      echo "$0 [--c-warnings-as-errors] [--cxx-warnings-as-errors] [--debug-build] [--build-aeron-driver] [--build-archive-api] [--sanitise-build] [--coverage-build] [--no-parallel] [--no-system-tests] [--slow-system-tests]"
       exit
       ;;
     *)


### PR DESCRIPTION
This PR contains the following changes:
- Logging of the untethered subscription state change
- Add missing options to the `cppbuild`'s help output
- Fix logging constants to be power of two

For the logging changes I'm not sure if `aeron_driver_context.c` is the right place for the implementation of the `aeron_untethered_subscription_state_change` function or if it would be better to define it as `inline` in the `aeron_driver_common.h`.