### PR TITLE
Separating of cpp_wrapper and direct cpp headers

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/CMakeLists.txt
+++ b/aeron-client/src/main/cpp_wrapper/CMakeLists.txt
@@ -106,5 +106,5 @@ endif ()
 target_link_libraries(aeron_client_wrapper INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 
 if (AERON_INSTALL_TARGETS)
-   install(DIRECTORY . DESTINATION include FILES_MATCHING PATTERN "*.h")
+   install(DIRECTORY . DESTINATION include/wrapper FILES_MATCHING PATTERN "*.h")
 endif ()


### PR DESCRIPTION
It will allow to avoid random overriding headers with the same  names but for different versions