### PR TITLE
Avoid issue where commit-pos counter is updated when cluster is CLOSED

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1836,7 +1836,10 @@ class ConsensusModuleAgent implements Agent
                 workCount += ingressAdapter.poll();
             }
 
-            workCount += updateLeaderPosition(nowNs);
+            if (ConsensusModule.State.CLOSED != state)
+            {
+                workCount += updateLeaderPosition(nowNs);
+            }
         }
         else
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3289,7 +3289,7 @@ public final class MediaDriver implements AutoCloseable
                 if (counterFreeToReuseTimeoutNs > 0)
                 {
                     clock = epochClock;
-                    reuseTimeoutMs = Math.min(TimeUnit.NANOSECONDS.toMillis(counterFreeToReuseTimeoutNs), 1);
+                    reuseTimeoutMs = Math.max(TimeUnit.NANOSECONDS.toMillis(counterFreeToReuseTimeoutNs), 1);
                 }
                 else
                 {


### PR DESCRIPTION
If Appended Position counter is re-used then the ConsensusModule would update the commit position counter to an incorrect value. Also includes a fix for an incorrect counter re-use timeout.