### PR TITLE
[C] Collapse destination add/remove poll to a single function per resource to match the shape of the C++ API.

### DIFF
--- a/aeron-client/src/main/c/aeron_client.c
+++ b/aeron-client/src/main/c/aeron_client.c
@@ -650,12 +650,12 @@ int aeron_publication_async_add_destination(
     return aeron_client_conductor_async_add_publication_destination(async, &client->conductor, publication, uri);
 }
 
-int aeron_publication_async_add_destination_poll(aeron_async_destination_t *async)
+int aeron_publication_async_destination_poll(aeron_async_destination_t *async)
 {
     return aeron_async_destination_poll(async);
 }
 
-int aeron_subscription_async_remove_destination(
+int aeron_publication_async_remove_destination(
     aeron_async_destination_t **async,
     aeron_t *client,
     aeron_publication_t *publication,
@@ -671,20 +671,38 @@ int aeron_subscription_async_remove_destination(
     return aeron_client_conductor_async_remove_publication_destination(async, &client->conductor, publication, uri);
 }
 
+int aeron_subscription_async_add_destination(
+    aeron_async_destination_t **async, aeron_t *client, aeron_subscription_t *subscription, const char *uri)
+{
+    if (NULL == subscription || uri == NULL)
+    {
+        errno = EINVAL;
+        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
+        return -1;
+    }
 
-int aeron_publication_async_remove_destination_poll(aeron_async_destination_t *async)
+    return aeron_client_conductor_async_add_subscription_destination(async, &client->conductor, subscription, uri);
+}
+
+int aeron_subscription_async_destination_poll(aeron_async_destination_t *async)
 {
     return aeron_async_destination_poll(async);
 }
 
-int aeron_subscription_async_add_destination_poll(aeron_async_destination_t *async)
+int aeron_subscription_async_remove_destination(
+    aeron_async_destination_t **async,
+    aeron_t *client,
+    aeron_subscription_t *subscription,
+    const char *uri)
 {
-    return aeron_async_destination_poll(async);
-}
+    if (NULL == subscription || uri == NULL)
+    {
+        errno = EINVAL;
+        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
+        return -1;
+    }
 
-int aeron_subscription_async_remove_destination_poll(aeron_async_destination_t *async)
-{
-    return aeron_async_destination_poll(async);
+    return aeron_client_conductor_async_remove_subscription_destination(async, &client->conductor, subscription, uri);
 }
 
 int aeron_exclusive_publication_async_add_destination(
@@ -704,9 +722,26 @@ int aeron_exclusive_publication_async_add_destination(
         async, &client->conductor, publication, uri);
 }
 
-int aeron_exclusive_publication_async_add_destination_poll(aeron_async_destination_t *async)
+int aeron_exclusive_publication_async_destination_poll(aeron_async_destination_t *async)
 {
     return aeron_async_destination_poll(async);
+}
+
+int aeron_exclusive_publication_async_remove_destination(
+    aeron_async_destination_t **async,
+    aeron_t *client,
+    aeron_exclusive_publication_t *publication,
+    const char *uri)
+{
+    if (NULL == publication || uri == NULL)
+    {
+        errno = EINVAL;
+        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
+        return -1;
+    }
+
+    return aeron_client_conductor_async_remove_exclusive_publication_destination(
+        async, &client->conductor, publication, uri);
 }
 
 int aeron_client_handler_cmd_await_processed(aeron_client_handler_cmd_t *cmd)

--- a/aeron-client/src/main/c/aeron_exclusive_publication.c
+++ b/aeron-client/src/main/c/aeron_exclusive_publication.c
@@ -580,34 +580,6 @@ int64_t aeron_exclusive_publication_position_limit(aeron_exclusive_publication_t
     return aeron_counter_get_volatile(publication->position_limit);
 }
 
-int aeron_exclusive_publication_add_destination(
-    aeron_exclusive_publication_t *publication, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == publication || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        publication->conductor, publication->registration_id, AERON_COMMAND_ADD_DESTINATION, uri, correlation_id);
-}
-
-int aeron_exclusive_publication_remove_destination(
-    aeron_exclusive_publication_t *publication, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == publication || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        publication->conductor, publication->registration_id, AERON_COMMAND_REMOVE_DESTINATION, uri, correlation_id);
-}
-
 extern void aeron_exclusive_publication_rotate_term(aeron_exclusive_publication_t *publication);
 
 extern int64_t aeron_exclusive_publication_new_position(

--- a/aeron-client/src/main/c/aeron_publication.c
+++ b/aeron-client/src/main/c/aeron_publication.c
@@ -467,32 +467,6 @@ int64_t aeron_publication_position_limit(aeron_publication_t *publication)
     return aeron_counter_get_volatile(publication->position_limit);
 }
 
-int aeron_publication_add_destination(aeron_publication_t *publication, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == publication || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        publication->conductor, publication->registration_id, AERON_COMMAND_ADD_DESTINATION, uri, correlation_id);
-}
-
-int aeron_publication_remove_destination(aeron_publication_t *publication, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == publication || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        publication->conductor, publication->registration_id, AERON_COMMAND_REMOVE_DESTINATION, uri, correlation_id);
-}
-
 extern int64_t aeron_publication_new_position(
     aeron_publication_t *publication,
     int32_t term_count,

--- a/aeron-client/src/main/c/aeron_subscription.c
+++ b/aeron-client/src/main/c/aeron_subscription.c
@@ -503,36 +503,6 @@ long aeron_subscription_block_poll(
     return bytes_consumed;
 }
 
-int aeron_subscription_add_destination(aeron_subscription_t *subscription, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == subscription || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        subscription->conductor, subscription->registration_id, AERON_COMMAND_ADD_RCV_DESTINATION, uri, correlation_id);
-}
-
-int aeron_subscription_remove_destination(aeron_subscription_t *subscription, const char *uri, int64_t *correlation_id)
-{
-    if (NULL == subscription || uri == NULL)
-    {
-        errno = EINVAL;
-        aeron_set_err(EINVAL, "%s", strerror(EINVAL));
-        return -1;
-    }
-
-    return aeron_client_conductor_offer_destination_command(
-        subscription->conductor,
-        subscription->registration_id,
-        AERON_COMMAND_REMOVE_RCV_DESTINATION,
-        uri,
-        correlation_id);
-}
-
 int aeron_header_values(aeron_header_t *header, aeron_header_values_t *values)
 {
     if (NULL == header || NULL == values)

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -887,16 +887,6 @@ int64_t aeron_publication_position_limit(aeron_publication_t *publication);
 /**
  * Add a destination manually to a multi-destination-cast publication.
  *
- * @param publication to add destination to.
- * @param uri for the destination to add.
- * @param correlation_id that can be used to track the addition of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_publication_add_destination(aeron_publication_t* publication, const char* uri, int64_t* correlation_id);
-
-/**
- * Add a destination manually to a multi-destination-cast publication.
- *
  * @param async object to use for polling completion.
  * @param publication to add destination to.
  * @param uri for the destination to add.
@@ -907,14 +897,6 @@ int aeron_publication_async_add_destination(
     aeron_t *client,
     aeron_publication_t *publication,
     const char *uri);
-
-/**
- * Poll the completion of the aeron_publication_async_add_destination call.
- *
- * @param async to check for completion.
- * @return 0 for not complete (try again), 1 for completed successfully, or -1 for an error.
- */
-int aeron_publication_async_add_destination_poll(aeron_async_destination_t *async);
 
 /**
  * Remove a destination manually from a multi-destination-cast publication.
@@ -931,12 +913,12 @@ int aeron_publication_async_remove_destination(
     const char *uri);
 
 /**
- * Poll the completion of the aeron_publication_async_remove_destination call.
+ * Poll the completion of the add/remove of a destination to/from a publication.
  *
  * @param async to check for completion.
  * @return 0 for not complete (try again), 1 for completed successfully, or -1 for an error.
  */
-int aeron_publication_async_remove_destination_poll(aeron_async_destination_t *async);
+int aeron_publication_async_destination_poll(aeron_async_destination_t *async);
 
 /**
  * Add a destination manually to a multi-destination-cast exclusive publication.
@@ -953,22 +935,26 @@ int aeron_exclusive_publication_async_add_destination(
     const char *uri);
 
 /**
- * Poll the completion of the aeron_exclusive_publication_async_add_destination call.
+ * Remove a destination manually from a multi-destination-cast exclusive publication.
+ *
+ * @param async object to use for polling completion.
+ * @param publication to remove destination from.
+ * @param uri for the destination to remove.
+ * @return 0 for success and -1 for error.
+ */
+int aeron_exclusive_publication_async_remove_destination(
+    aeron_async_destination_t **async,
+    aeron_t *client,
+    aeron_exclusive_publication_t *publication,
+    const char *uri);
+
+/**
+ * Poll the completion of the add/remove of a destination to/from an exclusive publication.
  *
  * @param async to check for completion.
  * @return 0 for not complete (try again), 1 for completed successfully, or -1 for an error.
  */
-int aeron_exclusive_publication_async_add_destination_poll(aeron_async_destination_t *async);
-
-/**
- * Remove a previously added destination manually from a multi-destination-cast publication.
- *
- * @param publication to remove destination from.
- * @param uri for the destination to remove.
- * @param correlation_id that can be used to track the removal of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_publication_remove_destination(aeron_publication_t* publication, const char* uri, int64_t* correlation_id);
+int aeron_exclusive_publication_async_destination_poll(aeron_async_destination_t *async);
 
 /**
  * Asynchronously close the publication.  Will callback on the on_complete notification when the subscription is closed.
@@ -1108,28 +1094,6 @@ int64_t aeron_exclusive_publication_position(aeron_exclusive_publication_t *publ
  * @return the position limit beyond which this publication will be back pressured or a negative error value.
  */
 int64_t aeron_exclusive_publication_position_limit(aeron_exclusive_publication_t *publication);
-
-/**
- * Add a destination manually to a multi-destination-cast publication.
- *
- * @param publication to add destination to.
- * @param uri for the destination to add.
- * @param correlation_id that can be used to track the addition of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_exclusive_publication_add_destination(
-    aeron_exclusive_publication_t *publication, const char *uri, int64_t *correlation_id);
-
-/**
- * Remove a previously added destination manually from a multi-destination-cast publication.
- *
- * @param publication to remove destination from.
- * @param uri for the destination to remove.
- * @param correlation_id that can be used to track the removal of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_exclusive_publication_remove_destination(
-    aeron_exclusive_publication_t *publication, const char *uri, int64_t *correlation_id);
 
 /**
  * Asynchronously close the publication.
@@ -1443,26 +1407,6 @@ bool aeron_subscription_is_closed(aeron_subscription_t *subscription);
 int64_t aeron_subscription_channel_status(aeron_subscription_t *subscription);
 
 /**
- * Add a destination manually to a multi-destination subscription.
- *
- * @param subscription to add destination to.
- * @param uri for the destination to add.
- * @param correlation_id that can be used to track the addition of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_subscription_add_destination(aeron_subscription_t *subscription, const char *uri, int64_t *correlation_id);
-
-/**
- * Remove a previously added destination from a multi-destination subscription.
- *
- * @param subscription to remove destination from.
- * @param uri for the destination to remove.
- * @param correlation_id that can be used to track the removal of the destination.
- * @return 0 for success and -1 for error.
- */
-int aeron_subscription_remove_destination(aeron_subscription_t *subscription, const char *uri, int64_t *correlation_id);
-
-/**
  * Add a destination manually to a multi-destination-subscription.
  *
  * @param async object to use for polling completion.
@@ -1473,16 +1417,8 @@ int aeron_subscription_remove_destination(aeron_subscription_t *subscription, co
 int aeron_subscription_async_add_destination(
     aeron_async_destination_t **async,
     aeron_t *client,
-    aeron_publication_t *publication,
+    aeron_subscription_t *subscription,
     const char *uri);
-
-/**
- * Poll the completion of the aeron_subscription_async_add_destination call.
- *
- * @param async to check for completion.
- * @return 0 for not complete (try again), 1 for completed successfully, or -1 for an error.
- */
-int aeron_subscription_async_add_destination_poll(aeron_async_destination_t *async);
 
 /**
  * Remove a destination manually from a multi-destination-subscription.
@@ -1495,17 +1431,16 @@ int aeron_subscription_async_add_destination_poll(aeron_async_destination_t *asy
 int aeron_subscription_async_remove_destination(
     aeron_async_destination_t **async,
     aeron_t *client,
-    aeron_publication_t *publication,
+    aeron_subscription_t *subscription,
     const char *uri);
 
 /**
- * Poll the completion of the aeron_subscription_async_remove_destination call.
+ * Poll the completion of add/remove of a destination to/from a subscription.
  *
  * @param async to check for completion.
  * @return 0 for not complete (try again), 1 for completed successfully, or -1 for an error.
  */
-int aeron_subscription_async_remove_destination_poll(aeron_async_destination_t *async);
-
+int aeron_subscription_async_destination_poll(aeron_async_destination_t *async);
 
 /**
  * Asynchronously close the subscription.  Will callback on the on_complete notification when the subscription is closed.

--- a/aeron-client/src/test/c/aeron_client_conductor_test.cpp
+++ b/aeron-client/src/test/c/aeron_client_conductor_test.cpp
@@ -722,7 +722,7 @@ TEST_F(ClientConductorTest, shouldHandlePublicationAddRemoveDestination)
     doWork();
     ASSERT_EQ(async_add_dest->registration_status, AERON_CLIENT_REGISTERED_MEDIA_DRIVER);
     ASSERT_EQ(async_add_dest->resource.publication->registration_id, publication->registration_id);
-    ASSERT_GT(aeron_publication_async_add_destination_poll(async_add_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_publication_async_destination_poll(async_add_dest), 0) << aeron_errmsg();
 
     ASSERT_EQ(
         aeron_client_conductor_async_remove_publication_destination(
@@ -730,7 +730,7 @@ TEST_F(ClientConductorTest, shouldHandlePublicationAddRemoveDestination)
         0);
     transmitOnOperationSuccess(async_remove_dest);
     doWork();
-    ASSERT_GT(aeron_publication_async_add_destination_poll(async_remove_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_publication_async_destination_poll(async_remove_dest), 0) << aeron_errmsg();
 
     // graceful close and reclaim for sanitize
     ASSERT_EQ(aeron_publication_close(publication, nullptr, nullptr), 0);
@@ -760,7 +760,7 @@ TEST_F(ClientConductorTest, shouldHandleExclusivePublicationAddDestination)
     doWork();
     ASSERT_EQ(async_dest->registration_status, AERON_CLIENT_REGISTERED_MEDIA_DRIVER);
     ASSERT_EQ(async_dest->resource.publication->registration_id, publication->registration_id);
-    ASSERT_GT(aeron_exclusive_publication_async_add_destination_poll(async_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_exclusive_publication_async_destination_poll(async_dest), 0) << aeron_errmsg();
 
     ASSERT_EQ(
         aeron_client_conductor_async_remove_exclusive_publication_destination(
@@ -768,7 +768,7 @@ TEST_F(ClientConductorTest, shouldHandleExclusivePublicationAddDestination)
         0);
     transmitOnOperationSuccess(async_dest);
     doWork();
-    ASSERT_GT(aeron_publication_async_add_destination_poll(async_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_exclusive_publication_async_destination_poll(async_dest), 0) << aeron_errmsg();
 
     // graceful close and reclaim for sanitize
     ASSERT_EQ(aeron_exclusive_publication_close(publication, nullptr, nullptr), 0);
@@ -801,14 +801,14 @@ TEST_F(ClientConductorTest, shouldHandleSubscriptionAddDestination)
     doWork();
     ASSERT_EQ(async_dest->registration_status, AERON_CLIENT_REGISTERED_MEDIA_DRIVER);
     ASSERT_EQ(async_dest->resource.subscription->registration_id, subscription->registration_id);
-    ASSERT_GT(aeron_subscription_async_add_destination_poll(async_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_subscription_async_destination_poll(async_dest), 0) << aeron_errmsg();
 
     ASSERT_EQ(
         aeron_client_conductor_async_remove_subscription_destination(&async_dest, &m_conductor, subscription, DEST_URI),
         0);
     transmitOnOperationSuccess(async_dest);
     doWork();
-    ASSERT_GT(aeron_subscription_async_remove_destination_poll(async_dest), 0) << aeron_errmsg();
+    ASSERT_GT(aeron_subscription_async_destination_poll(async_dest), 0) << aeron_errmsg();
 
     // graceful close and reclaim for sanitize
     ASSERT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);


### PR DESCRIPTION
* Add/correct functions declared in aeronc.h
* Uses a single poll function per resource for checking for the completion of destination commands (add/remove).  This matches the shape of the C++ API which has a single findDestinationResponse function shared for both adds and removes.
* Removes the older add/remove destination functions that did not use a async tracking for completion.