### PR TITLE
[CPP] make sure the cnc.dat have valid file length before init mpsc

### DIFF
--- a/aeron-client/src/main/cpp/Aeron.h
+++ b/aeron-client/src/main/cpp/Aeron.h
@@ -437,8 +437,6 @@ private:
     SleepingIdleStrategy m_idleStrategy;
     AgentRunner<ClientConductor, SleepingIdleStrategy> m_conductorRunner;
     AgentInvoker<ClientConductor> m_conductorInvoker;
-
-    MemoryMappedFile::ptr_t mapCncFile(Context &context);
 };
 
 }

--- a/aeron-client/src/main/cpp/Context.h
+++ b/aeron-client/src/main/cpp/Context.h
@@ -415,7 +415,9 @@ public:
     }
 
     static void requestDriverTermination(
-        const std::string &directory, const std::uint8_t *tokenBuffer, std::size_t tokenLength);
+        const std::string &directory,
+        const std::uint8_t *tokenBuffer,
+        std::size_t tokenLength, long timeoutMs = DEFAULT_MEDIA_DRIVER_TIMEOUT_MS);
 
     static std::string defaultAeronPath();
 


### PR DESCRIPTION
Without this patch, the following error arise:
```
74/74 Test #74: archiveTest .........................***Failed   10.65 sec
Running main() from D:\a\aeron\aeron\cppbuild\Release\thirdparty\gmock\src\gmock\googletest\src\gtest_main.cc
[==========] Running 13 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 13 tests from AeronArchiveTest
[ RUN      ] AeronArchiveTest.shouldSpinUpArchiveAndShutdown
Shutdown Archive...
ArchivingMediaDriver PID 476
Java 1.8
C:/Program Files/Java/jdk8u262-b10/bin/java.exe
D:/a/aeron/aeron/aeron-all/build/libs/aeron-all-1.29.1-SNAPSHOT.jar
D:/a/aeron/aeron/cppbuild/Release/aeron-archive/src/test/cpp/archive
Shutting down PID 476
Waiting finished: 0
Deleting C:\Users\RUNNER~1\AppData\Local\Temp\aeron-runneradmin
Deleting D:/a/aeron/aeron/cppbuild/Release/aeron-archive/src/test/cpp/archive
[       OK ] AeronArchiveTest.shouldSpinUpArchiveAndShutdown (1075 ms)
[ RUN      ] AeronArchiveTest.shouldBeAbleToConnectToArchive
Exception in thread "main" java.nio.file.FileSystemException: C:\Users\RUNNER~1\AppData\Local\Temp\aeron-runneradmin\cnc.dat: The process cannot access the file because it is being used by another process.
```
Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>