### PR TITLE
Move place of the following function:

### DIFF
--- a/aeron-client/src/main/c/util/aeron_clock.h
+++ b/aeron-client/src/main/c/util/aeron_clock.h
@@ -18,6 +18,20 @@
 #define AERON_AERON_CLOCK_H
 
 /**
+ * Return time in nanoseconds for machine. Is not wall clock time.
+ *
+ * @return nanoseconds since epoch for machine.
+ */
+int64_t aeron_nano_clock();
+
+/**
+ * Return time in milliseconds since epoch. Is wall clock time.
+ *
+ * @return milliseconds since epoch.
+ */
+int64_t aeron_epoch_clock();
+
+/**
  * Opaque reference to a cached clock instance.
  */
 typedef struct aeron_clock_cache_stct aeron_clock_cache_t;

--- a/aeron-driver/src/main/c/aeron_loss_detector.c
+++ b/aeron-driver/src/main/c/aeron_loss_detector.c
@@ -23,6 +23,7 @@
 #include "aeron_loss_detector.h"
 #include "aeronmd.h"
 #include "aeron_windows.h"
+#include "util/aeron_clock.h"
 
 int aeron_loss_detector_init(
     aeron_loss_detector_t *detector,

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -853,20 +853,6 @@ int aeron_delete_directory(const char *dirname);
 typedef int64_t (*aeron_clock_func_t)();
 
 /**
- * Return time in nanoseconds for machine. Is not wall clock time.
- *
- * @return nanoseconds since epoch for machine.
- */
-int64_t aeron_nano_clock();
-
-/**
- * Return time in milliseconds since epoch. Is wall clock time.
- *
- * @return milliseconds since epoch.
- */
-int64_t aeron_epoch_clock();
-
-/**
  * Function to return logging information.
  */
 typedef void (*aeron_log_func_t)(const char *);


### PR DESCRIPTION
They should belongs to utils and can be access by both driver and client
+/**
+ * Return time in nanoseconds for machine. Is not wall clock time.
+ *
+ * @return nanoseconds since epoch for machine.
+ */
+int64_t aeron_nano_clock();
+
+/**
+ * Return time in milliseconds since epoch. Is wall clock time.
+ *
+ * @return milliseconds since epoch.
+ */
+int64_t aeron_epoch_clock();
+