### PR TITLE
[Java] Auto-resize Catalog when full.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -85,7 +85,9 @@ public enum ArchiveEventCode implements EventCode
     CONTROL_SESSION_STATE_CHANGE(35, -1,
         (event, buffer, offset, builder) -> dissectControlSessionStateChange(buffer, offset, builder)),
     REPLAY_SESSION_ERROR(36, -1,
-        (event, buffer, offset, builder) -> dissectReplaySessionError(buffer, offset, builder));
+        (event, buffer, offset, builder) -> dissectReplaySessionError(buffer, offset, builder)),
+    CATALOG_RESIZE(37, -1,
+        (event, buffer, offset, builder) -> dissectCatalogResize(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();
     private static final ArchiveEventCode[] EVENT_CODE_BY_ID;

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -21,6 +21,7 @@ import org.agrona.MutableDirectBuffer;
 import static io.aeron.agent.ArchiveEventCode.*;
 import static io.aeron.agent.CommonEventDissector.dissectLogHeader;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
 
 final class ArchiveEventDissector
@@ -459,6 +460,27 @@ final class ArchiveEventDissector
         builder.append(", recordingId=").append(recordingId);
         builder.append(", errorMessage=");
         buffer.getStringAscii(absoluteOffset, builder);
+    }
+
+    static void dissectCatalogResize(
+        final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, CATALOG_RESIZE, buffer, absoluteOffset, builder);
+
+        final int maxEntries = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_INT;
+        final long catalogLength = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+
+        final int newMaxEntries = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_INT;
+        final long newCatalogLength = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+
+        builder.append(": ").append(maxEntries);
+        builder.append(" entries (").append(catalogLength).append(" bytes)");
+        builder.append(" => ").append(newMaxEntries);
+        builder.append(" entries (").append(newCatalogLength).append(" bytes)");
     }
 
     private static void appendConnect(final StringBuilder builder)

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
@@ -76,4 +76,29 @@ final class ArchiveEventEncoder
 
         encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - (SIZE_OF_INT * 2), errorMessage);
     }
+
+    static void encodeCatalogResize(
+        final UnsafeBuffer encodingBuffer,
+        final int offset,
+        final int captureLength,
+        final int length,
+        final int maxEntries,
+        final long catalogLength,
+        final int newMaxEntries,
+        final long newCatalogLength)
+    {
+        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+
+        encodingBuffer.putInt(offset + relativeOffset, maxEntries, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putLong(offset + relativeOffset, catalogLength, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_LONG;
+
+        encodingBuffer.putInt(offset + relativeOffset, newMaxEntries, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putLong(offset + relativeOffset, newCatalogLength, LITTLE_ENDIAN);
+    }
+
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveInterceptor.java
@@ -52,4 +52,14 @@ class ArchiveInterceptor
             LOGGER.logReplaySessionError(sessionId, recordingId, errorMessage);
         }
     }
+
+    static class Catalog
+    {
+        @Advice.OnMethodEnter
+        static void catalogResized(
+            final int maxEntries, final long catalogLength, final int newMaxEntries, final long newCatalogLength)
+        {
+            LOGGER.logCatalogResize(maxEntries, catalogLength, newMaxEntries, newCatalogLength);
+        }
+    }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -298,6 +298,7 @@ public final class EventLogAgent
         tempBuilder = addArchiveReplicationSessionInstrumentation(tempBuilder);
         tempBuilder = addArchiveControlSessionInstrumentation(tempBuilder);
         tempBuilder = addArchiveReplaySessionInstrumentation(tempBuilder);
+        tempBuilder = addArchiveCatalogInstrumentation(tempBuilder);
 
         return tempBuilder;
     }
@@ -370,6 +371,20 @@ public final class EventLogAgent
             .transform(((builder, typeDescription, classLoader, module) -> builder
                 .visit(to(ArchiveInterceptor.ReplaySession.class)
                     .on(named("onPendingError")))));
+    }
+
+    private static AgentBuilder addArchiveCatalogInstrumentation(final AgentBuilder agentBuilder)
+    {
+        if (!ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CATALOG_RESIZE))
+        {
+            return agentBuilder;
+        }
+
+        return agentBuilder
+            .type(nameEndsWith("Catalog"))
+            .transform(((builder, typeDescription, classLoader, module) -> builder
+                .visit(to(ArchiveInterceptor.Catalog.class)
+                    .on(named("catalogResized")))));
     }
 
     private static AgentBuilder addClusterInstrumentation(final AgentBuilder agentBuilder)

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -27,6 +27,7 @@ import static io.aeron.agent.EventConfiguration.MAX_EVENT_LENGTH;
 import static io.aeron.archive.codecs.ControlResponseCode.NULL_VAL;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -814,6 +815,22 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.6] " + CONTEXT + ": " + REPLAY_SESSION_ERROR.name() + " [6/100]:" +
             " sessionId=-8, recordingId=42, errorMessage=something went wrong",
+            builder.toString());
+    }
+
+    @Test
+    void catalogResize()
+    {
+        internalEncodeLogHeader(buffer, 0, 6, 100, () -> 5_600_000_000L);
+        buffer.putInt(LOG_HEADER_LENGTH, 24, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_INT, 100, LITTLE_ENDIAN);
+        buffer.putInt(LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, 777, LITTLE_ENDIAN);
+        buffer.putLong(LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, 10_000_000_000L, LITTLE_ENDIAN);
+
+        dissectCatalogResize(buffer, 0, builder);
+
+        assertEquals("[5.6] " + CONTEXT + ": " + CATALOG_RESIZE.name() + " [6/100]:" +
+            " 24 entries (100 bytes) => 777 entries (10000000000 bytes)",
             builder.toString());
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventEncoderTest.java
@@ -87,4 +87,27 @@ class ArchiveEventEncoderTest
         assertEquals(recordingId, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG));
         assertEquals(errorMessage, buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG * 2));
     }
+
+    @Test
+    void testEncodeCatalogResize()
+    {
+        final int offset = 24;
+        final int length = SIZE_OF_LONG * 2 + SIZE_OF_INT * 2;
+        final int captureLength = captureLength(length);
+        final int maxEntries = 3;
+        final long catalogLength = 128;
+        final int newMaxEntries = 7;
+        final long newCatalogLength = 1024;
+
+        encodeCatalogResize(
+            buffer, offset, captureLength, length, maxEntries, catalogLength, newMaxEntries, newCatalogLength);
+
+        assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
+        assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
+        assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(maxEntries, buffer.getInt(offset + LOG_HEADER_LENGTH));
+        assertEquals(catalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT));
+        assertEquals(newMaxEntries, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG));
+        assertEquals(newCatalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH + 2 * SIZE_OF_INT + SIZE_OF_LONG));
+    }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -197,7 +197,7 @@ class Catalog implements AutoCloseable
             }
             else
             {
-                forceWrites(archiveDirChannel, forceWrites, forceMetadata);
+                forceWrites(archiveDirChannel);
                 recordLength = DEFAULT_RECORD_LENGTH;
 
                 new CatalogHeaderEncoder()
@@ -376,7 +376,7 @@ class Catalog implements AutoCloseable
             .length(descriptorEncoder.encodedLength())
             .valid(VALID);
 
-        forceWrites(catalogChannel, forceWrites, forceMetadata);
+        forceWrites(catalogChannel);
 
         return recordingId;
     }
@@ -573,7 +573,7 @@ class Catalog implements AutoCloseable
 
         fieldAccessBuffer.putLong(offset + stopTimestampEncodingOffset(), timestampMs, BYTE_ORDER);
         fieldAccessBuffer.putLongVolatile(offset + stopPositionEncodingOffset(), stopPosition);
-        forceWrites(catalogChannel, forceWrites, forceMetadata);
+        forceWrites(catalogChannel);
     }
 
     void stopPosition(final long recordingId, final long position)
@@ -582,7 +582,7 @@ class Catalog implements AutoCloseable
         final long stopPosition = nativeOrder() == BYTE_ORDER ? position : Long.reverseBytes(position);
 
         fieldAccessBuffer.putLongVolatile(offset + stopPositionEncodingOffset(), stopPosition);
-        forceWrites(catalogChannel, forceWrites, forceMetadata);
+        forceWrites(catalogChannel);
     }
 
     void extendRecording(
@@ -596,7 +596,7 @@ class Catalog implements AutoCloseable
         fieldAccessBuffer.putLong(offset + stopTimestampEncodingOffset(), NULL_TIMESTAMP, BYTE_ORDER);
         fieldAccessBuffer.putInt(offset + sessionIdEncodingOffset(), sessionId, BYTE_ORDER);
         fieldAccessBuffer.putLongVolatile(offset + stopPositionEncodingOffset(), stopPosition);
-        forceWrites(catalogChannel, forceWrites, forceMetadata);
+        forceWrites(catalogChannel);
     }
 
     long startPosition(final long recordingId)
@@ -617,7 +617,7 @@ class Catalog implements AutoCloseable
             startPositionEncodingOffset();
 
         fieldAccessBuffer.putLong(offset, position, BYTE_ORDER);
-        forceWrites(catalogChannel, forceWrites, forceMetadata);
+        forceWrites(catalogChannel);
     }
 
     long stopPosition(final long recordingId)
@@ -754,7 +754,7 @@ class Catalog implements AutoCloseable
         nextRecordingId = recordingId + 1;
     }
 
-    private void forceWrites(final FileChannel channel, final boolean forceWrites, final boolean forceMetadata)
+    private void forceWrites(final FileChannel channel)
     {
         if (null != channel && forceWrites)
         {

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -296,8 +296,7 @@ class Catalog implements AutoCloseable
         if (!isClosed)
         {
             isClosed = true;
-            CloseHelper.quietClose(catalogChannel); // Ignore error so that the rest can be closed
-            IoUtil.unmap(catalogByteBuffer);
+            closeAndUnmapBuffer();
         }
     }
 
@@ -702,7 +701,7 @@ class Catalog implements AutoCloseable
 
         try
         {
-            catalogChannel.close();
+            closeAndUnmapBuffer();
             catalogChannel = FileChannel.open(catalogFile.toPath(), READ, WRITE, SPARSE);
             catalogByteBuffer = catalogChannel.map(READ_WRITE, 0, newCatalogLength);
         }
@@ -895,6 +894,12 @@ class Catalog implements AutoCloseable
     static boolean fragmentStraddlesPageBoundary(final int fragmentOffset, final int fragmentLength)
     {
         return fragmentOffset / PAGE_SIZE != (fragmentOffset + (fragmentLength - 1)) / PAGE_SIZE;
+    }
+
+    private void closeAndUnmapBuffer()
+    {
+        CloseHelper.quietClose(catalogChannel); // Ignore error so that the rest can be closed
+        IoUtil.unmap(catalogByteBuffer);
     }
 
     private static int recoverStopOffset(

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -719,11 +719,11 @@ class Catalog implements AutoCloseable
         final int newMaxEntries = (int)calculateMaxEntries(newCatalogLength, recordLength);
         maxRecordingId = newMaxEntries - 1;
 
-        catalogSizeChanged(oldMaxEntries, catalogLength, newMaxEntries, newCatalogLength);
+        catalogResized(oldMaxEntries, catalogLength, newMaxEntries, newCatalogLength);
     }
 
     @SuppressWarnings("unused")
-    void catalogSizeChanged(
+    void catalogResized(
         final int maxEntries, final long catalogLength, final int newMaxEntries, final long newCatalogLength)
     {
 //        System.out.println("Catalog size changed: " + maxEntries + " entries (" + catalogLength + " bytes) => " +


### PR DESCRIPTION
Catalog will auto-resize from within `io.aeron.archive.Catalog#addNewRecording(long, long, long, long, int, int, int, int, int, int, java.lang.String, java.lang.String, java.lang.String)` method whenever Catalog is full. If resize is not possible then an `ArchiveException` will be thrown.

The resize event is logged in the Agent under new event type `CATALOG_RESIZE`. The logging will print old maxEntries/catalogLength and the new ones after the resize, e.g.:
```
24 entries (100 bytes) => 777 entries (10000000000 bytes)
```