### PR TITLE
[Cpp] Wipe the include of <Windows.h> in Context.h and MemoryMappedFi…

### DIFF
--- a/aeron-client/src/main/cpp/Context.h
+++ b/aeron-client/src/main/cpp/Context.h
@@ -417,61 +417,7 @@ public:
     static void requestDriverTermination(
         const std::string &directory, const std::uint8_t *tokenBuffer, std::size_t tokenLength);
 
-    inline static std::string tmpDir()
-    {
-#if defined(_MSC_VER)
-        static char buff[MAX_PATH+1];
-        std::string dir = "";
-
-        if (::GetTempPath(MAX_PATH, &buff[0]) > 0)
-        {
-            dir = buff;
-        }
-
-        return dir;
-#else
-        std::string dir = "/tmp";
-
-        if (::getenv("TMPDIR"))
-        {
-            dir = ::getenv("TMPDIR");
-        }
-
-        return dir;
-#endif
-    }
-
-    inline static std::string getUserName()
-    {
-        const char *username = ::getenv("USER");
-#if (_MSC_VER)
-        if (nullptr == username)
-        {
-            username = ::getenv("USERNAME");
-            if (nullptr == username)
-            {
-                 username = "default";
-            }
-        }
-#else
-        if (nullptr == username)
-        {
-            username = "default";
-        }
-#endif
-        return username;
-    }
-
-    inline static std::string defaultAeronPath()
-    {
-#if defined(__linux__)
-        return "/dev/shm/aeron-" + getUserName();
-#elif (_MSC_VER)
-        return tmpDir() + "aeron-" + getUserName();
-#else
-        return tmpDir() + "/aeron-" + getUserName();
-#endif
-    }
+    static std::string defaultAeronPath();
 
 private:
     std::string m_dirName = defaultAeronPath();

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
@@ -20,6 +20,10 @@
     #include <fcntl.h>
     #include <unistd.h>
 #else
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif // !NOMINMAX
+    #include <Windows.h>
     #include "StringUtil.h"
 #endif
 

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.h
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.h
@@ -21,10 +21,8 @@
 #include "util/Export.h"
 
 #ifdef _WIN32
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif // !NOMINMAX
-    #include <windows.h>
+    #include <stddef.h>
+    typedef void* HANDLE;
 #else
     #include <sys/types.h>
 #endif


### PR DESCRIPTION
The generated SBE cpp files are conflict Windows.h, so they can not meet each other.