### PR TITLE
interceptor changes

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_name_resolver.c
+++ b/aeron-driver/src/main/c/aeron_driver_name_resolver.c
@@ -113,6 +113,7 @@ aeron_driver_name_resolver_t;
 
 void aeron_driver_name_resolver_receive(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
@@ -489,6 +490,7 @@ static void aeron_name_resolver_log_and_clear_error(aeron_driver_name_resolver_t
 
 void aeron_driver_name_resolver_receive(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -365,6 +365,13 @@ void aeron_driver_receiver_on_add_destination(void *clientd, void *item)
         return;
     }
 
+    if (aeron_udp_channel_interceptors_transport_notifications(
+        destination->data_paths, &destination->transport, AERON_UDP_CHANNEL_INTERCEPTOR_ADD_NOTIFICATION) < 0)
+    {
+        AERON_DRIVER_RECEIVER_ERROR(
+            receiver, "on_add_destination, interceptors transport notifications: %s", aeron_errmsg());
+    }
+
     if (endpoint->transport_bindings->poller_add_func(&receiver->poller, &destination->transport) < 0)
     {
         AERON_DRIVER_RECEIVER_ERROR(receiver, "on_add_destination, add to poller: %s", aeron_errmsg());
@@ -410,6 +417,13 @@ void aeron_driver_receiver_on_remove_destination(void *clientd, void *item)
 
     if (0 < aeron_receive_channel_endpoint_remove_destination(endpoint, channel, &destination) && NULL != destination)
     {
+        if (aeron_udp_channel_interceptors_transport_notifications(
+            destination->data_paths, &destination->transport, AERON_UDP_CHANNEL_INTERCEPTOR_REMOVE_NOTIFICATION) < 0)
+        {
+            AERON_DRIVER_RECEIVER_ERROR(
+                receiver, "on_add_destination, interceptors transport notifications: %s", aeron_errmsg());
+        }
+
         endpoint->transport_bindings->poller_remove_func(&receiver->poller, &destination->transport);
         endpoint->transport_bindings->close_func(&destination->transport);
 

--- a/aeron-driver/src/main/c/aeron_driver_sender.c
+++ b/aeron-driver/src/main/c/aeron_driver_sender.c
@@ -210,6 +210,13 @@ void aeron_driver_sender_on_add_endpoint(void *clientd, void *command)
     aeron_command_base_t *cmd = (aeron_command_base_t *)command;
     aeron_send_channel_endpoint_t *endpoint = (aeron_send_channel_endpoint_t *)cmd->item;
 
+    if (aeron_udp_channel_interceptors_transport_notifications(
+        endpoint->transport.data_paths, &endpoint->transport, AERON_UDP_CHANNEL_INTERCEPTOR_ADD_NOTIFICATION) < 0)
+    {
+        AERON_DRIVER_SENDER_ERROR(
+            sender, "sender on_add_endpoint interceptors transport notifications: %s", aeron_errmsg());
+    }
+
     if (sender->context->udp_channel_transport_bindings->poller_add_func(&sender->poller, &endpoint->transport) < 0)
     {
         AERON_DRIVER_SENDER_ERROR(sender, "sender on_add_endpoint: %s", aeron_errmsg());
@@ -221,6 +228,13 @@ void aeron_driver_sender_on_remove_endpoint(void *clientd, void *command)
     aeron_driver_sender_t *sender = (aeron_driver_sender_t *)clientd;
     aeron_command_base_t *cmd = (aeron_command_base_t *)command;
     aeron_send_channel_endpoint_t *endpoint = (aeron_send_channel_endpoint_t *)cmd->item;
+
+    if (aeron_udp_channel_interceptors_transport_notifications(
+        endpoint->transport.data_paths, &endpoint->transport, AERON_UDP_CHANNEL_INTERCEPTOR_REMOVE_NOTIFICATION) < 0)
+    {
+        AERON_DRIVER_SENDER_ERROR(
+            sender, "sender on_remove_endpoint interceptors transport notifications: %s", aeron_errmsg());
+    }
 
     if (sender->context->udp_channel_transport_bindings->poller_remove_func(&sender->poller, &endpoint->transport) < 0)
     {
@@ -235,6 +249,7 @@ void aeron_driver_sender_on_add_publication(void *clientd, void *command)
     aeron_driver_sender_t *sender = (aeron_driver_sender_t *)clientd;
     aeron_command_base_t *cmd = (aeron_command_base_t *)command;
     aeron_network_publication_t *publication = (aeron_network_publication_t *)cmd->item;
+    aeron_udp_channel_transport_t *transport = &publication->endpoint->transport;
 
     int ensure_capacity_result = 0;
     AERON_ARRAY_ENSURE_CAPACITY(
@@ -251,6 +266,13 @@ void aeron_driver_sender_on_add_publication(void *clientd, void *command)
     {
         AERON_DRIVER_SENDER_ERROR(sender, "sender on_add_publication add_publication: %s", aeron_errmsg());
     }
+
+    if (aeron_udp_channel_interceptors_publication_notifications(
+        transport->data_paths, transport, publication, AERON_UDP_CHANNEL_INTERCEPTOR_ADD_NOTIFICATION) < 0)
+    {
+        AERON_DRIVER_SENDER_ERROR(
+            sender, "sender on_add_publication interceptors publication notifications: %s", aeron_errmsg());
+    }
 }
 
 void aeron_driver_sender_on_remove_publication(void *clientd, void *command)
@@ -258,6 +280,7 @@ void aeron_driver_sender_on_remove_publication(void *clientd, void *command)
     aeron_driver_sender_t *sender = (aeron_driver_sender_t *)clientd;
     aeron_command_base_t *cmd = (aeron_command_base_t *)command;
     aeron_network_publication_t *publication = (aeron_network_publication_t *)cmd->item;
+    aeron_udp_channel_transport_t *transport = &publication->endpoint->transport;
 
     for (size_t i = 0, size = sender->network_publications.length, last_index = size - 1; i < size; i++)
     {
@@ -276,6 +299,13 @@ void aeron_driver_sender_on_remove_publication(void *clientd, void *command)
     if (aeron_send_channel_endpoint_remove_publication(publication->endpoint, publication) < 0)
     {
         AERON_DRIVER_SENDER_ERROR(sender, "sender on_remove_publication: %s", aeron_errmsg());
+    }
+
+    if (aeron_udp_channel_interceptors_publication_notifications(
+        transport->data_paths, transport, publication, AERON_UDP_CHANNEL_INTERCEPTOR_ADD_NOTIFICATION) < 0)
+    {
+        AERON_DRIVER_SENDER_ERROR(
+            sender, "sender on_remove_publication interceptors publication notifications: %s", aeron_errmsg());
     }
 
     aeron_network_publication_sender_release(publication);

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -308,6 +308,7 @@ int aeron_driver_agent_outgoing_msg(
 void aeron_driver_agent_incoming_msg(
     void *interceptor_state,
     aeron_udp_channel_incoming_interceptor_t *delegate,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
@@ -332,6 +333,7 @@ void aeron_driver_agent_incoming_msg(
     delegate->incoming_func(
         delegate->interceptor_state,
         delegate->next_interceptor,
+        transport,
         receiver_clientd,
         endpoint_clientd,
         destination_clientd,
@@ -402,6 +404,12 @@ int aeron_init_logging_events_interceptors(aeron_driver_context_t *context)
         incoming_bindings->incoming_init_func = aeron_driver_agent_interceptor_init;
         incoming_bindings->incoming_close_func = NULL;
         incoming_bindings->incoming_func = aeron_driver_agent_incoming_msg;
+        incoming_bindings->outgoing_transport_notification_func = NULL;
+        incoming_bindings->outgoing_publication_notification_func = NULL;
+        incoming_bindings->outgoing_image_notification_func = NULL;
+        incoming_bindings->incoming_transport_notification_func = NULL;
+        incoming_bindings->incoming_publication_notification_func = NULL;
+        incoming_bindings->incoming_image_notification_func = NULL;
 
         incoming_bindings->meta_info.name = "logging";
         incoming_bindings->meta_info.type = "interceptor";
@@ -441,6 +449,12 @@ int aeron_init_logging_events_interceptors(aeron_driver_context_t *context)
         outgoing_bindings->incoming_init_func = NULL;
         outgoing_bindings->incoming_close_func = NULL;
         outgoing_bindings->incoming_func = NULL;
+        outgoing_bindings->outgoing_transport_notification_func = NULL;
+        outgoing_bindings->outgoing_publication_notification_func = NULL;
+        outgoing_bindings->outgoing_image_notification_func = NULL;
+        outgoing_bindings->incoming_transport_notification_func = NULL;
+        outgoing_bindings->incoming_publication_notification_func = NULL;
+        outgoing_bindings->incoming_image_notification_func = NULL;
 
         outgoing_bindings->meta_info.name = "logging";
         outgoing_bindings->meta_info.type = "interceptor";

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
@@ -125,6 +125,7 @@ int aeron_receive_channel_endpoint_send_rttm(
 
 void aeron_receive_channel_endpoint_dispatch(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -282,6 +282,7 @@ int aeron_send_channel_endpoint_remove_publication(
 
 void aeron_send_channel_endpoint_dispatch(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *sender_clientd,
     void *endpoint_clientd,
     void *destination_clientd,

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
@@ -86,6 +86,7 @@ int aeron_send_channel_endpoint_remove_publication(
 
 void aeron_send_channel_endpoint_dispatch(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *sender_clientd,
     void *endpoint_clientd,
     void *destination_clientd,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -64,6 +64,11 @@ int aeron_udp_channel_transport_init(
 
     transport->fd = -1;
     transport->bindings_clientd = NULL;
+    for (size_t i = 0; i < AERON_UDP_CHANNEL_TRANSPORT_MAX_INTERCEPTORS; i++)
+    {
+        transport->interceptor_clientds[i] = NULL;
+    }
+
     if ((transport->fd = aeron_socket(bind_addr->ss_family, SOCK_DGRAM, 0)) < 0)
     {
         goto error;
@@ -262,6 +267,7 @@ int aeron_udp_channel_transport_recvmmsg(
         {
             recv_func(
                 transport->data_paths,
+                transport,
                 clientd,
                 transport->dispatch_clientd,
                 transport->destination_clientd,
@@ -301,6 +307,7 @@ int aeron_udp_channel_transport_recvmmsg(
         msgvec[i].msg_len = (unsigned int)result;
         recv_func(
             transport->data_paths,
+            transport,
             clientd,
             transport->dispatch_clientd,
             transport->destination_clientd,
@@ -398,3 +405,12 @@ int aeron_udp_channel_transport_bind_addr_and_port(
 
     return aeron_format_source_identity(buffer, length, &addr);
 }
+
+extern void *aeron_udp_channel_transport_get_interceptor_clientd(
+    aeron_udp_channel_transport_t *transport,
+    int interceptor_index);
+
+extern void aeron_udp_channel_transport_set_interceptor_clientd(
+    aeron_udp_channel_transport_t *transport,
+    int interceptor_index,
+    void *clientd);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
@@ -29,6 +29,7 @@ typedef struct aeron_udp_channel_transport_stct
     void *dispatch_clientd;
     void *bindings_clientd;
     void *destination_clientd;
+    void *interceptor_clientds[AERON_UDP_CHANNEL_TRANSPORT_MAX_INTERCEPTORS];
 }
 aeron_udp_channel_transport_t;
 
@@ -69,5 +70,20 @@ int aeron_udp_channel_transport_sendmsg(
 int aeron_udp_channel_transport_get_so_rcvbuf(aeron_udp_channel_transport_t *transport, size_t *so_rcvbuf);
 int aeron_udp_channel_transport_bind_addr_and_port(
     aeron_udp_channel_transport_t *transport, char *buffer, size_t length);
+
+inline void *aeron_udp_channel_transport_get_interceptor_clientd(
+    aeron_udp_channel_transport_t *transport,
+    int interceptor_index)
+{
+    return transport->interceptor_clientds[interceptor_index];
+}
+
+inline void aeron_udp_channel_transport_set_interceptor_clientd(
+    aeron_udp_channel_transport_t *transport,
+    int interceptor_index,
+    void *clientd)
+{
+    transport->interceptor_clientds[interceptor_index] = clientd;
+}
 
 #endif //AERON_UDP_CHANNEL_TRANSPORT_H

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -219,6 +219,9 @@ int aeron_udp_channel_data_paths_init(
             interceptor->outgoing_mmsg_func = binding->outgoing_mmsg_func;
             interceptor->outgoing_msg_func = binding->outgoing_msg_func;
             interceptor->close_func = binding->outgoing_close_func;
+            interceptor->outgoing_transport_notification_func = binding->outgoing_transport_notification_func;
+            interceptor->outgoing_publication_notification_func = binding->outgoing_publication_notification_func;
+            interceptor->outgoing_image_notification_func = binding->outgoing_image_notification_func;
             interceptor->next_interceptor = NULL;
 
             if (binding->outgoing_init_func(&interceptor->interceptor_state, affinity) < 0)
@@ -286,6 +289,9 @@ int aeron_udp_channel_data_paths_init(
             interceptor->interceptor_state = NULL;
             interceptor->incoming_func = binding->incoming_func;
             interceptor->close_func = binding->incoming_close_func;
+            interceptor->incoming_transport_notification_func = binding->incoming_transport_notification_func;
+            interceptor->incoming_publication_notification_func = binding->incoming_publication_notification_func;
+            interceptor->incoming_image_notification_func = binding->incoming_image_notification_func;
             interceptor->next_interceptor = NULL;
 
             if (binding->incoming_init_func(&interceptor->interceptor_state, affinity) < 0)
@@ -393,6 +399,7 @@ extern int aeron_udp_channel_outgoing_interceptor_msg_to_transport(
 
 extern void aeron_udp_channel_incoming_interceptor_recv_func(
     aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
@@ -403,9 +410,27 @@ extern void aeron_udp_channel_incoming_interceptor_recv_func(
 extern void aeron_udp_channel_incoming_interceptor_to_endpoint(
     void *interceptor_state,
     aeron_udp_channel_incoming_interceptor_t *delegate,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
     struct sockaddr_storage *addr);
+
+extern int aeron_udp_channel_interceptors_transport_notifications(
+    aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
+    aeron_udp_channnel_interceptor_notification_type_t type);
+
+extern int aeron_udp_channel_interceptors_publication_notifications(
+    aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
+    aeron_network_publication_t *publication,
+    aeron_udp_channnel_interceptor_notification_type_t type);
+
+extern int aeron_udp_channel_interceptors_image_notifications(
+    aeron_udp_channel_data_paths_t *data_paths,
+    aeron_udp_channel_transport_t *transport,
+    aeron_publication_image_t *image,
+    aeron_udp_channnel_interceptor_notification_type_t type);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
@@ -66,6 +66,12 @@ aeron_udp_channel_interceptor_bindings_t *aeron_udp_channel_interceptor_loss_loa
     interceptor_bindings->incoming_func = aeron_udp_channel_interceptor_loss_incoming;
     interceptor_bindings->outgoing_close_func = NULL;
     interceptor_bindings->incoming_close_func = NULL;
+    interceptor_bindings->outgoing_transport_notification_func = NULL;
+    interceptor_bindings->outgoing_publication_notification_func = NULL;
+    interceptor_bindings->outgoing_image_notification_func = NULL;
+    interceptor_bindings->incoming_transport_notification_func = NULL;
+    interceptor_bindings->incoming_publication_notification_func = NULL;
+    interceptor_bindings->incoming_image_notification_func = NULL;
 
     interceptor_bindings->meta_info.name = "loss";
     interceptor_bindings->meta_info.type = "interceptor";
@@ -135,6 +141,7 @@ static bool aeron_udp_channel_interceptor_loss_should_drop_frame(
 void aeron_udp_channel_interceptor_loss_incoming(
     void *interceptor_state,
     aeron_udp_channel_incoming_interceptor_t *delegate,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
@@ -149,6 +156,7 @@ void aeron_udp_channel_interceptor_loss_incoming(
         delegate->incoming_func(
             delegate->interceptor_state,
             delegate->next_interceptor,
+            transport,
             receiver_clientd,
             endpoint_clientd,
             destination_clientd,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
@@ -33,6 +33,7 @@ aeron_udp_channel_interceptor_bindings_t *aeron_udp_channel_interceptor_loss_loa
 void aeron_udp_channel_interceptor_loss_incoming(
     void *interceptor_state,
     aeron_udp_channel_incoming_interceptor_t *delegate,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,

--- a/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
+++ b/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
@@ -50,6 +50,7 @@ typedef struct delegate_recv_state_stct
 void aeron_udp_channel_interceptor_loss_incoming_delegate(
     void *interceptor_state,
     aeron_udp_channel_incoming_interceptor_t *delegate,
+    aeron_udp_channel_transport_t *transport,
     void *receiver_clientd,
     void *endpoint_clientd,
     void *destination_clientd,
@@ -88,9 +89,9 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardAllPacketsWithRateOfOne)
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_0, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_0, 1024, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_1, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_1, 1024, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 0);
 }
@@ -121,9 +122,9 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfOneWithD
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_0, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_0, 1024, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_1, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_1, 1024, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 2);
 }
@@ -153,9 +154,9 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfZero)
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_0, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_0, 1024, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        NULL, &delegate, NULL, NULL, NULL, data_1, 1024, NULL);
+        NULL, &delegate, NULL, NULL, NULL, NULL, data_1, 1024, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 2);
 }
@@ -186,7 +187,7 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardRoughlyHalfTheMessages)
         frame_header->type = msg_type;
 
         aeron_udp_channel_interceptor_loss_incoming(
-            NULL, &delegate, NULL, NULL, NULL, data + (i * 1024), 1024, NULL);
+            NULL, &delegate, NULL, NULL, NULL, NULL, data + (i * 1024), 1024, NULL);
     }
 
     EXPECT_LT(delegate_recv_state.messages_received, static_cast<int>(vlen));


### PR DESCRIPTION
To pass back and forth to see if comprehensive enough.

@mikeb01 see if this seems logical.

Interceptor changes to include transport in the incoming path and various notifications of transport/publication/image events, and addition of per interceptor state to transport.