### PR TITLE
[C++] Refactor includes and add option to play nice with CMake and large projects to avoid header name conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ option(AERON_INSTALL_TARGETS "Enable installation step" ${STANDALONE_BUILD})
 if (UNIX)
     option(AERON_ENABLE_NONSTANDARD_OPTIMIZATIONS "Enable Ofast for release builds" ${STANDALONE_BUILD})
 endif ()
+option(AERON_CLIENT_STUTTERING_HEADERS "Follow boost stuttering directory structure to avoid header name conflicts" OFF)
 
 unset(STANDALONE_BUILD)
 

--- a/aeron-client/src/main/cpp/Aeron.h
+++ b/aeron-client/src/main/cpp/Aeron.h
@@ -17,13 +17,13 @@
 #ifndef INCLUDED_AERON_H
 #define INCLUDED_AERON_H
 
-#include <util/Exceptions.h>
+#include "util/Exceptions.h"
 #include <iostream>
 #include <thread>
 #include <random>
-#include <concurrent/logbuffer/TermReader.h>
-#include <util/MemoryMappedFile.h>
-#include <concurrent/broadcast/CopyBroadcastReceiver.h>
+#include "concurrent/logbuffer/TermReader.h"
+#include "util/MemoryMappedFile.h"
+#include "concurrent/broadcast/CopyBroadcastReceiver.h"
 #include "ClientConductor.h"
 #include "concurrent/SleepingIdleStrategy.h"
 #include "concurrent/AgentRunner.h"

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -139,16 +139,16 @@ add_library(aeron_client_shared SHARED ${SOURCE} ${HEADERS})
 
 if (AERON_CLIENT_STUTTERING_HEADERS)
     message("Installing stuttering headers")
-    set(AERON_CLIENT_SOURCE_PREFIX "aeron")
+    set(AERON_CLIENT_SOURCE_PREFIX "aeron-client")
     file(INSTALL . DESTINATION ${AERON_CLIENT_SOURCE_PREFIX})
 
     target_include_directories(aeron_client
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${AERON_CLIENT_SOURCE_PREFIX}
+        PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${AERON_CLIENT_SOURCE_PREFIX}"
         INTERFACE ${CMAKE_INSTALL_PREFIX}
     )
 
     target_include_directories(aeron_client_shared
-        PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/aeron"
+        PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${AERON_CLIENT_SOURCE_PREFIX}"
         INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
     )
 else()

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -137,13 +137,29 @@ SET(HEADERS
 add_library(aeron_client STATIC ${SOURCE} ${HEADERS})
 add_library(aeron_client_shared SHARED ${SOURCE} ${HEADERS})
 
-target_include_directories(aeron_client
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+if (AERON_CLIENT_STUTTERING_HEADERS)
+    message("Installing stuttering headers")
+    set(AERON_CLIENT_SOURCE_PREFIX "aeron")
+    file(INSTALL . DESTINATION ${AERON_CLIENT_SOURCE_PREFIX})
+
+    target_include_directories(aeron_client
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${AERON_CLIENT_SOURCE_PREFIX}
+        INTERFACE ${CMAKE_INSTALL_PREFIX}
     )
 
-target_include_directories(aeron_client_shared
-    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    target_include_directories(aeron_client_shared
+        PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/aeron"
+        INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
     )
+else()
+    target_include_directories(aeron_client
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+
+    target_include_directories(aeron_client_shared
+        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+endif()
 
 if (MSVC)
     string(REPLACE "/" "\\\\" NATIVE_PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}")

--- a/aeron-client/src/main/cpp/CMakeLists.txt
+++ b/aeron-client/src/main/cpp/CMakeLists.txt
@@ -144,7 +144,7 @@ if (AERON_CLIENT_STUTTERING_HEADERS)
 
     target_include_directories(aeron_client
         PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${AERON_CLIENT_SOURCE_PREFIX}"
-        INTERFACE ${CMAKE_INSTALL_PREFIX}
+        INTERFACE ${CMAKE_CURRENT_BINARY_DIR}
     )
 
     target_include_directories(aeron_client_shared

--- a/aeron-client/src/main/cpp/ClientConductor.h
+++ b/aeron-client/src/main/cpp/ClientConductor.h
@@ -20,10 +20,10 @@
 #include <unordered_map>
 #include <vector>
 #include <mutex>
-#include <concurrent/logbuffer/TermReader.h>
-#include <concurrent/status/UnsafeBufferPosition.h>
-#include <util/LangUtil.h>
-#include <util/ScopeUtils.h>
+#include "concurrent/logbuffer/TermReader.h"
+#include "concurrent/status/UnsafeBufferPosition.h"
+#include "util/LangUtil.h"
+#include "util/ScopeUtils.h"
 #include "Publication.h"
 #include "ExclusivePublication.h"
 #include "Subscription.h"

--- a/aeron-client/src/main/cpp/CncFileDescriptor.h
+++ b/aeron-client/src/main/cpp/CncFileDescriptor.h
@@ -17,10 +17,10 @@
 #ifndef AERON_CNC_FILE_DESCRIPTOR_H
 #define AERON_CNC_FILE_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <util/MemoryMappedFile.h>
-#include <util/MacroUtil.h>
-#include <concurrent/AtomicBuffer.h>
+#include "util/Index.h"
+#include "util/MemoryMappedFile.h"
+#include "util/MacroUtil.h"
+#include "concurrent/AtomicBuffer.h"
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/Context.h
+++ b/aeron-client/src/main/cpp/Context.h
@@ -18,12 +18,12 @@
 #define AERON_CONTEXT_H
 
 #include <memory>
-#include <util/Exceptions.h>
-#include <concurrent/AgentRunner.h>
-#include <concurrent/broadcast/CopyBroadcastReceiver.h>
-#include <concurrent/CountersReader.h>
-#include <CncFileDescriptor.h>
 #include <iostream>
+#include "util/Exceptions.h"
+#include "concurrent/AgentRunner.h"
+#include "concurrent/broadcast/CopyBroadcastReceiver.h"
+#include "concurrent/CountersReader.h"
+#include "CncFileDescriptor.h"
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/Counter.h
+++ b/aeron-client/src/main/cpp/Counter.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include <atomic>
 
-#include <util/Index.h>
+#include "util/Index.h"
 #include "concurrent/AtomicCounter.h"
 #include "concurrent/CountersReader.h"
 

--- a/aeron-client/src/main/cpp/DriverListenerAdapter.h
+++ b/aeron-client/src/main/cpp/DriverListenerAdapter.h
@@ -17,16 +17,16 @@
 #ifndef AERON_DRIVER_LISTENER_ADAPTER_H
 #define AERON_DRIVER_LISTENER_ADAPTER_H
 
-#include <concurrent/broadcast/CopyBroadcastReceiver.h>
-#include <command/ControlProtocolEvents.h>
-#include <command/PublicationBuffersReadyFlyweight.h>
-#include <command/ImageBuffersReadyFlyweight.h>
-#include <command/ImageMessageFlyweight.h>
-#include <command/ErrorResponseFlyweight.h>
-#include <command/OperationSucceededFlyweight.h>
-#include <command/SubscriptionReadyFlyweight.h>
-#include <command/CounterUpdateFlyweight.h>
-#include <command/ClientTimeoutFlyweight.h>
+#include "concurrent/broadcast/CopyBroadcastReceiver.h"
+#include "command/ControlProtocolEvents.h"
+#include "command/PublicationBuffersReadyFlyweight.h"
+#include "command/ImageBuffersReadyFlyweight.h"
+#include "command/ImageMessageFlyweight.h"
+#include "command/ErrorResponseFlyweight.h"
+#include "command/OperationSucceededFlyweight.h"
+#include "command/SubscriptionReadyFlyweight.h"
+#include "command/CounterUpdateFlyweight.h"
+#include "command/ClientTimeoutFlyweight.h"
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/DriverProxy.h
+++ b/aeron-client/src/main/cpp/DriverProxy.h
@@ -18,14 +18,14 @@
 #define AERON_DRIVER_PROXY_H
 
 #include <array>
-#include <concurrent/ringbuffer/ManyToOneRingBuffer.h>
-#include <command/PublicationMessageFlyweight.h>
-#include <command/RemoveMessageFlyweight.h>
-#include <command/SubscriptionMessageFlyweight.h>
-#include <command/DestinationMessageFlyweight.h>
-#include <command/CounterMessageFlyweight.h>
-#include <command/TerminateDriverFlyweight.h>
-#include <command/ControlProtocolEvents.h>
+#include "concurrent/ringbuffer/ManyToOneRingBuffer.h"
+#include "command/PublicationMessageFlyweight.h"
+#include "command/RemoveMessageFlyweight.h"
+#include "command/SubscriptionMessageFlyweight.h"
+#include "command/DestinationMessageFlyweight.h"
+#include "command/CounterMessageFlyweight.h"
+#include "command/TerminateDriverFlyweight.h"
+#include "command/ControlProtocolEvents.h"
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/ExclusivePublication.h
+++ b/aeron-client/src/main/cpp/ExclusivePublication.h
@@ -22,10 +22,10 @@
 #include <memory>
 #include <string>
 
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/logbuffer/BufferClaim.h>
-#include <concurrent/logbuffer/ExclusiveTermAppender.h>
-#include <concurrent/status/UnsafeBufferPosition.h>
+#include "concurrent/AtomicBuffer.h"
+#include "concurrent/logbuffer/BufferClaim.h"
+#include "concurrent/logbuffer/ExclusiveTermAppender.h"
+#include "concurrent/status/UnsafeBufferPosition.h"
 #include "concurrent/status/StatusIndicatorReader.h"
 #include "Publication.h"
 #include "LogBuffers.h"

--- a/aeron-client/src/main/cpp/Image.h
+++ b/aeron-client/src/main/cpp/Image.h
@@ -17,19 +17,20 @@
 #ifndef AERON_IMAGE_H
 #define AERON_IMAGE_H
 
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/logbuffer/LogBufferDescriptor.h>
-#include <concurrent/logbuffer/FrameDescriptor.h>
-#include <concurrent/logbuffer/Header.h>
-#include <concurrent/logbuffer/TermReader.h>
-#include <concurrent/logbuffer/TermBlockScanner.h>
-#include <concurrent/status/UnsafeBufferPosition.h>
 #include <algorithm>
 #include <array>
 #include <vector>
 #include <atomic>
 #include <cassert>
 #include "LogBuffers.h"
+#include "concurrent/AtomicBuffer.h"
+#include "concurrent/logbuffer/LogBufferDescriptor.h"
+#include "concurrent/logbuffer/FrameDescriptor.h"
+#include "concurrent/logbuffer/Header.h"
+#include "concurrent/logbuffer/TermReader.h"
+#include "concurrent/logbuffer/TermBlockScanner.h"
+#include "concurrent/status/UnsafeBufferPosition.h"
+
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/LogBuffers.h
+++ b/aeron-client/src/main/cpp/LogBuffers.h
@@ -20,8 +20,8 @@
 #include <memory>
 #include <vector>
 
-#include <util/MemoryMappedFile.h>
-#include <concurrent/logbuffer/LogBufferDescriptor.h>
+#include "util/MemoryMappedFile.h"
+#include "concurrent/logbuffer/LogBufferDescriptor.h"
 #include "util/Export.h"
 
 namespace aeron

--- a/aeron-client/src/main/cpp/Publication.h
+++ b/aeron-client/src/main/cpp/Publication.h
@@ -22,10 +22,10 @@
 #include <memory>
 #include <string>
 
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/logbuffer/BufferClaim.h>
-#include <concurrent/logbuffer/TermAppender.h>
-#include <concurrent/status/UnsafeBufferPosition.h>
+#include "concurrent/AtomicBuffer.h"
+#include "concurrent/logbuffer/BufferClaim.h"
+#include "concurrent/logbuffer/TermAppender.h"
+#include "concurrent/status/UnsafeBufferPosition.h"
 #include "concurrent/status/StatusIndicatorReader.h"
 #include "LogBuffers.h"
 #include "util/Export.h"

--- a/aeron-client/src/main/cpp/command/CounterMessageFlyweight.h
+++ b/aeron-client/src/main/cpp/command/CounterMessageFlyweight.h
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <util/BitUtil.h>
+#include "../util/BitUtil.h"
 #include "CorrelatedMessageFlyweight.h"
 
 namespace aeron { namespace command

--- a/aeron-client/src/main/cpp/command/Flyweight.h
+++ b/aeron-client/src/main/cpp/command/Flyweight.h
@@ -17,7 +17,7 @@
 #define AERON_COMMON_FLYWEIGHT_H
 
 #include <string>
-#include <concurrent/AtomicBuffer.h>
+#include "../concurrent/AtomicBuffer.h"
 
 namespace aeron { namespace command
 {

--- a/aeron-client/src/main/cpp/command/ImageBuffersReadyFlyweight.h
+++ b/aeron-client/src/main/cpp/command/ImageBuffersReadyFlyweight.h
@@ -18,9 +18,9 @@
 
 #include <cstdint>
 #include <cstddef>
-#include <util/BitUtil.h>
-#include <util/Exceptions.h>
-#include <util/StringUtil.h>
+#include "../util/BitUtil.h"
+#include "../util/Exceptions.h"
+#include "../util/StringUtil.h"
 #include "Flyweight.h"
 
 namespace aeron { namespace command

--- a/aeron-client/src/main/cpp/command/TerminateDriverFlyweight.h
+++ b/aeron-client/src/main/cpp/command/TerminateDriverFlyweight.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <util/BitUtil.h>
+#include "../util/BitUtil.h"
 #include "CorrelatedMessageFlyweight.h"
 
 namespace aeron { namespace command

--- a/aeron-client/src/main/cpp/concurrent/AgentInvoker.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentInvoker.h
@@ -16,11 +16,11 @@
 #ifndef AERON_AGENT_INVOKER_H
 #define AERON_AGENT_INVOKER_H
 
-#include <util/Exceptions.h>
+#include "util/Exceptions.h"
 #include <functional>
 #include <thread>
 #include <atomic>
-#include <concurrent/logbuffer/TermReader.h>
+#include "logbuffer/TermReader.h"
 
 namespace aeron {
 

--- a/aeron-client/src/main/cpp/concurrent/AgentInvoker.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentInvoker.h
@@ -16,7 +16,7 @@
 #ifndef AERON_AGENT_INVOKER_H
 #define AERON_AGENT_INVOKER_H
 
-#include "util/Exceptions.h"
+#include "../util/Exceptions.h"
 #include <functional>
 #include <thread>
 #include <atomic>

--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -20,8 +20,8 @@
 #include <functional>
 #include <thread>
 #include <atomic>
-#include "util/Exceptions.h"
-#include "util/ScopeUtils.h"
+#include "../util/Exceptions.h"
+#include "../util/ScopeUtils.h"
 #include "logbuffer/TermReader.h"
 
 #if !defined(AERON_COMPILER_MSVC)

--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -20,9 +20,9 @@
 #include <functional>
 #include <thread>
 #include <atomic>
-#include <util/Exceptions.h>
-#include <util/ScopeUtils.h>
-#include <concurrent/logbuffer/TermReader.h>
+#include "util/Exceptions.h"
+#include "util/ScopeUtils.h"
+#include "logbuffer/TermReader.h"
 
 #if !defined(AERON_COMPILER_MSVC)
 #include <pthread.h>

--- a/aeron-client/src/main/cpp/concurrent/Atomic64.h
+++ b/aeron-client/src/main/cpp/concurrent/Atomic64.h
@@ -16,18 +16,18 @@
 #ifndef AERON_CONCURRENT_ATOMIC64_H
 #define AERON_CONCURRENT_ATOMIC64_H
 
-#include <util/Platform.h>
+#include "../util/Platform.h"
 
 #include <cstdint>
 
 #if defined(AERON_COMPILER_GCC)
     #if defined(AERON_CPU_X64)
-        #include <concurrent/atomic/Atomic64_gcc_x86_64.h>
+        #include "atomic/Atomic64_gcc_x86_64.h"
     #else
-        #include <concurrent/atomic/Atomic64_gcc_cpp11.h>
+        #include "atomic/Atomic64_gcc_cpp11.h"
     #endif
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
-    #include <concurrent/atomic/Atomic64_msvc.h>
+    #include "atomic/Atomic64_msvc.h"
 
 #else
     #error Unsupported platform!

--- a/aeron-client/src/main/cpp/concurrent/AtomicArrayUpdater.h
+++ b/aeron-client/src/main/cpp/concurrent/AtomicArrayUpdater.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <atomic>
 
-#include "concurrent/Atomic64.h"
+#include "Atomic64.h"
 
 namespace aeron
 {

--- a/aeron-client/src/main/cpp/concurrent/AtomicBuffer.h
+++ b/aeron-client/src/main/cpp/concurrent/AtomicBuffer.h
@@ -21,11 +21,11 @@
 #include <cstring>
 #include <string>
 #include <array>
-#include <util/Exceptions.h>
-#include <util/StringUtil.h>
-#include <util/Index.h>
+#include "../util/Exceptions.h"
+#include "../util/StringUtil.h"
+#include "../util/Index.h"
 
-#include <util/MacroUtil.h>
+#include "../util/MacroUtil.h"
 
 #include "Atomic64.h"
 

--- a/aeron-client/src/main/cpp/concurrent/AtomicCounter.h
+++ b/aeron-client/src/main/cpp/concurrent/AtomicCounter.h
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <memory>
 
-#include <util/Index.h>
+#include "../util/Index.h"
 #include "AtomicBuffer.h"
 #include "CountersManager.h"
 

--- a/aeron-client/src/main/cpp/concurrent/BackOffIdleStrategy.h
+++ b/aeron-client/src/main/cpp/concurrent/BackOffIdleStrategy.h
@@ -21,7 +21,7 @@
 #include <chrono>
 
 #include "Atomic64.h"
-#include "util/BitUtil.h"
+#include "../util/BitUtil.h"
 
 namespace aeron { namespace concurrent {
 

--- a/aeron-client/src/main/cpp/concurrent/CountersManager.h
+++ b/aeron-client/src/main/cpp/concurrent/CountersManager.h
@@ -23,10 +23,10 @@
 #include <iostream>
 #include <algorithm>
 
-#include <util/Exceptions.h>
-#include <util/StringUtil.h>
-#include <util/Index.h>
-#include <util/BitUtil.h>
+#include "../util/Exceptions.h"
+#include "../util/StringUtil.h"
+#include "../util/Index.h"
+#include "../util/BitUtil.h"
 
 #include "AtomicBuffer.h"
 #include "CountersReader.h"

--- a/aeron-client/src/main/cpp/concurrent/CountersReader.h
+++ b/aeron-client/src/main/cpp/concurrent/CountersReader.h
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <cstddef>
 #include <functional>
-#include <util/BitUtil.h>
+#include "../util/BitUtil.h"
 
 #include "AtomicBuffer.h"
 

--- a/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastBufferDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastBufferDescriptor.h
@@ -17,9 +17,9 @@
 #ifndef AERON_CONCURRENT_BROADCAST_BUFFER_DESCRIPTOR_H
 #define AERON_CONCURRENT_BROADCAST_BUFFER_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/BitUtil.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "../../util/BitUtil.h"
 
 namespace aeron { namespace concurrent { namespace broadcast {
 

--- a/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastReceiver.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastReceiver.h
@@ -18,8 +18,8 @@
 #define AERON_CONCURRENT_BROADCAST_RECEIVER_H
 
 #include <atomic>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "BroadcastBufferDescriptor.h"
 #include "RecordDescriptor.h"
 

--- a/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastTransmitter.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/BroadcastTransmitter.h
@@ -17,8 +17,8 @@
 #ifndef AERON_CONCURRENT_BROADCAST_TRANSMITTER_H
 #define AERON_CONCURRENT_BROADCAST_TRANSMITTER_H
 
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "BroadcastBufferDescriptor.h"
 #include "RecordDescriptor.h"
 

--- a/aeron-client/src/main/cpp/concurrent/broadcast/CopyBroadcastReceiver.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/CopyBroadcastReceiver.h
@@ -19,8 +19,8 @@
 
 #include <array>
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "BroadcastBufferDescriptor.h"
 #include "RecordDescriptor.h"
 #include "BroadcastReceiver.h"

--- a/aeron-client/src/main/cpp/concurrent/broadcast/RecordDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/broadcast/RecordDescriptor.h
@@ -17,9 +17,9 @@
 #ifndef AERON_CONCURRENT_BROADCAST_RECORD_DESCRIPTOR_H
 #define AERON_CONCURRENT_BROADCAST_RECORD_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/BitUtil.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "../../util/BitUtil.h"
 
 namespace aeron { namespace concurrent { namespace broadcast {
 

--- a/aeron-client/src/main/cpp/concurrent/errors/DistinctErrorLog.h
+++ b/aeron-client/src/main/cpp/concurrent/errors/DistinctErrorLog.h
@@ -22,9 +22,9 @@
 #include <algorithm>
 #include <mutex>
 #include <atomic>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/BitUtil.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "../../util/BitUtil.h"
 #include "ErrorLogDescriptor.h"
 
 namespace aeron { namespace concurrent { namespace errors {

--- a/aeron-client/src/main/cpp/concurrent/errors/ErrorLogDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/errors/ErrorLogDescriptor.h
@@ -17,8 +17,8 @@
 #define AERON_CONCURRENT_ERROR_LOG_DESCRIPTOR_H
 
 #include <cstddef>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 
 namespace aeron { namespace concurrent { namespace errors {
 

--- a/aeron-client/src/main/cpp/concurrent/errors/ErrorLogReader.h
+++ b/aeron-client/src/main/cpp/concurrent/errors/ErrorLogReader.h
@@ -17,9 +17,9 @@
 #define AERON_CONCURRENT_ERROR_LOG_READER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/BitUtil.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "../../util/BitUtil.h"
 #include "ErrorLogDescriptor.h"
 
 namespace aeron { namespace concurrent { namespace errors {

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/BufferClaim.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/BufferClaim.h
@@ -17,9 +17,9 @@
 #ifndef AERON_CONCURRENT_BUFFER_CLAIM_H
 #define AERON_CONCURRENT_BUFFER_CLAIM_H
 
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/logbuffer/DataFrameHeader.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "../logbuffer/DataFrameHeader.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer {
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/DataFrameHeader.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/DataFrameHeader.h
@@ -18,7 +18,7 @@
 #define AERON_CONCURRENT_DATA_FRAME_HEADER_H
 
 #include <cstddef>
-#include <util/Index.h>
+#include "../../util/Index.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer {
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/ExclusiveTermAppender.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/ExclusiveTermAppender.h
@@ -18,8 +18,8 @@
 #define AERON_CONCURRENT_EXCLUSIVE_TERM_APPENDER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "HeaderWriter.h"
 #include "LogBufferDescriptor.h"
 #include "BufferClaim.h"

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/FrameDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/FrameDescriptor.h
@@ -17,9 +17,9 @@
 #ifndef AERON_CONCURRENT_LOGBUFFER_FRAME_DESCRIPTOR_H
 #define AERON_CONCURRENT_LOGBUFFER_FRAME_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <util/StringUtil.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../../util/StringUtil.h"
+#include "..//AtomicBuffer.h"
 #include "DataFrameHeader.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer {

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/Header.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/Header.h
@@ -17,9 +17,9 @@
 #ifndef AERON_CONCURRENT_LOGBUFFER_HEADER_H
 #define AERON_CONCURRENT_LOGBUFFER_HEADER_H
 
-#include <util/Index.h>
-#include <util/BitUtil.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../../util/BitUtil.h"
+#include "../AtomicBuffer.h"
 #include "DataFrameHeader.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer {

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/HeaderWriter.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/HeaderWriter.h
@@ -17,8 +17,8 @@
 #ifndef AERON_CONCURRENT_LOGBUFFER_HEADER_WRITER_H
 #define AERON_CONCURRENT_LOGBUFFER_HEADER_WRITER_H
 
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "DataFrameHeader.h"
 #include "FrameDescriptor.h"
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/LogBufferDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/LogBufferDescriptor.h
@@ -17,11 +17,11 @@
 #ifndef AERON_CONCURRENT_LOGBUFFER_DESCRIPTOR_H
 #define AERON_CONCURRENT_LOGBUFFER_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <util/StringUtil.h>
-#include <util/BitUtil.h>
-#include <util/Exceptions.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../../util/StringUtil.h"
+#include "../../util/BitUtil.h"
+#include "../../util/Exceptions.h"
+#include "../AtomicBuffer.h"
 #include "FrameDescriptor.h"
 #include "DataFrameHeader.h"
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/TermAppender.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/TermAppender.h
@@ -18,8 +18,8 @@
 #define AERON_CONCURRENT_LOGBUFFER_TERM_APPENDER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "HeaderWriter.h"
 #include "LogBufferDescriptor.h"
 #include "BufferClaim.h"

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/TermBlockScanner.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/TermBlockScanner.h
@@ -18,8 +18,8 @@
 #define AERON_CONCURRENT_TERM_BLOCK_SCANNER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "LogBufferDescriptor.h"
 #include "Header.h"
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/TermGapScanner.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/TermGapScanner.h
@@ -17,7 +17,7 @@
 #ifndef AERON_CONCURRENT_TERM_GAP_SCANNER_H
 #define AERON_CONCURRENT_TERM_GAP_SCANNER_H
 
-#include <util/BitUtil.h>
+#include "../../util/BitUtil.h"
 #include "FrameDescriptor.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer {

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/TermReader.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/TermReader.h
@@ -18,8 +18,8 @@
 #define AERON_CONCURRENT_LOGBUFFER_TERM_READER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
 #include "LogBufferDescriptor.h"
 #include "Header.h"
 

--- a/aeron-client/src/main/cpp/concurrent/logbuffer/TermScanner.h
+++ b/aeron-client/src/main/cpp/concurrent/logbuffer/TermScanner.h
@@ -17,7 +17,7 @@
 #ifndef AERON_CONCURRENT_LOGBUFFER_TERM_SCANNER_H
 #define AERON_CONCURRENT_LOGBUFFER_TERM_SCANNER_H
 
-#include <util/BitUtil.h>
+#include "../../util/BitUtil.h"
 #include "FrameDescriptor.h"
 
 namespace aeron { namespace concurrent { namespace logbuffer

--- a/aeron-client/src/main/cpp/concurrent/reports/LossReportDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/reports/LossReportDescriptor.h
@@ -16,8 +16,8 @@
 #ifndef AERON_LOSS_REPORT_DESCRIPTOR_H
 #define AERON_LOSS_REPORT_DESCRIPTOR_H
 
-#include "util/Index.h"
-#include "util/BitUtil.h"
+#include "../../util/Index.h"
+#include "../../util/BitUtil.h"
 
 namespace aeron { namespace concurrent { namespace reports {
 

--- a/aeron-client/src/main/cpp/concurrent/reports/LossReportReader.h
+++ b/aeron-client/src/main/cpp/concurrent/reports/LossReportReader.h
@@ -17,10 +17,10 @@
 #define AERON_LOSS_REPORT_READER_H
 
 #include <functional>
-#include <util/Index.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/BitUtil.h>
-#include <concurrent/reports/LossReportDescriptor.h>
+#include "../../util/BitUtil.h"
+#include "../../util/Index.h"
+#include "../AtomicBuffer.h"
+#include "LossReportDescriptor.h"
 
 namespace aeron { namespace concurrent { namespace reports {
 

--- a/aeron-client/src/main/cpp/concurrent/ringbuffer/ManyToOneRingBuffer.h
+++ b/aeron-client/src/main/cpp/concurrent/ringbuffer/ManyToOneRingBuffer.h
@@ -20,10 +20,10 @@
 #include <climits>
 #include <functional>
 #include <algorithm>
-#include <util/Index.h>
-#include <util/LangUtil.h>
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/Atomic64.h>
+#include "../../util/Index.h"
+#include "../../util/LangUtil.h"
+#include "../AtomicBuffer.h"
+#include "../Atomic64.h"
 #include "RingBufferDescriptor.h"
 #include "RecordDescriptor.h"
 

--- a/aeron-client/src/main/cpp/concurrent/ringbuffer/OneToOneRingBuffer.h
+++ b/aeron-client/src/main/cpp/concurrent/ringbuffer/OneToOneRingBuffer.h
@@ -20,10 +20,10 @@
 #include <climits>
 #include <functional>
 #include <algorithm>
-#include <util/Index.h>
-#include <util/LangUtil.h>
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/Atomic64.h>
+#include "../../util/Index.h"
+#include "../../util/LangUtil.h"
+#include "../AtomicBuffer.h"
+#include "../Atomic64.h"
 #include "RingBufferDescriptor.h"
 #include "RecordDescriptor.h"
 

--- a/aeron-client/src/main/cpp/concurrent/ringbuffer/RecordDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/ringbuffer/RecordDescriptor.h
@@ -17,8 +17,8 @@
 #ifndef AERON_RING_BUFFER_RECORD_DESCRIPTOR_H
 #define AERON_RING_BUFFER_RECORD_DESCRIPTOR_H
 
-#include <util/Index.h>
-#include <util/StringUtil.h>
+#include "../../util/Index.h"
+#include "../../util/StringUtil.h"
 
 namespace aeron { namespace concurrent { namespace ringbuffer {
 

--- a/aeron-client/src/main/cpp/concurrent/ringbuffer/RingBufferDescriptor.h
+++ b/aeron-client/src/main/cpp/concurrent/ringbuffer/RingBufferDescriptor.h
@@ -18,10 +18,10 @@
 #define AERON_RING_BUFFER_DESCRIPTOR_H
 
 #include <functional>
-#include <util/Index.h>
-#include <util/BitUtil.h>
-#include <util/Exceptions.h>
-#include <util/StringUtil.h>
+#include "../../util/Index.h"
+#include "../../util/BitUtil.h"
+#include "../../util/Exceptions.h"
+#include "../../util/StringUtil.h"
 
 namespace aeron { namespace concurrent { namespace ringbuffer {
 

--- a/aeron-client/src/main/cpp/concurrent/status/StatusIndicatorReader.h
+++ b/aeron-client/src/main/cpp/concurrent/status/StatusIndicatorReader.h
@@ -17,8 +17,8 @@
 #ifndef AERON_STATUS_INDICATOR_READER_H
 #define AERON_STATUS_INDICATOR_READER_H
 
-#include "concurrent/AtomicBuffer.h"
-#include "concurrent/CountersManager.h"
+#include "../AtomicBuffer.h"
+#include "../CountersManager.h"
 
 namespace aeron { namespace concurrent { namespace status {
 

--- a/aeron-client/src/main/cpp/concurrent/status/UnsafeBufferPosition.h
+++ b/aeron-client/src/main/cpp/concurrent/status/UnsafeBufferPosition.h
@@ -17,8 +17,8 @@
 #ifndef AERON_UNSAFE_BUFFER_POSITION_H
 #define AERON_UNSAFE_BUFFER_POSITION_H
 
-#include <concurrent/AtomicBuffer.h>
-#include <concurrent/CountersManager.h>
+#include "../AtomicBuffer.h"
+#include "../CountersManager.h"
 #include "Position.h"
 
 namespace aeron { namespace concurrent { namespace status {

--- a/aeron-client/src/main/cpp/protocol/DataHeaderFlyweight.h
+++ b/aeron-client/src/main/cpp/protocol/DataHeaderFlyweight.h
@@ -21,9 +21,9 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <command/Flyweight.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/Index.h>
+#include "../command/Flyweight.h"
+#include "../concurrent/AtomicBuffer.h"
+#include "..util/Index.h"
 #include "HeaderFlyweight.h"
 
 namespace aeron { namespace protocol

--- a/aeron-client/src/main/cpp/protocol/HeaderFlyweight.h
+++ b/aeron-client/src/main/cpp/protocol/HeaderFlyweight.h
@@ -20,9 +20,9 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <command/Flyweight.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/Index.h>
+#include "../command/Flyweight.h"
+#include "../concurrent/AtomicBuffer.h"
+#include "../util/Index.h"
 
 namespace aeron { namespace protocol
 {

--- a/aeron-client/src/main/cpp/protocol/NakFlyweight.h
+++ b/aeron-client/src/main/cpp/protocol/NakFlyweight.h
@@ -20,9 +20,9 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <command/Flyweight.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/Index.h>
+#include "../command/Flyweight.h"
+#include "../concurrent/AtomicBuffer.h"
+#include "../util/Index.h"
 #include "HeaderFlyweight.h"
 
 namespace aeron { namespace protocol

--- a/aeron-client/src/main/cpp/protocol/SetupFlyweight.h
+++ b/aeron-client/src/main/cpp/protocol/SetupFlyweight.h
@@ -20,9 +20,9 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <command/Flyweight.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/Index.h>
+#include "../command/Flyweight.h"
+#include "../concurrent/AtomicBuffer.h"
+#include "../util/Index.h"
 #include "HeaderFlyweight.h"
 
 namespace aeron { namespace protocol

--- a/aeron-client/src/main/cpp/protocol/StatusMessageFlyweight.h
+++ b/aeron-client/src/main/cpp/protocol/StatusMessageFlyweight.h
@@ -20,9 +20,9 @@
 #include <cstdint>
 #include <string>
 #include <cstddef>
-#include <command/Flyweight.h>
-#include <concurrent/AtomicBuffer.h>
-#include <util/Index.h>
+#include "../command/Flyweight.h"
+#include "../concurrent/AtomicBuffer.h"
+#include "../util/Index.h"
 #include "HeaderFlyweight.h"
 
 namespace aeron { namespace protocol

--- a/aeron-client/src/main/cpp/util/BitUtil.h
+++ b/aeron-client/src/main/cpp/util/BitUtil.h
@@ -19,7 +19,7 @@
 #include <cassert>
 #include <cstdint>
 #include <type_traits>
-#include <util/Exceptions.h>
+#include "Exceptions.h"
 
 #if defined(_MSC_VER)
 #include <intrin.h>

--- a/aeron-client/src/main/cpp/util/CommandOption.h
+++ b/aeron-client/src/main/cpp/util/CommandOption.h
@@ -23,7 +23,7 @@
 #include <map>
 
 #include "Exceptions.h"
-#include "util/Export.h"
+#include "Export.h"
 
 namespace aeron { namespace util
 {

--- a/aeron-client/src/main/cpp/util/CommandOptionParser.h
+++ b/aeron-client/src/main/cpp/util/CommandOptionParser.h
@@ -22,7 +22,7 @@
 #include <iostream>
 
 #include "CommandOption.h"
-#include "util/Export.h"
+#include "Export.h"
 
 namespace aeron { namespace util
 {

--- a/aeron-client/src/main/cpp/util/Export.h
+++ b/aeron-client/src/main/cpp/util/Export.h
@@ -15,7 +15,7 @@
  */
 #ifndef AERON_UTIL_EXPORT_FILE_H
 #define AERON_UTIL_EXPORT_FILE_H
-#include <util/Platform.h>
+#include "Platform.h"
 
 #ifdef AERON_COMPILER_MSVC
 #   if defined CLIENT_SHARED

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.h
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.h
@@ -18,7 +18,7 @@
 
 #include <cstdint>
 #include <memory>
-#include "util/Export.h"
+#include "Export.h"
 
 #ifdef _WIN32
     #ifndef NOMINMAX


### PR DESCRIPTION
Some of the aeron-client headers have very common names like `Subscription.h` and `Context.h` which could lead to include conflicts in large projects.

A common practice for C++ libs is to use a stuttering directory structure (e.g. boost, folly, fmt, date, tl_expected, etc) so that the user can `#include "library/header.h"` instead of `#include "header.h"` directly.

This would be a breaking change though so the alternative I came up with was to add the **AERON_CLIENT_STUTTERING_HEADERS** option to CMakeLists.txt. This option installs the headers under an `aeron-client` directory during the build so the user can `#include "aeron-client/Aeron.h"` for example.

To make this work without breaking existing code I had to make all the local includes relative to the file path.
I'm not sure how you feel about this stylistically speaking but it's a compromise that allows existing code to continue as is while allowing new code to use the stuttering option.

Includes were also inconsistent between <> and "" so I changed all local includes to "".

This solution also plays nice with CMake FetchContent.

### Example usage:

CMakeLists.txt:
```
# aeron
FetchContent_Declare(
  aeron
  GIT_REPOSITORY git@github.com:e2m-investimentos/aeron.git
  GIT_TAG master
)

set(AERON_CLIENT_STUTTERING_HEADERS ON)

FetchContent_MakeAvailable(aeron)

install(
  TARGETS aeron aeronmd aeron_client_shared aeron_driver
  RUNTIME DESTINATION ${MY_BIN_INSTALL_DIR}/aeron
  LIBRARY DESTINATION ${MY_LIB_INSTALL_DIR}
  ARCHIVE DESTINATION ${MY_LIB_INSTALL_DIR}
)
```

MyClass.h:
```
#include "aeron-client/Aeron.h"
....
```