### PR TITLE
[C/C++] Use the same values for the controlled poll enum as the C++ A…

### DIFF
--- a/aeron-client/src/main/c/aeronc.h
+++ b/aeron-client/src/main/c/aeronc.h
@@ -1340,25 +1340,25 @@ typedef enum aeron_controlled_fragment_handler_action_en
     /**
      * Abort the current polling operation and do not advance the position for this fragment.
      */
-    AERON_ACTION_ABORT,
+    AERON_ACTION_ABORT = 1,
 
     /**
      * Break from the current polling operation and commit the position as of the end of the current fragment
      * being handled.
      */
-    AERON_ACTION_BREAK,
+    AERON_ACTION_BREAK = 2,
 
     /**
      * Continue processing but commit the position as of the end of the current fragment so that
      * flow control is applied to this point.
      */
-    AERON_ACTION_COMMIT,
+    AERON_ACTION_COMMIT = 3,
 
     /**
      * Continue processing until fragment limit or no fragments with position commit at end of poll as in
      * aeron_fragment_handler_t.
      */
-    AERON_ACTION_CONTINUE
+    AERON_ACTION_CONTINUE = 4
 }
 aeron_controlled_fragment_handler_action_t;
 

--- a/aeron-client/src/main/cpp_wrapper/Image.h
+++ b/aeron-client/src/main/cpp_wrapper/Image.h
@@ -27,6 +27,8 @@
 #include "concurrent/AtomicBuffer.h"
 #include "concurrent/logbuffer/Header.h"
 
+#include "aeronc.h"
+
 namespace aeron
 {
 
@@ -38,24 +40,24 @@ enum class ControlledPollAction : int
     /**
      * Abort the current polling operation and do not advance the position for this fragment.
      */
-    ABORT = 1,
+    ABORT = AERON_ACTION_ABORT,
 
     /**
      * Break from the current polling operation and commit the position as of the end of the current fragment
      * being handled.
      */
-    BREAK,
+    BREAK = AERON_ACTION_BREAK,
 
     /**
      * Continue processing but commit the position as of the end of the current fragment so that
      * flow control is applied to this point.
      */
-    COMMIT,
+    COMMIT = AERON_ACTION_COMMIT,
 
     /**
      * Continue processing taking the same approach as the in fragment_handler_t.
      */
-    CONTINUE
+    CONTINUE = AERON_ACTION_CONTINUE
 };
 
 /**
@@ -92,13 +94,7 @@ static aeron_controlled_fragment_handler_action_t doControlledPoll(
     Header headerWrapper(header, nullptr);
 
     ControlledPollAction action = handler(atomicBuffer, 0, static_cast<std::int32_t>(length), headerWrapper);
-    switch (action)
-    {
-        case ControlledPollAction::ABORT:    return AERON_ACTION_ABORT;
-        case ControlledPollAction::BREAK:    return AERON_ACTION_BREAK;
-        case ControlledPollAction::COMMIT:   return AERON_ACTION_COMMIT;
-        case ControlledPollAction::CONTINUE: return AERON_ACTION_CONTINUE;
-    }
+    return static_cast<aeron_controlled_fragment_handler_action_t>(action);
 
     throw IllegalStateException("Invalid action", SOURCEINFO);
 }


### PR DESCRIPTION
…PI.  Directly map C enum values to the C++ equivalent in the wrapper.  Replace switch with cast.

The debatable part here would be the use of the cast instead of the switch statement.  With the switch there will be a runtime failure if there is a mismatch between the two enums such that there wasn't a clear mapping.  If there was a value in `ControlledPollAction` that wasn't in `aeron_controlled_fragment_handler_action_t`, this would be undefined behaviour, however it would require explicitly declaring an out of range value on the `ControlledPollEnum`.  The cast does make the code more concise as the mapping between the enum values only needs to be declared on the enum itself.