### PR TITLE
[C] use aeron_epoch_clock instead of aeron_agent_epoch_clock

### DIFF
--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -59,23 +59,6 @@ aeron_mpsc_rb_t *aeron_driver_agent_mpsc_rb()
     return &logging_mpsc_rb;
 }
 
-int64_t aeron_agent_epoch_clock()
-{
-    struct timespec ts;
-#if defined(AERON_COMPILER_MSVC)
-    if (aeron_clock_gettime_realtime(&ts) < 0)
-    {
-        return -1;
-    }
-#else
-    if (clock_gettime(CLOCK_REALTIME, &ts) < 0)
-    {
-        return -1;
-    }
-#endif
-    return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
-}
-
 void aeron_agent_format_date(char *str, size_t count, int64_t timestamp)
 {
     char time_buffer[80];
@@ -170,7 +153,7 @@ static void initialize_agent_logging()
             exit(EXIT_FAILURE);
         }
 
-        fprintf(logfp, "%s\n", dissect_log_start(aeron_agent_epoch_clock()));
+        fprintf(logfp, "%s\n", dissect_log_start(aeron_epoch_clock()));
     }
 }
 
@@ -179,7 +162,7 @@ void aeron_driver_agent_conductor_to_driver_interceptor(
 {
     uint8_t buffer[MAX_CMD_LENGTH + sizeof(aeron_driver_agent_cmd_log_header_t)];
     aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->cmd_id = msg_type_id;
     memcpy(buffer + sizeof(aeron_driver_agent_cmd_log_header_t), message, length);
 
@@ -191,7 +174,7 @@ void aeron_driver_agent_conductor_to_client_interceptor(
 {
     uint8_t buffer[MAX_CMD_LENGTH + sizeof(aeron_driver_agent_cmd_log_header_t)];
     aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->cmd_id = msg_type_id;
     memcpy(buffer + sizeof(aeron_driver_agent_cmd_log_header_t), message, length);
 
@@ -211,7 +194,7 @@ int aeron_driver_agent_map_raw_log_interceptor(
     aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
     size_t path_len = strlen(path);
 
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->map_raw.map_raw_log.path_len = (int32_t)path_len;
     hdr->map_raw.map_raw_log.result = result;
     hdr->map_raw.map_raw_log.addr = (uintptr_t)mapped_raw_log;
@@ -229,7 +212,7 @@ int aeron_driver_agent_map_raw_log_close_interceptor(aeron_mapped_raw_log_t *map
     uint8_t buffer[AERON_MAX_PATH + sizeof(aeron_driver_agent_map_raw_log_op_header_t)];
     aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
 
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->map_raw.map_raw_log_close.addr = (uintptr_t)mapped_raw_log;
     memcpy(&hdr->map_raw.map_raw_log_close.log, mapped_raw_log, sizeof(hdr->map_raw.map_raw_log.log));
     hdr->map_raw.map_raw_log_close.result = aeron_map_raw_log_close(mapped_raw_log, filename);
@@ -247,7 +230,7 @@ void aeron_driver_agent_log_frame(
     aeron_driver_agent_frame_log_header_t *hdr = (aeron_driver_agent_frame_log_header_t *)buffer;
     size_t length = sizeof(aeron_driver_agent_frame_log_header_t);
 
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->result = (int32_t)result;
     hdr->sockaddr_len = msghdr->msg_namelen;
     hdr->message_len = message_len;
@@ -364,7 +347,7 @@ void aeron_driver_agent_untethered_subscription_state_change_interceptor(
     aeron_driver_agent_untethered_subscription_state_change_log_header_t *hdr =
         (aeron_driver_agent_untethered_subscription_state_change_log_header_t *)buffer;
 
-    hdr->time_ms = aeron_agent_epoch_clock();
+    hdr->time_ms = aeron_epoch_clock();
     hdr->subscription_id = tetherable_position->subscription_registration_id;
     hdr->stream_id = stream_id;
     hdr->session_id = session_id;


### PR DESCRIPTION
Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>