### PR TITLE
[C] Don't allow session ids on network publications to be re-used until the publication is completely closed.

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -901,20 +901,24 @@ aeron_ipc_publication_t *aeron_driver_conductor_get_or_add_ipc_publication(
     {
         aeron_ipc_publication_t *pub_entry = conductor->ipc_publications.array[i].publication;
 
-        if (stream_id == pub_entry->stream_id &&
-            pub_entry->conductor_fields.state == AERON_IPC_PUBLICATION_STATE_ACTIVE)
+        if (stream_id == pub_entry->stream_id)
         {
-            if (NULL == publication && !is_exclusive && !pub_entry->is_exclusive)
+            if (AERON_IPC_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state &&
+                NULL == publication && !is_exclusive && !pub_entry->is_exclusive)
             {
                 publication = pub_entry;
             }
 
-            if (params->has_session_id && pub_entry->session_id == params->session_id)
+            if (AERON_IPC_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state ||
+                AERON_IPC_PUBLICATION_STATE_INACTIVE == pub_entry->conductor_fields.state)
             {
-                is_session_id_in_use = true;
-            }
+                if (params->has_session_id && pub_entry->session_id == params->session_id)
+                {
+                    is_session_id_in_use = true;
+                }
 
-            aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
+                aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
+            }
         }
     }
 
@@ -1064,21 +1068,19 @@ aeron_network_publication_t *aeron_driver_conductor_get_or_add_network_publicati
 
         if (endpoint == pub_entry->endpoint && stream_id == pub_entry->stream_id)
         {
-            if (AERON_NETWORK_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state)
+            if (AERON_NETWORK_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state &&
+                NULL == publication && !is_exclusive && !pub_entry->is_exclusive)
             {
-                if (NULL == publication && !is_exclusive && !pub_entry->is_exclusive)
-                {
-                    publication = pub_entry;
-                }
+                publication = pub_entry;
             }
 
             if (params->has_session_id && pub_entry->session_id == params->session_id)
             {
                 is_session_id_in_use = true;
             }
-        }
 
-        aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
+            aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
+        }
     }
 
     int32_t speculated_session_id = 0;

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -1062,23 +1062,23 @@ aeron_network_publication_t *aeron_driver_conductor_get_or_add_network_publicati
     {
         aeron_network_publication_t *pub_entry = conductor->network_publications.array[i].publication;
 
-        if (AERON_NETWORK_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state)
+        if (endpoint == pub_entry->endpoint && stream_id == pub_entry->stream_id)
         {
-            if (endpoint == pub_entry->endpoint && stream_id == pub_entry->stream_id)
+            if (AERON_NETWORK_PUBLICATION_STATE_ACTIVE == pub_entry->conductor_fields.state)
             {
                 if (NULL == publication && !is_exclusive && !pub_entry->is_exclusive)
                 {
                     publication = pub_entry;
                 }
-
-                if (params->has_session_id && pub_entry->session_id == params->session_id)
-                {
-                    is_session_id_in_use = true;
-                }
             }
 
-            aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
+            if (params->has_session_id && pub_entry->session_id == params->session_id)
+            {
+                is_session_id_in_use = true;
+            }
         }
+
+        aeron_driver_conductor_track_session_id_offsets(conductor, &session_id_offsets, pub_entry->session_id);
     }
 
     int32_t speculated_session_id = 0;

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -29,7 +29,6 @@ import org.agrona.ErrorHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -165,9 +164,9 @@ public class SessionSpecificPublicationTest
     @MethodSource("data")
     @Timeout(10)
     @SlowTest
-    void shouldNotAddPublicationWithSameSessionUntilLingerCompletes(ChannelUriStringBuilder builder)
+    void shouldNotAddPublicationWithSameSessionUntilLingerCompletes(final ChannelUriStringBuilder builder)
     {
-        DirectBuffer msg = new UnsafeBuffer(new byte[8]);
+        final DirectBuffer msg = new UnsafeBuffer(new byte[8]);
         final String channel = builder.sessionId(SESSION_ID_1).build();
 
         final String subscriptionChannel = "ipc".equals(builder.media()) ? channel : SPY_PREFIX + channel;

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -201,8 +201,9 @@ public class SessionSpecificPublicationTest
     {
         final String channel = channelBuilder.sessionId(SESSION_ID_1).build();
 
-        try (final Publication publication1 = aeron.addPublication(channel, STREAM_ID);
-            final Publication publication2 = aeron.addPublication(channel, STREAM_ID + 1)) {
+        try (Publication publication1 = aeron.addPublication(channel, STREAM_ID);
+            Publication publication2 = aeron.addPublication(channel, STREAM_ID + 1))
+        {
             // No-op
         }
     }

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -176,7 +176,7 @@ public class SessionSpecificPublicationTest
 
         assertThrows(RegistrationException.class, () ->
         {
-            try (final Publication publication2 = aeron.addPublication(channel, STREAM_ID))
+            try (Publication publication2 = aeron.addPublication(channel, STREAM_ID))
             {
                 fail("Exception should have been thrown due lingering publication keeping session id active");
             }
@@ -187,7 +187,7 @@ public class SessionSpecificPublicationTest
             Tests.yieldingWait("Publication never cleaned up");
         }
 
-        try (final Publication publication2 = aeron.addPublication(channel, STREAM_ID))
+        try (Publication publication2 = aeron.addPublication(channel, STREAM_ID))
         {
             // No action required.
         }

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -20,6 +20,7 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.MediaDriverTestWatcher;
+import io.aeron.test.SlowTest;
 import io.aeron.test.TestMediaDriver;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
@@ -160,6 +161,7 @@ public class SessionSpecificPublicationTest
 
     @Test
     @Timeout(10)
+    @SlowTest
     void shouldNotAddPublicationWithSameSessionUntilLingerCompletes()
     {
         final String channel = new ChannelUriStringBuilder()
@@ -169,8 +171,8 @@ public class SessionSpecificPublicationTest
             .build();
 
         final Publication publication1 = aeron.addPublication(channel, STREAM_ID);
-        final int channelStatusId = publication1.channelStatusId();
-        assertEquals(CountersReader.RECORD_ALLOCATED, aeron.countersReader().getCounterState(channelStatusId));
+        final int positionLimitId = publication1.positionLimitId();
+        assertEquals(CountersReader.RECORD_ALLOCATED, aeron.countersReader().getCounterState(positionLimitId));
 
         publication1.close();
 
@@ -182,7 +184,7 @@ public class SessionSpecificPublicationTest
             }
         });
 
-        while (CountersReader.RECORD_ALLOCATED == aeron.countersReader().getCounterState(channelStatusId))
+        while (CountersReader.RECORD_ALLOCATED == aeron.countersReader().getCounterState(positionLimitId))
         {
             Tests.yieldingWait("Publication never cleaned up");
         }

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -194,4 +194,16 @@ public class SessionSpecificPublicationTest
             // No action required.
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    void shouldAllowTheSameSessionIdOnDifferentStreamIds(final ChannelUriStringBuilder channelBuilder)
+    {
+        final String channel = channelBuilder.sessionId(SESSION_ID_1).build();
+
+        try (final Publication publication1 = aeron.addPublication(channel, STREAM_ID);
+            final Publication publication2 = aeron.addPublication(channel, STREAM_ID + 1)) {
+            // No-op
+        }
+    }
 }


### PR DESCRIPTION
Add system test to show external behaviour as well.