### PR TITLE
[C] Add aeron specific errors codes.  Change error codes in conductor…

### DIFF
--- a/aeron-client/src/main/c/aeron_client.c
+++ b/aeron-client/src/main/c/aeron_client.c
@@ -358,7 +358,8 @@ int aeron_async_add_publication_poll(aeron_publication_t **publication, aeron_as
 
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
-            aeron_set_err(ETIMEDOUT, "%s", "async_add_publication no response from media driver");
+            aeron_set_err(
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }
@@ -424,7 +425,8 @@ int aeron_async_add_exclusive_publication_poll(
 
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
-            aeron_set_err(ETIMEDOUT, "%s", "async_add_exclusive_publication no response from media driver");
+            aeron_set_err(
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }
@@ -504,7 +506,8 @@ int aeron_async_add_subscription_poll(aeron_subscription_t **subscription, aeron
 
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
-            aeron_set_err(ETIMEDOUT, "%s", "async_add_subscription no response from media driver");
+            aeron_set_err(
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }
@@ -582,7 +585,8 @@ int aeron_async_add_counter_poll(aeron_counter_t **counter, aeron_async_add_coun
 
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
-            aeron_set_err(ETIMEDOUT, "%s", "async_add_counter no response from media driver");
+            aeron_set_err(
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }
@@ -631,7 +635,8 @@ static int aeron_async_destination_poll(aeron_async_destination_t *async)
 
         case AERON_CLIENT_TIMEOUT_MEDIA_DRIVER:
         {
-            aeron_set_err(ETIMEDOUT, "%s", "async_add_counter no response from media driver");
+            aeron_set_err(
+                AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "%s", "async_add_publication no response from media driver");
             aeron_async_cmd_free(async);
             return -1;
         }

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -823,7 +823,7 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
 
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "ADD_PUBLICATION could not be sent (%s:%d)", __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
             return;
         }
 
@@ -890,7 +890,7 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_EXCLUSIVE_PUBLICATION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
             return;
         }
 
@@ -957,7 +957,7 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_SUBSCRIPTION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
             return;
         }
 
@@ -1035,7 +1035,7 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_COUNTER could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
             return;
         }
 
@@ -1129,7 +1129,7 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
 
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "DESTINATION command could not be sent (%s:%d)", __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
             return;
         }
 
@@ -1306,7 +1306,7 @@ int aeron_client_conductor_command_offer(aeron_mpsc_concurrent_array_queue_t *co
     {
         if (++fail_count > AERON_CLIENT_COMMAND_QUEUE_FAIL_THRESHOLD)
         {
-            aeron_set_err(EXFULL, "%s", "could not offer to conductor command queue");
+            aeron_set_err(AERON_CLIENT_ERROR_BUFFER_FULL, "%s", "could not offer to conductor command queue");
             return -1;
         }
 
@@ -2384,8 +2384,8 @@ int aeron_client_conductor_offer_remove_command(
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "remove command could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
-            aeron_set_err(EXFULL, "%s", err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_set_err(AERON_CLIENT_ERROR_BUFFER_FULL, "%s", err_buffer);
             return -1;
         }
 
@@ -2422,8 +2422,8 @@ int aeron_client_conductor_offer_destination_command(
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "destination command could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
-            aeron_set_err(EXFULL, "%s", err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_set_err(AERON_CLIENT_ERROR_BUFFER_FULL, "%s", err_buffer);
             return -1;
         }
 

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -410,7 +410,7 @@ int aeron_client_conductor_check_liveness(aeron_client_conductor_t *conductor, l
                 "MediaDriver keepalive age exceeded (ms): timeout=%" PRId64 ", age=%" PRId64,
                 (int64_t)conductor->driver_timeout_ms,
                 (int64_t)(now_ms - last_keepalive_ms));
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, buffer);
+            conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_DRIVER_TIMEOUT, buffer);
             return -1;
         }
 
@@ -441,6 +441,7 @@ int aeron_client_conductor_check_liveness(aeron_client_conductor_t *conductor, l
                 aeron_client_conductor_force_close_resources(conductor);
                 snprintf(buffer, sizeof(buffer) - 1, "unexpected close of heartbeat timestamp counter: %" PRId32, id);
                 conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, buffer);
+                aeron_set_err(ETIMEDOUT, "%s", buffer);
                 return -1;
             }
 
@@ -543,7 +544,8 @@ int aeron_client_conductor_on_check_timeouts(aeron_client_conductor_t *conductor
                 "service interval exceeded (ns): timeout=%" PRId64 ", interval=%" PRId64,
                 (int64_t)conductor->inter_service_timeout_ns,
                 (int64_t)(now_ns - conductor->time_of_last_service_ns));
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, buffer);
+            conductor->error_handler(
+                conductor->error_handler_clientd, AERON_CLIENT_ERROR_CONDUCTOR_SERVICE_TIMEOUT, buffer);
             return -1;
         }
 
@@ -821,7 +823,7 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
 
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "ADD_PUBLICATION could not be sent (%s:%d)", __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
             return;
         }
 
@@ -888,7 +890,7 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_EXCLUSIVE_PUBLICATION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
             return;
         }
 
@@ -955,7 +957,7 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_SUBSCRIPTION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
             return;
         }
 
@@ -1033,7 +1035,7 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_COUNTER could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
             return;
         }
 
@@ -1127,7 +1129,7 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
 
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "DESTINATION command could not be sent (%s:%d)", __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
             return;
         }
 
@@ -1304,7 +1306,7 @@ int aeron_client_conductor_command_offer(aeron_mpsc_concurrent_array_queue_t *co
     {
         if (++fail_count > AERON_CLIENT_COMMAND_QUEUE_FAIL_THRESHOLD)
         {
-            aeron_set_err(ETIMEDOUT, "%s", "could not offer to conductor command queue");
+            aeron_set_err(EXFULL, "%s", "could not offer to conductor command queue");
             return -1;
         }
 
@@ -2356,7 +2358,7 @@ int aeron_client_conductor_on_client_timeout(aeron_client_conductor_t *conductor
         conductor->is_terminating = true;
         aeron_client_conductor_force_close_resources(conductor);
         snprintf(err_buffer, sizeof(err_buffer) - 1, "%s", "client timeout from driver");
-        conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
+        conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_CLIENT_TIMEOUT, err_buffer);
     }
 
     return 0;
@@ -2382,8 +2384,8 @@ int aeron_client_conductor_offer_remove_command(
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "remove command could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
-            aeron_set_err(ETIMEDOUT, "%s", err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            aeron_set_err(EXFULL, "%s", err_buffer);
             return -1;
         }
 
@@ -2420,8 +2422,8 @@ int aeron_client_conductor_offer_destination_command(
 
             snprintf(err_buffer, sizeof(err_buffer) - 1, "destination command could not be sent (%s:%d)",
                 __FILE__, __LINE__);
-            conductor->error_handler(conductor->error_handler_clientd, ETIMEDOUT, err_buffer);
-            aeron_set_err(ETIMEDOUT, "%s", err_buffer);
+            conductor->error_handler(conductor->error_handler_clientd, EXFULL, err_buffer);
+            aeron_set_err(EXFULL, "%s", err_buffer);
             return -1;
         }
 

--- a/aeron-client/src/main/c/aeron_context.c
+++ b/aeron-client/src/main/c/aeron_context.c
@@ -413,7 +413,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
     if (AERON_MAX_PATH < token_length)
     {
         aeron_set_err(EINVAL, "Token too long: %lu", (unsigned long)token_length);
-        return -EINVAL;
+        return -1;
     }
 
     char filename[AERON_MAX_PATH];
@@ -423,7 +423,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
     int64_t file_length_result = aeron_file_length(filename);
     if (file_length_result < 0)
     {
-        aeron_set_err(-1, "Invalid file length");
+        aeron_set_err(EINVAL, "Invalid file length");
         return -1;
     }
     
@@ -446,7 +446,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
             if (aeron_semantic_version_major(cnc_version) != aeron_semantic_version_major(AERON_CNC_VERSION))
             {
                 aeron_set_err(
-                    -1, 
+                    EINVAL,
                     "Aeron CnC version does not match: client=%" PRId32 ", file=%" PRId32,
                     AERON_CNC_VERSION, 
                     cnc_version);
@@ -458,7 +458,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
             if (aeron_semantic_version_minor(cnc_version) < aeron_semantic_version_minor(AERON_CNC_VERSION))
             {
                 aeron_set_err(
-                    -1,
+                    EINVAL,
                     "Driver version insufficient: client=%" PRId32 ", file=%" PRId32,
                     AERON_CNC_VERSION,
                     cnc_version);
@@ -469,7 +469,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
 
             if (!aeron_cnc_is_file_length_sufficient(&cnc_mmap))
             {
-                aeron_set_err(-1, "Aeron CnC file length not sufficient: length=%" PRId64, file_length_result);
+                aeron_set_err(EINVAL, "Aeron CnC file length not sufficient: length=%" PRId64, file_length_result);
                 result = -1;
                 goto cleanup;
             }
@@ -478,7 +478,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
             if (aeron_mpsc_rb_init(&rb, aeron_cnc_to_driver_buffer(metadata), (size_t)metadata->to_driver_buffer_length) < 0)
             {
                 aeron_set_err_from_last_err_code("Failed to setup ring buffer for termination");
-                result = aeron_errcode();
+                result = -1;
                 goto cleanup;
             }
 
@@ -494,7 +494,7 @@ int aeron_context_request_driver_termination(const char *directory, const uint8_
 
             if (AERON_RB_SUCCESS != aeron_mpsc_rb_write(&rb, AERON_COMMAND_TERMINATE_DRIVER, command, command_length))
             {
-                aeron_set_err(-1, "Unable to write to driver ring buffer");
+                aeron_set_err(AERON_CLIENT_ERROR_BUFFER_FULL, "Unable to write to driver ring buffer");
                 result = -1;
             }
 

--- a/aeron-client/src/main/c/aeronc.c
+++ b/aeron-client/src/main/c/aeronc.c
@@ -52,7 +52,7 @@ int aeron_client_connect_to_driver(aeron_mapped_file_t *cnc_mmap, aeron_context_
         {
             if (context->epoch_clock() > deadline_ms)
             {
-                aeron_set_err(ETIMEDOUT, "CnC file not created: %s", filename);
+                aeron_set_err(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "CnC file not created: %s", filename);
                 return -1;
             }
 
@@ -79,7 +79,7 @@ int aeron_client_connect_to_driver(aeron_mapped_file_t *cnc_mmap, aeron_context_
         {
             if (context->epoch_clock() > deadline_ms)
             {
-                aeron_set_err(ETIMEDOUT, "CnC file is created but not initialised");
+                aeron_set_err(AERON_CLIENT_ERROR_CLIENT_TIMEOUT, "CnC file is created but not initialised");
                 aeron_unmap(cnc_mmap);
                 return -1;
             }
@@ -121,7 +121,7 @@ int aeron_client_connect_to_driver(aeron_mapped_file_t *cnc_mmap, aeron_context_
         {
             if (context->epoch_clock() > deadline_ms)
             {
-                aeron_set_err(ETIMEDOUT, "no driver heartbeat detected");
+                aeron_set_err(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "no driver heartbeat detected");
                 aeron_unmap(cnc_mmap);
                 return -1;
             }
@@ -134,7 +134,7 @@ int aeron_client_connect_to_driver(aeron_mapped_file_t *cnc_mmap, aeron_context_
         {
             if (now_ms > deadline_ms)
             {
-                aeron_set_err(ETIMEDOUT, "no driver heartbeat detected");
+                aeron_set_err(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, "no driver heartbeat detected");
                 aeron_unmap(cnc_mmap);
                 return -1;
             }

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -28,6 +28,10 @@ extern "C"
 
 #define AERON_NULL_VALUE (-1)
 
+#define AERON_CLIENT_ERROR_DRIVER_TIMEOUT (-1000)
+#define AERON_CLIENT_ERROR_CLIENT_TIMEOUT (-1001)
+#define AERON_CLIENT_ERROR_CONDUCTOR_SERVICE_TIMEOUT (-1002)
+
 typedef struct aeron_context_stct aeron_context_t;
 typedef struct aeron_stct aeron_t;
 typedef struct aeron_buffer_claim_stct aeron_buffer_claim_t;

--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -31,6 +31,7 @@ extern "C"
 #define AERON_CLIENT_ERROR_DRIVER_TIMEOUT (-1000)
 #define AERON_CLIENT_ERROR_CLIENT_TIMEOUT (-1001)
 #define AERON_CLIENT_ERROR_CONDUCTOR_SERVICE_TIMEOUT (-1002)
+#define AERON_CLIENT_ERROR_BUFFER_FULL (-1003)
 
 typedef struct aeron_context_stct aeron_context_t;
 typedef struct aeron_stct aeron_t;

--- a/aeron-client/src/test/c/aeron_client_conductor_test.cpp
+++ b/aeron-client/src/test/c/aeron_client_conductor_test.cpp
@@ -408,7 +408,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddPublicationFromDriverError)
     doWork();
 
     ASSERT_EQ(aeron_async_add_publication_poll(&publication, async), -1);
-    ASSERT_EQ(EINVAL, errno);
+    ASSERT_EQ(EINVAL, aeron_errcode());
 }
 
 TEST_F(ClientConductorTest, shouldErrorOnAddPublicationFromDriverTimeout)
@@ -425,7 +425,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddPublicationFromDriverTimeout)
     doWorkForNs((m_context->driver_timeout_ms + 1000) * 1000000LL);
 
     ASSERT_EQ(aeron_async_add_publication_poll(&publication, async), -1);
-    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, errno);
+    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, aeron_errcode());
 }
 
 TEST_F(ClientConductorTest, shouldAddExclusivePublicationSuccessfully)
@@ -481,7 +481,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddExclusivePublicationFromDriverTimeou
     doWorkForNs((m_context->driver_timeout_ms + 1000) * 1000000LL);
 
     ASSERT_EQ(aeron_async_add_exclusive_publication_poll(&publication, async), -1);
-    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, errno);
+    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, aeron_errcode());
 }
 
 TEST_F(ClientConductorTest, shouldAddSubscriptionSuccessfully)
@@ -539,7 +539,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddSubscriptionFromDriverTimeout)
     doWorkForNs((m_context->driver_timeout_ms + 1000) * 1000000LL);
 
     ASSERT_EQ(aeron_async_add_subscription_poll(&subscription, async), -1);
-    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, errno);
+    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, aeron_errcode());
 }
 
 TEST_F(ClientConductorTest, shouldAddCounterSuccessfully)
@@ -597,7 +597,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddCounterFromDriverTimeout)
     doWorkForNs((m_context->driver_timeout_ms + 1000) * 1000000LL);
 
     ASSERT_EQ(aeron_async_add_counter_poll(&counter, async), -1);
-    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, errno);
+    ASSERT_EQ(AERON_CLIENT_ERROR_DRIVER_TIMEOUT, aeron_errcode());
 }
 
 TEST_F(ClientConductorTest, shouldAddPublicationAndHandleOnNewPublication)


### PR DESCRIPTION
… so that they can be distinguished in the wrapper.  Use EXFULL for situations where the client queue or driver ring buffer is full.

The use of `EXFULL` as an error code is a debatable one.  It was the closest standard error code that represented the case of a full buffer or queue (wanted avoid overloading `ETIMEDOUT`).  We need something fairly distinct in order to map it to an IllegalStateException in the wrapper.  If that naming is not particularly useful, then we should add a new Aeron specific code.