### PR TITLE
[C] Track images in a separate map to other resources to prevent id c…

### DIFF
--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -726,9 +726,9 @@ void aeron_client_conductor_force_close_resources(aeron_client_conductor_t *cond
      */
 
     aeron_int64_to_ptr_hash_map_for_each(
-        &conductor->resource_by_id_map, aeron_client_conductor_force_close_resource, NULL);
-    aeron_int64_to_ptr_hash_map_for_each(
         &conductor->image_by_id_map, aeron_client_conductor_force_close_resource, NULL);
+    aeron_int64_to_ptr_hash_map_for_each(
+        &conductor->resource_by_id_map, aeron_client_conductor_force_close_resource, NULL);
 }
 
 int aeron_client_conductor_linger_image(aeron_client_conductor_t *conductor, aeron_image_t *image)

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #include "aeron_client_conductor.h"
 #include "aeron_publication.h"
@@ -83,6 +84,15 @@ int aeron_client_conductor_init(aeron_client_conductor_t *conductor, aeron_conte
         int errcode = errno;
 
         aeron_set_err(errcode, "aeron_client_conductor_init - resource_by_id_map: %s", strerror(errcode));
+        return -1;
+    }
+
+    if (aeron_int64_to_ptr_hash_map_init(
+        &conductor->image_by_id_map, 16, AERON_MAP_DEFAULT_LOAD_FACTOR) < 0)
+    {
+        int errcode = errno;
+
+        aeron_set_err(errcode, "aeron_client_conductor_init - image_by_id_map: %s", strerror(errcode));
         return -1;
     }
 
@@ -647,6 +657,8 @@ void aeron_client_conductor_on_close(aeron_client_conductor_t *conductor)
         &conductor->log_buffer_by_id_map, aeron_client_conductor_delete_log_buffer, NULL);
     aeron_int64_to_ptr_hash_map_for_each(
         &conductor->resource_by_id_map, aeron_client_conductor_delete_resource, NULL);
+    aeron_int64_to_ptr_hash_map_for_each(
+        &conductor->image_by_id_map, aeron_client_conductor_delete_resource, NULL);
 
     for (size_t i = 0, length = conductor->lingering_resources.length; i < length; i++)
     {
@@ -655,6 +667,7 @@ void aeron_client_conductor_on_close(aeron_client_conductor_t *conductor)
 
     aeron_int64_to_ptr_hash_map_delete(&conductor->log_buffer_by_id_map);
     aeron_int64_to_ptr_hash_map_delete(&conductor->resource_by_id_map);
+    aeron_int64_to_ptr_hash_map_delete(&conductor->image_by_id_map);
     aeron_free(conductor->registering_resources.array);
     aeron_free(conductor->lingering_resources.array);
     aeron_free(conductor->available_counter_handlers.array);
@@ -714,6 +727,8 @@ void aeron_client_conductor_force_close_resources(aeron_client_conductor_t *cond
 
     aeron_int64_to_ptr_hash_map_for_each(
         &conductor->resource_by_id_map, aeron_client_conductor_force_close_resource, NULL);
+    aeron_int64_to_ptr_hash_map_for_each(
+        &conductor->image_by_id_map, aeron_client_conductor_force_close_resource, NULL);
 }
 
 int aeron_client_conductor_linger_image(aeron_client_conductor_t *conductor, aeron_image_t *image)
@@ -754,7 +769,7 @@ int aeron_client_conductor_linger_or_delete_all_images(
         aeron_image_decr_refcnt(image);
         refcnt = aeron_image_refcnt_volatile(image);
 
-        aeron_int64_to_ptr_hash_map_remove(&conductor->resource_by_id_map, image->correlation_id);
+        aeron_int64_to_ptr_hash_map_remove(&conductor->image_by_id_map, image->correlation_id);
 
         if (refcnt <= 0)
         {
@@ -1907,7 +1922,8 @@ int aeron_client_conductor_on_available_image(
             return -1;
         }
 
-        if (aeron_int64_to_ptr_hash_map_put(&conductor->resource_by_id_map, response->correlation_id, image) < 0)
+        size_t size = conductor->image_by_id_map.size;
+        if (aeron_int64_to_ptr_hash_map_put(&conductor->image_by_id_map, response->correlation_id, image) < 0)
         {
             int errcode = errno;
 
@@ -1915,6 +1931,7 @@ int aeron_client_conductor_on_available_image(
                 errcode, strerror(errcode));
             return -1;
         }
+        assert(size < conductor->image_by_id_map.size);
 
         if (aeron_client_conductor_subscription_add_image(subscription, image) < 0)
         {
@@ -1942,7 +1959,7 @@ int aeron_client_conductor_on_unavailable_image(
     if (NULL != subscription)
     {
         aeron_image_t *image = aeron_int64_to_ptr_hash_map_remove(
-            &conductor->resource_by_id_map, response->correlation_id);
+            &conductor->image_by_id_map, response->correlation_id);
 
         if (NULL != image)
         {

--- a/aeron-client/src/main/c/aeron_client_conductor.h
+++ b/aeron-client/src/main/c/aeron_client_conductor.h
@@ -156,6 +156,7 @@ typedef struct aeron_client_conductor_stct
 
     aeron_int64_to_ptr_hash_map_t log_buffer_by_id_map;
     aeron_int64_to_ptr_hash_map_t resource_by_id_map;
+    aeron_int64_to_ptr_hash_map_t image_by_id_map;
 
     struct available_counter_handlers_stct
     {

--- a/aeron-driver/src/test/c/aeron_c_system_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_system_test.cpp
@@ -22,12 +22,11 @@
 #include "aeronc.h"
 
 #define PUB_URI "aeron:udp?endpoint=localhost:24325"
-#define SUB_URI "aeron:udp?endpoint=localhost:24325"
 #define STREAM_ID (117)
 
 using namespace aeron;
 
-class CSystemTest : public testing::Test
+class CSystemTest : public testing::TestWithParam<std::tuple<const char *>>
 {
 public:
     using poll_handler_t = std::function<void(const uint8_t *, size_t, aeron_header_t *)>;
@@ -183,7 +182,12 @@ protected:
     image_handler_t m_onUnavailableImage = nullptr;
 };
 
-TEST_F(CSystemTest, shouldSpinUpDriverAndConnectSuccessfully)
+INSTANTIATE_TEST_SUITE_P(
+    CSystemTestWithParams,
+    CSystemTest,
+    testing::Values(std::make_tuple(PUB_URI), std::make_tuple(AERON_IPC_CHANNEL)));
+
+TEST_P(CSystemTest, shouldSpinUpDriverAndConnectSuccessfully)
 {
     aeron_context_t *context;
     aeron_t *aeron;
@@ -197,35 +201,35 @@ TEST_F(CSystemTest, shouldSpinUpDriverAndConnectSuccessfully)
     aeron_context_close(context);
 }
 
-TEST_F(CSystemTest, shouldAddAndClosePublication)
+TEST_P(CSystemTest, shouldAddAndClosePublication)
 {
     aeron_async_add_publication_t *async;
     aeron_publication_t *publication;
 
     ASSERT_TRUE(connect());
 
-    ASSERT_EQ(aeron_async_add_publication(&async, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async, m_aeron, std::get<0>(GetParam()), STREAM_ID), 0);
 
     ASSERT_TRUE((publication = awaitPublicationOrError(async))) << aeron_errmsg();
 
     aeron_publication_close(publication);
 }
 
-TEST_F(CSystemTest, shouldAddAndCloseExclusivePublication)
+TEST_P(CSystemTest, shouldAddAndCloseExclusivePublication)
 {
     aeron_async_add_exclusive_publication_t *async;
     aeron_exclusive_publication_t *publication;
 
     ASSERT_TRUE(connect());
 
-    ASSERT_EQ(aeron_async_add_exclusive_publication(&async, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&async, m_aeron, std::get<0>(GetParam()), STREAM_ID), 0);
 
     ASSERT_TRUE((publication = awaitExclusivePublicationOrError(async))) << aeron_errmsg();
 
     aeron_exclusive_publication_close(publication);
 }
 
-TEST_F(CSystemTest, shouldAddAndCloseSubscription)
+TEST_P(CSystemTest, shouldAddAndCloseSubscription)
 {
     aeron_async_add_subscription_t *async;
     aeron_subscription_t *subscription;
@@ -233,14 +237,14 @@ TEST_F(CSystemTest, shouldAddAndCloseSubscription)
     ASSERT_TRUE(connect());
 
     ASSERT_EQ(aeron_async_add_subscription(
-        &async, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+        &async, m_aeron, std::get<0>(GetParam()), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
 
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async))) << aeron_errmsg();
 
     aeron_subscription_close(subscription);
 }
 
-TEST_F(CSystemTest, shouldAddAndCloseCounter)
+TEST_P(CSystemTest, shouldAddAndCloseCounter)
 {
     aeron_async_add_counter_t *async;
     aeron_counter_t *counter;
@@ -255,7 +259,7 @@ TEST_F(CSystemTest, shouldAddAndCloseCounter)
     aeron_counter_close(counter);
 }
 
-TEST_F(CSystemTest, shouldAddPublicationAndSubscription)
+TEST_P(CSystemTest, shouldAddPublicationAndSubscription)
 {
     aeron_async_add_publication_t *async_pub;
     aeron_publication_t *publication;
@@ -264,12 +268,12 @@ TEST_F(CSystemTest, shouldAddPublicationAndSubscription)
 
     ASSERT_TRUE(connect());
 
-    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, std::get<0>(GetParam()), STREAM_ID), 0);
 
     ASSERT_TRUE((publication = awaitPublicationOrError(async_pub))) << aeron_errmsg();
 
     ASSERT_EQ(aeron_async_add_subscription(
-        &async_sub, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+        &async_sub, m_aeron, std::get<0>(GetParam()), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
 
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async_sub))) << aeron_errmsg();
 
@@ -279,7 +283,7 @@ TEST_F(CSystemTest, shouldAddPublicationAndSubscription)
     EXPECT_EQ(aeron_subscription_close(subscription), 0);
 }
 
-TEST_F(CSystemTest, shouldOfferAndPollOneMessage)
+TEST_P(CSystemTest, shouldOfferAndPollOneMessage)
 {
     aeron_async_add_publication_t *async_pub;
     aeron_publication_t *publication;
@@ -288,10 +292,10 @@ TEST_F(CSystemTest, shouldOfferAndPollOneMessage)
     const char message[] = "message";
 
     ASSERT_TRUE(connect());
-    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, std::get<0>(GetParam()), STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitPublicationOrError(async_pub))) << aeron_errmsg();
     ASSERT_EQ(aeron_async_add_subscription(
-        &async_sub, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+        &async_sub, m_aeron, std::get<0>(GetParam()), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async_sub))) << aeron_errmsg();
     awaitConnected(subscription);
 
@@ -320,7 +324,7 @@ TEST_F(CSystemTest, shouldOfferAndPollOneMessage)
     EXPECT_EQ(aeron_subscription_close(subscription), 0);
 }
 
-TEST_F(CSystemTest, shouldOfferAndPollThreeTermsOfMessages)
+TEST_P(CSystemTest, shouldOfferAndPollThreeTermsOfMessages)
 {
     aeron_async_add_publication_t *async_pub;
     aeron_publication_t *publication;
@@ -328,12 +332,15 @@ TEST_F(CSystemTest, shouldOfferAndPollThreeTermsOfMessages)
     aeron_subscription_t *subscription;
     const char message[1024] = "message";
     size_t num_messages = 64 * 3 + 1;
+    const char *uri = std::get<0>(GetParam());
+    bool isIpc = 0 == strncmp(AERON_IPC_CHANNEL, uri, strlen(AERON_IPC_CHANNEL) + 1);
+    std::string pubUri = isIpc ? std::string(uri) : std::string(uri) + "|term-length=64k";
 
     ASSERT_TRUE(connect());
-    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, PUB_URI "|term-length=64k", STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, pubUri.c_str(), STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitPublicationOrError(async_pub))) << aeron_errmsg();
     ASSERT_EQ(aeron_async_add_subscription(
-        &async_sub, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+        &async_sub, m_aeron, uri, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async_sub))) << aeron_errmsg();
     awaitConnected(subscription);
 
@@ -365,7 +372,7 @@ TEST_F(CSystemTest, shouldOfferAndPollThreeTermsOfMessages)
     EXPECT_EQ(aeron_subscription_close(subscription), 0);
 }
 
-TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithNoPollAfter)
+TEST_P(CSystemTest, shouldAllowImageToGoUnavailableWithNoPollAfter)
 {
     aeron_async_add_publication_t *async_pub;
     aeron_publication_t *publication;
@@ -374,6 +381,9 @@ TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithNoPollAfter)
     const char message[1024] = "message";
     size_t num_messages = 11;
     std::atomic<bool> on_unavailable_image_called = { false };
+    const char *uri = std::get<0>(GetParam());
+    bool isIpc = 0 == strncmp(AERON_IPC_CHANNEL, uri, strlen(AERON_IPC_CHANNEL) + 1);
+    std::string pubUri = isIpc ? std::string(uri) : std::string(uri) + "|linger=0";
 
     m_onUnavailableImage = [&](aeron_subscription_t *, aeron_image_t *)
     {
@@ -381,10 +391,10 @@ TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithNoPollAfter)
     };
 
     ASSERT_TRUE(connect());
-    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, PUB_URI "|linger=0", STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, pubUri.c_str(), STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitPublicationOrError(async_pub))) << aeron_errmsg();
     ASSERT_EQ(aeron_async_add_subscription(
-        &async_sub, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, onUnavailableImage, this), 0);
+        &async_sub, m_aeron, uri, STREAM_ID, nullptr, nullptr, onUnavailableImage, this), 0);
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async_sub))) << aeron_errmsg();
     awaitConnected(subscription);
 
@@ -422,7 +432,7 @@ TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithNoPollAfter)
     EXPECT_EQ(aeron_subscription_close(subscription), 0);
 }
 
-TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithPollAfter)
+TEST_P(CSystemTest, shouldAllowImageToGoUnavailableWithPollAfter)
 {
     aeron_async_add_publication_t *async_pub;
     aeron_publication_t *publication;
@@ -431,6 +441,9 @@ TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithPollAfter)
     const char message[1024] = "message";
     size_t num_messages = 11;
     std::atomic<bool> on_unavailable_image_called = { false };
+    const char *uri = std::get<0>(GetParam());
+    bool isIpc = 0 == strncmp(AERON_IPC_CHANNEL, uri, strlen(AERON_IPC_CHANNEL) + 1);
+    std::string pubUri = isIpc ? std::string(uri) : std::string(uri) + "|linger=0";
 
     m_onUnavailableImage = [&](aeron_subscription_t *, aeron_image_t *)
     {
@@ -438,10 +451,10 @@ TEST_F(CSystemTest, shouldAllowImageToGoUnavailableWithPollAfter)
     };
 
     ASSERT_TRUE(connect());
-    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, PUB_URI "|linger=0", STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, pubUri.c_str(), STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitPublicationOrError(async_pub))) << aeron_errmsg();
     ASSERT_EQ(aeron_async_add_subscription(
-        &async_sub, m_aeron, SUB_URI, STREAM_ID, nullptr, nullptr, onUnavailableImage, this), 0);
+        &async_sub, m_aeron, uri, STREAM_ID, nullptr, nullptr, onUnavailableImage, this), 0);
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async_sub))) << aeron_errmsg();
     awaitConnected(subscription);
 


### PR DESCRIPTION
…lashes.  Parameterise C system test to include IPC channels.