### PR TITLE
[Java] Add support for zero port in `egressChannel` for AeronCluster.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/Subscription.java
+++ b/aeron-client/src/main/java/io/aeron/Subscription.java
@@ -510,41 +510,6 @@ public class Subscription extends SubscriptionFields implements AutoCloseable
     }
 
     /**
-     * Resolve channel endpoint and replace it with assigned local socket address. If there are no addresses, or if
-     * there is more than one, returned from {@link #localSocketAddresses()} then the original {@link #channel()} is
-     * returned. This method will resolve names to IP address and the port, if port is 0 then the system assigned
-     * port from the ephemeral range is returned.
-     * <p>
-     * If the channel is not {@link io.aeron.status.ChannelEndpointStatus#ACTIVE}, then {@code null} will be returned.
-     *
-     * @return channel URI string with an endpoint being resolved to the allocated address:port pairing.
-     * @see #channelStatus()
-     * @see #localSocketAddresses()
-     */
-    public String tryResolveChannelEndpoint()
-    {
-        final long channelStatus = channelStatus();
-
-        if (ChannelEndpointStatus.ACTIVE == channelStatus)
-        {
-            final List<String> localSocketAddresses = LocalSocketAddressStatus.findAddresses(
-                conductor.countersReader(), channelStatus, channelStatusId);
-
-            if (1 == localSocketAddresses.size())
-            {
-                final ChannelUri uri = ChannelUri.parse(channel);
-                uri.put(CommonContext.ENDPOINT_PARAM_NAME, localSocketAddresses.get(0));
-
-                return uri.toString();
-            }
-
-            return channel;
-        }
-
-        return null;
-    }
-
-    /**
      * Resolve channel endpoint and replace it with the port from the ephemeral range when 0 was provided. If there are
      * no addresses, or if there is more than one, returned from {@link #localSocketAddresses()} then the original
      * {@link #channel()} is returned.

--- a/aeron-client/src/test/java/io/aeron/SubscriptionTest.java
+++ b/aeron-client/src/test/java/io/aeron/SubscriptionTest.java
@@ -160,36 +160,36 @@ public class SubscriptionTest
 
     @ValueSource(longs = { INITIALIZING, ERRORED, CLOSING })
     @ParameterizedTest
-    void tryResolveChannelEndpointReturnsNullIfChannelStatusIsNotActive(final long channelStatus)
+    void tryResolveChannelEndpointPortReturnsNullIfChannelStatusIsNotActive(final long channelStatus)
     {
         final int channelStatusId = 555;
         subscription.channelStatusId(channelStatusId);
         when(conductor.channelStatus(channelStatusId)).thenReturn(channelStatus);
 
-        assertNull(subscription.tryResolveChannelEndpoint());
+        assertNull(subscription.tryResolveChannelEndpointPort());
     }
 
     @Test
-    void tryResolveChannelEndpointReturnsNullIfSubscriptionIsClosed()
+    void tryResolveChannelEndpointPortReturnsNullIfSubscriptionIsClosed()
     {
         subscription.close();
         assertTrue(subscription.isClosed());
 
-        assertNull(subscription.tryResolveChannelEndpoint());
+        assertNull(subscription.tryResolveChannelEndpointPort());
     }
 
     @Test
-    void tryResolveChannelEndpointReturnsOriginalChannelIfNoAddressesFound()
+    void tryResolveChannelEndpointPortReturnsOriginalChannelIfNoAddressesFound()
     {
         final int channelStatusId = 123;
         subscription.channelStatusId(channelStatusId);
         when(conductor.channelStatus(channelStatusId)).thenReturn(ACTIVE);
 
-        assertSame(CHANNEL, subscription.tryResolveChannelEndpoint());
+        assertSame(CHANNEL, subscription.tryResolveChannelEndpointPort());
     }
 
     @Test
-    void tryResolveChannelEndpointReturnsOriginalChannelIfMoreThanOneAddressFound()
+    void tryResolveChannelEndpointPortReturnsOriginalChannelIfMoreThanOneAddressFound()
     {
         final int channelStatusId = 123;
         subscription.channelStatusId(channelStatusId);
@@ -198,11 +198,11 @@ public class SubscriptionTest
         allocateAddressCounter("localhost:5555", channelStatusId, ACTIVE);
         allocateAddressCounter("localhost:7777", channelStatusId, ACTIVE);
 
-        assertSame(CHANNEL, subscription.tryResolveChannelEndpoint());
+        assertSame(CHANNEL, subscription.tryResolveChannelEndpointPort());
     }
 
     @Test
-    void tryResolveChannelEndpointReturnsChannelWithAResolvedEndpoint()
+    void tryResolveChannelEndpointPortReturnsOriginalChannelIfNonZeroPortWasSpecified()
     {
         final int channelStatusId = 444;
         final String channel = "aeron:udp?endpoint=localhost:40124|interface=192.168.5.0/24|reliable=false";
@@ -219,40 +219,11 @@ public class SubscriptionTest
         allocateAddressCounter("127.0.0.1:19091", channelStatusId, ACTIVE);
         allocateAddressCounter("localhost:21212", channelStatusId, ERRORED);
 
-        final String channelWithResolvedEndpoint = subscription.tryResolveChannelEndpoint();
-
-        assertEquals(
-            ChannelUri.parse("aeron:udp?endpoint=127.0.0.1:19091|interface=192.168.5.0/24|reliable=false"),
-            ChannelUri.parse(channelWithResolvedEndpoint));
+        assertSame(channel, subscription.tryResolveChannelEndpointPort());
     }
 
     @Test
-    void tryResolveChannelEndpointReturnsChannelWithAResolvedEndpointAndPort()
-    {
-        final int channelStatusId = 444;
-        final String channel = "aeron:udp?endpoint=localhost:0|interface=192.168.5.0/24|reliable=false";
-        subscription = new Subscription(
-            conductor,
-            channel,
-            STREAM_ID_1,
-            SUBSCRIPTION_CORRELATION_ID,
-            availableImageHandlerMock,
-            unavailableImageHandlerMock);
-        subscription.channelStatusId(channelStatusId);
-        when(conductor.channelStatus(channelStatusId)).thenReturn(ACTIVE);
-
-        allocateAddressCounter("127.0.0.1:19091", channelStatusId, ACTIVE);
-        allocateAddressCounter("localhost:21212", channelStatusId, ERRORED);
-
-        final String channelWithResolvedEndpoint = subscription.tryResolveChannelEndpoint();
-
-        assertEquals(
-            ChannelUri.parse("aeron:udp?endpoint=127.0.0.1:19091|interface=192.168.5.0/24|reliable=false"),
-            ChannelUri.parse(channelWithResolvedEndpoint));
-    }
-
-    @Test
-    void tryResolveChannelEndpointReturnsChannelWithAResolvedEndpointPortOnly()
+    void tryResolveChannelEndpointPortReturnsChannelWithResolvedPort()
     {
         final int channelStatusId = 444;
         final String channel = "aeron:udp?endpoint=localhost:0|interface=192.168.5.0/24|reliable=false";

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -615,6 +615,14 @@ public class TestCluster implements AutoCloseable
 
     AeronCluster connectClient()
     {
+        return connectClient(
+            new AeronCluster.Context()
+                .ingressChannel(INGRESS_CHANNEL)
+                .egressChannel(EGRESS_CHANNEL));
+    }
+
+    AeronCluster connectClient(final AeronCluster.Context clientCtx)
+    {
         final String aeronDirName = CommonContext.getAeronDirectoryName();
 
         if (null == clientMediaDriver)
@@ -631,11 +639,9 @@ public class TestCluster implements AutoCloseable
 
         CloseHelper.close(client);
         client = AeronCluster.connect(
-            new AeronCluster.Context()
+            clientCtx
                 .aeronDirectoryName(aeronDirName)
                 .egressListener(egressMessageListener)
-                .ingressChannel(INGRESS_CHANNEL)
-                .egressChannel(EGRESS_CHANNEL)
                 .ingressEndpoints(staticClusterMemberEndpoints));
 
         return client;

--- a/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
@@ -23,7 +23,10 @@ import io.aeron.test.TestMediaDriver;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
@@ -74,35 +77,6 @@ public class ResolvedEndpointSystemTest
     @Test
     @Timeout(5)
     void shouldSubscribeWithSystemAssignedPort()
-    {
-        final String uri = "aeron:udp?endpoint=localhost:0";
-
-        try (Subscription sub = client.addSubscription(uri, STREAM_ID))
-        {
-            String resolvedUri;
-            while (null == (resolvedUri = sub.tryResolveChannelEndpoint()))
-            {
-                Tests.yieldingWait("No bind address/port for sub");
-            }
-
-            try (Publication pub = client.addPublication(resolvedUri, STREAM_ID))
-            {
-                while (pub.offer(buffer, 0, buffer.capacity()) < 0)
-                {
-                    Tests.yieldingWait("Failed to publish to pub");
-                }
-
-                while (sub.poll(fragmentHandler, 1) < 0)
-                {
-                    Tests.yieldingWait("Failed to receive from sub");
-                }
-            }
-        }
-    }
-
-    @Test
-    @Timeout(5)
-    void shouldSubscribeWithSystemAssignedPortOnly()
     {
         final String uri = "aeron:udp?endpoint=localhost:0";
 


### PR DESCRIPTION
It is now possible to specify zero port in `egressChannel` configuration in which case a port from an ephemeral range will be used.