### PR TITLE
fix cluster example start script

### DIFF
--- a/aeron-samples/scripts/cluster/basic-auction-cluster
+++ b/aeron-samples/scripts/cluster/basic-auction-cluster
@@ -34,7 +34,7 @@ function startNode() {
         -Daeron.event.cluster.log=all \
         -Daeron.cluster.tutorial.nodeId=$1 \
         ${JVM_OPTS} ${ADD_OPENS} \
-        io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode > logs/cluster-$1.log &
+        io.aeron.samples.cluster.BasicAuctionClusteredServiceNode > logs/cluster-$1.log &
 }
 
 function startAll() {


### PR DESCRIPTION
without this change, the example doesn't start with an error like 
```
Error: Could not find or load main class io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
Caused by: java.lang.ClassNotFoundException: io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
Error: Could not find or load main class io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
Caused by: java.lang.ClassNotFoundException: io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
Error: Could not find or load main class io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
Caused by: java.lang.ClassNotFoundException: io.aeron.samples.tutorial.cluster.BasicAuctionClusteredServiceNode
```

should the parameters for the example contain the word "tutorial", like in `aeron.cluster.tutorial.bidIntervalMs`?

thanks! 