### PR TITLE
[Java] Allow control response channel in the Archive to be configured without specifying the port.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2929,8 +2929,13 @@ public class AeronArchive implements AutoCloseable
 
             if (2 == step)
             {
-                if (!archiveProxy.tryConnect(
-                    ctx.controlResponseChannel(), ctx.controlResponseStreamId(), correlationId))
+                final String controlResponseChannel = controlResponsePoller.subscription().tryResolveChannelEndpoint();
+                if (null == controlResponseChannel)
+                {
+                    return null;
+                }
+
+                if (!archiveProxy.tryConnect(controlResponseChannel, ctx.controlResponseStreamId(), correlationId))
                 {
                     return null;
                 }

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2092,11 +2092,28 @@ public class AeronArchive implements AutoCloseable
 
         /**
          * Channel for receiving control response messages from an archive.
+         *
+         * <p>
+         * Channel's <em>endpoint</em> can be specified explicitly (i.e. by providing IP and port pair) or by using
+         * zero as a port number and/or special address {@code 0.0.0.0} as an IP address. Here is an example of valid
+         * response channels:
+         * <ul>
+         *     <li>{@code aeron:udp?endpoint=localhost:8020} - listen on port {@code 8020} on localhost.</li>
+         *     <li>{@code aeron:udp?endpoint=192.168.10.10:8020} - listen on port {@code 8020} on
+         *     {@code 192.168.10.10}.</li>
+         *     <li>{@code aeron:udp?endpoint=localhost:0} - in this case the port is unspecified and the OS
+         *     will assign a free port from an
+         *     <a href="https://en.wikipedia.org/wiki/Ephemeral_port">ephemeral port range</a>.</li>
+         *     <li>{@code aeron:udp?endpoint=0.0.0.0:5555} - special address {@code 0.0.0.0} indicates that
+         *     the underlying socket should listen on all local IPv4 interfaces using port {@code 5555}.</li>
+         *     <li>{@code aeron:udp?endpoint=0.0.0.0:0} - the same as the above but the port should be
+         *     assigned by the OS.</li>
+         * </ul>
          */
         public static final String CONTROL_RESPONSE_CHANNEL_PROP_NAME = "aeron.archive.control.response.channel";
 
         /**
-         * Channel for receiving control response messages from an archive.
+         * Default channel for receiving control response messages from an archive.
          */
         public static final String CONTROL_RESPONSE_CHANNEL_DEFAULT = "aeron:udp?endpoint=localhost:0";
 

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2095,8 +2095,7 @@ public class AeronArchive implements AutoCloseable
          *
          * <p>
          * Channel's <em>endpoint</em> can be specified explicitly (i.e. by providing IP and port pair) or by using
-         * zero as a port number and/or special <em>any address</em> as an IP address. Here is an example of valid
-         * response channels:
+         * zero as a port number. Here is an example of valid response channels:
          * <ul>
          *     <li>{@code aeron:udp?endpoint=localhost:8020} - listen on port {@code 8020} on localhost.</li>
          *     <li>{@code aeron:udp?endpoint=192.168.10.10:8020} - listen on port {@code 8020} on
@@ -2104,14 +2103,6 @@ public class AeronArchive implements AutoCloseable
          *     <li>{@code aeron:udp?endpoint=localhost:0} - in this case the port is unspecified and the OS
          *     will assign a free port from an
          *     <a href="https://en.wikipedia.org/wiki/Ephemeral_port">ephemeral port range</a>.</li>
-         *     <li>{@code aeron:udp?endpoint=0.0.0.0:5555} - special address {@code 0.0.0.0} indicates that
-         *     the underlying socket should listen on all local IPv4 interfaces using port {@code 5555}.</li>
-         *     <li>{@code aeron:udp?endpoint=0.0.0.0:0} - the same as the above but the port should be
-         *     assigned by the OS.</li>
-         *     <li>{@code aeron:udp?endpoint=[::]:5555} - special address {@code [::]} indicates that
-         *     the underlying socket should listen on all local IPv6 interfaces using port {@code 5555}.</li>
-         *     <li>{@code aeron:udp?endpoint=[::]:0} - the same as the above but the port should be
-         *     assigned by the OS.</li>
          * </ul>
          */
         public static final String CONTROL_RESPONSE_CHANNEL_PROP_NAME = "aeron.archive.control.response.channel";

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2098,7 +2098,7 @@ public class AeronArchive implements AutoCloseable
         /**
          * Channel for receiving control response messages from an archive.
          */
-        public static final String CONTROL_RESPONSE_CHANNEL_DEFAULT = "aeron:udp?endpoint=localhost:8020";
+        public static final String CONTROL_RESPONSE_CHANNEL_DEFAULT = "aeron:udp?endpoint=localhost:0";
 
         /**
          * Stream id within a channel for receiving control messages from an archive.

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -2095,7 +2095,7 @@ public class AeronArchive implements AutoCloseable
          *
          * <p>
          * Channel's <em>endpoint</em> can be specified explicitly (i.e. by providing IP and port pair) or by using
-         * zero as a port number and/or special address {@code 0.0.0.0} as an IP address. Here is an example of valid
+         * zero as a port number and/or special <em>any address</em> as an IP address. Here is an example of valid
          * response channels:
          * <ul>
          *     <li>{@code aeron:udp?endpoint=localhost:8020} - listen on port {@code 8020} on localhost.</li>
@@ -2107,6 +2107,10 @@ public class AeronArchive implements AutoCloseable
          *     <li>{@code aeron:udp?endpoint=0.0.0.0:5555} - special address {@code 0.0.0.0} indicates that
          *     the underlying socket should listen on all local IPv4 interfaces using port {@code 5555}.</li>
          *     <li>{@code aeron:udp?endpoint=0.0.0.0:0} - the same as the above but the port should be
+         *     assigned by the OS.</li>
+         *     <li>{@code aeron:udp?endpoint=[::]:5555} - special address {@code [::]} indicates that
+         *     the underlying socket should listen on all local IPv6 interfaces using port {@code 5555}.</li>
+         *     <li>{@code aeron:udp?endpoint=[::]:0} - the same as the above but the port should be
          *     assigned by the OS.</li>
          * </ul>
          */

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -403,7 +403,7 @@ public class ArchiveTest
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "0.0.0.0:0", "0.0.0.0:11111", "[::]:0", "[::]:11111", "localhost:0", "localhost:8888" })
+    @ValueSource(strings = { "localhost:0", "localhost:8888" })
     public void shouldResolveControlResponseEndpointAddress(final String endpoint)
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -402,9 +402,8 @@ public class ArchiveTest
         assertSame(context.dataBuffer(), buffer);
     }
 
-
     @ParameterizedTest
-    @ValueSource(strings = { "0.0.0.0:0", "localhost:0", "localhost:8888" })
+    @ValueSource(strings = { "0.0.0.0:0", "0.0.0.0:11111", "localhost:0", "localhost:8888" })
     public void shouldResolveControlResponseEndpointAddress(final String endpoint)
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -403,7 +403,7 @@ public class ArchiveTest
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "0.0.0.0:0", "0.0.0.0:11111", "localhost:0", "localhost:8888" })
+    @ValueSource(strings = { "0.0.0.0:0", "0.0.0.0:11111", "[::]:0", "[::]:11111", "localhost:0", "localhost:8888" })
     public void shouldResolveControlResponseEndpointAddress(final String endpoint)
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()

--- a/aeron-client/src/main/java/io/aeron/ChannelUri.java
+++ b/aeron-client/src/main/java/io/aeron/ChannelUri.java
@@ -240,7 +240,7 @@ public class ChannelUri
      */
     public String channelTag()
     {
-        return (null != tags && tags.length > CHANNEL_TAG_INDEX) ? tags[CHANNEL_TAG_INDEX] : null;
+        return tags.length > CHANNEL_TAG_INDEX ? tags[CHANNEL_TAG_INDEX] : null;
     }
 
     /**
@@ -252,7 +252,34 @@ public class ChannelUri
      */
     public String entityTag()
     {
-        return (null != tags && tags.length > ENTITY_TAG_INDEX) ? tags[ENTITY_TAG_INDEX] : null;
+        return tags.length > ENTITY_TAG_INDEX ? tags[ENTITY_TAG_INDEX] : null;
+    }
+
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        final ChannelUri that = (ChannelUri)o;
+        return Objects.equals(prefix, that.prefix) &&
+            Objects.equals(media, that.media) &&
+            Objects.equals(params, that.params) &&
+            Arrays.equals(tags, that.tags);
+    }
+
+    public int hashCode()
+    {
+        int result = 19;
+        result = 31 * result + Objects.hashCode(prefix);
+        result = 31 * result + Objects.hashCode(media);
+        result = 31 * result + Objects.hashCode(params);
+        result = 31 * result + Arrays.hashCode(tags);
+        return result;
     }
 
     /**


### PR DESCRIPTION
This PR implements a feature that allows `aeron.archive.control.response.channel` to be configured without specifying an explicit port number.

Below are the examples of valid configurations:
- `aeron:udp?endpoint=localhost:8020` - listen on port {@code 8020} on localhost.
- `aeron:udp?endpoint=192.168.10.10:8020` - listen on port {@code 8020} on `192.168.10.10`.
- `aeron:udp?endpoint=localhost:0` - in this case the port is unspecified and the OS will assign a free port from an  [ephemeral port range](https://en.wikipedia.org/wiki/Ephemeral_port).
