### PR TITLE
[CPP] Convert the usage of sbeTemplateId from switch/case to if/else …

### DIFF
--- a/aeron-archive/src/main/cpp/client/ControlResponseAdapter.cpp
+++ b/aeron-archive/src/main/cpp/client/ControlResponseAdapter.cpp
@@ -63,9 +63,8 @@ void ControlResponseAdapter::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case ControlResponse::sbeTemplateId():
+        if (ControlResponse::sbeTemplateId() == templateId)
         {
             ControlResponse response(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -79,10 +78,8 @@ void ControlResponseAdapter::onFragment(
                 response.relevantId(),
                 response.code(),
                 response.errorMessage());
-            break;
         }
-
-        case RecordingDescriptor::sbeTemplateId():
+        else if (RecordingDescriptor::sbeTemplateId() == templateId)
         {
             RecordingDescriptor descriptor(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -107,10 +104,6 @@ void ControlResponseAdapter::onFragment(
                 descriptor.strippedChannel(),
                 descriptor.originalChannel(),
                 descriptor.sourceIdentity());
-            break;
         }
-
-        default:
-            break;
     }
 }

--- a/aeron-archive/src/main/cpp/client/RecordingDescriptorPoller.cpp
+++ b/aeron-archive/src/main/cpp/client/RecordingDescriptorPoller.cpp
@@ -69,9 +69,8 @@ ControlledPollAction RecordingDescriptorPoller::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case ControlResponse::sbeTemplateId():
+        if (ControlResponse::sbeTemplateId() == templateId)
         {
             ControlResponse response(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -109,10 +108,8 @@ ControlledPollAction RecordingDescriptorPoller::onFragment(
                     }
                 }
             }
-            break;
         }
-
-        case RecordingDescriptor::sbeTemplateId():
+        else if (RecordingDescriptor::sbeTemplateId() == templateId)
         {
             RecordingDescriptor descriptor(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -147,11 +144,7 @@ ControlledPollAction RecordingDescriptorPoller::onFragment(
                     return ControlledPollAction::BREAK;
                 }
             }
-            break;
         }
-
-        default:
-            break;
     }
 
     return ControlledPollAction::CONTINUE;

--- a/aeron-archive/src/main/cpp/client/RecordingEventsAdapter.cpp
+++ b/aeron-archive/src/main/cpp/client/RecordingEventsAdapter.cpp
@@ -66,9 +66,8 @@ void RecordingEventsAdapter::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case RecordingStarted::sbeTemplateId():
+        if (RecordingStarted::sbeTemplateId() == templateId)
         {
             RecordingStarted event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -83,10 +82,8 @@ void RecordingEventsAdapter::onFragment(
                 event.streamId(),
                 event.channel(),
                 event.sourceIdentity());
-            break;
         }
-
-        case RecordingProgress::sbeTemplateId():
+        else if (RecordingProgress::sbeTemplateId() == templateId)
         {
             RecordingProgress event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -98,10 +95,8 @@ void RecordingEventsAdapter::onFragment(
                 event.recordingId(),
                 event.startPosition(),
                 event.position());
-            break;
         }
-
-        case RecordingStopped::sbeTemplateId():
+        else if (RecordingStopped::sbeTemplateId() == templateId)
         {
             RecordingStopped event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -113,10 +108,6 @@ void RecordingEventsAdapter::onFragment(
                 event.recordingId(),
                 event.startPosition(),
                 event.stopPosition());
-            break;
         }
-
-        default:
-            break;
     }
 }

--- a/aeron-archive/src/main/cpp/client/RecordingEventsPoller.cpp
+++ b/aeron-archive/src/main/cpp/client/RecordingEventsPoller.cpp
@@ -57,9 +57,8 @@ void RecordingEventsPoller::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case RecordingStarted::sbeTemplateId():
+        if (RecordingStarted::sbeTemplateId() == templateId)
         {
             RecordingStarted event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -73,10 +72,8 @@ void RecordingEventsPoller::onFragment(
             m_recordingPosition = m_recordingStartPosition;
             m_recordingStopPosition = aeron::NULL_VALUE;
             m_pollComplete = true;
-            break;
         }
-
-        case RecordingProgress::sbeTemplateId():
+        else if (RecordingProgress::sbeTemplateId() == templateId)
         {
             RecordingProgress event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -90,10 +87,8 @@ void RecordingEventsPoller::onFragment(
             m_recordingPosition = event.position();
             m_recordingStopPosition = aeron::NULL_VALUE;
             m_pollComplete = true;
-            break;
         }
-
-        case RecordingStopped::sbeTemplateId():
+        else if (RecordingStopped::sbeTemplateId() == templateId)
         {
             RecordingStopped event(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -107,10 +102,6 @@ void RecordingEventsPoller::onFragment(
             m_recordingPosition = event.stopPosition();
             m_recordingStopPosition = m_recordingPosition;
             m_pollComplete = true;
-            break;
         }
-
-        default:
-            break;
     }
 }

--- a/aeron-archive/src/main/cpp/client/RecordingSignalAdapter.cpp
+++ b/aeron-archive/src/main/cpp/client/RecordingSignalAdapter.cpp
@@ -71,9 +71,8 @@ ControlledPollAction RecordingSignalAdapter::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case ControlResponse::sbeTemplateId():
+        if (ControlResponse::sbeTemplateId() == templateId)
         {
             ControlResponse response(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -90,10 +89,8 @@ ControlledPollAction RecordingSignalAdapter::onFragment(
                     response.code(),
                     response.errorMessage());
             }
-            break;
         }
-
-        case RecordingSignalEvent::sbeTemplateId():
+        else if (RecordingSignalEvent::sbeTemplateId() == templateId)
         {
             RecordingSignalEvent recordingSignalEvent(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -113,9 +110,7 @@ ControlledPollAction RecordingSignalAdapter::onFragment(
                 m_isAbort = true;
                 return ControlledPollAction::BREAK;
             }
-            break;
         }
     }
-
     return ControlledPollAction::CONTINUE;
 }

--- a/aeron-archive/src/main/cpp/client/RecordingSubscriptionDescriptorPoller.cpp
+++ b/aeron-archive/src/main/cpp/client/RecordingSubscriptionDescriptorPoller.cpp
@@ -69,9 +69,8 @@ ControlledPollAction RecordingSubscriptionDescriptorPoller::onFragment(
     }
 
     const std::uint16_t templateId = msgHeader.templateId();
-    switch (templateId)
     {
-        case ControlResponse::sbeTemplateId():
+        if (ControlResponse::sbeTemplateId() == templateId)
         {
             ControlResponse response(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -109,10 +108,8 @@ ControlledPollAction RecordingSubscriptionDescriptorPoller::onFragment(
                     }
                 }
             }
-            break;
         }
-
-        case RecordingSubscriptionDescriptor::sbeTemplateId():
+        else if (RecordingSubscriptionDescriptor::sbeTemplateId() == templateId)
         {
             RecordingSubscriptionDescriptor descriptor(
                 buffer.sbeData() + offset + MessageHeader::encodedLength(),
@@ -136,11 +133,7 @@ ControlledPollAction RecordingSubscriptionDescriptorPoller::onFragment(
                     return ControlledPollAction::BREAK;
                 }
             }
-            break;
         }
-
-        default:
-            break;
     }
 
     return ControlledPollAction::CONTINUE;


### PR DESCRIPTION
For reduce the patch size of #999 
Without this change, then aeron-archive always depends on constexpr, all other part are not depends on C++17