### PR TITLE
[CPP] Fixes msvc warning.

### DIFF
--- a/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp
+++ b/aeron-client/src/test/cpp/ExclusivePublicationTest.cpp
@@ -203,7 +203,7 @@ TEST_F(ExclusivePublicationTest, shouldRotateWhenAppendTrips)
     const int nextIndex = LogBufferDescriptor::indexByTerm(TERM_ID_1, TERM_ID_1 + 1);
     EXPECT_EQ(m_logMetaDataBuffer.getInt32(LogBufferDescriptor::LOG_ACTIVE_TERM_COUNT_OFFSET), 1);
 
-    auto expectedTail = static_cast<std::int64_t>(static_cast<std::uint64_t>(TERM_ID_1 + 1) << 32u);
+    auto expectedTail = (static_cast<std::uint64_t>(TERM_ID_1 + 1)) << 32u;
     EXPECT_EQ(m_logMetaDataBuffer.getInt64(termTailCounterOffset(nextIndex)), expectedTail);
 
     EXPECT_GT(m_publication->offer(m_srcBuffer), initialPosition + DataFrameHeader::LENGTH + m_srcBuffer.capacity());
@@ -226,7 +226,7 @@ TEST_F(ExclusivePublicationTest, shouldRotateWhenClaimTrips)
     const int nextIndex = LogBufferDescriptor::indexByTerm(TERM_ID_1, TERM_ID_1 + 1);
     EXPECT_EQ(m_logMetaDataBuffer.getInt32(LogBufferDescriptor::LOG_ACTIVE_TERM_COUNT_OFFSET), 1);
 
-    auto expectedTail = static_cast<std::int64_t>(static_cast<std::uint64_t>(TERM_ID_1 + 1) << 32u);
+    auto expectedTail = (static_cast<std::uint64_t>(TERM_ID_1 + 1)) << 32u;
     EXPECT_EQ(m_logMetaDataBuffer.getInt64(termTailCounterOffset(nextIndex)), expectedTail);
 
     EXPECT_GT(m_publication->tryClaim(SRC_BUFFER_LENGTH, bufferClaim),


### PR DESCRIPTION
[build] ..\..\aeron-client\src\test\cpp\ExclusivePublicationTest.cpp(206): warning C4554: “<<”: 检查运算符优先级可能存在的错误；请使用圆括号阐明优先级
[build] ..\..\aeron-client\src\test\cpp\ExclusivePublicationTest.cpp(229): warning C4554: “<<”: 检查运算符优先级可能存在的错误；请使用圆括号阐明优先级