### PR TITLE
[C] Add initial term id to message header in C API.

### DIFF
--- a/aeron-client/src/main/c/aeron_image.c
+++ b/aeron-client/src/main/c/aeron_image.c
@@ -26,35 +26,35 @@
 #endif
 
 _Static_assert(
-    sizeof(aeron_header_values_t) == sizeof(aeron_data_header_t),
-    "sizeof(aeron_header_values_t) must match sizeof(aeron_data_header_t)");
+    sizeof(struct aeron_header_values_frame_stct) == sizeof(aeron_data_header_t),
+    "sizeof(struct aeron_header_values_frame_stct) must match sizeof(aeron_data_header_t)");
 _Static_assert(
-    offsetof(aeron_header_values_t, frame_length) == offsetof(aeron_frame_header_t, frame_length),
-    "offsetof(aeron_header_values_t, frame_length) must match offsetof(aeron_frame_header_t, frame_length)");
+    offsetof(struct aeron_header_values_frame_stct, frame_length) == offsetof(aeron_frame_header_t, frame_length),
+    "offsetof(struct aeron_header_values_frame_stct, frame_length) must match offsetof(aeron_frame_header_t, frame_length)");
 _Static_assert(
-    offsetof(aeron_header_values_t, version) == offsetof(aeron_frame_header_t, version),
-    "offsetof(aeron_header_values_t, version) must match offsetof(aeron_frame_header_t, version)");
+    offsetof(struct aeron_header_values_frame_stct, version) == offsetof(aeron_frame_header_t, version),
+    "offsetof(struct aeron_header_values_frame_stct, version) must match offsetof(aeron_frame_header_t, version)");
 _Static_assert(
-    offsetof(aeron_header_values_t, flags) == offsetof(aeron_frame_header_t, flags),
-    "offsetof(aeron_header_values_t, flags) == offsetof(aeron_frame_header_t, flags)");
+    offsetof(struct aeron_header_values_frame_stct, flags) == offsetof(aeron_frame_header_t, flags),
+    "offsetof(struct aeron_header_values_frame_stct, flags) == offsetof(aeron_frame_header_t, flags)");
 _Static_assert(
-    offsetof(aeron_header_values_t, type) == offsetof(aeron_frame_header_t, type),
-    "offsetof(aeron_header_values_t, type) == offsetof(aeron_frame_header_t, type)");
+    offsetof(struct aeron_header_values_frame_stct, type) == offsetof(aeron_frame_header_t, type),
+    "offsetof(struct aeron_header_values_frame_stct, type) == offsetof(aeron_frame_header_t, type)");
 _Static_assert(
-    offsetof(aeron_header_values_t, term_offset) == offsetof(aeron_data_header_t, term_offset),
-    "offsetof(aeron_header_values_t, term_offset) == offsetof(aeron_data_header_t, term_offset)");
+    offsetof(struct aeron_header_values_frame_stct, term_offset) == offsetof(aeron_data_header_t, term_offset),
+    "offsetof(struct aeron_header_values_frame_stct, term_offset) == offsetof(aeron_data_header_t, term_offset)");
 _Static_assert(
-    offsetof(aeron_header_values_t, session_id) == offsetof(aeron_data_header_t, session_id),
-    "offsetof(aeron_header_values_t, session_id) == offsetof(aeron_data_header_t, session_id)");
+    offsetof(struct aeron_header_values_frame_stct, session_id) == offsetof(aeron_data_header_t, session_id),
+    "offsetof(struct aeron_header_values_frame_stct, session_id) == offsetof(aeron_data_header_t, session_id)");
 _Static_assert(
-    offsetof(aeron_header_values_t, stream_id) == offsetof(aeron_data_header_t, stream_id),
-    "offsetof(aeron_header_values_t, stream_id) == offsetof(aeron_data_header_t, stream_id)");
+    offsetof(struct aeron_header_values_frame_stct, stream_id) == offsetof(aeron_data_header_t, stream_id),
+    "offsetof(struct aeron_header_values_frame_stct, stream_id) == offsetof(aeron_data_header_t, stream_id)");
 _Static_assert(
-    offsetof(aeron_header_values_t, term_id) == offsetof(aeron_data_header_t, term_id),
-    "offsetof(aeron_header_values_t, term_id) == offsetof(aeron_data_header_t, term_id)");
+    offsetof(struct aeron_header_values_frame_stct, term_id) == offsetof(aeron_data_header_t, term_id),
+    "offsetof(struct aeron_header_values_frame_stct, term_id) == offsetof(aeron_data_header_t, term_id)");
 _Static_assert(
-    offsetof(aeron_header_values_t, reserved_value) == offsetof(aeron_data_header_t, reserved_value),
-    "offsetof(aeron_header_values_t, reserved_value) == offsetof(aeron_data_header_t, reserved_value)");
+    offsetof(struct aeron_header_values_frame_stct, reserved_value) == offsetof(aeron_data_header_t, reserved_value),
+    "offsetof(struct aeron_header_values_frame_stct, reserved_value) == offsetof(aeron_data_header_t, reserved_value)");
 
 int aeron_image_create(
     aeron_image_t **image,
@@ -287,7 +287,7 @@ int aeron_image_poll(aeron_image_t *image, aeron_fragment_handler_t handler, voi
 
         if (AERON_HDR_TYPE_PAD != frame->frame_header.type)
         {
-            aeron_header_t header = { frame };
+            aeron_header_t header = { frame, image->metadata->initial_term_id };
 
             handler(
                 clientd,
@@ -354,7 +354,7 @@ int aeron_image_controlled_poll(
             continue;
         }
 
-        aeron_header_t header = { frame };
+        aeron_header_t header = { frame, image->metadata->initial_term_id };
         aeron_controlled_fragment_handler_action_t action =
             handler(
                 clientd,
@@ -436,7 +436,7 @@ int aeron_image_bounded_poll(
 
         if (AERON_HDR_TYPE_PAD != frame->frame_header.type)
         {
-            aeron_header_t header = { frame };
+            aeron_header_t header = { frame, image->metadata->initial_term_id };
 
             handler(
                 clientd,
@@ -506,7 +506,7 @@ int aeron_image_bounded_controlled_poll(
             continue;
         }
 
-        aeron_header_t header = { frame };
+        aeron_header_t header = { frame, image->metadata->initial_term_id };
         aeron_controlled_fragment_handler_action_t action =
             handler(
                 clientd,
@@ -608,7 +608,7 @@ int64_t aeron_image_controlled_peek(
             continue;
         }
 
-        aeron_header_t header = { frame };
+        aeron_header_t header = { frame, image->metadata->initial_term_id };
         aeron_controlled_fragment_handler_action_t action =
             handler(
                 clientd,

--- a/aeron-client/src/main/c/aeron_image.c
+++ b/aeron-client/src/main/c/aeron_image.c
@@ -26,35 +26,35 @@
 #endif
 
 _Static_assert(
-    sizeof(struct aeron_header_values_frame_stct) == sizeof(aeron_data_header_t),
-    "sizeof(struct aeron_header_values_frame_stct) must match sizeof(aeron_data_header_t)");
+    sizeof(aeron_header_values_frame_t) == sizeof(aeron_data_header_t),
+    "sizeof(aeron_header_values_frame_t) must match sizeof(aeron_data_header_t)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, frame_length) == offsetof(aeron_frame_header_t, frame_length),
-    "offsetof(struct aeron_header_values_frame_stct, frame_length) must match offsetof(aeron_frame_header_t, frame_length)");
+    offsetof(aeron_header_values_frame_t, frame_length) == offsetof(aeron_frame_header_t, frame_length),
+    "offsetof(aeron_header_values_frame_t, frame_length) must match offsetof(aeron_frame_header_t, frame_length)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, version) == offsetof(aeron_frame_header_t, version),
-    "offsetof(struct aeron_header_values_frame_stct, version) must match offsetof(aeron_frame_header_t, version)");
+    offsetof(aeron_header_values_frame_t, version) == offsetof(aeron_frame_header_t, version),
+    "offsetof(aeron_header_values_frame_t, version) must match offsetof(aeron_frame_header_t, version)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, flags) == offsetof(aeron_frame_header_t, flags),
-    "offsetof(struct aeron_header_values_frame_stct, flags) == offsetof(aeron_frame_header_t, flags)");
+    offsetof(aeron_header_values_frame_t, flags) == offsetof(aeron_frame_header_t, flags),
+    "offsetof(aeron_header_values_frame_t, flags) == offsetof(aeron_frame_header_t, flags)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, type) == offsetof(aeron_frame_header_t, type),
-    "offsetof(struct aeron_header_values_frame_stct, type) == offsetof(aeron_frame_header_t, type)");
+    offsetof(aeron_header_values_frame_t, type) == offsetof(aeron_frame_header_t, type),
+    "offsetof(aeron_header_values_frame_t, type) == offsetof(aeron_frame_header_t, type)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, term_offset) == offsetof(aeron_data_header_t, term_offset),
-    "offsetof(struct aeron_header_values_frame_stct, term_offset) == offsetof(aeron_data_header_t, term_offset)");
+    offsetof(aeron_header_values_frame_t, term_offset) == offsetof(aeron_data_header_t, term_offset),
+    "offsetof(aeron_header_values_frame_t, term_offset) == offsetof(aeron_data_header_t, term_offset)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, session_id) == offsetof(aeron_data_header_t, session_id),
-    "offsetof(struct aeron_header_values_frame_stct, session_id) == offsetof(aeron_data_header_t, session_id)");
+    offsetof(aeron_header_values_frame_t, session_id) == offsetof(aeron_data_header_t, session_id),
+    "offsetof(aeron_header_values_frame_t, session_id) == offsetof(aeron_data_header_t, session_id)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, stream_id) == offsetof(aeron_data_header_t, stream_id),
-    "offsetof(struct aeron_header_values_frame_stct, stream_id) == offsetof(aeron_data_header_t, stream_id)");
+    offsetof(aeron_header_values_frame_t, stream_id) == offsetof(aeron_data_header_t, stream_id),
+    "offsetof(aeron_header_values_frame_t, stream_id) == offsetof(aeron_data_header_t, stream_id)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, term_id) == offsetof(aeron_data_header_t, term_id),
-    "offsetof(struct aeron_header_values_frame_stct, term_id) == offsetof(aeron_data_header_t, term_id)");
+    offsetof(aeron_header_values_frame_t, term_id) == offsetof(aeron_data_header_t, term_id),
+    "offsetof(aeron_header_values_frame_t, term_id) == offsetof(aeron_data_header_t, term_id)");
 _Static_assert(
-    offsetof(struct aeron_header_values_frame_stct, reserved_value) == offsetof(aeron_data_header_t, reserved_value),
-    "offsetof(struct aeron_header_values_frame_stct, reserved_value) == offsetof(aeron_data_header_t, reserved_value)");
+    offsetof(aeron_header_values_frame_t, reserved_value) == offsetof(aeron_data_header_t, reserved_value),
+    "offsetof(aeron_header_values_frame_t, reserved_value) == offsetof(aeron_data_header_t, reserved_value)");
 
 int aeron_image_create(
     aeron_image_t **image,

--- a/aeron-client/src/main/c/aeron_image.h
+++ b/aeron-client/src/main/c/aeron_image.h
@@ -57,6 +57,7 @@ aeron_image_t;
 typedef struct aeron_header_stct
 {
     aeron_data_header_t *frame;
+    int32_t initial_term_id;
 }
 aeron_header_t;
 

--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -535,7 +535,7 @@ int aeron_header_values(aeron_header_t *header, aeron_header_values_t *values)
         return -1;
     }
 
-    memcpy(&values->frame, header->frame, sizeof(struct aeron_header_values_frame_stct));
+    memcpy(&values->frame, header->frame, sizeof(aeron_header_values_frame_t));
     values->initial_term_id = header->initial_term_id;
     return 0;
 }

--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -535,7 +535,8 @@ int aeron_header_values(aeron_header_t *header, aeron_header_values_t *values)
         return -1;
     }
 
-    memcpy(values, header->frame, sizeof(aeron_header_values_t));
+    memcpy(&values->frame, header->frame, sizeof(struct aeron_header_values_frame_stct));
+    values->initial_term_id = header->initial_term_id;
     return 0;
 }
 

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -36,21 +36,23 @@ typedef struct aeron_exclusive_publication_stct aeron_exclusive_publication_t;
 typedef struct aeron_header_stct aeron_header_t;
 #pragma pack(push)
 #pragma pack(4)
+typedef struct aeron_header_values_frame_stct
+{
+    int32_t frame_length;
+    int8_t version;
+    uint8_t flags;
+    int16_t type;
+    int32_t term_offset;
+    int32_t session_id;
+    int32_t stream_id;
+    int32_t term_id;
+    int64_t reserved_value;
+}
+aeron_header_values_frame_t;
+
 typedef struct aeron_header_values_stct
 {
-    struct aeron_header_values_frame_stct
-    {
-        int32_t frame_length;
-        int8_t version;
-        uint8_t flags;
-        int16_t type;
-        int32_t term_offset;
-        int32_t session_id;
-        int32_t stream_id;
-        int32_t term_id;
-        int64_t reserved_value;
-    }
-    frame;
+    aeron_header_values_frame_t frame;
     int32_t initial_term_id;
 }
 aeron_header_values_t;

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -38,15 +38,20 @@ typedef struct aeron_header_stct aeron_header_t;
 #pragma pack(4)
 typedef struct aeron_header_values_stct
 {
-    int32_t frame_length;
-    int8_t version;
-    uint8_t flags;
-    int16_t type;
-    int32_t term_offset;
-    int32_t session_id;
-    int32_t stream_id;
-    int32_t term_id;
-    int64_t reserved_value;
+    struct aeron_header_values_frame_stct
+    {
+        int32_t frame_length;
+        int8_t version;
+        uint8_t flags;
+        int16_t type;
+        int32_t term_offset;
+        int32_t session_id;
+        int32_t stream_id;
+        int32_t term_id;
+        int64_t reserved_value;
+    }
+    frame;
+    int32_t initial_term_id;
 }
 aeron_header_values_t;
 #pragma pack(pop)

--- a/aeron-client/src/test/c/aeron_fragment_assembler_test.cpp
+++ b/aeron-client/src/test/c/aeron_fragment_assembler_test.cpp
@@ -133,7 +133,7 @@ TEST_F(CFragmentAssemblerTest, shouldPassThroughUnfragmentedMessage)
         EXPECT_EQ(length, msgLength);
         aeron_header_values_t header_values;
         EXPECT_EQ(0, aeron_header_values(header, &header_values));
-        EXPECT_EQ(SESSION_ID, header_values.session_id);
+        EXPECT_EQ(SESSION_ID, header_values.frame.session_id);
         verifyPayload(buffer, length);
     };
 
@@ -151,7 +151,7 @@ TEST_F(CFragmentAssemblerTest, shouldReassembleFromTwoFragments)
         EXPECT_EQ(length, msgLength * 2);
         aeron_header_values_t header_values;
         EXPECT_EQ(0, aeron_header_values(header, &header_values));
-        EXPECT_EQ(SESSION_ID, header_values.session_id);
+        EXPECT_EQ(SESSION_ID, header_values.frame.session_id);
         verifyPayload(buffer, length);
     };
 
@@ -174,7 +174,7 @@ TEST_F(CFragmentAssemblerTest, shouldReassembleFromThreeFragments)
         EXPECT_EQ(length, msgLength * 3);
         aeron_header_values_t header_values;
         EXPECT_EQ(0, aeron_header_values(header, &header_values));
-        EXPECT_EQ(SESSION_ID, header_values.session_id);
+        EXPECT_EQ(SESSION_ID, header_values.frame.session_id);
         verifyPayload(buffer, length);
     };
 

--- a/aeron-client/src/test/c/aeron_image_test.cpp
+++ b/aeron-client/src/test/c/aeron_image_test.cpp
@@ -477,6 +477,8 @@ TEST_F(ImageTest, shouldPollOneFragmentToControlledFragmentHandlerOnBreak)
 
     appendMessage(m_sub_pos, messageLength);
     appendMessage(m_sub_pos + alignedMessageLength, messageLength);
+    aeron_image_constants_t image_constants;
+    aeron_image_constants(m_image, &image_constants);
 
     auto handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
         -> aeron_controlled_fragment_handler_action_t
@@ -487,7 +489,9 @@ TEST_F(ImageTest, shouldPollOneFragmentToControlledFragmentHandlerOnBreak)
         EXPECT_EQ(buffer, termBuffer(0) + AERON_DATA_HEADER_LENGTH);
         EXPECT_EQ(length, messageLength);
         EXPECT_EQ(header->frame->frame_header.type, AERON_HDR_TYPE_DATA);
-        EXPECT_EQ(values.type, AERON_HDR_TYPE_DATA);
+        EXPECT_EQ(values.frame.type, AERON_HDR_TYPE_DATA);
+        EXPECT_EQ(image_constants.initial_term_id, values.initial_term_id);
+
         return AERON_ACTION_BREAK;
     };
 

--- a/aeron-samples/src/main/c/basic_subscriber.c
+++ b/aeron-samples/src/main/c/basic_subscriber.c
@@ -77,7 +77,7 @@ void poll_handler(void *clientd, const uint8_t *buffer, size_t length, aeron_hea
     printf(
         "Message to stream %" PRId32 " from session %" PRId32 " (%" PRIu32 " bytes) <<%*s>>\n",
         subscription_constants.stream_id,
-        header_values.session_id,
+        header_values.frame.session_id,
         (uint32_t)length,
         (int)length,
         buffer);


### PR DESCRIPTION
Needed in order to access the initial_term_id in the C++ Wrapper.  Useful for feature parity with the Java driver also.