### PR TITLE
[C] Move Windows.h out of aeron_dlopen.h

### DIFF
--- a/aeron-client/src/main/c/util/aeron_dlopen.c
+++ b/aeron-client/src/main/c/util/aeron_dlopen.c
@@ -42,6 +42,7 @@ const char *aeron_dlinfo(const void *addr, char *buffer, size_t max_buffer_lengt
 
 #include "concurrent/aeron_counters_manager.h"
 #include "aeronc.h"
+#include <Windows.h>
 
 void *aeron_dlsym_fallback(LPCSTR name)
 {
@@ -74,7 +75,7 @@ void aeron_init_dlopen_support()
     }
 }
 
-void *aeron_dlsym(HMODULE module, LPCSTR name)
+void *aeron_dlsym(HMODULE module, const char *name)
 {
     aeron_init_dlopen_support();
 
@@ -115,7 +116,7 @@ void *aeron_dlsym(HMODULE module, LPCSTR name)
     return GetProcAddress(module, name);
 }
 
-HMODULE aeron_dlopen(LPCSTR filename)
+void *aeron_dlopen(const char *filename)
 {
     aeron_init_dlopen_support();
 

--- a/aeron-client/src/main/c/util/aeron_dlopen.h
+++ b/aeron-client/src/main/c/util/aeron_dlopen.h
@@ -32,14 +32,11 @@ const char *aeron_dlinfo(const void *addr, char *buffer, size_t max_buffer_lengt
 
 #elif defined(AERON_COMPILER_MSVC) && defined(AERON_CPU_X64)
 
-#include <WinSock2.h>
-#include <windows.h>
+#define RTLD_DEFAULT ((void*)-123)
+#define RTLD_NEXT ((void*)-124)
 
-#define RTLD_DEFAULT ((HMODULE)-123)
-#define RTLD_NEXT ((HMODULE)-124)
-
-void *aeron_dlsym(HMODULE module, LPCSTR name);
-HMODULE aeron_dlopen(LPCSTR filename);
+void *aeron_dlsym(void *module, const char *name);
+void *aeron_dlopen(const char *filename);
 char *aeron_dlerror();
 const char *aeron_dlinfo(const void *addr, char *buffer, size_t max_buffer_length);
 


### PR DESCRIPTION
Windows.h is a very big header that pulls a lot of things.