### PR TITLE
[C] Add notifications that resources (publications, subscriptions, counters) have been closed.

### DIFF
--- a/aeron-client/src/main/c/aeron_client_conductor.h
+++ b/aeron-client/src/main/c/aeron_client_conductor.h
@@ -251,12 +251,18 @@ void aeron_client_conductor_on_cmd_close_publication(void *clientd, void *item);
 int aeron_client_conductor_async_add_publication(
     aeron_async_add_publication_t **async, aeron_client_conductor_t *conductor, const char *uri, int32_t stream_id);
 int aeron_client_conductor_async_close_publication(
-    aeron_client_conductor_t *conductor, aeron_publication_t *publication);
+    aeron_client_conductor_t *conductor,
+    aeron_publication_t *publication,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 int aeron_client_conductor_async_add_exclusive_publication(
     aeron_async_add_exclusive_publication_t **async, aeron_client_conductor_t *conductor, const char *uri, int32_t stream_id);
 int aeron_client_conductor_async_close_exclusive_publication(
-    aeron_client_conductor_t *conductor, aeron_exclusive_publication_t *publication);
+    aeron_client_conductor_t *conductor,
+    aeron_exclusive_publication_t *publication,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 int aeron_client_conductor_async_add_subscription(
     aeron_async_add_subscription_t **async,
@@ -268,7 +274,10 @@ int aeron_client_conductor_async_add_subscription(
     aeron_on_unavailable_image_t on_unavailable_image_handler,
     void *on_unavailable_image_clientd);
 int aeron_client_conductor_async_close_subscription(
-    aeron_client_conductor_t *conductor, aeron_subscription_t *subscription);
+    aeron_client_conductor_t *conductor,
+    aeron_subscription_t *subscription,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 int aeron_client_conductor_async_add_counter(
     aeron_async_add_counter_t **async,
@@ -278,7 +287,11 @@ int aeron_client_conductor_async_add_counter(
     size_t key_buffer_length,
     const char *label_buffer,
     size_t label_buffer_length);
-int aeron_client_conductor_async_close_counter(aeron_client_conductor_t *conductor, aeron_counter_t *counter);
+int aeron_client_conductor_async_close_counter(
+    aeron_client_conductor_t *conductor,
+    aeron_counter_t *counter,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 int aeron_client_conductor_async_handler(aeron_client_conductor_t *conductor, aeron_client_handler_cmd_t *cmd);
 

--- a/aeron-client/src/main/c/aeron_counter.c
+++ b/aeron-client/src/main/c/aeron_counter.c
@@ -78,7 +78,8 @@ int aeron_counter_constants(aeron_counter_t *counter, aeron_counter_constants_t 
     return 0;
 }
 
-int aeron_counter_close(aeron_counter_t *counter)
+int aeron_counter_close(
+    aeron_counter_t *counter, aeron_notification_t on_close_complete, void *on_close_complete_clientd)
 {
     if (NULL != counter)
     {
@@ -88,7 +89,8 @@ int aeron_counter_close(aeron_counter_t *counter)
         if (!is_closed)
         {
             AERON_PUT_ORDERED(counter->is_closed, true);
-            if (aeron_client_conductor_async_close_counter(counter->conductor, counter) < 0)
+            if (aeron_client_conductor_async_close_counter(
+                counter->conductor, counter, on_close_complete, on_close_complete_clientd) < 0)
             {
                 return -1;
             }

--- a/aeron-client/src/main/c/aeron_counter.h
+++ b/aeron-client/src/main/c/aeron_counter.h
@@ -31,6 +31,8 @@ typedef struct aeron_counter_stct
     int64_t registration_id;
     int32_t counter_id;
 
+    aeron_notification_t on_close_complete;
+    void *on_close_complete_clientd;
     bool is_closed;
 }
 aeron_counter_t;

--- a/aeron-client/src/main/c/aeron_exclusive_publication.c
+++ b/aeron-client/src/main/c/aeron_exclusive_publication.c
@@ -105,7 +105,10 @@ void aeron_exclusive_publication_force_close(aeron_exclusive_publication_t *publ
     AERON_PUT_ORDERED(publication->is_closed, true);
 }
 
-int aeron_exclusive_publication_close(aeron_exclusive_publication_t *publication)
+int aeron_exclusive_publication_close(
+    aeron_exclusive_publication_t *publication,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd)
 {
     if (NULL != publication)
     {
@@ -115,7 +118,8 @@ int aeron_exclusive_publication_close(aeron_exclusive_publication_t *publication
         if (!is_closed)
         {
             AERON_PUT_ORDERED(publication->is_closed, true);
-            if (aeron_client_conductor_async_close_exclusive_publication(publication->conductor, publication) < 0)
+            if (aeron_client_conductor_async_close_exclusive_publication(
+                publication->conductor, publication, on_close_complete, on_close_complete_clientd) < 0)
             {
                 return -1;
             }

--- a/aeron-client/src/main/c/aeron_exclusive_publication.h
+++ b/aeron-client/src/main/c/aeron_exclusive_publication.h
@@ -48,6 +48,8 @@ typedef struct aeron_exclusive_publication_stct
 
     int32_t position_limit_counter_id;
     int32_t channel_status_indicator_id;
+    aeron_notification_t on_close_complete;
+    void *on_close_complete_clientd;
 
     bool is_closed;
 

--- a/aeron-client/src/main/c/aeron_publication.c
+++ b/aeron-client/src/main/c/aeron_publication.c
@@ -95,7 +95,8 @@ void aeron_publication_force_close(aeron_publication_t *publication)
     AERON_PUT_ORDERED(publication->is_closed, true);
 }
 
-int aeron_publication_close(aeron_publication_t *publication)
+int aeron_publication_close(
+    aeron_publication_t *publication, aeron_notification_t on_close_complete, void *on_close_complete_clientd)
 {
     if (NULL != publication)
     {
@@ -106,7 +107,8 @@ int aeron_publication_close(aeron_publication_t *publication)
         {
             AERON_PUT_ORDERED(publication->is_closed, true);
 
-            if (aeron_client_conductor_async_close_publication(publication->conductor, publication) < 0)
+            if (aeron_client_conductor_async_close_publication(
+                publication->conductor, publication, on_close_complete, on_close_complete_clientd) < 0)
             {
                 return -1;
             }

--- a/aeron-client/src/main/c/aeron_publication.h
+++ b/aeron-client/src/main/c/aeron_publication.h
@@ -48,6 +48,9 @@ typedef struct aeron_publication_stct
     int32_t position_limit_counter_id;
     int32_t channel_status_indicator_id;
 
+    aeron_notification_t on_close_complete;
+    void *on_close_complete_clientd;
+
     bool is_closed;
 }
 aeron_publication_t;

--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -97,7 +97,8 @@ void aeron_subscription_force_close(aeron_subscription_t *subscription)
     AERON_PUT_ORDERED(subscription->is_closed, true);
 }
 
-int aeron_subscription_close(aeron_subscription_t *subscription)
+int aeron_subscription_close(
+    aeron_subscription_t *subscription, aeron_notification_t on_close_complete, void *on_close_complete_clientd)
 {
     if (NULL != subscription)
     {
@@ -107,7 +108,8 @@ int aeron_subscription_close(aeron_subscription_t *subscription)
         if (!is_closed)
         {
             AERON_PUT_ORDERED(subscription->is_closed, true);
-            if (aeron_client_conductor_async_close_subscription(subscription->conductor, subscription) < 0)
+            if (aeron_client_conductor_async_close_subscription(
+                subscription->conductor, subscription, on_close_complete, on_close_complete_clientd) < 0)
             {
                 return -1;
             }

--- a/aeron-client/src/main/c/aeron_subscription.h
+++ b/aeron-client/src/main/c/aeron_subscription.h
@@ -56,13 +56,15 @@ typedef struct aeron_subscription_stct
     void *on_available_image_clientd;
     aeron_on_unavailable_image_t on_unavailable_image;
     void *on_unavailable_image_clientd;
+    aeron_notification_t on_close_complete;
+    void *on_close_complete_clientd;
 
     int64_t registration_id;
     int32_t stream_id;
     int32_t channel_status_indicator_id;
     size_t round_robin_index;
-    bool is_closed;
 
+    bool is_closed;
     uint8_t post_fields_padding[AERON_CACHE_LINE_LENGTH];
 }
 aeron_subscription_t;

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -103,6 +103,11 @@ bool aeron_context_get_pre_touch_mapped_memory(aeron_context_t *context);
  */
 typedef void (*aeron_error_handler_t)(void *clientd, int errcode, const char *message);
 
+/**
+ * Generalised notification callback.
+ */
+typedef void (*aeron_notification_t)(void *clientd);
+
 int aeron_context_set_error_handler(aeron_context_t *context, aeron_error_handler_t handler, void *clientd);
 aeron_error_handler_t aeron_context_get_error_handler(aeron_context_t *context);
 void *aeron_context_get_error_handler_clientd(aeron_context_t *context);
@@ -883,12 +888,16 @@ int aeron_publication_add_destination(aeron_publication_t* publication, const ch
 int aeron_publication_remove_destination(aeron_publication_t* publication, const char* uri, int64_t* correlation_id);
 
 /**
- * Asynchronously close the publication.
+ * Asynchronously close the publication.  Will callback on the on_complete notification when the subscription is closed.
+ * The callback is optional, use NULL for the on_complete callback if not required.
  *
  * @param publication to close
+ * @param on_close_complete optional callback to execute once the subscription has been closed and freed.  This may happen on a
+ * separate thread, so the caller should ensure that clientd has the appropriate lifetime.
+ * @param on_close_complete_clientd parameter to pass to the on_complete callback.
  * @return 0 for success or -1 for error.
  */
-int aeron_publication_close(aeron_publication_t *publication);
+int aeron_publication_close(aeron_publication_t *publication, aeron_notification_t on_close_complete, void *on_close_complete_clientd);
 
 /*
  * Exclusive Publication functions
@@ -1044,7 +1053,10 @@ int aeron_exclusive_publication_remove_destination(
  * @param publication to close
  * @return 0 for success or -1 for error.
  */
-int aeron_exclusive_publication_close(aeron_exclusive_publication_t *publication);
+int aeron_exclusive_publication_close(
+    aeron_exclusive_publication_t *publication,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 /**
  * Has the exclusive publication closed?
@@ -1359,12 +1371,16 @@ int aeron_subscription_add_destination(aeron_subscription_t *subscription, const
 int aeron_subscription_remove_destination(aeron_subscription_t *subscription, const char *uri, int64_t *correlation_id);
 
 /**
- * Asynchronously close the subscription.
+ * Asynchronously close the subscription.  Will callback on the on_complete notification when the subscription is closed.
+ * The callback is optional, use NULL for the on_complete callback if not required.
  *
  * @param subscription to close
+ * @param on_close_complete optional callback to execute once the subscription has been closed and freed.  This may happen on a
+ * separate thread, so the caller should ensure that clientd has the appropriate lifetime.
+ * @param on_close_complete_clientd parameter to pass to the on_complete callback.
  * @return 0 for success or -1 for error.
  */
-int aeron_subscription_close(aeron_subscription_t *subscription);
+int aeron_subscription_close(aeron_subscription_t *subscription, aeron_notification_t on_close_complete, void *on_close_complete_clientd);
 
 /**
  * Image Functions
@@ -1781,7 +1797,10 @@ int aeron_counter_constants(aeron_counter_t *counter, aeron_counter_constants_t 
  * @param counter to close.
  * @return 0 for success or -1 for error.
  */
-int aeron_counter_close(aeron_counter_t *counter);
+int aeron_counter_close(
+    aeron_counter_t *counter,
+    aeron_notification_t on_close_complete,
+    void *on_close_complete_clientd);
 
 /**
  * Return full version and build string.

--- a/aeron-client/src/test/c/aeron_client_conductor_test.cpp
+++ b/aeron-client/src/test/c/aeron_client_conductor_test.cpp
@@ -361,7 +361,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationSuccessfully)
     ASSERT_GT(aeron_async_add_publication_poll(&publication, async), 0) << aeron_errmsg();
     ASSERT_TRUE(nullptr != publication);
 
-    ASSERT_EQ(aeron_publication_close(publication), 0);
+    ASSERT_EQ(aeron_publication_close(publication, NULL, NULL), 0);
     doWork();
 }
 
@@ -416,7 +416,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationSuccessfully)
     ASSERT_GT(aeron_async_add_exclusive_publication_poll(&publication, async), 0) << aeron_errmsg();
     ASSERT_TRUE(nullptr != publication);
 
-    ASSERT_EQ(aeron_exclusive_publication_close(publication), 0);
+    ASSERT_EQ(aeron_exclusive_publication_close(publication, NULL, NULL), 0);
     doWork();
 }
 
@@ -471,7 +471,7 @@ TEST_F(ClientConductorTest, shouldAddSubscriptionSuccessfully)
     ASSERT_GT(aeron_async_add_subscription_poll(&subscription, async), 0) << aeron_errmsg();
     ASSERT_TRUE(nullptr != subscription);
 
-    ASSERT_EQ(aeron_subscription_close(subscription), 0);
+    ASSERT_EQ(aeron_subscription_close(subscription, NULL, NULL), 0);
     doWork();
 }
 
@@ -528,7 +528,7 @@ TEST_F(ClientConductorTest, shouldAddCounterSuccessfully)
     ASSERT_GT(aeron_async_add_counter_poll(&counter, async), 0) << aeron_errmsg();
     ASSERT_TRUE(nullptr != counter);
 
-    ASSERT_EQ(aeron_counter_close(counter), 0);
+    ASSERT_EQ(aeron_counter_close(counter, NULL, NULL), 0);
     doWork();
 }
 
@@ -600,7 +600,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationAndHandleOnNewPublication)
     EXPECT_TRUE(was_on_new_publication_called);
 
     // graceful close and reclaim for sanitize
-    ASSERT_EQ(aeron_publication_close(publication), 0);
+    ASSERT_EQ(aeron_publication_close(publication, NULL, NULL), 0);
     doWork();
 }
 
@@ -637,7 +637,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationAndHandleOnNewPublicati
     EXPECT_TRUE(was_on_new_exclusive_publication_called);
 
     // graceful close and reclaim for sanitize
-    ASSERT_EQ(aeron_exclusive_publication_close(publication), 0);
+    ASSERT_EQ(aeron_exclusive_publication_close(publication, NULL, NULL), 0);
     doWork();
 }
 
@@ -673,6 +673,6 @@ TEST_F(ClientConductorTest, shouldAddSubscriptionAndHandleOnNewSubscription)
     EXPECT_TRUE(was_on_new_subscription_called);
 
     // graceful close and reclaim for sanitize
-    ASSERT_EQ(aeron_subscription_close(subscription), 0);
+    ASSERT_EQ(aeron_subscription_close(subscription, NULL, NULL), 0);
     doWork();
 }

--- a/aeron-samples/src/main/c/basic_publisher.c
+++ b/aeron-samples/src/main/c/basic_publisher.c
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
     }
 
     cleanup:
-        aeron_publication_close(publication);
+    aeron_publication_close(publication, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
 

--- a/aeron-samples/src/main/c/basic_subscriber.c
+++ b/aeron-samples/src/main/c/basic_subscriber.c
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
     status = EXIT_SUCCESS;
 
     cleanup:
-        aeron_subscription_close(subscription);
+        aeron_subscription_close(subscription, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
         aeron_fragment_assembler_delete(fragment_assembler);

--- a/aeron-samples/src/main/c/cping.c
+++ b/aeron-samples/src/main/c/cping.c
@@ -358,8 +358,8 @@ int main(int argc, char **argv)
 
     cleanup:
         aeron_subscription_image_release(subscription, image);
-        aeron_subscription_close(subscription);
-        aeron_exclusive_publication_close(publication);
+        aeron_subscription_close(subscription, NULL, NULL);
+    aeron_exclusive_publication_close(publication, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
         aeron_image_fragment_assembler_delete(fragment_assembler);

--- a/aeron-samples/src/main/c/cpong.c
+++ b/aeron-samples/src/main/c/cpong.c
@@ -274,8 +274,8 @@ int main(int argc, char **argv)
 
     cleanup:
         aeron_subscription_image_release(subscription, image);
-        aeron_subscription_close(subscription);
-        aeron_exclusive_publication_close(publication);
+        aeron_subscription_close(subscription, NULL, NULL);
+    aeron_exclusive_publication_close(publication, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
         aeron_image_fragment_assembler_delete(fragment_assembler);

--- a/aeron-samples/src/main/c/rate_subscriber.c
+++ b/aeron-samples/src/main/c/rate_subscriber.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
     status = EXIT_SUCCESS;
 
     cleanup:
-        aeron_subscription_close(subscription);
+        aeron_subscription_close(subscription, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
         aeron_fragment_assembler_delete(fragment_assembler);

--- a/aeron-samples/src/main/c/streaming_exclusive_publisher.c
+++ b/aeron-samples/src/main/c/streaming_exclusive_publisher.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
     status = EXIT_SUCCESS;
 
     cleanup:
-        aeron_exclusive_publication_close(publication);
+    aeron_exclusive_publication_close(publication, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
 

--- a/aeron-samples/src/main/c/streaming_publisher.c
+++ b/aeron-samples/src/main/c/streaming_publisher.c
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
     status = EXIT_SUCCESS;
 
     cleanup:
-        aeron_publication_close(publication);
+    aeron_publication_close(publication, NULL, NULL);
         aeron_close(aeron);
         aeron_context_close(context);
         aeron_free(message);


### PR DESCRIPTION
This is useful for knowing when client resourcing can be cleaned up.  The common example is clientd values assigned to subscription's image available/unavailable notifications.  Notifications for publications, exclusive publications, and counters are there for completeness.