### PR TITLE
[Java/C++] Archive variable length recordings.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -89,7 +89,7 @@ public enum ArchiveEventCode implements EventCode
     CATALOG_RESIZE(37, -1,
         (event, buffer, offset, builder) -> dissectCatalogResize(buffer, offset, builder)),
 
-    CMD_IN_INVALIDATE_RECORDING(38, InvalidateRecordingRequestDecoder.TEMPLATE_ID,
+    CMD_IN_PURGE_RECORDING(38, PurgeRecordingRequestDecoder.TEMPLATE_ID,
         ArchiveEventDissector::dissectControlRequest);
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -87,7 +87,10 @@ public enum ArchiveEventCode implements EventCode
     REPLAY_SESSION_ERROR(36, -1,
         (event, buffer, offset, builder) -> dissectReplaySessionError(buffer, offset, builder)),
     CATALOG_RESIZE(37, -1,
-        (event, buffer, offset, builder) -> dissectCatalogResize(buffer, offset, builder));
+        (event, buffer, offset, builder) -> dissectCatalogResize(buffer, offset, builder)),
+
+    CMD_IN_INVALIDATE_RECORDING(38, InvalidateRecordingRequestDecoder.TEMPLATE_ID,
+        ArchiveEventDissector::dissectControlRequest);
 
     static final int EVENT_CODE_TYPE = EventCodeType.ARCHIVE.getTypeCode();
     private static final ArchiveEventCode[] EVENT_CODE_BY_ID;

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -80,8 +80,8 @@ final class ArchiveEventDissector
         new TaggedReplicateRequestDecoder();
     private static final StopRecordingByIdentityRequestDecoder STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER =
         new StopRecordingByIdentityRequestDecoder();
-    private static final InvalidateRecordingRequestDecoder INVALIDATE_RECORDING_REQUEST_DECODER =
-        new InvalidateRecordingRequestDecoder();
+    private static final PurgeRecordingRequestDecoder PURGE_RECORDING_REQUEST_DECODER =
+        new PurgeRecordingRequestDecoder();
     private static final ControlResponseDecoder CONTROL_RESPONSE_DECODER = new ControlResponseDecoder();
 
     private ArchiveEventDissector()
@@ -390,13 +390,13 @@ final class ArchiveEventDissector
                 appendStopRecordingByIdentity(builder);
                 break;
 
-            case CMD_IN_INVALIDATE_RECORDING:
-                INVALIDATE_RECORDING_REQUEST_DECODER.wrap(
+            case CMD_IN_PURGE_RECORDING:
+                PURGE_RECORDING_REQUEST_DECODER.wrap(
                     buffer,
                     offset + relativeOffset,
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
-                appendInvalidateRecording(builder);
+                appendPurgeRecording(builder);
                 break;
 
             default:
@@ -797,11 +797,11 @@ final class ArchiveEventDissector
         TAGGED_REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
 
-    private static void appendInvalidateRecording(final StringBuilder builder)
+    private static void appendPurgeRecording(final StringBuilder builder)
     {
-        builder.append(": controlSessionId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.recordingId());
+        builder.append(": controlSessionId=").append(PURGE_RECORDING_REQUEST_DECODER.controlSessionId())
+            .append(", correlationId=").append(PURGE_RECORDING_REQUEST_DECODER.correlationId())
+            .append(", recordingId=").append(PURGE_RECORDING_REQUEST_DECODER.recordingId());
     }
 
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -80,6 +80,8 @@ final class ArchiveEventDissector
         new TaggedReplicateRequestDecoder();
     private static final StopRecordingByIdentityRequestDecoder STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER =
         new StopRecordingByIdentityRequestDecoder();
+    private static final InvalidateRecordingRequestDecoder INVALIDATE_RECORDING_REQUEST_DECODER =
+        new InvalidateRecordingRequestDecoder();
     private static final ControlResponseDecoder CONTROL_RESPONSE_DECODER = new ControlResponseDecoder();
 
     private ArchiveEventDissector()
@@ -386,6 +388,15 @@ final class ArchiveEventDissector
                     HEADER_DECODER.blockLength(),
                     HEADER_DECODER.version());
                 appendStopRecordingByIdentity(builder);
+                break;
+
+            case CMD_IN_INVALIDATE_RECORDING:
+                INVALIDATE_RECORDING_REQUEST_DECODER.wrap(
+                    buffer,
+                    offset + relativeOffset,
+                    HEADER_DECODER.blockLength(),
+                    HEADER_DECODER.version());
+                appendInvalidateRecording(builder);
                 break;
 
             default:
@@ -785,4 +796,12 @@ final class ArchiveEventDissector
         builder.append(", liveDestination=");
         TAGGED_REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
+
+    private static void appendInvalidateRecording(final StringBuilder builder)
+    {
+        builder.append(": controlSessionId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.controlSessionId())
+            .append(", correlationId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.correlationId())
+            .append(", recordingId=").append(INVALIDATE_RECORDING_REQUEST_DECODER.recordingId());
+    }
+
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventEncoder.java
@@ -82,21 +82,13 @@ final class ArchiveEventEncoder
         final int offset,
         final int captureLength,
         final int length,
-        final int maxEntries,
         final long catalogLength,
-        final int newMaxEntries,
         final long newCatalogLength)
     {
         int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodingBuffer.putInt(offset + relativeOffset, maxEntries, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
-
         encodingBuffer.putLong(offset + relativeOffset, catalogLength, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_LONG;
-
-        encodingBuffer.putInt(offset + relativeOffset, newMaxEntries, LITTLE_ENDIAN);
-        relativeOffset += SIZE_OF_INT;
 
         encodingBuffer.putLong(offset + relativeOffset, newCatalogLength, LITTLE_ENDIAN);
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventLogger.java
@@ -135,10 +135,9 @@ public final class ArchiveEventLogger
         }
     }
 
-    public void logCatalogResize(
-        final int maxEntries, final long catalogLength, final int newMaxEntries, final long newCatalogLength)
+    public void logCatalogResize(final long catalogLength, final long newCatalogLength)
     {
-        final int length = SIZE_OF_LONG * 2 + 2 * SIZE_OF_INT;
+        final int length = SIZE_OF_LONG * 2;
         final int captureLength = captureLength(length);
         final int encodedLength = encodedLength(captureLength);
         final ManyToOneRingBuffer ringBuffer = this.ringBuffer;
@@ -153,9 +152,7 @@ public final class ArchiveEventLogger
                     index,
                     captureLength,
                     length,
-                    maxEntries,
                     catalogLength,
-                    newMaxEntries,
                     newCatalogLength);
             }
             finally

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveInterceptor.java
@@ -56,10 +56,9 @@ class ArchiveInterceptor
     static class Catalog
     {
         @Advice.OnMethodEnter
-        static void catalogResized(
-            final int maxEntries, final long catalogLength, final int newMaxEntries, final long newCatalogLength)
+        static void catalogResized(final long catalogLength, final long newCatalogLength)
         {
-            LOGGER.logCatalogResize(maxEntries, catalogLength, newMaxEntries, newCatalogLength);
+            LOGGER.logCatalogResize(catalogLength, newCatalogLength);
         }
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -835,18 +835,18 @@ class ArchiveEventDissectorTest
     }
 
     @Test
-    void controlRequestInvalidateRecording()
+    void controlRequestPurgeRecording()
     {
         internalEncodeLogHeader(buffer, 0, 56, 901, () -> 1_125_000_000L);
-        final InvalidateRecordingRequestEncoder requestEncoder = new InvalidateRecordingRequestEncoder();
+        final PurgeRecordingRequestEncoder requestEncoder = new PurgeRecordingRequestEncoder();
         requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
             .controlSessionId(15)
             .correlationId(421)
             .recordingId(6);
 
-        dissectControlRequest(CMD_IN_INVALIDATE_RECORDING, buffer, 0, builder);
+        dissectControlRequest(CMD_IN_PURGE_RECORDING, buffer, 0, builder);
 
-        assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_INVALIDATE_RECORDING.name() + " [56/901]:" +
+        assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_PURGE_RECORDING.name() + " [56/901]:" +
             " controlSessionId=15" +
             ", correlationId=421" +
             ", recordingId=6",

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -833,4 +833,24 @@ class ArchiveEventDissectorTest
             " 24 entries (100 bytes) => 777 entries (10000000000 bytes)",
             builder.toString());
     }
+
+    @Test
+    void controlRequestInvalidateRecording()
+    {
+        internalEncodeLogHeader(buffer, 0, 56, 901, () -> 1_125_000_000L);
+        final InvalidateRecordingRequestEncoder requestEncoder = new InvalidateRecordingRequestEncoder();
+        requestEncoder.wrapAndApplyHeader(buffer, LOG_HEADER_LENGTH, headerEncoder)
+            .controlSessionId(15)
+            .correlationId(421)
+            .recordingId(6);
+
+        dissectControlRequest(CMD_IN_INVALIDATE_RECORDING, buffer, 0, builder);
+
+        assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_INVALIDATE_RECORDING.name() + " [56/901]:" +
+            " controlSessionId=15" +
+            ", correlationId=421" +
+            ", recordingId=6",
+            builder.toString());
+    }
+
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventEncoderTest.java
@@ -94,20 +94,16 @@ class ArchiveEventEncoderTest
         final int offset = 24;
         final int length = SIZE_OF_LONG * 2 + SIZE_OF_INT * 2;
         final int captureLength = captureLength(length);
-        final int maxEntries = 3;
         final long catalogLength = 128;
-        final int newMaxEntries = 7;
         final long newCatalogLength = 1024;
 
         encodeCatalogResize(
-            buffer, offset, captureLength, length, maxEntries, catalogLength, newMaxEntries, newCatalogLength);
+            buffer, offset, captureLength, length, catalogLength, newCatalogLength);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
         assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(maxEntries, buffer.getInt(offset + LOG_HEADER_LENGTH));
-        assertEquals(catalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT));
-        assertEquals(newMaxEntries, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG));
-        assertEquals(newCatalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH + 2 * SIZE_OF_INT + SIZE_OF_LONG));
+        assertEquals(catalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH));
+        assertEquals(newCatalogLength, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventLoggerTest.java
@@ -189,21 +189,16 @@ class ArchiveEventLoggerTest
     {
         final int offset = ALIGNMENT * 3;
         logBuffer.putLong(CAPACITY + TAIL_POSITION_OFFSET, offset);
-        final int captureLength = SIZE_OF_LONG * 2 + SIZE_OF_INT * 2;
-        final int maxEntries = 21;
+        final int captureLength = SIZE_OF_LONG * 2;
         final long catalogLength = 42;
-        final int newMaxEntries = 121;
         final long newCatalogLength = 142;
 
-        logger.logCatalogResize(maxEntries, catalogLength, newMaxEntries, newCatalogLength);
+        logger.logCatalogResize(catalogLength, newCatalogLength);
 
         verifyLogHeader(logBuffer, offset, toEventCodeId(CATALOG_RESIZE), captureLength, captureLength);
-        assertEquals(maxEntries, logBuffer.getInt(encodedMsgOffset(offset + LOG_HEADER_LENGTH), LITTLE_ENDIAN));
         assertEquals(catalogLength,
-            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_INT), LITTLE_ENDIAN));
-        assertEquals(newMaxEntries, logBuffer.getInt(
-            encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG), LITTLE_ENDIAN));
-        assertEquals(newCatalogLength, logBuffer.getLong(
-            encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG), LITTLE_ENDIAN));
+            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH), LITTLE_ENDIAN));
+        assertEquals(newCatalogLength,
+            logBuffer.getLong(encodedMsgOffset(offset + LOG_HEADER_LENGTH + SIZE_OF_LONG), LITTLE_ENDIAN));
     }
 }

--- a/aeron-archive/src/main/cpp/CMakeLists.txt
+++ b/aeron-archive/src/main/cpp/CMakeLists.txt
@@ -36,6 +36,7 @@ set(GENERATED_CODECS
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/ExtendRecordingRequest2.h
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/RecordingPositionRequest.h
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/TruncateRecordingRequest.h
+    ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/PurgeRecordingRequest.h
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/StopRecordingSubscriptionRequest.h
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/StartPositionRequest.h
     ${ARCHIVE_CODEC_TARGET_DIR}/aeron_archive_client/StopPositionRequest.h

--- a/aeron-archive/src/main/cpp/client/AeronArchive.h
+++ b/aeron-archive/src/main/cpp/client/AeronArchive.h
@@ -1209,7 +1209,7 @@ public:
      * Purge a stopped recording, i.e. mark recording as 'RecordingState#INVALID' and delete the corresponding segment
      * files. The space in the Catalog will be reclaimed upon compaction.
      *
-     * @param recordingId      of the stopped recording to be truncated.
+     * @param recordingId      of the stopped recording to be purged.
      * @tparam IdleStrategy to use for polling operations.
      */
     template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>

--- a/aeron-archive/src/main/cpp/client/AeronArchive.h
+++ b/aeron-archive/src/main/cpp/client/AeronArchive.h
@@ -1206,6 +1206,30 @@ public:
     }
 
     /**
+     * Purge a stopped recording, i.e. mark recording as 'RecordingState#INVALID' and delete the corresponding segment
+     * files. The space in the Catalog will be reclaimed upon compaction.
+     *
+     * @param recordingId      of the stopped recording to be truncated.
+     * @tparam IdleStrategy to use for polling operations.
+     */
+    template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>
+    inline void purgeRecording(std::int64_t recordingId)
+    {
+        std::lock_guard<std::recursive_mutex> lock(m_lock);
+        ensureOpen();
+        ensureNotReentrant();
+
+        m_lastCorrelationId = m_aeron->nextCorrelationId();
+
+        if (!m_archiveProxy->purgeRecording<IdleStrategy>(recordingId, m_lastCorrelationId, m_controlSessionId))
+        {
+            throw ArchiveException("failed to send purge recording request", SOURCEINFO);
+        }
+
+        pollForResponse<IdleStrategy>(m_lastCorrelationId);
+    }
+
+    /**
      * List active recording subscriptions in the archive. These are the result of requesting one of
      * #startRecording(String, int, SourceLocation) or a
      * #extendRecording(long, String, int, SourceLocation). The returned subscription id can be used for

--- a/aeron-archive/src/main/cpp/client/ArchiveProxy.cpp
+++ b/aeron-archive/src/main/cpp/client/ArchiveProxy.cpp
@@ -50,6 +50,7 @@
 #include "aeron_archive_client/KeepAliveRequest.h"
 #include "aeron_archive_client/ChallengeResponse.h"
 #include "aeron_archive_client/TaggedReplicateRequest.h"
+#include "aeron_archive_client/PurgeRecordingRequest.h"
 
 using namespace aeron;
 using namespace aeron::concurrent;
@@ -457,6 +458,22 @@ util::index_t ArchiveProxy::truncateRecording(
         .correlationId(correlationId)
         .recordingId(recordingId)
         .position(position);
+
+    return messageAndHeaderLength(request);
+}
+
+util::index_t ArchiveProxy::purgeRecording(
+        AtomicBuffer &buffer,
+        std::int64_t recordingId,
+        std::int64_t correlationId,
+        std::int64_t controlSessionId)
+{
+    PurgeRecordingRequest request;
+
+    wrapAndApplyHeader(request, buffer)
+            .controlSessionId(controlSessionId)
+            .correlationId(correlationId)
+            .recordingId(recordingId);
 
     return messageAndHeaderLength(request);
 }

--- a/aeron-archive/src/main/cpp/client/ArchiveProxy.h
+++ b/aeron-archive/src/main/cpp/client/ArchiveProxy.h
@@ -578,7 +578,7 @@ public:
      * Purge a stopped recording, i.e. mark recording as 'RecordingState#INVALID' and delete the corresponding segment
      * files. The space in the Catalog will be reclaimed upon compaction.
      *
-     * @param recordingId      of the stopped recording to be truncated.
+     * @param recordingId      of the stopped recording to be purged.
      * @param correlationId    for this request.
      * @param controlSessionId for this request.
      * @return true if successfully offered otherwise false.

--- a/aeron-archive/src/main/cpp/client/ArchiveProxy.h
+++ b/aeron-archive/src/main/cpp/client/ArchiveProxy.h
@@ -575,6 +575,26 @@ public:
     }
 
     /**
+     * Purge a stopped recording, i.e. mark recording as 'RecordingState#INVALID' and delete the corresponding segment
+     * files. The space in the Catalog will be reclaimed upon compaction.
+     *
+     * @param recordingId      of the stopped recording to be truncated.
+     * @param correlationId    for this request.
+     * @param controlSessionId for this request.
+     * @return true if successfully offered otherwise false.
+     */
+    template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>
+    bool purgeRecording(
+            std::int64_t recordingId,
+            std::int64_t correlationId,
+            std::int64_t controlSessionId)
+    {
+        const util::index_t length = purgeRecording(m_buffer, recordingId, correlationId, controlSessionId);
+
+        return offer<IdleStrategy>(m_buffer, 0, length);
+    }
+
+    /**
      * List registered subscriptions in the archive which have been used to record streams.
      *
      * @param pseudoIndex       in the list of active recording subscriptions.
@@ -1039,6 +1059,12 @@ private:
         AtomicBuffer &buffer,
         std::int64_t recordingId,
         std::int64_t position,
+        std::int64_t correlationId,
+        std::int64_t controlSessionId);
+
+    static util::index_t purgeRecording(
+        AtomicBuffer &buffer,
+        std::int64_t recordingId,
         std::int64_t correlationId,
         std::int64_t controlSessionId);
 

--- a/aeron-archive/src/main/java/io/aeron/archive/AbstractListRecordingsSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/AbstractListRecordingsSession.java
@@ -22,12 +22,6 @@ abstract class AbstractListRecordingsSession implements Session
 {
     static final int MAX_SCANS_PER_WORK_CYCLE = 256;
 
-    final UnsafeBuffer descriptorBuffer;
-    final Catalog catalog;
-    final ControlSession controlSession;
-    final ControlResponseProxy proxy;
-    final long correlationId;
-    boolean isDone = false;
     private final UnsafeBuffer descriptorBuffer;
     private final Catalog catalog;
     private final int count;
@@ -142,5 +136,5 @@ abstract class AbstractListRecordingsSession implements Session
         controlSession.activeListing(null);
     }
 
-    protected abstract boolean acceptDescriptor(UnsafeBuffer descriptorBuffer);
+    abstract boolean acceptDescriptor(UnsafeBuffer descriptorBuffer);
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -318,7 +318,10 @@ public final class Archive implements AutoCloseable
          * Maximum number of entries for the archive {@link Catalog}. Increasing this limit will require use of the
          * {@link CatalogTool}. The number of entries can be reduced by extending existing recordings rather than
          * creating new ones.
+         *
+         * @deprecated Use {@link #CATALOG_CAPACITY_PROP_NAME} instead.
          */
+        @Deprecated
         public static final String MAX_CATALOG_ENTRIES_PROP_NAME = "aeron.archive.max.catalog.entries";
 
         /**
@@ -326,7 +329,21 @@ public final class Archive implements AutoCloseable
          *
          * @see #MAX_CATALOG_ENTRIES_PROP_NAME
          */
+        @Deprecated
         public static final long MAX_CATALOG_ENTRIES_DEFAULT = Catalog.DEFAULT_MAX_ENTRIES;
+
+        /**
+         * Default capacity in bytes of the archive {@link Catalog}. {@link Catalog} will resize itself when this
+         * limit is reached.
+         */
+        public static final String CATALOG_CAPACITY_PROP_NAME = "aeron.archive.catalog.capacity";
+
+        /**
+         * Default capacity in bytes for the {@link Catalog}.
+         *
+         * @see #CATALOG_CAPACITY_PROP_NAME
+         */
+        public static final long CATALOG_CAPACITY_DEFAULT = Catalog.DEFAULT_CAPACITY;
 
         /**
          * Timeout for making a connection back to a client for a control session or replay.
@@ -564,11 +581,25 @@ public final class Archive implements AutoCloseable
         /**
          * Maximum number of catalog entries to allocate for the catalog file.
          *
+         * @deprecated Use {@link #catalogCapacity()} instead.
+         *
          * @return the maximum number of catalog entries to support for the catalog file.
+         * @see #catalogCapacity()
          */
+        @Deprecated
         public static long maxCatalogEntries()
         {
             return Long.getLong(MAX_CATALOG_ENTRIES_PROP_NAME, MAX_CATALOG_ENTRIES_DEFAULT);
+        }
+
+        /**
+         * Default capacity (size) in bytes for the catalog file.
+         *
+         * @return default size of the catalog file in bytes.
+         */
+        public static long catalogCapacity()
+        {
+            return Long.getLong(CATALOG_CAPACITY_PROP_NAME, CATALOG_CAPACITY_DEFAULT);
         }
 
         /**
@@ -720,6 +751,7 @@ public final class Archive implements AutoCloseable
         private long connectTimeoutNs = Configuration.connectTimeoutNs();
         private long replayLingerTimeoutNs = Configuration.replayLingerTimeoutNs();
         private long maxCatalogEntries = Configuration.maxCatalogEntries();
+        private long catalogCapacity = Configuration.catalogCapacity();
         private int segmentFileLength = Configuration.segmentFileLength();
         private int fileSyncLevel = Configuration.fileSyncLevel();
         private int catalogFileSyncLevel = Configuration.catalogFileSyncLevel();
@@ -918,7 +950,7 @@ public final class Archive implements AutoCloseable
                     archiveDir,
                     archiveDirChannel,
                     catalogFileSyncLevel,
-                    maxCatalogEntries,
+                    catalogCapacity,
                     epochClock,
                     recordChecksum,
                     null != recordChecksum ? recordChecksumBuffer() : dataBuffer());
@@ -1999,9 +2031,14 @@ public final class Archive implements AutoCloseable
         /**
          * Maximum number of catalog entries for the Archive.
          *
+         * @deprecated This method was deprecated in favor of {@link #catalogCapacity(long)} which works with bytes
+         * rather than number of entries.
+         *
          * @param maxCatalogEntries for the archive.
          * @return this for a fluent API.
+         * @see #catalogCapacity(long)
          */
+        @Deprecated
         public Context maxCatalogEntries(final long maxCatalogEntries)
         {
             this.maxCatalogEntries = maxCatalogEntries;
@@ -2011,11 +2048,38 @@ public final class Archive implements AutoCloseable
         /**
          * Maximum number of catalog entries for the Archive.
          *
+         * @deprecated This method was deprecated in favor of {@link #catalogCapacity()} which returns capacity of
+         * the {@link Catalog} in bytes rathen than in number of entries.
+         *
          * @return maximum number of catalog entries for the Archive.
+         * @see #catalogCapacity()
          */
+        @Deprecated
         public long maxCatalogEntries()
         {
             return maxCatalogEntries;
+        }
+
+        /**
+         * Capacity in bytes of the {@link Catalog}.
+         *
+         * @param catalogCapacity in bytes.
+         * @return this for a fluent API.
+         */
+        public Context catalogCapacity(final long catalogCapacity)
+        {
+            this.catalogCapacity = catalogCapacity;
+            return this;
+        }
+
+        /**
+         * Capacity in bytes of the {@link Catalog}.
+         *
+         * @return capacity in bytes of the {@link Catalog}.
+         */
+        public long catalogCapacity()
+        {
+            return catalogCapacity;
         }
 
         /**

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -522,7 +522,7 @@ abstract class ArchiveConductor
             final String msg = "active listing already in progress";
             controlSession.sendErrorResponse(correlationId, ACTIVE_LISTING, msg, controlResponseProxy);
         }
-        else if (catalog.wrapAndValidateDescriptor(recordingId, descriptorBuffer))
+        else if (catalog.wrapDescriptor(recordingId, descriptorBuffer))
         {
             controlSession.sendDescriptor(correlationId, descriptorBuffer, controlResponseProxy);
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -478,8 +478,7 @@ abstract class ArchiveConductor
                 catalog,
                 controlResponseProxy,
                 controlSession,
-                descriptorBuffer,
-                recordingDescriptorDecoder);
+                descriptorBuffer);
             addSession(session);
             controlSession.activeListing(session);
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -860,6 +860,20 @@ abstract class ArchiveConductor
         }
     }
 
+    void invalidateRecording(
+        final long correlationId, final long recordingId, final ControlSession controlSession)
+    {
+        if (hasRecording(recordingId, correlationId, controlSession) &&
+            isValidTruncate(correlationId, controlSession, recordingId, -1))
+        {
+            // FIXME: Should segment files be deleted right away or removed only upon Catalog compaction?
+
+            catalog.invalidateRecording(recordingId);
+
+            controlSession.sendOkResponse(correlationId, controlResponseProxy);
+        }
+    }
+
     void listRecordingSubscriptions(
         final long correlationId,
         final int pseudoIndex,

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -478,7 +478,8 @@ abstract class ArchiveConductor
                 catalog,
                 controlResponseProxy,
                 controlSession,
-                descriptorBuffer);
+                descriptorBuffer,
+                recordingDescriptorDecoder);
             addSession(session);
             controlSession.activeListing(session);
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
@@ -42,7 +42,7 @@ public class ArchiveMarkFile implements AutoCloseable
     /**
      * Major version for the archive files stored on disk. A change to this requires migration.
      */
-    public static final int MAJOR_VERSION = 2;
+    public static final int MAJOR_VERSION = 3;
 
     /**
      * Minor version for the archive files stored on disk. A change to this indicates new features.

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigrationPlanner.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigrationPlanner.java
@@ -28,7 +28,7 @@ import java.util.List;
  * A step need not be a complete operation. A series of operations may be broken down in steps and
  * included with the same minimum version.
  */
-class ArchiveMigrationPlanner
+final class ArchiveMigrationPlanner
 {
     private static final ArrayList<ArchiveMigrationStep> ALL_MIGRATION_STEPS = new ArrayList<>();
 
@@ -36,7 +36,12 @@ class ArchiveMigrationPlanner
     {
         ALL_MIGRATION_STEPS.add(new ArchiveMigration_0_1());
         ALL_MIGRATION_STEPS.add(new ArchiveMigration_1_2());
+        ALL_MIGRATION_STEPS.add(new ArchiveMigration_2_3());
         // as migrations are added, they are added to the static list in order of operation
+    }
+
+    private ArchiveMigrationPlanner()
+    {
     }
 
     public static List<ArchiveMigrationStep> createPlan(final int version)

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
@@ -55,7 +55,7 @@ class ArchiveMigration_0_1 implements ArchiveMigrationStep
             archiveDir, markFile.decoder().version(), minimumVersion()))
         {
             catalog.forEach(
-                (headerEncoder, headerDecoder, encoder, decoder) ->
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, encoder, decoder) ->
                 {
                     final String version0Prefix = decoder.recordingId() + "-";
                     final String version0Suffix = ".rec";

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
@@ -21,20 +21,20 @@ import io.aeron.archive.codecs.RecordingDescriptorHeaderDecoder;
 import io.aeron.archive.codecs.RecordingDescriptorHeaderEncoder;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import org.agrona.AsciiEncoding;
-import org.agrona.CloseHelper;
 import org.agrona.LangUtil;
 import org.agrona.SemanticVersion;
 import org.agrona.collections.ArrayUtil;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
-import static io.aeron.archive.Catalog.INVALID;
 import static io.aeron.archive.MigrationUtils.fullVersionString;
+import static io.aeron.archive.codecs.RecordingState.INVALID;
 
 class ArchiveMigration_0_1 implements ArchiveMigrationStep
 {
@@ -51,38 +51,41 @@ class ArchiveMigration_0_1 implements ArchiveMigrationStep
         final Catalog catalog,
         final File archiveDir)
     {
-        final FileChannel migrationTimestampFile = MigrationUtils.createMigrationTimestampFile(
-            archiveDir, markFile.decoder().version(), minimumVersion());
-
-        catalog.forEach(
-            (headerEncoder, headerDecoder, encoder, decoder) ->
-            {
-                final String version0Prefix = decoder.recordingId() + "-";
-                final String version0Suffix = ".rec";
-                String[] segmentFiles = archiveDir.list(
-                    (dir, filename) -> filename.startsWith(version0Prefix) && filename.endsWith(version0Suffix));
-
-                if (null == segmentFiles)
+        try (FileChannel ignore = MigrationUtils.createMigrationTimestampFile(
+            archiveDir, markFile.decoder().version(), minimumVersion()))
+        {
+            catalog.forEach(
+                (headerEncoder, headerDecoder, encoder, decoder) ->
                 {
-                    segmentFiles = ArrayUtil.EMPTY_STRING_ARRAY;
-                }
+                    final String version0Prefix = decoder.recordingId() + "-";
+                    final String version0Suffix = ".rec";
+                    String[] segmentFiles = archiveDir.list(
+                        (dir, filename) -> filename.startsWith(version0Prefix) && filename.endsWith(version0Suffix));
 
-                migrateRecording(
-                    stream,
-                    archiveDir,
-                    segmentFiles,
-                    version0Prefix,
-                    version0Suffix,
-                    headerEncoder,
-                    headerDecoder,
-                    encoder,
-                    decoder);
-            });
+                    if (null == segmentFiles)
+                    {
+                        segmentFiles = ArrayUtil.EMPTY_STRING_ARRAY;
+                    }
 
-        markFile.encoder().version(minimumVersion());
-        catalog.updateVersion(minimumVersion());
+                    migrateRecording(
+                        stream,
+                        archiveDir,
+                        segmentFiles,
+                        version0Prefix,
+                        version0Suffix,
+                        headerEncoder,
+                        headerDecoder,
+                        encoder,
+                        decoder);
+                });
 
-        CloseHelper.close(migrationTimestampFile);
+            markFile.encoder().version(minimumVersion());
+            catalog.updateVersion(minimumVersion());
+        }
+        catch (final IOException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     public void migrateRecording(
@@ -102,7 +105,7 @@ class ArchiveMigration_0_1 implements ArchiveMigrationStep
         final long segmentBasePosition = startPosition - (startPosition & (segmentLength - 1));
         final int positionBitsToShift = LogBufferDescriptor.positionBitsToShift((int)segmentLength);
 
-        if (headerDecoder.valid() == INVALID)
+        if (headerDecoder.state() == INVALID)
         {
             return;
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_1_2.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_1_2.java
@@ -55,7 +55,7 @@ class ArchiveMigration_1_2 implements ArchiveMigrationStep
             archiveDir, markFile.decoder().version(), minimumVersion()))
         {
             catalog.forEach(
-                (headerEncoder, headerDecoder, encoder, decoder) ->
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, encoder, decoder) ->
                 {
                     final String version1Prefix = decoder.recordingId() + "-";
                     final String version1Suffix = ".rec";

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
@@ -77,7 +77,7 @@ class ArchiveMigration_2_3 implements ArchiveMigrationStep
                 final MutableInteger offset = new MutableInteger(catalogHeaderLength);
 
                 catalog.forEach(
-                    (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                    (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
                     {
                         final int strippedChannelLength = descriptorDecoder.strippedChannelLength();
                         descriptorDecoder.skipStrippedChannel();

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
@@ -15,15 +15,29 @@
  */
 package io.aeron.archive;
 
+import org.agrona.DirectBuffer;
+import org.agrona.IoUtil;
 import org.agrona.LangUtil;
 import org.agrona.SemanticVersion;
+import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.UnsafeBuffer;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import static io.aeron.archive.Archive.Configuration.CATALOG_FILE_NAME;
+import static io.aeron.archive.Catalog.DESCRIPTOR_HEADER_LENGTH;
+import static io.aeron.archive.Catalog.MAX_CATALOG_LENGTH;
 import static io.aeron.archive.MigrationUtils.fullVersionString;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
+import static java.nio.file.StandardOpenOption.*;
+import static org.agrona.BitUtil.*;
 
 class ArchiveMigration_2_3 implements ArchiveMigrationStep
 {
@@ -40,13 +54,81 @@ class ArchiveMigration_2_3 implements ArchiveMigrationStep
         final Catalog catalog,
         final File archiveDir)
     {
+        final int version = minimumVersion();
         try (FileChannel ignore = MigrationUtils.createMigrationTimestampFile(
-            archiveDir, markFile.decoder().version(), minimumVersion()))
+            archiveDir, markFile.decoder().version(), version))
         {
-            // FIXME: Migrate Catalog file...
+            final File newFile = new File(archiveDir, CATALOG_FILE_NAME + ".updated");
+            IoUtil.deleteIfExists(newFile);
+            final Path updatedCatalogFile = newFile.toPath();
 
-            markFile.encoder().version(minimumVersion());
-            catalog.updateVersion(minimumVersion());
+            try (FileChannel channel = FileChannel.open(updatedCatalogFile, READ, WRITE, CREATE_NEW))
+            {
+                final MappedByteBuffer mappedByteBuffer = channel.map(READ_WRITE, 0, MAX_CATALOG_LENGTH);
+                mappedByteBuffer.order(LITTLE_ENDIAN);
+                final UnsafeBuffer buffer = new UnsafeBuffer(mappedByteBuffer);
+
+                final int alignment = CACHE_LINE_LENGTH;
+
+                // Create CatalogHeader for version 3.0.0
+                final int catalogHeaderLength =
+                    writeCatalogHeader(buffer, version, catalog.nextRecordingId(), alignment);
+
+                final MutableInteger offset = new MutableInteger(catalogHeaderLength);
+
+                catalog.forEach(
+                    (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                    {
+                        final int strippedChannelLength = descriptorDecoder.strippedChannelLength();
+                        descriptorDecoder.skipStrippedChannel();
+
+                        final int originalChannelLength = descriptorDecoder.originalChannelLength();
+                        descriptorDecoder.skipOriginalChannel();
+
+                        final int sourceIdentityLength = descriptorDecoder.sourceIdentityLength();
+
+                        final int frameLength =
+                            align(DESCRIPTOR_HEADER_LENGTH + 7 * SIZE_OF_LONG + 6 * SIZE_OF_INT +
+                            SIZE_OF_INT + strippedChannelLength +
+                            SIZE_OF_INT + originalChannelLength +
+                            SIZE_OF_INT + sourceIdentityLength,
+                            alignment);
+
+                        final DirectBuffer srcBuffer = headerDecoder.buffer();
+                        final int headerLength = headerDecoder.encodedLength();
+
+                        // Copy recording header
+                        int index = offset.get();
+                        buffer.putBytes(
+                            index,
+                            srcBuffer,
+                            0,
+                            headerLength);
+                        index += headerLength;
+
+                        // Correct length
+                        buffer.putInt(offset.get(), frameLength - headerLength, LITTLE_ENDIAN);
+
+                        // Copy recording descriptor
+                        buffer.putBytes(
+                            index,
+                            srcBuffer,
+                            headerLength,
+                            frameLength - headerLength);
+
+                        offset.addAndGet(frameLength);
+                    });
+
+                channel.truncate(offset.get()); // trim file to actual length used
+            }
+
+            catalog.close();
+
+            final Path catalogFilePath = updatedCatalogFile.resolveSibling(CATALOG_FILE_NAME);
+            Files.delete(catalogFilePath);
+            Files.move(updatedCatalogFile, catalogFilePath);
+
+            markFile.encoder().version(version);
         }
         catch (final IOException ex)
         {
@@ -57,5 +139,28 @@ class ArchiveMigration_2_3 implements ArchiveMigrationStep
     public String toString()
     {
         return "to " + fullVersionString(minimumVersion());
+    }
+
+    private int writeCatalogHeader(
+        final UnsafeBuffer buffer,
+        final int version,
+        final long nextRecordingId,
+        final int alignment)
+    {
+        final int catalogHeaderLength = 32;
+
+        int index = 0;
+        buffer.putInt(index, version, LITTLE_ENDIAN); // version
+        index += SIZE_OF_INT;
+
+        buffer.putInt(index, catalogHeaderLength, LITTLE_ENDIAN); // length
+        index += SIZE_OF_INT;
+
+        buffer.putLong(index, nextRecordingId, LITTLE_ENDIAN); // nextRecordingId
+        index += SIZE_OF_LONG;
+
+        buffer.putInt(index, alignment, LITTLE_ENDIAN); // alignment
+
+        return catalogHeaderLength;
     }
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
@@ -119,6 +119,7 @@ class ArchiveMigration_2_3 implements ArchiveMigrationStep
                         offset.addAndGet(frameLength);
                     });
 
+                IoUtil.unmap(mappedByteBuffer);
                 channel.truncate(offset.get()); // trim file to actual length used
             }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_2_3.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import org.agrona.LangUtil;
+import org.agrona.SemanticVersion;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.channels.FileChannel;
+
+import static io.aeron.archive.MigrationUtils.fullVersionString;
+
+class ArchiveMigration_2_3 implements ArchiveMigrationStep
+{
+    private static final int MINIMUM_VERSION = SemanticVersion.compose(3, 0, 0);
+
+    public int minimumVersion()
+    {
+        return MINIMUM_VERSION;
+    }
+
+    public void migrate(
+        final PrintStream stream,
+        final ArchiveMarkFile markFile,
+        final Catalog catalog,
+        final File archiveDir)
+    {
+        try (FileChannel ignore = MigrationUtils.createMigrationTimestampFile(
+            archiveDir, markFile.decoder().version(), minimumVersion()))
+        {
+            // FIXME: Migrate Catalog file...
+
+            markFile.encoder().version(minimumVersion());
+            catalog.updateVersion(minimumVersion());
+        }
+        catch (final IOException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+    public String toString()
+    {
+        return "to " + fullVersionString(minimumVersion());
+    }
+}

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -287,12 +287,15 @@ public class ArchiveTool
      *
      * @param archiveDir containing the {@link Catalog}.
      * @return the maximum number of entries supported by a {@link Catalog}.
+     * @see #capacity(File)
+     * @deprecated Use {@link #capacity} instead.
      */
+    @Deprecated
     public static int maxEntries(final File archiveDir)
     {
         try (Catalog catalog = openCatalogReadOnly(archiveDir, INSTANCE))
         {
-            return catalog.maxEntries();
+            return (int)(catalog.capacity() / DEFAULT_RECORD_LENGTH);
         }
     }
 
@@ -302,12 +305,46 @@ public class ArchiveTool
      * @param archiveDir    containing the {@link Catalog}.
      * @param newMaxEntries value to set.
      * @return the maximum number of entries supported by a {@link Catalog} after update.
+     * @see #capacity(File, long)
+     * @deprecated Use {@link #capacity(File, long)} instead.
      */
+    @Deprecated
     public static int maxEntries(final File archiveDir, final long newMaxEntries)
     {
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, newMaxEntries, INSTANCE, null, null))
+        final long capacity = newMaxEntries * DEFAULT_RECORD_LENGTH;
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, capacity, INSTANCE, null, null))
         {
-            return catalog.maxEntries();
+            return (int)(catalog.capacity() / DEFAULT_RECORD_LENGTH);
+        }
+    }
+
+    /**
+     * Get the capacity in bytes of the {@link Catalog}.
+     *
+     * @param archiveDir containing the {@link Catalog}.
+     * @return capacity in bytes of the {@link Catalog}, i.e. size of the {@link Catalog} file.
+     */
+    public static long capacity(final File archiveDir)
+    {
+        try (Catalog catalog = openCatalogReadOnly(archiveDir, INSTANCE))
+        {
+            return catalog.capacity();
+        }
+    }
+
+    /**
+     * Set the capacity in bytes of the {@link Catalog}. If new capacity is smaller than current {@link Catalog}
+     * capacity then this method is a no op.
+     *
+     * @param archiveDir  containing the {@link Catalog}.
+     * @param newCapacity value to set.
+     * @return the capacity of the {@link Catalog} after update.
+     */
+    public static long capacity(final File archiveDir, final long newCapacity)
+    {
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, newCapacity, INSTANCE, null, null))
+        {
+            return catalog.capacity();
         }
     }
 
@@ -323,7 +360,7 @@ public class ArchiveTool
             ArchiveMarkFile markFile = openMarkFile(archiveDir, out::println))
         {
             printMarkInformation(markFile, out);
-            out.println("Catalog Max Entries: " + catalog.maxEntries());
+            out.println("Catalog capacity in bytes: " + catalog.capacity());
             catalog.forEach((he, hd, e, d) -> out.println(d));
         }
     }
@@ -404,7 +441,7 @@ public class ArchiveTool
             ArchiveMarkFile markFile = openMarkFile(archiveDir, out::println))
         {
             printMarkInformation(markFile, out);
-            out.println("Catalog Max Entries: " + catalog.maxEntries());
+            out.println("Catalog capacity in bytes: " + catalog.capacity());
 
             out.println();
             out.println("Dumping up to " + fragmentCountLimit + " fragments per recording");

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -1439,7 +1439,7 @@ public class ArchiveTool
             "     (e.g. io.aeron.archive.checksum.Crc32).%n" +
             "     Only the last segment file of each recording is processed by default,%n" +
             "     unless flag '-a' is specified in which case all of the segment files are processed.%n" +
-            "  count-entries: queries the number of recording entries in the catalog.%n" +
+            "  count-entries: queries the number of `VALID` recording entries in the catalog.%n" +
             "  max-entries [number of entries]: DEPRECATED: use `capacity` instead.%n" +
             "  capacity [capacity in bytes]: gets or increases catalog capacity.%n" +
             "  compact: compact Catalog file by removing entries in state `INVALID` and delete the corresponding" +

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveTool.java
@@ -50,6 +50,8 @@ import static io.aeron.archive.MigrationUtils.fullVersionString;
 import static io.aeron.archive.ReplaySession.isInvalidHeader;
 import static io.aeron.archive.checksum.Checksums.newInstance;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
+import static io.aeron.archive.codecs.RecordingState.INVALID;
+import static io.aeron.archive.codecs.RecordingState.VALID;
 import static io.aeron.logbuffer.FrameDescriptor.*;
 import static io.aeron.logbuffer.LogBufferDescriptor.computeTermIdFromPosition;
 import static io.aeron.logbuffer.LogBufferDescriptor.positionBitsToShift;
@@ -838,7 +840,7 @@ public class ArchiveTool
         if (isPositionInvariantViolated(out, recordingId, startPosition, stopPosition))
         {
             errorCount.increment();
-            headerEncoder.valid(INVALID);
+            headerEncoder.state(INVALID);
             return;
         }
 
@@ -860,7 +862,7 @@ public class ArchiveTool
                         startPosition + " and/or stopPosition=" + stopPosition + " exceed max segment file position=" +
                         maxSegmentPosition);
                     errorCount.increment();
-                    headerEncoder.valid(INVALID);
+                    headerEncoder.state(INVALID);
                     return;
                 }
             }
@@ -880,7 +882,7 @@ public class ArchiveTool
             final String message = ex.getMessage();
             out.println("(recordingId=" + recordingId + ") ERR: " + (null != message ? message : ex.toString()));
             errorCount.increment();
-            headerEncoder.valid(INVALID);
+            headerEncoder.state(INVALID);
             return;
         }
 
@@ -907,7 +909,7 @@ public class ArchiveTool
                         headerFlyweight))
                     {
                         errorCount.increment();
-                        headerEncoder.valid(INVALID);
+                        headerEncoder.state(INVALID);
                         return;
                     }
                 }
@@ -927,7 +929,7 @@ public class ArchiveTool
                 headerFlyweight))
             {
                 errorCount.increment();
-                headerEncoder.valid(INVALID);
+                headerEncoder.state(INVALID);
                 return;
             }
         }
@@ -938,7 +940,7 @@ public class ArchiveTool
             encoder.stopTimestamp(epochClock.time());
         }
 
-        headerEncoder.valid(VALID);
+        headerEncoder.state(VALID);
         out.println("(recordingId=" + recordingId + ") OK");
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -118,7 +118,6 @@ class Catalog implements AutoCloseable
 
 
     private final int recordLength;
-    private final int maxDescriptorStringsCombinedLength;
     private final boolean forceWrites;
     private final boolean forceMetadata;
     private boolean isClosed;
@@ -209,8 +208,6 @@ class Catalog implements AutoCloseable
                     .version(ArchiveMarkFile.SEMANTIC_VERSION);
             }
 
-            maxDescriptorStringsCombinedLength =
-                recordLength - (DESCRIPTOR_HEADER_LENGTH + RecordingDescriptorEncoder.BLOCK_LENGTH + 12);
             maxRecordingId = (int)calculateMaxEntries(catalogLength, recordLength) - 1;
 
             refreshCatalog(true, checksum, buffer);
@@ -277,8 +274,6 @@ class Catalog implements AutoCloseable
             }
 
             recordLength = catalogHeaderDecoder.entryLength();
-            maxDescriptorStringsCombinedLength =
-                recordLength - (DESCRIPTOR_HEADER_LENGTH + RecordingDescriptorEncoder.BLOCK_LENGTH + 12);
             maxRecordingId = (int)calculateMaxEntries(catalogLength, recordLength) - 1;
 
             refreshCatalog(false, null, null);
@@ -342,15 +337,6 @@ class Catalog implements AutoCloseable
         if (nextRecordingId > maxRecordingId)
         {
             growCatalog(MAX_CATALOG_LENGTH);
-        }
-
-        final int combinedStringsLen = strippedChannel.length() + sourceIdentity.length() + originalChannel.length();
-        if (combinedStringsLen > maxDescriptorStringsCombinedLength)
-        {
-            throw new ArchiveException("combined length of channel:'" + strippedChannel +
-                "' and sourceIdentity:'" + sourceIdentity +
-                "' and originalChannel:'" + originalChannel +
-                "' exceeds max allowed:" + maxDescriptorStringsCombinedLength);
         }
 
         final long recordingId = nextRecordingId++;

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -625,6 +625,11 @@ class Catalog implements AutoCloseable
         return nativeOrder() == BYTE_ORDER ? stopPosition : Long.reverseBytes(stopPosition);
     }
 
+    void invalidateRecording(final long recordingId)
+    {
+
+    }
+
     RecordingSummary recordingSummary(final long recordingId, final RecordingSummary summary)
     {
         final int offset = recordingDescriptorOffset(recordingId) + DESCRIPTOR_HEADER_LENGTH;

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -801,6 +801,19 @@ final class Catalog implements AutoCloseable
         }
     }
 
+    int computeRecordingDescriptorChecksum(final int recordingDescriptorOffset, final int recordingLength)
+    {
+        final Checksum checksum = this.checksum;
+        if (null != checksum)
+        {
+            return checksum.compute(
+                catalogByteBufferAddress,
+                DESCRIPTOR_HEADER_LENGTH + recordingDescriptorOffset,
+                recordingLength);
+        }
+        return 0;
+    }
+
     void catalogResized(final long oldCapacity, final long newCapacity)
     {
 //        System.out.println("Catalog capacity changed: " + oldCapacity + " bytes => " + newCapacity + " bytes");
@@ -872,19 +885,6 @@ final class Catalog implements AutoCloseable
         }
 
         return -1;
-    }
-
-    private int computeRecordingDescriptorChecksum(final int recordingDescriptorOffset, final int recordingLength)
-    {
-        final Checksum checksum = this.checksum;
-        if (null != checksum)
-        {
-            return checksum.compute(
-                catalogByteBufferAddress,
-                DESCRIPTOR_HEADER_LENGTH + recordingDescriptorOffset,
-                recordingLength);
-        }
-        return 0;
     }
 
     private void invokeEntryProcessor(final int recordingDescriptorOffset, final CatalogEntryProcessor consumer)

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -734,29 +734,29 @@ final class Catalog implements AutoCloseable
         return (int)recordingDescriptorOffset;
     }
 
-    void growCatalog(final long maxCatalogLength, final int frameLength)
+    void growCatalog(final long maxCatalogCapacity, final int frameLength)
     {
         final long oldCapacity = capacity;
         final long recordingOffset = nextRecordingDescriptorOffset;
         final long targetCapacity = recordingOffset + frameLength;
-        if (targetCapacity > maxCatalogLength)
+        if (targetCapacity > maxCatalogCapacity)
         {
-            if (maxCatalogLength == oldCapacity)
+            if (maxCatalogCapacity == oldCapacity)
             {
-                throw new ArchiveException("catalog is full, max length reached: " + maxCatalogLength);
+                throw new ArchiveException("catalog is full, max capacity reached: " + maxCatalogCapacity);
             }
             else
             {
                 throw new ArchiveException(String.format(
                     "recording is too big: total recording length is %d bytes, available space is %d bytes",
-                    frameLength, maxCatalogLength - recordingOffset));
+                    frameLength, maxCatalogCapacity - recordingOffset));
             }
         }
 
         long newCapacity = oldCapacity;
         while (newCapacity < targetCapacity)
         {
-            newCapacity = min(newCapacity + (newCapacity >> 1), maxCatalogLength);
+            newCapacity = min(newCapacity + (newCapacity >> 1), maxCatalogCapacity);
         }
 
         final MappedByteBuffer mappedByteBuffer;

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -320,6 +320,11 @@ class Catalog implements AutoCloseable
         return catalogIndex.size();
     }
 
+    long nextRecordingId()
+    {
+        return nextRecordingId;
+    }
+
     int version()
     {
         return catalogHeaderDecoder.version();
@@ -479,6 +484,11 @@ class Catalog implements AutoCloseable
 
     long findLast(final long minRecordingId, final int sessionId, final int streamId, final byte[] channelFragment)
     {
+        if (minRecordingId < 0 || minRecordingId >= nextRecordingId)
+        {
+            return NULL_RECORD_ID;
+        }
+
         long recordingId = nextRecordingId;
         while (--recordingId >= minRecordingId)
         {

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -678,10 +678,10 @@ final class Catalog implements AutoCloseable
         final long offset = catalogIndex.remove(recordingId);
         if (CatalogIndex.NULL_VALUE != offset)
         {
-            wrapDescriptorAtOffset(catalogBuffer, (int)offset);
-
-            descriptorHeaderEncoder.wrap(catalogBuffer, 0)
-                .state(INVALID);
+            fieldAccessBuffer.putInt(
+                (int)offset + RecordingDescriptorHeaderEncoder.stateEncodingOffset(),
+                INVALID.value(),
+                BYTE_ORDER);
 
             forceWrites(catalogChannel);
 

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -214,16 +214,15 @@ class Catalog implements AutoCloseable
             }
             else
             {
-                forceWrites(archiveDirChannel);
-
                 alignment = CACHE_LINE_LENGTH;
-                nextRecordingId = 0;
 
                 catalogHeaderEncoder
                     .version(ArchiveMarkFile.SEMANTIC_VERSION)
                     .length(CatalogHeaderEncoder.BLOCK_LENGTH)
                     .nextRecordingId(nextRecordingId)
                     .alignment(alignment);
+
+                forceWrites(archiveDirChannel);
             }
             firstRecordingDescriptorOffset = CatalogHeaderEncoder.BLOCK_LENGTH;
 
@@ -751,6 +750,11 @@ class Catalog implements AutoCloseable
         capacity = newCapacity;
         catalogBuffer = new UnsafeBuffer(catalogByteBuffer);
         fieldAccessBuffer = new UnsafeBuffer(catalogByteBuffer);
+
+        final UnsafeBuffer catalogHeaderBuffer = new UnsafeBuffer(catalogByteBuffer);
+        catalogHeaderDecoder.wrap(
+            catalogHeaderBuffer, 0, CatalogHeaderDecoder.BLOCK_LENGTH, CatalogHeaderDecoder.SCHEMA_VERSION);
+        catalogHeaderEncoder.wrap(catalogHeaderBuffer, 0);
 
         catalogResized(oldCapacity, newCapacity);
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -874,8 +874,8 @@ final class Catalog implements AutoCloseable
 
     private int wrapDescriptorAtOffset(final UnsafeBuffer buffer, final int recordingDescriptorOffset)
     {
-        final int recordingLength = catalogByteBuffer.getInt(
-            recordingDescriptorOffset + RecordingDescriptorHeaderDecoder.lengthEncodingOffset());
+        final int recordingLength = fieldAccessBuffer.getInt(
+            recordingDescriptorOffset + RecordingDescriptorHeaderDecoder.lengthEncodingOffset(), BYTE_ORDER);
 
         if (recordingLength > 0)
         {

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
@@ -82,7 +82,7 @@ final class CatalogIndex
         ensurePositive(recordingId, "recordingId");
 
         final long[] index = this.index;
-        final int lastPosition = (count << 1) - 2;
+        final int lastPosition = lastPosition();
         final int position = find(index, recordingId, lastPosition);
         if (position < 0)
         {
@@ -117,7 +117,7 @@ final class CatalogIndex
         ensurePositive(recordingId, "recordingId");
 
         final long[] index = this.index;
-        final int lastPosition = (count << 1) - 2;
+        final int lastPosition = lastPosition();
         final int position = find(index, recordingId, lastPosition);
         if (position < 0)
         {
@@ -135,6 +135,16 @@ final class CatalogIndex
     int size()
     {
         return count;
+    }
+
+    /**
+     * Position of the last inserted entry.
+     *
+     * @return position of the last entry or negative value if index is empty.
+     */
+    int lastPosition()
+    {
+        return (count << 1) - 2;
     }
 
     private static int find(final long[] index, final long recordingId, final int lastPosition)

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
@@ -128,30 +128,6 @@ final class CatalogIndex
     }
 
     /**
-     * Consumer function to be implemented by caller of the {@link #forEach(IndexEntryConsumer)} method.
-     */
-    @FunctionalInterface
-    interface IndexEntryConsumer
-    {
-        void accept(long recordingId, long recordingDescriptorOffset);
-    }
-
-    /**
-     * Iterates over an entire index calling consumer for each entry.
-     *
-     * @param consumer to invoke upon each entry.
-     */
-    void forEach(final IndexEntryConsumer consumer)
-    {
-        final long[] index = this.index;
-        final int lastPosition = (count << 1) - 2;
-        for (int i = 0; i <= lastPosition; i += 2)
-        {
-            consumer.accept(index[i], index[i + 1]);
-        }
-    }
-
-    /**
      * Returns size of the index.
      *
      * @return number of the entries in the index.

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import static java.util.Arrays.copyOf;
+
+/**
+ * {@code CatalogIndex} maps recording id to its position in the catalog file.
+ */
+final class CatalogIndex
+{
+    static final int DEFAULT_INDEX_SIZE = 10;
+
+    static final long NULL_VALUE = -1;
+
+    long[] index;
+
+    CatalogIndex()
+    {
+        index = new long[DEFAULT_INDEX_SIZE << 1];
+    }
+
+    int count = 0;
+
+    /**
+     * Add mapping between recording id and its file offset to the index.
+     *
+     * @param recordingId     to add.
+     * @param recordingOffset for the given id.
+     * @throws IllegalArgumentException if {@code recordingId < 0 || recordingOffset < 0}.
+     * @throws IllegalArgumentException if {@code recordingId} is less than or equal to the last recording id added,
+     *                                  i.e. {@code recordingId} must always increase.
+     */
+    void add(final long recordingId, final long recordingOffset)
+    {
+        ensurePositive(recordingId, "recordingId");
+        ensurePositive(recordingOffset, "recordingOffset");
+
+        final int nextPosition = count << 1;
+        long[] index = this.index;
+        if (nextPosition > 0)
+        {
+            if (recordingId <= index[nextPosition - 2])
+            {
+                throw new IllegalArgumentException(
+                    String.format("recordingId %d is less than or equal to the last recordingId %d",
+                        recordingId, index[nextPosition - 2]));
+            }
+            if (nextPosition == index.length)
+            {
+                index = expand(index);
+                this.index = index;
+            }
+        }
+        index[nextPosition] = recordingId;
+        index[nextPosition + 1] = recordingOffset;
+
+        count++;
+    }
+
+    /**
+     * Remove given recording id from the index.
+     *
+     * @param recordingId to remove.
+     * @return recording file offset or {@link #NULL_VALUE} if not found.
+     */
+    long remove(final long recordingId)
+    {
+        ensurePositive(recordingId, "recordingId");
+
+        final long[] index = this.index;
+        final int lastPosition = (count << 1) - 2;
+        final int position = find(index, recordingId, lastPosition);
+        if (position < 0)
+        {
+            return NULL_VALUE;
+        }
+
+        final long recordingOffset = index[position + 1];
+
+        count--;
+
+        // Shift data to the left
+        for (int i = position; i < lastPosition; i += 2)
+        {
+            index[i] = index[i + 2];
+            index[i + 1] = index[i + 3];
+        }
+        // Reset last copied element
+        index[lastPosition] = 0;
+        index[lastPosition + 1] = 0;
+
+        return recordingOffset;
+    }
+
+    /**
+     * Get recoding file offset by its id.
+     *
+     * @param recordingId to lookup.
+     * @return recording file offset or {@link #NULL_VALUE} if not found.
+     */
+    long get(final long recordingId)
+    {
+        ensurePositive(recordingId, "recordingId");
+
+        final long[] index = this.index;
+        final int lastPosition = (count << 1) - 2;
+        final int position = find(index, recordingId, lastPosition);
+        if (position < 0)
+        {
+            return NULL_VALUE;
+        }
+
+        return index[position + 1];
+    }
+
+    /**
+     * Consumer function to be implemented by caller of the {@link #forEach(IndexEntryConsumer)} method.
+     */
+    @FunctionalInterface
+    interface IndexEntryConsumer
+    {
+        void accept(long recordingId, long recordingOffset);
+    }
+
+    /**
+     * Iterates over an entire index calling consumer for each entry.
+     *
+     * @param consumer to invoke upon each entry.
+     */
+    void forEach(final IndexEntryConsumer consumer)
+    {
+        final long[] index = this.index;
+        final int lastPosition = (count << 1) - 2;
+        for (int i = 0; i <= lastPosition; i += 2)
+        {
+            consumer.accept(index[i], index[i + 1]);
+        }
+    }
+
+    /**
+     * Returns size of the index.
+     *
+     * @return number of the entries in the index.
+     */
+    int size()
+    {
+        return count;
+    }
+
+    private static int find(final long[] index, final long recordingId, final int lastPosition)
+    {
+        if (lastPosition > 0 && recordingId >= index[0] && recordingId <= index[lastPosition])
+        {
+            int position = (int)((recordingId - index[0]) * lastPosition / (index[lastPosition] - index[0]));
+            position = 0 == (position & 1) ? position : position + 1;
+
+            if (recordingId == index[position])
+            {
+                return position;
+            }
+            else if (recordingId > index[position])
+            {
+                for (int i = position + 2; i <= lastPosition; i += 2)
+                {
+                    final long id = index[i];
+                    if (recordingId == id)
+                    {
+                        return i;
+                    }
+                    else if (id > recordingId)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = position - 2; i >= 0; i -= 2)
+                {
+                    final long id = index[i];
+                    if (recordingId == id)
+                    {
+                        return i;
+                    }
+                    else if (id < recordingId)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+        else if (0 == lastPosition && recordingId == index[0])
+        {
+            return 0;
+        }
+
+        return -1;
+    }
+
+    private static long[] expand(final long[] index)
+    {
+        final int length = index.length;
+        final int entries = length >> 1;
+        final int newLength = (entries + (entries >> 1)) << 1;
+        return copyOf(index, newLength);
+    }
+
+    private static void ensurePositive(final long value, final String msg)
+    {
+        if (value < 0L)
+        {
+            throw new IllegalArgumentException(String.format("%s cannot be negative, got %d", msg, value));
+        }
+    }
+
+}

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
@@ -38,16 +38,16 @@ final class CatalogIndex
     /**
      * Add mapping between recording id and its file offset to the index.
      *
-     * @param recordingId     to add.
-     * @param recordingOffset for the given id.
-     * @throws IllegalArgumentException if {@code recordingId < 0 || recordingOffset < 0}.
+     * @param recordingId               to add.
+     * @param recordingDescriptorOffset for the given id.
+     * @throws IllegalArgumentException if {@code recordingId < 0 || recordingDescriptorOffset < 0}.
      * @throws IllegalArgumentException if {@code recordingId} is less than or equal to the last recording id added,
      *                                  i.e. {@code recordingId} must always increase.
      */
-    void add(final long recordingId, final long recordingOffset)
+    void add(final long recordingId, final long recordingDescriptorOffset)
     {
         ensurePositive(recordingId, "recordingId");
-        ensurePositive(recordingOffset, "recordingOffset");
+        ensurePositive(recordingDescriptorOffset, "recordingDescriptorOffset");
 
         final int nextPosition = count << 1;
         long[] index = this.index;
@@ -66,7 +66,7 @@ final class CatalogIndex
             }
         }
         index[nextPosition] = recordingId;
-        index[nextPosition + 1] = recordingOffset;
+        index[nextPosition + 1] = recordingDescriptorOffset;
 
         count++;
     }
@@ -89,7 +89,7 @@ final class CatalogIndex
             return NULL_VALUE;
         }
 
-        final long recordingOffset = index[position + 1];
+        final long recordingDescriptorOffset = index[position + 1];
 
         count--;
 
@@ -103,7 +103,7 @@ final class CatalogIndex
         index[lastPosition] = 0;
         index[lastPosition + 1] = 0;
 
-        return recordingOffset;
+        return recordingDescriptorOffset;
     }
 
     /**
@@ -133,7 +133,7 @@ final class CatalogIndex
     @FunctionalInterface
     interface IndexEntryConsumer
     {
-        void accept(long recordingId, long recordingOffset);
+        void accept(long recordingId, long recordingDescriptorOffset);
     }
 
     /**

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogIndex.java
@@ -26,14 +26,14 @@ final class CatalogIndex
 
     static final long NULL_VALUE = -1;
 
-    long[] index;
+    private long[] index;
+    private int count;
 
     CatalogIndex()
     {
         index = new long[DEFAULT_INDEX_SIZE << 1];
     }
 
-    int count = 0;
 
     /**
      * Add mapping between recording id and its file offset to the index.
@@ -147,7 +147,17 @@ final class CatalogIndex
         return (count << 1) - 2;
     }
 
-    private static int find(final long[] index, final long recordingId, final int lastPosition)
+    /**
+     * Index array.
+     *
+     * @return index array.
+     */
+    long[] index()
+    {
+        return index;
+    }
+
+    static int find(final long[] index, final long recordingId, final int lastPosition)
     {
         if (lastPosition > 0 && recordingId >= index[0] && recordingId <= index[lastPosition])
         {
@@ -212,5 +222,4 @@ final class CatalogIndex
             throw new IllegalArgumentException(String.format("%s cannot be negative, got %d", msg, value));
         }
     }
-
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/CatalogView.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/CatalogView.java
@@ -74,6 +74,7 @@ public class CatalogView
         }
 
         public void accept(
+            final int recordingDescriptorOffset,
             final RecordingDescriptorHeaderEncoder headerEncoder,
             final RecordingDescriptorHeaderDecoder headerDecoder,
             final RecordingDescriptorEncoder descriptorEncoder,

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
@@ -34,7 +34,7 @@ class ControlRequestDecoders
     final ExtendRecordingRequest2Decoder extendRecordingRequest2 = new ExtendRecordingRequest2Decoder();
     final RecordingPositionRequestDecoder recordingPositionRequest = new RecordingPositionRequestDecoder();
     final TruncateRecordingRequestDecoder truncateRecordingRequest = new TruncateRecordingRequestDecoder();
-    final InvalidateRecordingRequestDecoder invalidateRecordingRequest = new InvalidateRecordingRequestDecoder();
+    final PurgeRecordingRequestDecoder purgeRecordingRequest = new PurgeRecordingRequestDecoder();
     final StopRecordingSubscriptionRequestDecoder stopRecordingSubscriptionRequest =
         new StopRecordingSubscriptionRequestDecoder();
     final StopPositionRequestDecoder stopPositionRequest = new StopPositionRequestDecoder();

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
@@ -34,6 +34,7 @@ class ControlRequestDecoders
     final ExtendRecordingRequest2Decoder extendRecordingRequest2 = new ExtendRecordingRequest2Decoder();
     final RecordingPositionRequestDecoder recordingPositionRequest = new RecordingPositionRequestDecoder();
     final TruncateRecordingRequestDecoder truncateRecordingRequest = new TruncateRecordingRequestDecoder();
+    final InvalidateRecordingRequestDecoder invalidateRecordingRequest = new InvalidateRecordingRequestDecoder();
     final StopRecordingSubscriptionRequestDecoder stopRecordingSubscriptionRequest =
         new StopRecordingSubscriptionRequestDecoder();
     final StopPositionRequestDecoder stopPositionRequest = new StopPositionRequestDecoder();

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
@@ -388,12 +388,12 @@ final class ControlSession implements Session
         }
     }
 
-    void onInvalidateRecording(final long correlationId, final long recordingId)
+    void onPurgeRecording(final long correlationId, final long recordingId)
     {
         attemptToGoActive();
         if (State.ACTIVE == state)
         {
-            conductor.invalidateRecording(correlationId, recordingId, this);
+            conductor.purgeRecording(correlationId, recordingId, this);
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
@@ -390,7 +390,7 @@ final class ControlSession implements Session
 
     void onPurgeRecording(final long correlationId, final long recordingId)
     {
-        attemptToGoActive();
+        attemptToActivate();
         if (State.ACTIVE == state)
         {
             conductor.purgeRecording(correlationId, recordingId, this);

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
@@ -388,6 +388,15 @@ final class ControlSession implements Session
         }
     }
 
+    void onInvalidateRecording(final long correlationId, final long recordingId)
+    {
+        attemptToGoActive();
+        if (State.ACTIVE == state)
+        {
+            conductor.invalidateRecording(correlationId, recordingId, this);
+        }
+    }
+
     void onGetStopPosition(final long correlationId, final long recordingId)
     {
         attemptToActivate();

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
@@ -767,6 +767,23 @@ class ControlSessionDemuxer implements Session, FragmentHandler
                 controlSession.onStopRecordingByIdentity(correlationId, decoder.recordingId());
                 break;
             }
+
+            case InvalidateRecordingRequestDecoder.TEMPLATE_ID:
+            {
+                final InvalidateRecordingRequestDecoder decoder = decoders.invalidateRecordingRequest;
+                decoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    headerDecoder.blockLength(),
+                    headerDecoder.version());
+
+                final long correlationId = decoder.correlationId();
+                final long controlSessionId = decoder.controlSessionId();
+                final ControlSession controlSession = getControlSession(controlSessionId, correlationId);
+
+                controlSession.onInvalidateRecording(correlationId, decoder.recordingId());
+                break;
+            }
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
@@ -768,9 +768,9 @@ class ControlSessionDemuxer implements Session, FragmentHandler
                 break;
             }
 
-            case InvalidateRecordingRequestDecoder.TEMPLATE_ID:
+            case PurgeRecordingRequestDecoder.TEMPLATE_ID:
             {
-                final InvalidateRecordingRequestDecoder decoder = decoders.invalidateRecordingRequest;
+                final PurgeRecordingRequestDecoder decoder = decoders.purgeRecordingRequest;
                 decoder.wrap(
                     buffer,
                     offset + MessageHeaderDecoder.ENCODED_LENGTH,
@@ -781,7 +781,7 @@ class ControlSessionDemuxer implements Session, FragmentHandler
                 final long controlSessionId = decoder.controlSessionId();
                 final ControlSession controlSession = getControlSession(controlSessionId, correlationId);
 
-                controlSession.onInvalidateRecording(correlationId, decoder.recordingId());
+                controlSession.onPurgeRecording(correlationId, decoder.recordingId());
                 break;
             }
         }

--- a/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsForUriSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsForUriSession.java
@@ -52,7 +52,7 @@ class ListRecordingsForUriSession extends AbstractListRecordingsSession
         descriptorDecoder = recordingDescriptorDecoder;
     }
 
-    protected boolean acceptDescriptor(final UnsafeBuffer descriptorBuffer)
+    boolean acceptDescriptor(final UnsafeBuffer descriptorBuffer)
     {
         descriptorDecoder.wrap(
             descriptorBuffer,

--- a/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsSession.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.archive;
 
-import io.aeron.archive.codecs.RecordingDescriptorDecoder;
 import org.agrona.concurrent.UnsafeBuffer;
 
 class ListRecordingsSession extends AbstractListRecordingsSession
@@ -27,8 +26,7 @@ class ListRecordingsSession extends AbstractListRecordingsSession
         final Catalog catalog,
         final ControlResponseProxy proxy,
         final ControlSession controlSession,
-        final UnsafeBuffer descriptorBuffer,
-        final RecordingDescriptorDecoder recordingDescriptorDecoder)
+        final UnsafeBuffer descriptorBuffer)
     {
         super(
             correlationId,
@@ -37,11 +35,11 @@ class ListRecordingsSession extends AbstractListRecordingsSession
             catalog,
             proxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer
+        );
     }
 
-    protected boolean acceptDescriptor(final RecordingDescriptorDecoder descriptorDecoder)
+    protected boolean acceptDescriptor(final UnsafeBuffer descriptorBuffer)
     {
         return true;
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ListRecordingsSession.java
@@ -39,7 +39,7 @@ class ListRecordingsSession extends AbstractListRecordingsSession
         );
     }
 
-    protected boolean acceptDescriptor(final UnsafeBuffer descriptorBuffer)
+    boolean acceptDescriptor(final UnsafeBuffer descriptorBuffer)
     {
         return true;
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/MigrationUtils.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/MigrationUtils.java
@@ -23,16 +23,20 @@ import java.nio.channels.FileChannel;
 
 import static java.nio.file.StandardOpenOption.*;
 
-class MigrationUtils
+final class MigrationUtils
 {
     private static final String MIGRATION_TIMESTAMP_FILE_PREFIX = "migration-";
     private static final String MIGRATION_TIMESTAMP_FILE_SUFFIX = ".dat";
 
-    public static FileChannel createMigrationTimestampFile(
+    private MigrationUtils()
+    {
+    }
+
+    static FileChannel createMigrationTimestampFile(
         final File directory, final int fromVersion, final int toVersion)
     {
         final String filename =
-            MIGRATION_TIMESTAMP_FILE_PREFIX + fromVersion + "-to-" + toVersion + MIGRATION_TIMESTAMP_FILE_SUFFIX;
+            migrationTimestampFileName(fromVersion, toVersion);
         final File timestampFile = new File(directory, filename);
 
         FileChannel fileChannel = null;
@@ -51,7 +55,12 @@ class MigrationUtils
         return fileChannel;
     }
 
-    public static String fullVersionString(final int version)
+    static String migrationTimestampFileName(final int fromVersion, final int toVersion)
+    {
+        return MIGRATION_TIMESTAMP_FILE_PREFIX + fromVersion + "-to-" + toVersion + MIGRATION_TIMESTAMP_FILE_SUFFIX;
+    }
+
+    static String fullVersionString(final int version)
     {
         return version +
             "(Major " + SemanticVersion.major(version) +

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -1418,13 +1418,12 @@ public class AeronArchive implements AutoCloseable
 
 
     /**
-     * Invalidate a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
-     * which effectively deletes the recording. The space used by the recording data and metadata will be reclaimed
-     * upon compaction of the Catalog.
+     * Purge a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
+     * and delete the corresponding segment files. The space in the Catalog will be reclaimed upon compaction.
      *
      * @param recordingId of the stopped recording to be invalidated.
      */
-    public void invalidateRecording(final long recordingId)
+    public void purgeRecording(final long recordingId)
     {
         lock.lock();
         try
@@ -1434,7 +1433,7 @@ public class AeronArchive implements AutoCloseable
 
             lastCorrelationId = aeron.nextCorrelationId();
 
-            if (!archiveProxy.invalidateRecording(recordingId, lastCorrelationId, controlSessionId))
+            if (!archiveProxy.purgeRecording(recordingId, lastCorrelationId, controlSessionId))
             {
                 throw new ArchiveException("failed to send invalidate recording request");
             }

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -1421,7 +1421,7 @@ public class AeronArchive implements AutoCloseable
      * Purge a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
      * and delete the corresponding segment files. The space in the Catalog will be reclaimed upon compaction.
      *
-     * @param recordingId of the stopped recording to be invalidated.
+     * @param recordingId of the stopped recording to be purged.
      */
     public void purgeRecording(final long recordingId)
     {

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -59,7 +59,7 @@ public class ArchiveProxy
     private ExtendRecordingRequest2Encoder extendRecordingRequest2;
     private RecordingPositionRequestEncoder recordingPositionRequest;
     private TruncateRecordingRequestEncoder truncateRecordingRequest;
-    private InvalidateRecordingRequestEncoder invalidateRecordingRequest;
+    private PurgeRecordingRequestEncoder purgeRecordingRequest;
     private StopPositionRequestEncoder stopPositionRequest;
     private FindLastMatchingRecordingRequestEncoder findLastMatchingRecordingRequest;
     private ListRecordingSubscriptionsRequestEncoder listRecordingSubscriptionsRequest;
@@ -766,30 +766,29 @@ public class ArchiveProxy
     }
 
     /**
-     * Invalidate a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
-     * which effectively deletes the recording. The space used by the recording data and metadata will be reclaimed
-     * upon compaction of the Catalog.
+     * Purge a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
+     * and delete the corresponding segment files. The space in the Catalog will be reclaimed upon compaction.
      *
      * @param recordingId      of the stopped recording to be truncated.
      * @param correlationId    for this request.
      * @param controlSessionId for this request.
      * @return true if successfully offered otherwise false.
      */
-    public boolean invalidateRecording(
+    public boolean purgeRecording(
         final long recordingId, final long correlationId, final long controlSessionId)
     {
-        if (null == invalidateRecordingRequest)
+        if (null == purgeRecordingRequest)
         {
-            invalidateRecordingRequest = new InvalidateRecordingRequestEncoder();
+            purgeRecordingRequest = new PurgeRecordingRequestEncoder();
         }
 
-        invalidateRecordingRequest
+        purgeRecordingRequest
             .wrapAndApplyHeader(buffer, 0, messageHeader)
             .controlSessionId(controlSessionId)
             .correlationId(correlationId)
             .recordingId(recordingId);
 
-        return offer(invalidateRecordingRequest.encodedLength());
+        return offer(purgeRecordingRequest.encodedLength());
     }
 
     /**

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -59,6 +59,7 @@ public class ArchiveProxy
     private ExtendRecordingRequest2Encoder extendRecordingRequest2;
     private RecordingPositionRequestEncoder recordingPositionRequest;
     private TruncateRecordingRequestEncoder truncateRecordingRequest;
+    private InvalidateRecordingRequestEncoder invalidateRecordingRequest;
     private StopPositionRequestEncoder stopPositionRequest;
     private FindLastMatchingRecordingRequestEncoder findLastMatchingRecordingRequest;
     private ListRecordingSubscriptionsRequestEncoder listRecordingSubscriptionsRequest;
@@ -762,6 +763,33 @@ public class ArchiveProxy
             .position(position);
 
         return offer(truncateRecordingRequest.encodedLength());
+    }
+
+    /**
+     * Invalidate a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
+     * which effectively deletes the recording. The space used by the recording data and metadata will be reclaimed
+     * upon compaction of the Catalog.
+     *
+     * @param recordingId      of the stopped recording to be truncated.
+     * @param correlationId    for this request.
+     * @param controlSessionId for this request.
+     * @return true if successfully offered otherwise false.
+     */
+    public boolean invalidateRecording(
+        final long recordingId, final long correlationId, final long controlSessionId)
+    {
+        if (null == invalidateRecordingRequest)
+        {
+            invalidateRecordingRequest = new InvalidateRecordingRequestEncoder();
+        }
+
+        invalidateRecordingRequest
+            .wrapAndApplyHeader(buffer, 0, messageHeader)
+            .controlSessionId(controlSessionId)
+            .correlationId(correlationId)
+            .recordingId(recordingId);
+
+        return offer(invalidateRecordingRequest.encodedLength());
     }
 
     /**

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -769,7 +769,7 @@ public class ArchiveProxy
      * Purge a stopped recording, i.e. mark recording as {@link io.aeron.archive.codecs.RecordingState#INVALID}
      * and delete the corresponding segment files. The space in the Catalog will be reclaimed upon compaction.
      *
-     * @param recordingId      of the stopped recording to be truncated.
+     * @param recordingId      of the stopped recording to be purged.
      * @param correlationId    for this request.
      * @param controlSessionId for this request.
      * @return true if successfully offered otherwise false.

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.archive.codecs"
                    id="101"
-                   version="4"
+                   version="5"
                    semanticVersion="5.2"
                    description="Message Codecs for communicating with an Aeron Archive."
                    byteOrder="littleEndian">
@@ -47,6 +47,10 @@
             <validValue name="REPLICATE" description="Recording descriptor replicated from source archive.">3</validValue>
             <validValue name="MERGE" description="Recording merged with live stream after replay.">4</validValue>
             <validValue name="SYNC" description="Recording synchronised with source archive.">5</validValue>
+        </enum>
+        <enum name="RecordingState" encodingType="int32" description="State of a recording in the Catalog.">
+            <validValue name="INVALID" description="Recording is invalid.">0</validValue>
+            <validValue name="VALID" description="Recording is valid.">1</validValue>
         </enum>
         <type name="time_t" primitiveType="int64" description="Epoch time in milliseconds since 1 Jan 1970 UTC."/>
         <type name="version_t" primitiveType="int32" presence="optional" nullValue="0" minValue="2" maxValue="16777215"
@@ -329,7 +333,7 @@
                  id="21"
                  description="Used in the catalog to describe the recording descriptor entry which follows.">
         <field name="length"               id="1" type="int32"/>
-        <field name="valid"                id="2" type="int8"/>
+        <field name="state"                id="2" type="RecordingState" description="State of the recording."/>
         <field name="reserved"             id="3" type="int8" offset="31"/>
     </sbe:message>
 

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -565,4 +565,12 @@
         <field name="stopPosition"         id="3" type="int64"/>
     </sbe:message>
 
+    <sbe:message name="InvalidateRecordingRequest"
+                 id="104"
+                 description="Request the invalidation of stopped recording.">
+        <field name="controlSessionId"     id="1" type="int64"/>
+        <field name="correlationId"        id="2" type="int64"/>
+        <field name="recordingId"          id="3" type="int64"/>
+    </sbe:message>
+
 </sbe:messageSchema>

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -324,15 +324,18 @@
 
     <sbe:message name="CatalogHeader"
                  id="20"
-                 description="Used as first element in Catalog to set the version and length of entries.">
+                 description="Used as first element in Catalog to set the version and alignment of entries.">
         <field name="version"              id="1"  type="int32"/>
-        <field name="entryLength"          id="2"  type="int32"/>
+        <field name="length"               id="2"  type="int32"/>
+        <field name="nextRecordingId"      id="3"  type="int64"/>
+        <field name="alignment"            id="4"  type="int32"/>
+        <field name="reserved"             id="5"  type="int8" offset="31"/>
     </sbe:message>
 
     <sbe:message name="RecordingDescriptorHeader"
                  id="21"
                  description="Used in the catalog to describe the recording descriptor entry which follows.">
-        <field name="length"               id="1" type="int32"/>
+        <field name="length"               id="1" type="int32" description="Length of the RecordingDescriptor in bytes."/>
         <field name="state"                id="2" type="RecordingState" description="State of the recording."/>
         <field name="reserved"             id="3" type="int8" offset="31"/>
     </sbe:message>

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -335,8 +335,11 @@
     <sbe:message name="RecordingDescriptorHeader"
                  id="21"
                  description="Used in the catalog to describe the recording descriptor entry which follows.">
-        <field name="length"               id="1" type="int32" description="Length of the RecordingDescriptor in bytes."/>
+        <field name="length"               id="1" type="int32"
+               description="Length of the RecordingDescriptor in bytes including alignment padding."/>
         <field name="state"                id="2" type="RecordingState" description="State of the recording."/>
+        <field name="checksum"             id="4" type="int32"
+               description="Checksum of the entire RecordingDescriptor."/>
         <field name="reserved"             id="3" type="int8" offset="31"/>
     </sbe:message>
 

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -565,7 +565,7 @@
         <field name="stopPosition"         id="3" type="int64"/>
     </sbe:message>
 
-    <sbe:message name="InvalidateRecordingRequest"
+    <sbe:message name="PurgeRecordingRequest"
                  id="104"
                  description="Request the invalidation of stopped recording.">
         <field name="controlSessionId"     id="1" type="int64"/>

--- a/aeron-archive/src/test/cpp/AeronArchiveTest.cpp
+++ b/aeron-archive/src/test/cpp/AeronArchiveTest.cpp
@@ -1003,3 +1003,150 @@ TEST_F(AeronArchiveTest, shouldExceptionForIncorrectChallengeCredentials)
         },
         ArchiveException);
 }
+
+TEST_F(AeronArchiveTest, shouldPurgeStoppedRecording)
+{
+    const std::string messagePrefix = "Message ";
+    const std::size_t messageCount = 10;
+    std::int32_t sessionId;
+    std::int64_t recordingIdFromCounter;
+    std::int64_t stopPosition;
+
+    std::shared_ptr<AeronArchive> aeronArchive = AeronArchive::connect(m_context);
+
+    const std::int64_t subscriptionId = aeronArchive->startRecording(
+            m_recordingChannel, m_recordingStreamId, AeronArchive::SourceLocation::LOCAL);
+
+    {
+        std::shared_ptr<Subscription> subscription = addSubscription(
+                *aeronArchive->context().aeron(), m_recordingChannel, m_recordingStreamId);
+        std::shared_ptr<Publication> publication = addPublication(
+                *aeronArchive->context().aeron(), m_recordingChannel, m_recordingStreamId);
+
+        sessionId = publication->sessionId();
+
+        CountersReader &countersReader = aeronArchive->context().aeron()->countersReader();
+        const std::int32_t counterId = getRecordingCounterId(sessionId, countersReader);
+        recordingIdFromCounter = RecordingPos::getRecordingId(countersReader, counterId);
+
+        offerMessages(*publication, messageCount, messagePrefix);
+        consumeMessages(*subscription, messageCount, messagePrefix);
+
+        stopPosition = publication->position();
+
+        aeron::concurrent::YieldingIdleStrategy idle;
+        while (countersReader.getCounterValue(counterId) < stopPosition)
+        {
+            idle.idle();
+        }
+
+        EXPECT_EQ(aeronArchive->getRecordingPosition(recordingIdFromCounter), stopPosition);
+        EXPECT_EQ(aeronArchive->getStopPosition(recordingIdFromCounter), aeron::NULL_VALUE);
+    }
+
+    aeronArchive->stopRecording(subscriptionId);
+
+    const std::int64_t recordingId = aeronArchive->findLastMatchingRecording(
+            0, "endpoint=localhost:3333", m_recordingStreamId, sessionId);
+
+    EXPECT_EQ(recordingIdFromCounter, recordingId);
+    EXPECT_EQ(aeronArchive->getStopPosition(recordingIdFromCounter), stopPosition);
+
+    aeronArchive->purgeRecording(recordingId);
+
+    const std::int32_t count = aeronArchive->listRecording(
+            recordingId,
+            [&](std::int64_t controlSessionId,
+                std::int64_t correlationId,
+                std::int64_t recordingId1,
+                std::int64_t startTimestamp,
+                std::int64_t stopTimestamp,
+                std::int64_t startPosition,
+                std::int64_t newStopPosition,
+                std::int32_t initialTermId,
+                std::int32_t segmentFileLength,
+                std::int32_t termBufferLength,
+                std::int32_t mtuLength,
+                std::int32_t sessionId1,
+                std::int32_t streamId,
+                const std::string &strippedChannel,
+                const std::string &originalChannel,
+                const std::string &sourceIdentity)
+            {
+                FAIL();
+            });
+
+    EXPECT_EQ(count, 0);
+}
+
+TEST_F(AeronArchiveTest, shouldReadJumboRecordingDescriptor)
+{
+    const std::string messagePrefix = "Message ";
+    const std::size_t messageCount = 10;
+    std::int32_t sessionId;
+    std::int64_t recordingId;
+    std::int64_t stopPosition;
+    std::string recordingChannel = "aeron:udp?endpoint=localhost:3333|term-length=64k|alias=";
+    recordingChannel.append(2000, 'X');
+
+    std::shared_ptr<AeronArchive> aeronArchive = AeronArchive::connect(m_context);
+
+    const std::int64_t subscriptionId = aeronArchive->startRecording(
+            recordingChannel, m_recordingStreamId, AeronArchive::SourceLocation::LOCAL);
+
+    {
+        std::shared_ptr<Subscription> subscription = addSubscription(
+                *aeronArchive->context().aeron(), recordingChannel, m_recordingStreamId);
+        std::shared_ptr<Publication> publication = addPublication(
+                *aeronArchive->context().aeron(), recordingChannel, m_recordingStreamId);
+
+        sessionId = publication->sessionId();
+
+        CountersReader &countersReader = aeronArchive->context().aeron()->countersReader();
+        const std::int32_t counterId = getRecordingCounterId(sessionId, countersReader);
+        recordingId = RecordingPos::getRecordingId(countersReader, counterId);
+
+        offerMessages(*publication, messageCount, messagePrefix);
+        consumeMessages(*subscription, messageCount, messagePrefix);
+
+        stopPosition = publication->position();
+
+        aeron::concurrent::YieldingIdleStrategy idle;
+        while (countersReader.getCounterValue(counterId) < stopPosition)
+        {
+            idle.idle();
+        }
+
+        EXPECT_EQ(aeronArchive->getRecordingPosition(recordingId), stopPosition);
+        EXPECT_EQ(aeronArchive->getStopPosition(recordingId), aeron::NULL_VALUE);
+    }
+
+    aeronArchive->stopRecording(subscriptionId);
+
+    EXPECT_EQ(aeronArchive->getStopPosition(recordingId), stopPosition);
+
+    const std::int32_t count = aeronArchive->listRecording(
+            recordingId,
+            [&](std::int64_t controlSessionId,
+                std::int64_t correlationId,
+                std::int64_t recordingId1,
+                std::int64_t startTimestamp,
+                std::int64_t stopTimestamp,
+                std::int64_t startPosition,
+                std::int64_t newStopPosition,
+                std::int32_t initialTermId,
+                std::int32_t segmentFileLength,
+                std::int32_t termBufferLength,
+                std::int32_t mtuLength,
+                std::int32_t sessionId1,
+                std::int32_t streamId,
+                const std::string &strippedChannel,
+                const std::string &originalChannel,
+                const std::string &sourceIdentity)
+            {
+                EXPECT_EQ(recordingId, recordingId1);
+                EXPECT_EQ(streamId, m_recordingStreamId);
+            });
+
+    EXPECT_EQ(count, 1);
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.archive.client.ArchiveException;
+import org.agrona.LangUtil;
+import org.agrona.SemanticVersion;
+import org.agrona.concurrent.EpochClock;
+import org.agrona.concurrent.UnsafeBuffer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
+import static java.nio.file.StandardOpenOption.*;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+
+final class ArchiveMigrationUtils
+{
+    static final int VERSION_2_1_0 = SemanticVersion.compose(2, 1, 0);
+
+    private static final int MARK_FILE_HEADER_LENGTH_V2 = 8 * 1024;
+    static final int RECORDING_FRAME_LENGTH_V2 = 1024;
+
+    private ArchiveMigrationUtils()
+    {
+    }
+
+    static ArchiveMarkFile createArchiveMarkFileInVersion2(final File archiveDir, final EpochClock epochClock)
+    {
+        final Path markFile = archiveDir.toPath().resolve(ArchiveMarkFile.FILENAME);
+        try (FileChannel channel = FileChannel.open(markFile, CREATE_NEW, READ, WRITE, SPARSE))
+        {
+            final int errorBufferLength = 100;
+            final String controlChannel = "ctx.controlChannel()";
+            final String localControlChannel = "ctx.localControlChannel()";
+            final String eventsChannel = "ctx.recordingEventsChannel()";
+            final String aeronDirectory = "ctx.aeronDirectoryName()";
+
+            final MappedByteBuffer mappedBuffer = channel
+                .map(READ_WRITE,
+                0,
+                totalMarkFileLengthInVersion2(
+                controlChannel, localControlChannel, eventsChannel, aeronDirectory, errorBufferLength));
+            mappedBuffer.order(LITTLE_ENDIAN);
+
+            final UnsafeBuffer buffer = new UnsafeBuffer(mappedBuffer);
+            final long currentTime = epochClock.time();
+
+            int index = 0;
+            buffer.putInt(index, VERSION_2_1_0); // version
+            index += SIZE_OF_INT;
+
+            buffer.putLong(index, currentTime, LITTLE_ENDIAN); // activityTimestamp
+            index += SIZE_OF_LONG;
+
+            buffer.putLong(index, currentTime, LITTLE_ENDIAN); // startTimestamp
+            index += SIZE_OF_LONG;
+
+            buffer.putLong(index, 1, LITTLE_ENDIAN); // pid
+            index += SIZE_OF_LONG;
+
+            buffer.putInt(index, 777, LITTLE_ENDIAN); // controlStreamId
+            index += SIZE_OF_INT;
+
+            buffer.putInt(index, 42, LITTLE_ENDIAN); // localControlStreamId
+            index += SIZE_OF_INT;
+
+            buffer.putInt(index, 13, LITTLE_ENDIAN); // eventsStreamId
+            index += SIZE_OF_INT;
+
+            buffer.putInt(index, MARK_FILE_HEADER_LENGTH_V2, LITTLE_ENDIAN); // headerLength
+            index += SIZE_OF_INT;
+
+            buffer.putInt(index, errorBufferLength, LITTLE_ENDIAN); // errorBufferLength
+            index += SIZE_OF_INT;
+
+            index += buffer.putStringAscii(index, controlChannel, LITTLE_ENDIAN); // controlChannel
+
+            index += buffer.putStringAscii(index, localControlChannel, LITTLE_ENDIAN); // localControlChannel
+
+            index += buffer.putStringAscii(index, eventsChannel, LITTLE_ENDIAN); // eventsChannel
+
+            // aeronDirectory
+            buffer.putStringAscii(index, aeronDirectory, LITTLE_ENDIAN);
+        }
+        catch (final IOException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+
+        return new ArchiveMarkFile(
+            archiveDir,
+            ArchiveMarkFile.FILENAME,
+            epochClock,
+            TimeUnit.SECONDS.toMillis(5),
+            (version) -> {},
+            null);
+    }
+
+    static Catalog createCatalogInVersion2(
+        final File archiveDir, final EpochClock epochClock, final List<RecordingDescriptorV2> recordings)
+    {
+        final Path catalogFile = archiveDir.toPath().resolve(Archive.Configuration.CATALOG_FILE_NAME);
+        try (FileChannel channel = FileChannel.open(catalogFile, CREATE_NEW, READ, WRITE, SPARSE))
+        {
+            final MappedByteBuffer mappedBuffer = channel.map(
+                READ_WRITE,
+                0,
+                RECORDING_FRAME_LENGTH_V2 + recordings.size() * RECORDING_FRAME_LENGTH_V2);
+            mappedBuffer.order(LITTLE_ENDIAN);
+
+            final UnsafeBuffer buffer = new UnsafeBuffer(mappedBuffer);
+
+            int index = 0;
+            buffer.putInt(index, VERSION_2_1_0); // version
+            index += SIZE_OF_INT;
+
+            buffer.putInt(index, RECORDING_FRAME_LENGTH_V2); // entryLength
+
+            index = RECORDING_FRAME_LENGTH_V2;
+
+            for (final RecordingDescriptorV2 recording : recordings)
+            {
+                writeRecording(buffer, index, recording);
+                index += RECORDING_FRAME_LENGTH_V2;
+            }
+
+            channel.truncate(index);
+        }
+        catch (final IOException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+
+        return new Catalog(archiveDir, epochClock, true, (version) -> {});
+    }
+
+    private static int totalMarkFileLengthInVersion2(
+        final String controlChannel,
+        final String localControlChannel,
+        final String eventsChannel,
+        final String aeronDirectory,
+        final int errorBufferLength)
+    {
+        final int headerContentLength =
+            128 + 4 * SIZE_OF_INT +
+            controlChannel.length() +
+            localControlChannel.length() +
+            eventsChannel.length() +
+            aeronDirectory.length();
+
+        if (headerContentLength > MARK_FILE_HEADER_LENGTH_V2)
+        {
+            throw new ArchiveException(
+                "MarkFile length required " + headerContentLength + " greater than " +
+                    MARK_FILE_HEADER_LENGTH_V2);
+        }
+
+        return MARK_FILE_HEADER_LENGTH_V2 + errorBufferLength;
+    }
+
+    private static void writeRecording(
+        final UnsafeBuffer buffer, final int index, final RecordingDescriptorV2 recording)
+    {
+        int offset = index + 32;
+
+        // RecordingDescriptor
+        buffer.putLong(offset, recording.controlSessionId, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.correlationId, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.recordingId, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.startTimestamp, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.stopTimestamp, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.startPosition, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putLong(offset, recording.stopPosition, LITTLE_ENDIAN);
+        offset += SIZE_OF_LONG;
+
+        buffer.putInt(offset, recording.initialTermId, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        buffer.putInt(offset, recording.segmentFileLength, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        buffer.putInt(offset, recording.termBufferLength, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        buffer.putInt(offset, recording.mtuLength, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        buffer.putInt(offset, recording.sessionId, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        buffer.putInt(offset, recording.streamId, LITTLE_ENDIAN);
+        offset += SIZE_OF_INT;
+
+        offset += buffer.putStringAscii(offset, recording.strippedChannel, LITTLE_ENDIAN);
+
+        offset += buffer.putStringAscii(offset, recording.originalChannel, LITTLE_ENDIAN);
+
+        offset += buffer.putStringAscii(offset, recording.sourceIdentity, LITTLE_ENDIAN);
+
+        final int totalLength = offset - index;
+        if (totalLength > RECORDING_FRAME_LENGTH_V2)
+        {
+            throw new IllegalArgumentException("recordingId=" + recording.recordingId + "encoded length is " +
+                totalLength + " bytes which exceeds max recording length of " + RECORDING_FRAME_LENGTH_V2 + " bytes");
+        }
+
+        // RecordingDescriptorHeader
+        buffer.putInt(index, totalLength - 32, LITTLE_ENDIAN); // Length of the recording w/o header
+        buffer.putByte(index + SIZE_OF_INT, recording.valid);
+    }
+
+    static final class RecordingDescriptorV2
+    {
+        // RecordingDescriptorHeader
+        final byte valid;
+
+        // RecordingDescriptor
+        final long controlSessionId;
+        final long correlationId;
+        final long recordingId;
+        final long startTimestamp;
+        final long stopTimestamp;
+        final long startPosition;
+        final long stopPosition;
+        final int initialTermId;
+        final int segmentFileLength;
+        final int termBufferLength;
+        final int mtuLength;
+        final int sessionId;
+        final int streamId;
+        final String strippedChannel;
+        final String originalChannel;
+        final String sourceIdentity;
+
+        RecordingDescriptorV2(
+            final byte valid,
+            final long controlSessionId,
+            final long correlationId,
+            final long recordingId,
+            final long startTimestamp,
+            final long stopTimestamp,
+            final long startPosition,
+            final long stopPosition,
+            final int initialTermId,
+            final int segmentFileLength,
+            final int termBufferLength,
+            final int mtuLength,
+            final int sessionId,
+            final int streamId,
+            final String strippedChannel,
+            final String originalChannel,
+            final String sourceIdentity)
+        {
+            this.valid = valid;
+            this.controlSessionId = controlSessionId;
+            this.correlationId = correlationId;
+            this.recordingId = recordingId;
+            this.startTimestamp = startTimestamp;
+            this.stopTimestamp = stopTimestamp;
+            this.startPosition = startPosition;
+            this.stopPosition = stopPosition;
+            this.initialTermId = initialTermId;
+            this.segmentFileLength = segmentFileLength;
+            this.termBufferLength = termBufferLength;
+            this.mtuLength = mtuLength;
+            this.sessionId = sessionId;
+            this.streamId = streamId;
+            this.strippedChannel = strippedChannel;
+            this.originalChannel = originalChannel;
+            this.sourceIdentity = sourceIdentity;
+        }
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.aeron.archive.Catalog.MIN_CAPACITY;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import static java.nio.file.StandardOpenOption.*;
@@ -153,7 +154,7 @@ final class ArchiveMigrationUtils
             LangUtil.rethrowUnchecked(ex);
         }
 
-        return new Catalog(archiveDir, epochClock, true, (version) -> {});
+        return new Catalog(archiveDir, epochClock, MIN_CAPACITY, true, (version) -> {});
     }
 
     private static int totalMarkFileLengthInVersion2(

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
@@ -154,7 +154,7 @@ final class ArchiveMigrationUtils
             LangUtil.rethrowUnchecked(ex);
         }
 
-        return new Catalog(archiveDir, epochClock, MIN_CAPACITY, true, (version) -> {});
+        return new Catalog(archiveDir, epochClock, MIN_CAPACITY, true, null, (version) -> {});
     }
 
     private static int totalMarkFileLengthInVersion2(

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
@@ -146,8 +146,6 @@ final class ArchiveMigrationUtils
                 writeRecording(buffer, index, recording);
                 index += RECORDING_FRAME_LENGTH_V2;
             }
-
-            channel.truncate(index);
         }
         catch (final IOException ex)
         {

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import org.agrona.IoUtil;
+import org.agrona.SemanticVersion;
+import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.EpochClock;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.aeron.archive.ArchiveMigrationUtils.*;
+import static io.aeron.archive.MigrationUtils.createMigrationTimestampFile;
+import static io.aeron.archive.MigrationUtils.migrationTimestampFileName;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.size;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.agrona.BitUtil.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArchiveMigration_2_3Test
+{
+    private static final byte INVALID = (byte)0;
+    private static final byte VALID = (byte)1;
+
+    private final File archiveDir = ArchiveTests.makeTestDirectory();
+
+    private long currentTimeMs = 1;
+    private final EpochClock clock = () -> currentTimeMs;
+
+    private final ArchiveMigration_2_3 migration = new ArchiveMigration_2_3();
+
+    @AfterEach
+    void after()
+    {
+        IoUtil.delete(archiveDir, false);
+    }
+
+    @Test
+    void minimumVersion()
+    {
+        assertEquals(SemanticVersion.compose(3, 0, 0), migration.minimumVersion());
+    }
+
+    @Test
+    void shouldThrowExceptionIfMigrationTimestampFileAlreadyExists() throws IOException
+    {
+        try (ArchiveMarkFile markFile = createArchiveMarkFileInVersion2(archiveDir, clock);
+            Catalog catalog = createCatalogInVersion2(archiveDir, clock, emptyList());
+            FileChannel timestampFile =
+                createMigrationTimestampFile(archiveDir, markFile.decoder().version(), migration.minimumVersion()))
+        {
+            assertNotNull(timestampFile);
+
+            final FileAlreadyExistsException exception = assertThrows(FileAlreadyExistsException.class,
+                () -> migration.migrate(System.out, markFile, catalog, archiveDir));
+            assertThat(
+                exception.getMessage(),
+                containsString(migrationTimestampFileName(VERSION_2_1_0, migration.minimumVersion())));
+        }
+    }
+
+    @Test
+    void migrateEmptyCatalogFile() throws IOException
+    {
+        final Path catalogFile = archiveDir.toPath().resolve(Archive.Configuration.CATALOG_FILE_NAME);
+
+        try (ArchiveMarkFile markFile = createArchiveMarkFileInVersion2(archiveDir, clock);
+            Catalog catalog = createCatalogInVersion2(archiveDir, clock, emptyList()))
+        {
+            assertEquals(RECORDING_FRAME_LENGTH_V2, size(catalogFile));
+
+            migration.migrate(System.out, markFile, catalog, archiveDir);
+
+            assertEquals(migration.minimumVersion(), markFile.decoder().version());
+
+            assertEquals(32, size(catalogFile));
+            assertTrue(catalog.isClosed());
+
+            verifyCatalogHeader(catalogFile, 0);
+        }
+
+        final String migrationTimestampFileName =
+            migrationTimestampFileName(VERSION_2_1_0, migration.minimumVersion());
+        assertTrue(exists(archiveDir.toPath().resolve(migrationTimestampFileName)));
+    }
+
+    @Test
+    @SuppressWarnings("methodLength")
+    void migrateRemovesGapsBetweenRecordings() throws IOException
+    {
+        final Path catalogFile = archiveDir.toPath().resolve(Archive.Configuration.CATALOG_FILE_NAME);
+
+        final List<RecordingDescriptorV2> recordings = asList(
+            new RecordingDescriptorV2(
+            VALID,
+            42,
+            21,
+            0,
+            123,
+            456,
+            0,
+            1024,
+            3,
+            500,
+            1024,
+            1408,
+            8,
+            55,
+            "strCh",
+            "aeron:udp?endpoint=localhost:9090",
+            "sourceA"),
+            new RecordingDescriptorV2(
+            VALID,
+            41,
+            14,
+            4,
+            400,
+            4000,
+            44,
+            444,
+            4,
+            44,
+            44444,
+            4000,
+            44,
+            4040,
+            "ch1024",
+            "aeron:udp?endpoint=localhost:44444",
+            source("source", "B", 854)),
+            new RecordingDescriptorV2(
+            INVALID,
+            333,
+            333,
+            56,
+            100,
+            200,
+            999,
+            100999,
+            8,
+            2048,
+            4096,
+            9000,
+            -10,
+            1,
+            "ch",
+            "channel",
+            "sourceC")
+        );
+
+        try (ArchiveMarkFile markFile = createArchiveMarkFileInVersion2(archiveDir, clock);
+            Catalog catalog = createCatalogInVersion2(archiveDir, clock, recordings))
+        {
+            assertEquals(RECORDING_FRAME_LENGTH_V2 * 4, size(catalogFile));
+
+            migration.migrate(System.out, markFile, catalog, archiveDir);
+
+            assertEquals(migration.minimumVersion(), markFile.decoder().version());
+
+            assertEquals(1440, size(catalogFile));
+            assertTrue(catalog.isClosed());
+
+            verifyCatalogHeader(catalogFile, 57);
+        }
+
+        final String migrationTimestampFileName =
+            migrationTimestampFileName(VERSION_2_1_0, migration.minimumVersion());
+        assertTrue(exists(archiveDir.toPath().resolve(migrationTimestampFileName)));
+
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, 1024, clock, null, null))
+        {
+            final MutableInteger index = new MutableInteger();
+            catalog.forEach(
+                (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                {
+                    final RecordingDescriptorV2 recording = recordings.get(index.getAndIncrement());
+
+                    assertNotEquals(RECORDING_FRAME_LENGTH_V2, headerDecoder.length());
+                    assertEquals(recording.valid, headerDecoder.state().value());
+
+                    assertEquals(recording.controlSessionId, descriptorDecoder.controlSessionId());
+                    assertEquals(recording.correlationId, descriptorDecoder.correlationId());
+                    assertEquals(recording.recordingId, descriptorDecoder.recordingId());
+                    assertEquals(recording.startTimestamp, descriptorDecoder.startTimestamp());
+                    assertEquals(recording.stopTimestamp, descriptorDecoder.stopTimestamp());
+                    assertEquals(recording.startPosition, descriptorDecoder.startPosition());
+                    assertEquals(recording.stopPosition, descriptorDecoder.stopPosition());
+                    assertEquals(recording.initialTermId, descriptorDecoder.initialTermId());
+                    assertEquals(recording.segmentFileLength, descriptorDecoder.segmentFileLength());
+                    assertEquals(recording.termBufferLength, descriptorDecoder.termBufferLength());
+                    assertEquals(recording.mtuLength, descriptorDecoder.mtuLength());
+                    assertEquals(recording.sessionId, descriptorDecoder.sessionId());
+                    assertEquals(recording.streamId, descriptorDecoder.streamId());
+                    assertEquals(recording.strippedChannel, descriptorDecoder.strippedChannel());
+                    assertEquals(recording.originalChannel, descriptorDecoder.originalChannel());
+                    assertEquals(recording.sourceIdentity, descriptorDecoder.sourceIdentity());
+                });
+
+            assertEquals(recordings.size(), index.get());
+        }
+    }
+
+    private void verifyCatalogHeader(final Path catalogFile, final long nextRecordingId) throws IOException
+    {
+        try (FileChannel channel = FileChannel.open(catalogFile, READ))
+        {
+            final MappedByteBuffer mappedByteBuffer = channel.map(READ_ONLY, 0, channel.size());
+            mappedByteBuffer.order(LITTLE_ENDIAN);
+            final UnsafeBuffer buffer = new UnsafeBuffer(mappedByteBuffer);
+
+            int index = 0;
+
+            // version
+            assertEquals(migration.minimumVersion(), buffer.getInt(index, LITTLE_ENDIAN));
+            index += SIZE_OF_INT;
+
+            // length
+            assertEquals(32, buffer.getInt(index, LITTLE_ENDIAN));
+            index += SIZE_OF_INT;
+
+            // nextRecordingId
+            assertEquals(nextRecordingId, buffer.getLong(index, LITTLE_ENDIAN));
+            index += SIZE_OF_LONG;
+
+            // alignment
+            assertEquals(CACHE_LINE_LENGTH, buffer.getInt(index, LITTLE_ENDIAN));
+        }
+    }
+
+    private String source(final String prefix, final String suffix, final int repeatSuffixTimes)
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(prefix);
+        for (int i = 0; i < repeatSuffixTimes; i++)
+        {
+            builder.append(suffix);
+        }
+        return builder.toString();
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
@@ -34,6 +34,7 @@ import java.util.List;
 import static io.aeron.archive.ArchiveMigrationUtils.*;
 import static io.aeron.archive.MigrationUtils.createMigrationTimestampFile;
 import static io.aeron.archive.MigrationUtils.migrationTimestampFileName;
+import static io.aeron.test.Tests.generateStringWithSuffix;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
 import static java.nio.file.Files.exists;
@@ -155,7 +156,7 @@ class ArchiveMigration_2_3Test
             4040,
             "ch1024",
             "aeron:udp?endpoint=localhost:44444",
-            source("source", "B", 854)),
+            generateStringWithSuffix("source", "B", 854)),
             new RecordingDescriptorV2(
             INVALID,
             333,
@@ -255,14 +256,4 @@ class ArchiveMigration_2_3Test
         }
     }
 
-    private String source(final String prefix, final String suffix, final int repeatSuffixTimes)
-    {
-        final StringBuilder builder = new StringBuilder();
-        builder.append(prefix);
-        for (int i = 0; i < repeatSuffixTimes; i++)
-        {
-            builder.append(suffix);
-        }
-        return builder.toString();
-    }
 }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigration_2_3Test.java
@@ -199,7 +199,7 @@ class ArchiveMigration_2_3Test
         {
             final MutableInteger index = new MutableInteger();
             catalog.forEach(
-                (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
                 {
                     final RecordingDescriptorV2 recording = recordings.get(index.getAndIncrement());
 

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -218,7 +218,7 @@ public class ArchiveTest
         try (Catalog catalog = openCatalog(archiveCtx))
         {
             final Catalog.CatalogEntryProcessor catalogEntryProcessor =
-                (headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
                 descriptorEncoder.stopPosition(Aeron.NULL_VALUE);
 
             assertTrue(catalog.forEntry(recordingId, catalogEntryProcessor));
@@ -247,6 +247,7 @@ public class ArchiveTest
             new SystemEpochClock(),
             MIN_CAPACITY,
             true,
+            null,
             intConsumer);
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -52,6 +52,7 @@ import java.util.function.IntConsumer;
 
 import static io.aeron.archive.ArchiveThreadingMode.DEDICATED;
 import static io.aeron.archive.ArchiveThreadingMode.SHARED;
+import static io.aeron.archive.Catalog.MIN_CAPACITY;
 import static io.aeron.archive.client.AeronArchive.segmentFileBasePosition;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
 import static org.junit.jupiter.api.Assertions.*;
@@ -241,7 +242,12 @@ public class ArchiveTest
     private static Catalog openCatalog(final Context archiveCtx)
     {
         final IntConsumer intConsumer = (version) -> {};
-        return new Catalog(new File(archiveCtx.archiveDirectoryName()), new SystemEpochClock(), true, intConsumer);
+        return new Catalog(
+            new File(archiveCtx.archiveDirectoryName()),
+            new SystemEpochClock(),
+            MIN_CAPACITY,
+            true,
+            intConsumer);
     }
 
     @Test

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -42,8 +42,7 @@ import static io.aeron.archive.Archive.segmentFileName;
 import static io.aeron.archive.ArchiveTool.*;
 import static io.aeron.archive.ArchiveTool.VerifyOption.APPLY_CHECKSUM;
 import static io.aeron.archive.ArchiveTool.VerifyOption.VERIFY_ALL_SEGMENT_FILES;
-import static io.aeron.archive.Catalog.PAGE_SIZE;
-import static io.aeron.archive.Catalog.listSegmentFiles;
+import static io.aeron.archive.Catalog.*;
 import static io.aeron.archive.checksum.Checksums.crc32;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
@@ -505,7 +504,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording0, INVALID, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording0, INVALID, 0, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -518,8 +517,8 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording1, INVALID, FRAME_ALIGNMENT - 7, NULL_POSITION, 2, NULL_TIMESTAMP,
-                0, 1, "ch1", "src1");
+            assertRecording(catalog, invalidRecording1, INVALID, 0, FRAME_ALIGNMENT - 7, NULL_POSITION, 2,
+                NULL_TIMESTAMP, 0, 1, "ch1", "src1");
         }
     }
 
@@ -531,7 +530,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording2, INVALID, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording2, INVALID, 0, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -544,7 +543,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording3, INVALID, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording3, INVALID, 0, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -557,7 +556,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording4, INVALID, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording4, INVALID, 0, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -570,7 +569,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording5, INVALID, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording5, INVALID, 0, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -583,7 +582,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording6, INVALID, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording6, INVALID, 0, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -596,7 +595,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording7, INVALID, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording7, INVALID, 0, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -609,7 +608,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording8, INVALID, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording8, INVALID, 0, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -622,7 +621,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording9, INVALID, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording9, INVALID, 0, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -635,7 +634,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording10, INVALID, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording10, INVALID, 0, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
         }
     }
@@ -648,7 +647,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording11, INVALID, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording11, INVALID, 0, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
                 5, 1, "ch1", "src1");
         }
     }
@@ -661,7 +660,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording12, INVALID, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording12, INVALID, 0, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
                 9, 6, "ch1", "src1");
         }
     }
@@ -674,7 +673,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording13, INVALID, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording13, INVALID, 0, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
                 0, 13, "ch1", "src1");
         }
     }
@@ -687,7 +686,8 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording14, INVALID, 128, NULL_POSITION, -14, 41, -14, 0, "ch1", "src1");
+            assertRecording(catalog, invalidRecording14, INVALID, 0, 128, NULL_POSITION,
+                -14, 41, -14, 0, "ch1", "src1");
         }
     }
 
@@ -699,7 +699,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording0, VALID, 0, TERM_LENGTH + 64, 15, 100, 0, 2, "ch2", "src2");
+            assertRecording(catalog, validRecording0, VALID, 0, 0, TERM_LENGTH + 64, 15, 100, 0, 2, "ch2", "src2");
         }
     }
 
@@ -711,7 +711,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording1, VALID, 1024, 1024, 16, 100, 0, 2, "ch2", "src2");
+            assertRecording(catalog, validRecording1, VALID, 0, 1024, 1024, 16, 100, 0, 2, "ch2", "src2");
         }
     }
 
@@ -723,7 +723,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording2, VALID, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96, 17, 100,
+            assertRecording(catalog, validRecording2, VALID, 0, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96, 17, 100,
                 0, 2, "ch2", "src2");
         }
     }
@@ -736,7 +736,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, VALID, 0, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 100, 7, 13, "ch2", "src2");
         }
     }
@@ -749,7 +749,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording4, VALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, VALID, 0, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
         }
     }
@@ -762,7 +762,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, VALID, 0, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 100, 7, 13, "ch2", "src2");
         }
     }
@@ -775,7 +775,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording4, INVALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, INVALID, 0, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
         }
     }
@@ -787,7 +787,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, 0, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
         }
     }
@@ -799,7 +799,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, 100,
+            assertRecording(catalog, validRecording52, VALID, 0, 0, 128 + MTU_LENGTH, 21, 100,
                 0, 52, "ch2", "src2");
         }
     }
@@ -812,7 +812,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording53, VALID, 0, 64, 22, 100, 0, 53, "ch2", "src2");
+            assertRecording(catalog, validRecording53, VALID, 0, 0, 64, 22, 100, 0, 53, "ch2", "src2");
         }
     }
 
@@ -824,7 +824,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording53, VALID, 0, 64 + 3 * PAGE_SIZE, 22, 100, 0, 53, "ch2", "src2");
+            assertRecording(catalog, validRecording53, VALID, 0, 0, 64 + 3 * PAGE_SIZE, 22, 100, 0, 53, "ch2", "src2");
         }
     }
 
@@ -836,7 +836,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 100, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, 0, 352, 960, 23, 100, 0, 6, "ch2", "src2");
         }
     }
 
@@ -848,7 +848,7 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, INVALID, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
+            assertRecording(catalog, validRecording3, INVALID, 0, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
                 18, NULL_TIMESTAMP, 7, 13, "ch2", "src2");
         }
     }
@@ -860,52 +860,54 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording0, INVALID, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording0, INVALID, 0, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording1, INVALID, FRAME_ALIGNMENT - 7, NULL_POSITION, 2, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording1, INVALID, 0, FRAME_ALIGNMENT - 7, NULL_POSITION, 2,
+                NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording2, INVALID, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording2, INVALID, 0, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording3, INVALID, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording3, INVALID, 0, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording4, INVALID, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording4, INVALID, 0, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording5, INVALID, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording5, INVALID, 0, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording6, INVALID, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording6, INVALID, 0, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording7, INVALID, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording7, INVALID, 0, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording8, INVALID, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording8, INVALID, 0, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording9, INVALID, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording9, INVALID, 0, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording10, INVALID, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording10, INVALID, 0, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording11, INVALID, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording11, INVALID, 0, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
                 5, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording12, INVALID, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording12, INVALID, 0, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
                 9, 6, "ch1", "src1");
-            assertRecording(catalog, invalidRecording13, INVALID, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording13, INVALID, 0, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
                 0, 13, "ch1", "src1");
-            assertRecording(catalog, invalidRecording14, INVALID, 128, NULL_POSITION, -14, 41, -14, 0, "ch1", "src1");
-            assertRecording(catalog, validRecording0, VALID, 0, TERM_LENGTH + 64, 15, 100,
+            assertRecording(catalog, invalidRecording14, INVALID, 0, 128, NULL_POSITION, -14,
+                41, -14, 0, "ch1", "src1");
+            assertRecording(catalog, validRecording0, VALID, 0, 0, TERM_LENGTH + 64, 15, 100,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording1, VALID, 1024, 1024, 16, 200,
+            assertRecording(catalog, validRecording1, VALID, 0, 1024, 1024, 16, 200,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording2, VALID, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
+            assertRecording(catalog, validRecording2, VALID, 0, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
                 17, 300, 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96,
+            assertRecording(catalog, validRecording3, VALID, 0, 7 * TERM_LENGTH + 96,
                 11 * TERM_LENGTH + 320, 18, 400, 7, 13, "ch2", "src2");
-            assertRecording(catalog, validRecording4, VALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, VALID, 0, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, 0, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
-            assertRecording(catalog, validRecording52, VALID, 0, 128 + MTU_LENGTH, 21, 500,
+            assertRecording(catalog, validRecording52, VALID, 0, 0, 128 + MTU_LENGTH, 21, 500,
                 0, 52, "ch2", "src2");
-            assertRecording(catalog, validRecording53, VALID, 0, 64 + 3 * PAGE_SIZE, 22, 600,
+            assertRecording(catalog, validRecording53, VALID, 0, 0, 64 + 3 * PAGE_SIZE, 22, 600,
                 0, 53, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 700, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, 0, 352, 960, 23, 700, 0, 6, "ch2", "src2");
         }
 
         Mockito.verify(out, times(24)).println(any(String.class));
@@ -918,52 +920,53 @@ class ArchiveToolTests
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording0, INVALID, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording0, INVALID, 0, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording1, INVALID, FRAME_ALIGNMENT - 7, NULL_POSITION, 2, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording1, INVALID, 0, FRAME_ALIGNMENT - 7, NULL_POSITION, 2,
+                NULL_TIMESTAMP, 0, 1, "ch1", "src1");
+            assertRecording(catalog, invalidRecording2, INVALID, 0, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording2, INVALID, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording3, INVALID, 0, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording3, INVALID, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording4, INVALID, 0, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording4, INVALID, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording5, INVALID, 0, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording5, INVALID, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording6, INVALID, 0, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording6, INVALID, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording7, INVALID, 0, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording7, INVALID, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording8, INVALID, 0, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording8, INVALID, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording9, INVALID, 0, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording9, INVALID, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording10, INVALID, 0, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording10, INVALID, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
-                0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording11, INVALID, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording11, INVALID, 0, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
                 5, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording12, INVALID, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording12, INVALID, 0, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
                 9, 6, "ch1", "src1");
-            assertRecording(catalog, invalidRecording13, INVALID, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording13, INVALID, 0, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
                 0, 13, "ch1", "src1");
-            assertRecording(catalog, invalidRecording14, INVALID, 128, NULL_POSITION, -14, 41, -14, 0, "ch1", "src1");
-            assertRecording(catalog, validRecording0, VALID, 0, TERM_LENGTH + 64, 15, 100,
+            assertRecording(catalog, invalidRecording14, INVALID, 0, 128, NULL_POSITION, -14,
+                41, -14, 0, "ch1", "src1");
+            assertRecording(catalog, validRecording0, VALID, 0, 0, TERM_LENGTH + 64, 15, 100,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording1, VALID, 1024, 1024, 16, 200,
+            assertRecording(catalog, validRecording1, VALID, 0, 1024, 1024, 16, 200,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording2, VALID, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
+            assertRecording(catalog, validRecording2, VALID, 0, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
                 17, 300, 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording3, INVALID, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
+            assertRecording(catalog, validRecording3, INVALID, 0, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
                 18, NULL_TIMESTAMP, 7, 13, "ch2", "src2");
-            assertRecording(catalog, validRecording4, INVALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, INVALID, 0, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, 0, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
-            assertRecording(catalog, validRecording52, INVALID, 0, NULL_POSITION, 21, NULL_TIMESTAMP,
+            assertRecording(catalog, validRecording52, INVALID, 0, 0, NULL_POSITION, 21, NULL_TIMESTAMP,
                 0, 52, "ch2", "src2");
-            assertRecording(catalog, validRecording53, INVALID, 0, NULL_POSITION, 22, NULL_TIMESTAMP,
+            assertRecording(catalog, validRecording53, INVALID, 0, 0, NULL_POSITION, 22, NULL_TIMESTAMP,
                 0, 53, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 400, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, 0, 352, 960, 23, 400, 0, 6, "ch2", "src2");
         }
 
         Mockito.verify(out, times(24)).println(any(String.class));
@@ -978,7 +981,7 @@ class ArchiveToolTests
             out, archiveDir, validRecording3, of(APPLY_CHECKSUM), crc32(), epochClock, (file) -> false));
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, VALID, 963969455, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 100, 7, 13, "ch2", "src2");
         }
 
@@ -986,7 +989,7 @@ class ArchiveToolTests
             out, archiveDir, validRecording3, allOf(VerifyOption.class), crc32(), epochClock, (file) -> false);
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, INVALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, INVALID, 963969455, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 100, 7, 13, "ch2", "src2");
         }
     }
@@ -1000,7 +1003,7 @@ class ArchiveToolTests
             out, archiveDir, validRecording3, allOf(VerifyOption.class), crc32(), epochClock, (file) -> false));
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, VALID, 963969455, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 100, 7, 13, "ch2", "src2");
         }
     }
@@ -1013,19 +1016,19 @@ class ArchiveToolTests
         assertFalse(verify(out, archiveDir, allOf(VerifyOption.class), crc32(), epochClock, (file) -> false));
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording0, VALID, 0, TERM_LENGTH + 64, 15, 100,
+            assertRecording(catalog, validRecording0, VALID, 356725588, 0, TERM_LENGTH + 64, 15, 100,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording1, VALID, 1024, 1024, 16, 200,
+            assertRecording(catalog, validRecording1, VALID, -1571032591, 1024, 1024, 16, 200,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording2, VALID, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
+            assertRecording(catalog, validRecording2, VALID, 114203747, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
                 17, 300, 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording3, INVALID, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
+            assertRecording(catalog, validRecording3, INVALID, 963969455, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
                 18, NULL_TIMESTAMP, 7, 13, "ch2", "src2");
-            assertRecording(catalog, validRecording4, INVALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, INVALID, 162247708, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, -940881948, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 600, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, -175549265, 352, 960, 23, 600, 0, 6, "ch2", "src2");
         }
     }
 
@@ -1037,19 +1040,19 @@ class ArchiveToolTests
         assertFalse(verify(out, archiveDir, allOf(VerifyOption.class), crc32(), epochClock, (file) -> false));
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording0, VALID, 0, TERM_LENGTH + 64, 15, 100,
+            assertRecording(catalog, validRecording0, VALID, 356725588, 0, TERM_LENGTH + 64, 15, 100,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording1, VALID, 1024, 1024, 16, 200,
+            assertRecording(catalog, validRecording1, VALID, -1571032591, 1024, 1024, 16, 200,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording2, VALID, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
+            assertRecording(catalog, validRecording2, VALID, 114203747, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
                 17, 300, 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording3, VALID, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
+            assertRecording(catalog, validRecording3, VALID, 963969455, 7 * TERM_LENGTH + 96, 11 * TERM_LENGTH + 320,
                 18, 400, 7, 13, "ch2", "src2");
-            assertRecording(catalog, validRecording4, INVALID, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+            assertRecording(catalog, validRecording4, INVALID, 162247708, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, -940881948, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 352, 960, 23, 700, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, -175549265, 352, 960, 23, 700, 0, 6, "ch2", "src2");
         }
     }
 
@@ -1110,7 +1113,7 @@ class ArchiveToolTests
         verifyRecording(
             out, archiveDir, validRecording3, allOf(VerifyOption.class), crc32(), epochClock, (file) -> false);
 
-        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock))
+        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock, MIN_CAPACITY, null, null))
         {
             assertRecordingState(catalog, validRecording3, INVALID);
 
@@ -1133,9 +1136,9 @@ class ArchiveToolTests
             assertNoRecording(catalog, validRecording6);
 
             assertEquals(22, catalog.countEntries());
-            assertRecording(catalog, validRecording0, VALID, 0, NULL_POSITION, 15, NULL_TIMESTAMP,
+            assertRecording(catalog, validRecording0, VALID, 0, 0, NULL_POSITION, 15, NULL_TIMESTAMP,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, 0, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
         }
 
@@ -1249,6 +1252,7 @@ class ArchiveToolTests
         final Catalog catalog,
         final long recordingId,
         final RecordingState state,
+        final int checksum,
         final long startPosition,
         final long stopPosition,
         final long startTimestamp,
@@ -1259,25 +1263,29 @@ class ArchiveToolTests
         final String sourceIdentity)
     {
         final MutableBoolean found = new MutableBoolean();
-        catalog.forEach((headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
-        {
-            if (recordingId == descriptorDecoder.recordingId())
+        catalog
+            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
             {
-                found.set(true);
-                assertEquals(state, headerDecoder.state());
-                assertEquals(startPosition, descriptorDecoder.startPosition());
-                assertEquals(stopPosition, descriptorDecoder.stopPosition());
-                assertEquals(startTimestamp, descriptorDecoder.startTimestamp());
-                assertEquals(stopTimeStamp, descriptorDecoder.stopTimestamp());
-                assertEquals(initialTermId, descriptorDecoder.initialTermId());
-                assertEquals(MTU_LENGTH, descriptorDecoder.mtuLength());
-                assertEquals(SEGMENT_LENGTH, descriptorDecoder.segmentFileLength());
-                assertEquals(streamId, descriptorDecoder.streamId());
-                assertEquals(strippedChannel, descriptorDecoder.strippedChannel());
-                assertNotNull(descriptorDecoder.originalChannel());
-                assertEquals(sourceIdentity, descriptorDecoder.sourceIdentity());
-            }
-        });
+                if (recordingId == descriptorDecoder.recordingId())
+                {
+                    found.set(true);
+
+                    assertEquals(state, headerDecoder.state());
+                    assertEquals(checksum, headerDecoder.checksum());
+
+                    assertEquals(startPosition, descriptorDecoder.startPosition());
+                    assertEquals(stopPosition, descriptorDecoder.stopPosition());
+                    assertEquals(startTimestamp, descriptorDecoder.startTimestamp());
+                    assertEquals(stopTimeStamp, descriptorDecoder.stopTimestamp());
+                    assertEquals(initialTermId, descriptorDecoder.initialTermId());
+                    assertEquals(MTU_LENGTH, descriptorDecoder.mtuLength());
+                    assertEquals(SEGMENT_LENGTH, descriptorDecoder.segmentFileLength());
+                    assertEquals(streamId, descriptorDecoder.streamId());
+                    assertEquals(strippedChannel, descriptorDecoder.strippedChannel());
+                    assertNotNull(descriptorDecoder.originalChannel());
+                    assertEquals(sourceIdentity, descriptorDecoder.sourceIdentity());
+                }
+            });
 
         assertTrue(found.get(), () -> "recordingId=" + recordingId + " was not found");
     }
@@ -1285,14 +1293,15 @@ class ArchiveToolTests
     private void assertRecordingState(final Catalog catalog, final long recordingId, final RecordingState expectedState)
     {
         final MutableBoolean found = new MutableBoolean();
-        catalog.forEach((headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
-        {
-            if (recordingId == descriptorDecoder.recordingId())
+        catalog
+            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
             {
-                found.set(true);
-                assertEquals(expectedState, headerDecoder.state());
-            }
-        });
+                if (recordingId == descriptorDecoder.recordingId())
+                {
+                    found.set(true);
+                    assertEquals(expectedState, headerDecoder.state());
+                }
+            });
 
         assertTrue(found.get(), () -> "recordingId=" + recordingId + " was not found");
     }
@@ -1302,13 +1311,14 @@ class ArchiveToolTests
         final long recordingId)
     {
         final MutableBoolean found = new MutableBoolean();
-        catalog.forEach((headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
-        {
-            if (recordingId == descriptorDecoder.recordingId())
+        catalog
+            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
             {
-                found.set(true);
-            }
-        });
+                if (recordingId == descriptorDecoder.recordingId())
+                {
+                    found.set(true);
+                }
+            });
 
         assertFalse(found.get(), () -> "recordingId=" + recordingId + " was found");
     }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -42,7 +42,8 @@ import static io.aeron.archive.Archive.segmentFileName;
 import static io.aeron.archive.ArchiveTool.*;
 import static io.aeron.archive.ArchiveTool.VerifyOption.APPLY_CHECKSUM;
 import static io.aeron.archive.ArchiveTool.VerifyOption.VERIFY_ALL_SEGMENT_FILES;
-import static io.aeron.archive.Catalog.*;
+import static io.aeron.archive.Catalog.PAGE_SIZE;
+import static io.aeron.archive.Catalog.listSegmentFiles;
 import static io.aeron.archive.checksum.Checksums.crc32;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
@@ -1141,6 +1142,30 @@ class ArchiveToolTests
         assertTrue(segmentFiles.stream().noneMatch(file -> new File(archiveDir, file).exists()),
             "Segment files not deleted");
         Mockito.verify(out).println("Compaction result: deleted 2 records and reclaimed 384 bytes");
+    }
+
+    @Test
+    void capacityReturnsCurrentCapacityInBytesOfTheCatalog()
+    {
+        final long capacity;
+        try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
+        {
+            capacity = catalog.capacity();
+        }
+
+        assertEquals(capacity, capacity(archiveDir));
+    }
+
+    @Test
+    void capacityIncreasesCapacityOfTheCatalog()
+    {
+        final long capacity;
+        try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
+        {
+            capacity = catalog.capacity();
+        }
+
+        assertEquals(capacity * 2, capacity(archiveDir, capacity * 2));
     }
 
     private static List<Arguments> verifyChecksumClassValidation()

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -118,7 +118,7 @@ class ArchiveToolTests
     {
         archiveDir = ArchiveTests.makeTestDirectory();
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, 128, epochClock, null, null))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, 128 * 1024, epochClock, null, null))
         {
             invalidRecording0 = catalog.addNewRecording(NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP, 0,
                 SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 1, 1, "ch1", "ch1?tag=ERR", "src1");

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveToolTests.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.archive;
 
+import io.aeron.archive.checksum.Checksum;
 import io.aeron.archive.codecs.RecordingState;
 import io.aeron.protocol.DataHeaderFlyweight;
 import org.agrona.IoUtil;
@@ -831,12 +832,34 @@ class ArchiveToolTests
     @Test
     void verifyRecordingValidRecordingPerformCRC()
     {
+        final Checksum checksum = crc32();
+        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock, MIN_CAPACITY, checksum, null))
+        {
+            assertRecording(catalog,
+                validRecording6,
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                catalog.updateChecksum(recordingDescriptorOffset));
+        }
+
         assertTrue(verifyRecording(
+            out, archiveDir, validRecording6, of(APPLY_CHECKSUM), checksum, epochClock, (file) -> false));
+
+        try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
+        {
+            assertRecording(catalog, validRecording6, VALID, -175549265, 352, 960, 23, 100, 0, 6, "ch2", "src2");
+        }
+    }
+
+    @Test
+    void verifyRecordingShouldMarkRecordingAsInvalidIfCatalogChecksumIsWrong()
+    {
+        assertFalse(verifyRecording(
             out, archiveDir, validRecording6, of(APPLY_CHECKSUM), crc32(), epochClock, (file) -> false));
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, validRecording6, VALID, 0, 352, 960, 23, 100, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, INVALID, 0, 352, NULL_POSITION, 23,
+                NULL_TIMESTAMP, 0, 6, "ch2", "src2");
         }
     }
 
@@ -916,57 +939,109 @@ class ArchiveToolTests
     @Test
     void verifyAllOptionsTruncateOnPageStraddle()
     {
-        assertFalse(verify(out, archiveDir, allOf(VerifyOption.class), crc32(), epochClock, (file) -> true));
+        final Checksum checksum = crc32();
+        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock, MIN_CAPACITY, checksum, null))
+        {
+            catalog.forEach(
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                catalog.updateChecksum(recordingDescriptorOffset));
+        }
+
+        assertFalse(verify(out, archiveDir, allOf(VerifyOption.class), checksum, epochClock, (file) -> true));
 
         try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
         {
-            assertRecording(catalog, invalidRecording0, INVALID, 0, NULL_POSITION, NULL_POSITION, 1, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording0, INVALID, -119969720, NULL_POSITION, NULL_POSITION, 1,
+                NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording1, INVALID, 0, FRAME_ALIGNMENT - 7, NULL_POSITION, 2,
+            assertRecording(catalog, invalidRecording1, INVALID, 768794941, FRAME_ALIGNMENT - 7, NULL_POSITION, 2,
                 NULL_TIMESTAMP, 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording2, INVALID, 0, 1024, FRAME_ALIGNMENT * 2, 3, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording2, INVALID, -1340428433, 1024, FRAME_ALIGNMENT * 2,
+                3, NULL_TIMESTAMP, 0, 1, "ch1", "src1");
+            assertRecording(catalog, invalidRecording3, INVALID, 1464972620, 0, FRAME_ALIGNMENT * 5 + 11,
+                4, NULL_TIMESTAMP, 0, 1, "ch1", "src1");
+            assertRecording(catalog, invalidRecording4, INVALID, 21473288, SEGMENT_LENGTH, NULL_POSITION, 5,
+                NULL_TIMESTAMP, 0, 1, "ch1", "src1");
+            assertRecording(catalog, invalidRecording5, INVALID, -2119992405, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording3, INVALID, 0, 0, FRAME_ALIGNMENT * 5 + 11, 4, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording6, INVALID, 2054096463, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording4, INVALID, 0, SEGMENT_LENGTH, NULL_POSITION, 5, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording7, INVALID, -1050175867, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording5, INVALID, 0, 0, SEGMENT_LENGTH, 6, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording8, INVALID, -504693275, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording6, INVALID, 0, 0, NULL_POSITION, 7, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording9, INVALID, -2036430506, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording7, INVALID, 0, 0, NULL_POSITION, 8, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording10, INVALID, -414736820, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
                 0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording8, INVALID, 0, 0, NULL_POSITION, 9, NULL_TIMESTAMP,
-                0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording9, INVALID, 0, 0, NULL_POSITION, 10, NULL_TIMESTAMP,
-                0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording10, INVALID, 0, 128, NULL_POSITION, 11, NULL_TIMESTAMP,
-                0, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording11, INVALID, 0, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording11, INVALID, 1983095657, 0, NULL_POSITION, 12, NULL_TIMESTAMP,
                 5, 1, "ch1", "src1");
-            assertRecording(catalog, invalidRecording12, INVALID, 0, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording12, INVALID, -1308504240, 0, NULL_POSITION, 13, NULL_TIMESTAMP,
                 9, 6, "ch1", "src1");
-            assertRecording(catalog, invalidRecording13, INVALID, 0, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
+            assertRecording(catalog, invalidRecording13, INVALID, -273182324, 0, NULL_POSITION, 14, NULL_TIMESTAMP,
                 0, 13, "ch1", "src1");
-            assertRecording(catalog, invalidRecording14, INVALID, 0, 128, NULL_POSITION, -14,
+            assertRecording(catalog, invalidRecording14, INVALID, 213018412, 128, NULL_POSITION, -14,
                 41, -14, 0, "ch1", "src1");
-            assertRecording(catalog, validRecording0, VALID, 0, 0, TERM_LENGTH + 64, 15, 100,
+            assertRecording(catalog, validRecording0, VALID, 356725588, 0, TERM_LENGTH + 64, 15, 100,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording1, VALID, 0, 1024, 1024, 16, 200,
+            assertRecording(catalog, validRecording1, VALID, -1571032591, 1024, 1024, 16, 200,
                 0, 2, "ch2", "src2");
-            assertRecording(catalog, validRecording2, VALID, 0, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
+            assertRecording(catalog, validRecording2, VALID, 114203747, TERM_LENGTH * 3 + 96, TERM_LENGTH * 3 + 96,
                 17, 300, 0, 2, "ch2", "src2");
+            assertRecording(catalog, validRecording3, INVALID, 963969455, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
+                18, NULL_TIMESTAMP, 7, 13, "ch2", "src2");
+            assertRecording(catalog, validRecording4, INVALID, 162247708, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
+                22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
+            assertRecording(catalog, validRecording51, VALID, -940881948, 0, 64 + PAGE_SIZE, 20, 777,
+                0, 20, "ch2", "src2");
+            assertRecording(catalog, validRecording52, INVALID, 1046083782, 0, NULL_POSITION, 21, NULL_TIMESTAMP,
+                0, 52, "ch2", "src2");
+            assertRecording(catalog, validRecording53, INVALID, 428178649, 0, NULL_POSITION, 22, NULL_TIMESTAMP,
+                0, 53, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, -175549265, 352, 960, 23, 400, 0, 6, "ch2", "src2");
+        }
+
+        Mockito.verify(out, times(24)).println(any(String.class));
+    }
+
+    @Test
+    void verifyChecksum()
+    {
+        final Checksum checksum = crc32();
+        try (Catalog catalog = openCatalogReadWrite(archiveDir, epochClock, MIN_CAPACITY, checksum, null))
+        {
+            assertRecording(catalog,
+                validRecording51,
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                catalog.updateChecksum(recordingDescriptorOffset));
+
+            assertRecording(catalog,
+                validRecording6,
+                (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+                catalog.updateChecksum(recordingDescriptorOffset));
+        }
+
+        assertFalse(verify(out, archiveDir, of(APPLY_CHECKSUM), checksum, epochClock, (file) -> true));
+
+        try (Catalog catalog = openCatalogReadOnly(archiveDir, epochClock))
+        {
+            assertRecording(catalog, validRecording0, INVALID, 0, 0, NULL_POSITION, 15, NULL_TIMESTAMP,
+                0, 2, "ch2", "src2");
+            assertRecording(catalog, validRecording1, INVALID, 0, 1024, NULL_POSITION, 16, NULL_TIMESTAMP,
+                0, 2, "ch2", "src2");
+            assertRecording(catalog, validRecording2, INVALID, 0, TERM_LENGTH * 3 + 96, NULL_POSITION,
+                17, NULL_TIMESTAMP, 0, 2, "ch2", "src2");
             assertRecording(catalog, validRecording3, INVALID, 0, 7 * TERM_LENGTH + 96, 7 * TERM_LENGTH + 128,
                 18, NULL_TIMESTAMP, 7, 13, "ch2", "src2");
             assertRecording(catalog, validRecording4, INVALID, 0, 21 * TERM_LENGTH + (TERM_LENGTH - 64),
                 22 * TERM_LENGTH + 992, 19, 1, -25, 7, "ch2", "src2");
-            assertRecording(catalog, validRecording51, VALID, 0, 0, 64 + PAGE_SIZE, 20, 777,
+            assertRecording(catalog, validRecording51, VALID, -940881948, 0, 64 + PAGE_SIZE, 20, 777,
                 0, 20, "ch2", "src2");
             assertRecording(catalog, validRecording52, INVALID, 0, 0, NULL_POSITION, 21, NULL_TIMESTAMP,
                 0, 52, "ch2", "src2");
             assertRecording(catalog, validRecording53, INVALID, 0, 0, NULL_POSITION, 22, NULL_TIMESTAMP,
                 0, 53, "ch2", "src2");
-            assertRecording(catalog, validRecording6, VALID, 0, 352, 960, 23, 400, 0, 6, "ch2", "src2");
+            assertRecording(catalog, validRecording6, VALID, -175549265, 352, 960, 23, 100, 0, 6, "ch2", "src2");
         }
 
         Mockito.verify(out, times(24)).println(any(String.class));
@@ -1249,6 +1324,25 @@ class ArchiveToolTests
     }
 
     private void assertRecording(
+        final Catalog catalog, final long recordingId, final CatalogEntryProcessor catalogEntryProcessor)
+    {
+        final MutableBoolean found = new MutableBoolean();
+        catalog
+            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+            {
+                if (recordingId == descriptorDecoder.recordingId())
+                {
+                    found.set(true);
+
+                    catalogEntryProcessor.accept(
+                        recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder);
+                }
+            });
+
+        assertTrue(found.get(), () -> "recordingId=" + recordingId + " was not found");
+    }
+
+    private void assertRecording(
         final Catalog catalog,
         final long recordingId,
         final RecordingState state,
@@ -1262,53 +1356,36 @@ class ArchiveToolTests
         final String strippedChannel,
         final String sourceIdentity)
     {
-        final MutableBoolean found = new MutableBoolean();
-        catalog
-            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+        assertRecording(
+            catalog,
+            recordingId,
+            (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
             {
-                if (recordingId == descriptorDecoder.recordingId())
-                {
-                    found.set(true);
+                assertEquals(state, headerDecoder.state());
+                assertEquals(checksum, headerDecoder.checksum());
 
-                    assertEquals(state, headerDecoder.state());
-                    assertEquals(checksum, headerDecoder.checksum());
-
-                    assertEquals(startPosition, descriptorDecoder.startPosition());
-                    assertEquals(stopPosition, descriptorDecoder.stopPosition());
-                    assertEquals(startTimestamp, descriptorDecoder.startTimestamp());
-                    assertEquals(stopTimeStamp, descriptorDecoder.stopTimestamp());
-                    assertEquals(initialTermId, descriptorDecoder.initialTermId());
-                    assertEquals(MTU_LENGTH, descriptorDecoder.mtuLength());
-                    assertEquals(SEGMENT_LENGTH, descriptorDecoder.segmentFileLength());
-                    assertEquals(streamId, descriptorDecoder.streamId());
-                    assertEquals(strippedChannel, descriptorDecoder.strippedChannel());
-                    assertNotNull(descriptorDecoder.originalChannel());
-                    assertEquals(sourceIdentity, descriptorDecoder.sourceIdentity());
-                }
+                assertEquals(startPosition, descriptorDecoder.startPosition());
+                assertEquals(stopPosition, descriptorDecoder.stopPosition());
+                assertEquals(startTimestamp, descriptorDecoder.startTimestamp());
+                assertEquals(stopTimeStamp, descriptorDecoder.stopTimestamp());
+                assertEquals(initialTermId, descriptorDecoder.initialTermId());
+                assertEquals(MTU_LENGTH, descriptorDecoder.mtuLength());
+                assertEquals(SEGMENT_LENGTH, descriptorDecoder.segmentFileLength());
+                assertEquals(streamId, descriptorDecoder.streamId());
+                assertEquals(strippedChannel, descriptorDecoder.strippedChannel());
+                assertNotNull(descriptorDecoder.originalChannel());
+                assertEquals(sourceIdentity, descriptorDecoder.sourceIdentity());
             });
-
-        assertTrue(found.get(), () -> "recordingId=" + recordingId + " was not found");
     }
 
     private void assertRecordingState(final Catalog catalog, final long recordingId, final RecordingState expectedState)
     {
-        final MutableBoolean found = new MutableBoolean();
-        catalog
-            .forEach((recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
-            {
-                if (recordingId == descriptorDecoder.recordingId())
-                {
-                    found.set(true);
-                    assertEquals(expectedState, headerDecoder.state());
-                }
-            });
-
-        assertTrue(found.get(), () -> "recordingId=" + recordingId + " was not found");
+        assertRecording(catalog, recordingId,
+            (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
+            assertEquals(expectedState, headerDecoder.state()));
     }
 
-    private void assertNoRecording(
-        final Catalog catalog,
-        final long recordingId)
+    private void assertNoRecording(final Catalog catalog, final long recordingId)
     {
         final MutableBoolean found = new MutableBoolean();
         catalog

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
@@ -15,19 +15,16 @@
  */
 package io.aeron.archive;
 
-import io.aeron.archive.CatalogIndex.IndexEntryConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.InOrder;
 
 import java.util.Random;
 
 import static io.aeron.archive.CatalogIndex.DEFAULT_INDEX_SIZE;
 import static io.aeron.archive.CatalogIndex.NULL_VALUE;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class CatalogIndexTest
 {
@@ -318,53 +315,5 @@ class CatalogIndexTest
         assertEquals(DEFAULT_INDEX_SIZE - 1, catalogIndex.size());
 
         assertEquals(NULL_VALUE, catalogIndex.get(DEFAULT_INDEX_SIZE));
-    }
-
-    @Test
-    void forEachIsANoOpWhenIndexIsEmpty()
-    {
-        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
-
-        catalogIndex.forEach(consumer);
-
-        verifyNoInteractions(consumer);
-    }
-
-    @Test
-    void forEachInvokesConsumerForEachExistingEntry()
-    {
-        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
-        catalogIndex.add(5, 500);
-        catalogIndex.add(7, 777);
-        catalogIndex.add(13, 1000);
-        catalogIndex.add(29, 1024);
-        catalogIndex.remove(7);
-
-        catalogIndex.forEach(consumer);
-
-        final InOrder inOrder = inOrder(consumer);
-        inOrder.verify(consumer).accept(5, 500);
-        inOrder.verify(consumer).accept(13, 1000);
-        inOrder.verify(consumer).accept(29, 1024);
-        verifyNoMoreInteractions(consumer);
-    }
-
-    @Test
-    void forEachOnFullIndex()
-    {
-        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
-        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++)
-        {
-            catalogIndex.add(i, i);
-        }
-
-        catalogIndex.forEach(consumer);
-
-        final InOrder inOrder = inOrder(consumer);
-        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++)
-        {
-            inOrder.verify(consumer).accept(i, i);
-        }
-        verifyNoMoreInteractions(consumer);
     }
 }

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
@@ -35,7 +35,7 @@ class CatalogIndexTest
     {
         final long[] emptyIndex = new long[20];
 
-        assertArrayEquals(emptyIndex, catalogIndex.index);
+        assertArrayEquals(emptyIndex, catalogIndex.index());
     }
 
     @Test
@@ -67,7 +67,7 @@ class CatalogIndexTest
         final long[] expected = new long[20];
         expected[0] = recordingId;
         expected[1] = recordingOffset;
-        assertArrayEquals(expected, catalogIndex.index);
+        assertArrayEquals(expected, catalogIndex.index());
         assertEquals(1, catalogIndex.size());
     }
 
@@ -87,7 +87,7 @@ class CatalogIndexTest
         expected[1] = recordingOffset1;
         expected[2] = recordingId2;
         expected[3] = recordingOffset2;
-        assertArrayEquals(expected, catalogIndex.index);
+        assertArrayEquals(expected, catalogIndex.index());
         assertEquals(2, catalogIndex.size());
     }
 
@@ -120,7 +120,7 @@ class CatalogIndexTest
         expectedIndex[pos + 1] = Long.MAX_VALUE;
         catalogIndex.add(Long.MAX_VALUE, Long.MAX_VALUE);
 
-        assertArrayEquals(expectedIndex, catalogIndex.index);
+        assertArrayEquals(expectedIndex, catalogIndex.index());
         assertEquals(DEFAULT_INDEX_SIZE + 1, catalogIndex.size());
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogIndexTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.archive.CatalogIndex.IndexEntryConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InOrder;
+
+import java.util.Random;
+
+import static io.aeron.archive.CatalogIndex.DEFAULT_INDEX_SIZE;
+import static io.aeron.archive.CatalogIndex.NULL_VALUE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CatalogIndexTest
+{
+    private final CatalogIndex catalogIndex = new CatalogIndex();
+
+    @Test
+    void defaultIndexCapacityIsTenEntries()
+    {
+        final long[] emptyIndex = new long[20];
+
+        assertArrayEquals(emptyIndex, catalogIndex.index);
+    }
+
+    @Test
+    void sizeReturnsZeroForAnEmptyIndex()
+    {
+        assertEquals(0, catalogIndex.size());
+    }
+
+    @Test
+    void addThrowsIllegalArgumentExceptionIfRecordingIdIsNegative()
+    {
+        assertThrows(IllegalArgumentException.class, () -> catalogIndex.add(-1, 0));
+    }
+
+    @Test
+    void addThrowsIllegalArgumentExceptionIfRecordingOffsetIsNegative()
+    {
+        assertThrows(IllegalArgumentException.class, () -> catalogIndex.add(1024, Integer.MIN_VALUE));
+    }
+
+    @Test
+    void addOneRecording()
+    {
+        final long recordingId = 3;
+        final long recordingOffset = 100;
+
+        catalogIndex.add(recordingId, recordingOffset);
+
+        final long[] expected = new long[20];
+        expected[0] = recordingId;
+        expected[1] = recordingOffset;
+        assertArrayEquals(expected, catalogIndex.index);
+        assertEquals(1, catalogIndex.size());
+    }
+
+    @Test
+    void addAppendsToTheEndOfTheIndex()
+    {
+        final long recordingId1 = 6;
+        final long recordingOffset1 = 50;
+        final long recordingId2 = 21;
+        final long recordingOffset2 = 64;
+
+        catalogIndex.add(recordingId1, recordingOffset1);
+        catalogIndex.add(recordingId2, recordingOffset2);
+
+        final long[] expected = new long[20];
+        expected[0] = recordingId1;
+        expected[1] = recordingOffset1;
+        expected[2] = recordingId2;
+        expected[3] = recordingOffset2;
+        assertArrayEquals(expected, catalogIndex.index);
+        assertEquals(2, catalogIndex.size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 5, 100 })
+    void addAppendsThrowsIllegalArgumentExceptionIfNewRecordingIdIsLessThanOrEqualToTheExistingRecordingId(
+        final long recordingId2)
+    {
+        catalogIndex.add(100, 0);
+
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> catalogIndex.add(recordingId2, 200));
+        assertEquals("recordingId " + recordingId2 + " is less than or equal to the last recordingId 100",
+            exception.getMessage());
+    }
+
+    @Test
+    void addExpandsIndexWhenFull()
+    {
+        final long[] expectedIndex = new long[(DEFAULT_INDEX_SIZE + (DEFAULT_INDEX_SIZE >> 1)) << 1];
+
+        int pos = 0;
+        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++, pos += 2)
+        {
+            expectedIndex[pos] = i;
+            expectedIndex[pos + 1] = i;
+            catalogIndex.add(i, i);
+        }
+        expectedIndex[pos] = Long.MAX_VALUE;
+        expectedIndex[pos + 1] = Long.MAX_VALUE;
+        catalogIndex.add(Long.MAX_VALUE, Long.MAX_VALUE);
+
+        assertArrayEquals(expectedIndex, catalogIndex.index);
+        assertEquals(DEFAULT_INDEX_SIZE + 1, catalogIndex.size());
+    }
+
+    @Test
+    void getThrowsIllegalArgumentExceptionIfRecordingIdIsNegative()
+    {
+        assertThrows(IllegalArgumentException.class, () -> catalogIndex.get(-100));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 0, 1, DEFAULT_INDEX_SIZE, DEFAULT_INDEX_SIZE << 1, 100, Long.MAX_VALUE })
+    void getReturnsNullValueOnAnEmptyIndex(final long recordingId)
+    {
+        assertEquals(NULL_VALUE, catalogIndex.get(recordingId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 0, 199, 201, Long.MAX_VALUE })
+    void getReturnsNullValueIfRecordingIdIsNotFoundSingleEntry(final long recordingId)
+    {
+        catalogIndex.add(200, 0);
+
+        assertEquals(NULL_VALUE, catalogIndex.get(recordingId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 9, 101, 1_000_000_000, 4002662252L, Long.MAX_VALUE })
+    void getReturnsNullValueIfRecordingIdIsNotFoundMultipleEntries(final long recordingId)
+    {
+        for (int i = 10; i < 100; i++)
+        {
+            catalogIndex.add(i, i);
+        }
+
+        assertEquals(NULL_VALUE, catalogIndex.get(recordingId));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = { "0,0", "1,1", "2,3", "100,777", "1000,2000", "1001,2002" })
+    void getReturnsOffsetAssociatedWithRecordingId(final long recordingId, final long recordingOffset)
+    {
+        catalogIndex.add(0, 0);
+        catalogIndex.add(1, 1);
+        catalogIndex.add(2, 3);
+        catalogIndex.add(100, 777);
+        catalogIndex.add(1000, 2_000);
+        catalogIndex.add(1001, 2_002);
+
+        assertEquals(recordingOffset, catalogIndex.get(recordingId));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { 0, 100, Long.MAX_VALUE })
+    void getSingleElement(final long recordingId)
+    {
+        catalogIndex.add(recordingId, recordingId * 3);
+
+        assertEquals(recordingId * 3, catalogIndex.get(recordingId));
+    }
+
+    @Test
+    void getFirstElement()
+    {
+        catalogIndex.add(0, 10);
+        catalogIndex.add(1, 20);
+        catalogIndex.add(2, 30);
+
+        assertEquals(10, catalogIndex.get(0));
+    }
+
+    @Test
+    void getLastElement()
+    {
+        catalogIndex.add(1, 10);
+        catalogIndex.add(5, 20);
+        catalogIndex.add(12, 30);
+
+        assertEquals(30, catalogIndex.get(12));
+    }
+
+    @Test
+    void getLastElementWhenIndexIsFull()
+    {
+        final long[] values = new Random(8327434)
+            .longs(0, Long.MAX_VALUE)
+            .distinct()
+            .limit(DEFAULT_INDEX_SIZE)
+            .sorted()
+            .toArray();
+
+        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++)
+        {
+            catalogIndex.add(values[i], i + 1);
+        }
+
+        final long lastValue = values[values.length - 1];
+        assertEquals(DEFAULT_INDEX_SIZE, catalogIndex.get(lastValue));
+    }
+
+    @Test
+    void removeThrowsIllegalArgumentExceptionIfNegativeRecordingIdIsProvided()
+    {
+        assertThrows(IllegalArgumentException.class, () -> catalogIndex.remove(-1));
+    }
+
+    @Test
+    void removeReturnsNullValueWhenIndexIsEmpty()
+    {
+        assertEquals(NULL_VALUE, catalogIndex.remove(1));
+    }
+
+    @Test
+    void removeReturnsNullValueWhenNonExistingRecordingIdIsProvided()
+    {
+        catalogIndex.add(1, 0);
+        catalogIndex.add(20, 10);
+
+        assertEquals(NULL_VALUE, catalogIndex.remove(7));
+
+        assertEquals(2, catalogIndex.size());
+    }
+
+    @Test
+    void removeTheOnlyEntryFromTheIndex()
+    {
+        final long recordingId = 0;
+        final long recordingOffset = 1024;
+        catalogIndex.add(recordingId, recordingOffset);
+
+        assertEquals(recordingOffset, catalogIndex.remove(recordingId));
+        assertEquals(0, catalogIndex.size());
+
+        assertEquals(NULL_VALUE, catalogIndex.get(recordingId));
+    }
+
+    @Test
+    void removeFirstElement()
+    {
+        catalogIndex.add(0, 500);
+        catalogIndex.add(1, 1000);
+        catalogIndex.add(2, 1500);
+
+        assertEquals(500, catalogIndex.remove(0));
+        assertEquals(2, catalogIndex.size());
+
+        assertEquals(NULL_VALUE, catalogIndex.get(0));
+        assertEquals(1000, catalogIndex.get(1));
+        assertEquals(1500, catalogIndex.get(2));
+    }
+
+    @Test
+    void removeLastElement()
+    {
+        catalogIndex.add(0, 500);
+        catalogIndex.add(1, 1000);
+        catalogIndex.add(2, 1500);
+
+        assertEquals(1500, catalogIndex.remove(2));
+        assertEquals(2, catalogIndex.size());
+
+        assertEquals(NULL_VALUE, catalogIndex.get(2));
+        assertEquals(500, catalogIndex.get(0));
+        assertEquals(1000, catalogIndex.get(1));
+    }
+
+    @Test
+    void removeMiddleElement()
+    {
+        catalogIndex.add(0, 500);
+        catalogIndex.add(10, 1000);
+        catalogIndex.add(20, 1500);
+        catalogIndex.add(30, 7777);
+
+        assertEquals(1000, catalogIndex.remove(10));
+        assertEquals(3, catalogIndex.size());
+
+        assertEquals(NULL_VALUE, catalogIndex.get(10));
+        assertEquals(500, catalogIndex.get(0));
+        assertEquals(1500, catalogIndex.get(20));
+        assertEquals(7777, catalogIndex.get(30));
+    }
+
+    @Test
+    void removeLastElementFromTheFullIndex()
+    {
+        for (int i = 1; i <= DEFAULT_INDEX_SIZE; i++)
+        {
+            catalogIndex.add(i, i);
+        }
+
+        assertEquals(DEFAULT_INDEX_SIZE, catalogIndex.remove(DEFAULT_INDEX_SIZE));
+        assertEquals(DEFAULT_INDEX_SIZE - 1, catalogIndex.size());
+
+        assertEquals(NULL_VALUE, catalogIndex.get(DEFAULT_INDEX_SIZE));
+    }
+
+    @Test
+    void forEachIsANoOpWhenIndexIsEmpty()
+    {
+        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
+
+        catalogIndex.forEach(consumer);
+
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void forEachInvokesConsumerForEachExistingEntry()
+    {
+        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
+        catalogIndex.add(5, 500);
+        catalogIndex.add(7, 777);
+        catalogIndex.add(13, 1000);
+        catalogIndex.add(29, 1024);
+        catalogIndex.remove(7);
+
+        catalogIndex.forEach(consumer);
+
+        final InOrder inOrder = inOrder(consumer);
+        inOrder.verify(consumer).accept(5, 500);
+        inOrder.verify(consumer).accept(13, 1000);
+        inOrder.verify(consumer).accept(29, 1024);
+        verifyNoMoreInteractions(consumer);
+    }
+
+    @Test
+    void forEachOnFullIndex()
+    {
+        final IndexEntryConsumer consumer = mock(IndexEntryConsumer.class);
+        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++)
+        {
+            catalogIndex.add(i, i);
+        }
+
+        catalogIndex.forEach(consumer);
+
+        final InOrder inOrder = inOrder(consumer);
+        for (int i = 0; i < DEFAULT_INDEX_SIZE; i++)
+        {
+            inOrder.verify(consumer).accept(i, i);
+        }
+        verifyNoMoreInteractions(consumer);
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CatalogTest
 {
-    private static final long CAPACITY = 64 * 1024;
+    private static final long CAPACITY = 1024;
     private static final int TERM_LENGTH = 2 * PAGE_SIZE;
     private static final int SEGMENT_LENGTH = 2 * TERM_LENGTH;
     private static final int MTU_LENGTH = 1024;
@@ -431,9 +431,8 @@ class CatalogTest
     {
         after();
         final File archiveDir = ArchiveTests.makeTestDirectory();
-        final long capacity = 384 + CatalogHeaderEncoder.BLOCK_LENGTH;
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, capacity, clock, null, null))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, MIN_CAPACITY, clock, null, null))
         {
             for (int i = 0; i < 4; i++)
             {
@@ -455,7 +454,7 @@ class CatalogTest
         try (Catalog catalog = new Catalog(archiveDir, clock))
         {
             assertEquals(4, catalog.countEntries());
-            assertEquals(936, catalog.capacity());
+            assertEquals(819, catalog.capacity());
         }
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -524,7 +524,7 @@ class CatalogTest
         {
             final ArchiveException exception =
                 assertThrows(ArchiveException.class, () -> catalog.growCatalog(CAPACITY, (int)(CAPACITY + 1)));
-            assertEquals("catalog is full, max length reached: " + CAPACITY, exception.getMessage());
+            assertEquals("catalog is full, max capacity reached: " + CAPACITY, exception.getMessage());
         }
     }
 
@@ -539,6 +539,17 @@ class CatalogTest
                 "recording is too big: total recording length is %d bytes, available space is %d bytes",
                 Integer.MAX_VALUE, CAPACITY * 2 - 800),
                 exception.getMessage());
+        }
+    }
+
+    @Test
+    void growCatalogShouldNotExceedMaxCatalogCapacity()
+    {
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, null, segmentFileBuffer))
+        {
+            final long maxCatalogCapacity = CAPACITY * 1024;
+            catalog.growCatalog(maxCatalogCapacity, (int)(maxCatalogCapacity - 10_000));
+            assertEquals(maxCatalogCapacity, catalog.capacity());
         }
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -117,7 +117,7 @@ class CatalogTest
         IoUtil.deleteIfExists(catalogFile);
         Files.write(catalogFile.toPath(), new byte[oldRecordLength], CREATE_NEW);
 
-        try (Catalog catalog = new Catalog(archiveDir, clock, true, (version) -> {}))
+        try (Catalog catalog = new Catalog(archiveDir, clock, MIN_CAPACITY, true, (version) -> {}))
         {
             assertEquals(oldRecordLength, catalog.alignment());
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -145,7 +145,7 @@ class CatalogTest
         final ArchiveException exception = assertThrows(ArchiveException.class,
             () -> new Catalog(archiveDir, null, 0, CAPACITY, clock, null, segmentFileBuffer));
         assertEquals(
-            "invalid nextRecordingId: expected value greater or equal to " + (recordingThreeId + 1) +
+            "ERROR - invalid nextRecordingId: expected value greater or equal to " + (recordingThreeId + 1) +
             ", was " + recordingTwoId,
             exception.getMessage());
     }
@@ -524,7 +524,7 @@ class CatalogTest
         {
             final ArchiveException exception =
                 assertThrows(ArchiveException.class, () -> catalog.growCatalog(CAPACITY, (int)(CAPACITY + 1)));
-            assertEquals("catalog is full, max capacity reached: " + CAPACITY, exception.getMessage());
+            assertEquals("ERROR - catalog is full, max capacity reached: " + CAPACITY, exception.getMessage());
         }
     }
 
@@ -536,7 +536,7 @@ class CatalogTest
             final ArchiveException exception =
                 assertThrows(ArchiveException.class, () -> catalog.growCatalog(CAPACITY * 2, Integer.MAX_VALUE));
             assertEquals(String.format(
-                "recording is too big: total recording length is %d bytes, available space is %d bytes",
+                "ERROR - recording is too big: total recording length is %d bytes, available space is %d bytes",
                 Integer.MAX_VALUE, CAPACITY * 2 - 800),
                 exception.getMessage());
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogViewTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogViewTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.*;
 
 public class CatalogViewTest
 {
-    private static final long MAX_ENTRIES = 1024;
+    private static final long CAPACITY = 1024 * 1024;
     private static final int TERM_LENGTH = 2 * Catalog.PAGE_SIZE;
     private static final int SEGMENT_LENGTH = 2 * TERM_LENGTH;
     private static final int MTU_LENGTH = 1024;
@@ -49,7 +49,7 @@ public class CatalogViewTest
     {
         clock.update(1);
 
-        try (Catalog catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null, null))
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, null, null))
         {
             recordingOneId = catalog.addNewRecording(
                 10L, 4L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 7, 1, "channelG", "channelG?tag=f", "sourceA");

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.*;
 
 public class ListRecordingsForUriSessionTest
 {
-    private static final long MAX_ENTRIES = 1024;
+    private static final long CAPACITY = 1024 * 1024;
     private static final int SEGMENT_FILE_SIZE = 128 * 1024 * 1024;
     public static final byte[] LOCALHOST_BYTES = "localhost".getBytes(StandardCharsets.US_ASCII);
     private final UnsafeBuffer descriptorBuffer = new UnsafeBuffer();
@@ -37,7 +37,7 @@ public class ListRecordingsForUriSessionTest
     @BeforeEach
     public void before()
     {
-        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null, null);
+        catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, null, null);
         matchingRecordingIds[0] = catalog.addNewRecording(
             0L, 0L, 0, SEGMENT_FILE_SIZE, 4096, 1024, 6, 1, "localhost", "localhost?tag=f", "sourceA");
         catalog.addNewRecording(

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
@@ -76,7 +76,7 @@ public class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        session.doWork();
+        assertEquals(3, session.doWork());
         verify(controlSession, times(3)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
     }
 
@@ -100,7 +100,7 @@ public class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        session.doWork();
+        assertEquals(2, session.doWork());
         verify(controlSession, times(2)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
     }
 
@@ -121,14 +121,14 @@ public class ListRecordingsForUriSessionTest
             recordingDescriptorDecoder);
 
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy))).thenReturn(0);
-        session.doWork();
+        assertEquals(0, session.doWork());
         verify(controlSession, times(1)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
 
         final MutableLong counter = new MutableLong(fromRecordingId);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        session.doWork();
+        assertEquals(1, session.doWork());
         verify(controlSession, times(2)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
     }
 
@@ -151,8 +151,7 @@ public class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        session.doWork();
-
+        assertEquals(2, session.doWork());
         verify(controlSession, times(2)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
         verify(controlSession).sendRecordingUnknown(eq(correlationId), eq(5L), eq(controlResponseProxy));
     }
@@ -172,7 +171,7 @@ public class ListRecordingsForUriSessionTest
             descriptorBuffer,
             recordingDescriptorDecoder);
 
-        session.doWork();
+        assertEquals(0, session.doWork());
 
         verify(controlSession, never()).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
         verify(controlSession).sendRecordingUnknown(eq(correlationId), eq(5L), eq(controlResponseProxy));
@@ -195,7 +194,7 @@ public class ListRecordingsForUriSessionTest
             descriptorBuffer,
             recordingDescriptorDecoder);
 
-        session.doWork();
+        assertEquals(0, session.doWork());
 
         verify(controlSession, never()).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
         verify(controlSession).sendRecordingUnknown(eq(correlationId), eq(5L), eq(controlResponseProxy));

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
@@ -61,8 +61,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer
+        );
 
         final MutableLong counter = new MutableLong(0);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -83,8 +83,7 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer);
 
         final MutableLong counter = new MutableLong(fromId);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -105,8 +104,7 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer);
 
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy))).thenReturn(0);
         session.doWork();
@@ -130,8 +128,7 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer);
 
         final MutableLong counter = new MutableLong(1);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -153,8 +150,7 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer,
-            recordingDescriptorDecoder);
+            descriptorBuffer);
 
         session.doWork();
 

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.*;
 
 public class ListRecordingsSessionTest
 {
-    private static final int MAX_ENTRIES = 1024;
+    private static final long CAPACITY = 1024 * 1024;
     private static final int SEGMENT_FILE_SIZE = 128 * 1024 * 1024;
     private final RecordingDescriptorDecoder recordingDescriptorDecoder = new RecordingDescriptorDecoder();
     private final long[] recordingIds = new long[3];
@@ -35,7 +35,7 @@ public class ListRecordingsSessionTest
     @BeforeEach
     public void before()
     {
-        catalog = new Catalog(archiveDir, null, 0, MAX_ENTRIES, clock, null, null);
+        catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, null, null);
         recordingIds[0] = catalog.addNewRecording(
             0L, 0L, 0, SEGMENT_FILE_SIZE, 4096, 1024, 6, 1, "channelG", "channelG?tag=f", "sourceA");
         recordingIds[1] = catalog.addNewRecording(

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsSessionTest.java
@@ -61,7 +61,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer);
+            descriptorBuffer,
+            recordingDescriptorDecoder);
 
         final MutableLong counter = new MutableLong(0);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -82,7 +83,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer);
+            descriptorBuffer,
+            recordingDescriptorDecoder);
 
         final MutableLong counter = new MutableLong(fromId);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -103,7 +105,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer);
+            descriptorBuffer,
+            recordingDescriptorDecoder);
 
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy))).thenReturn(0);
         session.doWork();
@@ -127,7 +130,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer);
+            descriptorBuffer,
+            recordingDescriptorDecoder);
 
         final MutableLong counter = new MutableLong(1);
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
@@ -149,7 +153,8 @@ public class ListRecordingsSessionTest
             catalog,
             controlResponseProxy,
             controlSession,
-            descriptorBuffer);
+            descriptorBuffer,
+            recordingDescriptorDecoder);
 
         session.doWork();
 

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -806,11 +806,10 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
 
     const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
 
-    const size_t static_buffer_length = sizeof(aeron_publication_command_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_publication_command_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -894,11 +893,10 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
 
     const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
 
-    const size_t static_buffer_length = sizeof(aeron_publication_command_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_publication_command_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -982,11 +980,10 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
 
     const size_t command_length = sizeof(aeron_subscription_command_t) + async->uri_length;
 
-    const size_t static_buffer_length = sizeof(aeron_subscription_command_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_subscription_command_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_subscription_command_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -1075,12 +1072,10 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
         sizeof(int32_t) +
         (size_t)async->counter.label_buffer_length;
 
-    const size_t static_buffer_length =
-        sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH);
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH)];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH))
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -1197,11 +1192,10 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
 
     const size_t command_length = sizeof(aeron_destination_command_t) + async->uri_length;
 
-    const size_t static_buffer_length = sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -2513,11 +2507,10 @@ int aeron_client_conductor_offer_destination_command(
     size_t uri_length = strlen(uri);
     const size_t command_length = sizeof(aeron_destination_command_t) + uri_length;
 
-    const size_t static_buffer_length = sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -804,7 +804,25 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
     aeron_client_conductor_t *conductor = (aeron_client_conductor_t *)clientd;
     aeron_async_add_publication_t *async = (aeron_async_add_publication_t *)item;
 
-    char buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
+    const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
+
+    const size_t static_buffer_length = sizeof(aeron_publication_command_t) + AERON_MAX_PATH;
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "ADD_PUBLICATION could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return;
+        }
+        buffer = dynamic_buffer;
+    }
+
     aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
 
@@ -818,7 +836,7 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
         &conductor->to_driver_buffer,
         AERON_COMMAND_ADD_PUBLICATION,
         buffer,
-        sizeof(aeron_publication_command_t) + async->uri_length))
+        command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {
@@ -827,11 +845,14 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "ADD_PUBLICATION could not be sent (%s:%d)", __FILE__, __LINE__);
             conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_free(dynamic_buffer);
             return;
         }
 
         sched_yield();
     }
+
+    aeron_free(dynamic_buffer);
 
     AERON_ARRAY_ENSURE_CAPACITY(
         ensure_capacity_result, conductor->registering_resources, aeron_client_registering_resource_entry_t);
@@ -871,7 +892,25 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
     aeron_client_conductor_t *conductor = (aeron_client_conductor_t *)clientd;
     aeron_async_add_exclusive_publication_t *async = (aeron_async_add_exclusive_publication_t *)item;
 
-    char buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
+    const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
+
+    const size_t static_buffer_length = sizeof(aeron_publication_command_t) + AERON_MAX_PATH;
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "ADD_EXCLUSIVE_PUBLICATION could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return;
+        }
+        buffer = dynamic_buffer;
+    }
+
     aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
 
@@ -885,7 +924,7 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
         &conductor->to_driver_buffer,
         AERON_COMMAND_ADD_EXCLUSIVE_PUBLICATION,
         buffer,
-        sizeof(aeron_publication_command_t) + async->uri_length))
+        command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {
@@ -894,11 +933,14 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_EXCLUSIVE_PUBLICATION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
             conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_free(dynamic_buffer);
             return;
         }
 
         sched_yield();
     }
+
+    aeron_free(dynamic_buffer);
 
     AERON_ARRAY_ENSURE_CAPACITY(
         ensure_capacity_result, conductor->registering_resources, aeron_client_registering_resource_entry_t);
@@ -938,7 +980,25 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
     aeron_client_conductor_t *conductor = (aeron_client_conductor_t *)clientd;
     aeron_async_add_subscription_t *async = (aeron_async_add_subscription_t *)item;
 
-    char buffer[sizeof(aeron_subscription_command_t) + AERON_MAX_PATH];
+    const size_t command_length = sizeof(aeron_subscription_command_t) + async->uri_length;
+
+    const size_t static_buffer_length = sizeof(aeron_subscription_command_t) + AERON_MAX_PATH;
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "ADD_SUBSCRIPTION could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return;
+        }
+        buffer = dynamic_buffer;
+    }
+
     aeron_subscription_command_t *command = (aeron_subscription_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
 
@@ -952,7 +1012,7 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
         &conductor->to_driver_buffer,
         AERON_COMMAND_ADD_SUBSCRIPTION,
         buffer,
-        sizeof(aeron_subscription_command_t) + async->uri_length))
+        command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {
@@ -961,11 +1021,14 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_SUBSCRIPTION could not be sent (%s:%d)",
                 __FILE__, __LINE__);
             conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_free(dynamic_buffer);
             return;
         }
 
         sched_yield();
     }
+
+    aeron_free(dynamic_buffer);
 
     AERON_ARRAY_ENSURE_CAPACITY(
         ensure_capacity_result, conductor->registering_resources, aeron_client_registering_resource_entry_t);
@@ -1005,7 +1068,31 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
     aeron_client_conductor_t *conductor = (aeron_client_conductor_t *)clientd;
     aeron_async_add_counter_t *async = (aeron_async_add_counter_t *)item;
 
-    char buffer[sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH)];
+    const size_t command_length =
+        sizeof(aeron_counter_command_t) +
+        sizeof(int32_t) +
+        (size_t)(AERON_ALIGN(async->counter.key_buffer_length, sizeof(int32_t))) +
+        sizeof(int32_t) +
+        (size_t)async->counter.label_buffer_length;
+
+    const size_t static_buffer_length =
+        sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH);
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "ADD_COUNTER could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return;
+        }
+        buffer = dynamic_buffer;
+    }
+
     aeron_counter_command_t *command = (aeron_counter_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
     char *cursor = buffer + sizeof(aeron_counter_command_t);
@@ -1022,15 +1109,8 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
     cursor += sizeof(int32_t);
     memcpy(cursor, async->counter.label_buffer, (size_t)async->counter.label_buffer_length);
 
-    size_t length =
-        sizeof(aeron_counter_command_t) +
-        sizeof(int32_t) +
-        (size_t)(AERON_ALIGN(async->counter.key_buffer_length, sizeof(int32_t))) +
-        sizeof(int32_t) +
-        (size_t)async->counter.label_buffer_length;
-
     while (AERON_RB_SUCCESS != aeron_mpsc_rb_write(
-        &conductor->to_driver_buffer, AERON_COMMAND_ADD_COUNTER, buffer, length))
+            &conductor->to_driver_buffer, AERON_COMMAND_ADD_COUNTER, buffer, command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {
@@ -1039,11 +1119,14 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
             snprintf(err_buffer, sizeof(err_buffer) - 1, "ADD_COUNTER could not be sent (%s:%d)",
                 __FILE__, __LINE__);
             conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_free(dynamic_buffer);
             return;
         }
 
         sched_yield();
     }
+
+    aeron_free(dynamic_buffer);
 
     AERON_ARRAY_ENSURE_CAPACITY(
         ensure_capacity_result, conductor->registering_resources, aeron_client_registering_resource_entry_t);
@@ -1082,8 +1165,6 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
     aeron_client_conductor_t *conductor = (aeron_client_conductor_t *)clientd;
     aeron_async_destination_t *async = (aeron_async_destination_t *)item;
 
-    char buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
-    aeron_destination_command_t *command = (aeron_destination_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
 
     int64_t resource_registration_id = 0;
@@ -1114,6 +1195,27 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
         }
     }
 
+    const size_t command_length = sizeof(aeron_destination_command_t) + async->uri_length;
+
+    const size_t static_buffer_length = sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH;
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "DESTINATION could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return;
+        }
+        buffer = dynamic_buffer;
+    }
+
+    aeron_destination_command_t *command = (aeron_destination_command_t *)buffer;
+
     command->correlated.correlation_id = async->registration_id;
     command->correlated.client_id = conductor->client_id;
     command->registration_id = resource_registration_id;
@@ -1124,7 +1226,7 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
         &conductor->to_driver_buffer,
         msg_type_id,
         buffer,
-        sizeof(aeron_destination_command_t) + async->uri_length))
+        command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {
@@ -1133,11 +1235,14 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
             snprintf(
                 err_buffer, sizeof(err_buffer) - 1, "DESTINATION command could not be sent (%s:%d)", __FILE__, __LINE__);
             conductor->error_handler(conductor->error_handler_clientd, AERON_CLIENT_ERROR_BUFFER_FULL, err_buffer);
+            aeron_free(dynamic_buffer);
             return;
         }
 
         sched_yield();
     }
+
+    aeron_free(dynamic_buffer);
 
     AERON_ARRAY_ENSURE_CAPACITY(
         ensure_capacity_result, conductor->registering_resources, aeron_client_registering_resource_entry_t);
@@ -2406,7 +2511,25 @@ int aeron_client_conductor_offer_destination_command(
     int64_t *correlation_id)
 {
     size_t uri_length = strlen(uri);
-    char buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
+    const size_t command_length = sizeof(aeron_destination_command_t) + uri_length;
+
+    const size_t static_buffer_length = sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH;
+    char static_buffer[static_buffer_length];
+    char *buffer = static_buffer;
+    char *dynamic_buffer = NULL;
+    if (command_length > static_buffer_length)
+    {
+        if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
+        {
+            char err_buffer[AERON_MAX_PATH];
+            snprintf(
+                    err_buffer, sizeof(err_buffer) - 1, "destination could not be sent (%s:%d)", __FILE__, __LINE__);
+            conductor->error_handler(conductor->error_handler_clientd, ENOMEM, err_buffer);
+            return -1;
+        }
+        buffer = dynamic_buffer;
+    }
+
     aeron_destination_command_t *command = (aeron_destination_command_t *)buffer;
     int rb_offer_fail_count = 0;
 
@@ -2417,7 +2540,7 @@ int aeron_client_conductor_offer_destination_command(
     memcpy(buffer + sizeof(aeron_destination_command_t), uri, uri_length);
 
     while (AERON_RB_SUCCESS != aeron_mpsc_rb_write(
-        &conductor->to_driver_buffer, command_type, buffer,sizeof(aeron_destination_command_t) + uri_length))
+            &conductor->to_driver_buffer, command_type, buffer, command_length))
     {
         if (++rb_offer_fail_count > AERON_CLIENT_COMMAND_RB_FAIL_THRESHOLD)
         {

--- a/aeron-client/src/main/c/aeron_client_conductor.c
+++ b/aeron-client/src/main/c/aeron_client_conductor.c
@@ -806,8 +806,7 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
 
     const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
 
-    char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_publication_command_t) + AERON_MAX_PATH)
     {
@@ -820,6 +819,11 @@ void aeron_client_conductor_on_cmd_add_publication(void *clientd, void *item)
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
     }
 
     aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
@@ -893,8 +897,7 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
 
     const size_t command_length = sizeof(aeron_publication_command_t) + async->uri_length;
 
-    char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_publication_command_t) + AERON_MAX_PATH)
     {
@@ -908,7 +911,11 @@ void aeron_client_conductor_on_cmd_add_exclusive_publication(void *clientd, void
         }
         buffer = dynamic_buffer;
     }
-
+    else
+    {
+        char static_buffer[sizeof(aeron_publication_command_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
+    }
     aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
     int ensure_capacity_result = 0, rb_offer_fail_count = 0;
 
@@ -980,8 +987,7 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
 
     const size_t command_length = sizeof(aeron_subscription_command_t) + async->uri_length;
 
-    char static_buffer[sizeof(aeron_subscription_command_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_subscription_command_t) + AERON_MAX_PATH)
     {
@@ -994,6 +1000,11 @@ void aeron_client_conductor_on_cmd_add_subscription(void *clientd, void *item)
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_subscription_command_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
     }
 
     aeron_subscription_command_t *command = (aeron_subscription_command_t *)buffer;
@@ -1072,8 +1083,7 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
         sizeof(int32_t) +
         (size_t)async->counter.label_buffer_length;
 
-    char static_buffer[sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH)];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH))
     {
@@ -1086,6 +1096,11 @@ void aeron_client_conductor_on_cmd_add_counter(void *clientd, void *item)
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_async_add_counter_t) + (2 * sizeof(int32_t)) + (2 * AERON_MAX_PATH)];
+        buffer = static_buffer;
     }
 
     aeron_counter_command_t *command = (aeron_counter_command_t *)buffer;
@@ -1192,8 +1207,7 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
 
     const size_t command_length = sizeof(aeron_destination_command_t) + async->uri_length;
 
-    char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH)
     {
@@ -1206,6 +1220,11 @@ static void aeron_client_conductor_on_cmd_destination(const void *clientd, const
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
     }
 
     aeron_destination_command_t *command = (aeron_destination_command_t *)buffer;
@@ -2507,8 +2526,7 @@ int aeron_client_conductor_offer_destination_command(
     size_t uri_length = strlen(uri);
     const size_t command_length = sizeof(aeron_destination_command_t) + uri_length;
 
-    char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH)
     {
@@ -2521,6 +2539,11 @@ int aeron_client_conductor_offer_destination_command(
             return -1;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_destination_command_t) + sizeof(int32_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
     }
 
     aeron_destination_command_t *command = (aeron_destination_command_t *)buffer;

--- a/aeron-client/src/main/cpp/DriverProxy.h
+++ b/aeron-client/src/main/cpp/DriverProxy.h
@@ -340,7 +340,7 @@ public:
     }
 
 private:
-    typedef std::array<std::uint8_t, 512> driver_proxy_command_buffer_t;
+    typedef std::array<std::uint8_t, 4096> driver_proxy_command_buffer_t;
 
     ManyToOneRingBuffer &m_toDriverCommandBuffer;
     std::int64_t m_clientId;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.spy;
 
 public class AuthenticationTest
 {
-    private static final long MAX_CATALOG_ENTRIES = 1024;
+    private static final long CATALOG_CAPACITY = 1024 * 1024;
     private static final String CREDENTIALS_STRING = "username=\"admin\"|password=\"secret\"";
     private static final String CHALLENGE_STRING = "I challenge you!";
     private static final String PRINCIPAL_STRING = "I am THE Principal!";
@@ -475,7 +475,7 @@ public class AuthenticationTest
                 .dirDeleteOnStart(true)
                 .dirDeleteOnShutdown(false),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .threadingMode(ArchiveThreadingMode.SHARED)
                 .recordingEventsEnabled(false)
                 .deleteArchiveOnStart(true),

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.*;
 
 public class ClusterNodeRestartTest
 {
-    private static final long MAX_CATALOG_ENTRIES = 1024;
+    private static final long CATALOG_CAPACITY = 1024 * 1024;
     private static final int MESSAGE_LENGTH = SIZE_OF_INT;
     private static final int TIMER_MESSAGE_LENGTH = SIZE_OF_INT + SIZE_OF_LONG + SIZE_OF_LONG;
     private static final int MESSAGE_VALUE_OFFSET = 0;
@@ -653,7 +653,7 @@ public class ClusterNodeRestartTest
                 .errorHandler(ClusterTests.errorHandler(0))
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .recordingEventsEnabled(false)
                 .threadingMode(ArchiveThreadingMode.SHARED)
                 .deleteArchiveOnStart(initialLaunch),

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClusterNodeTest
 {
-    private static final long MAX_CATALOG_ENTRIES = 1024;
+    private static final long CATALOG_CAPACITY = 1024 * 1024;
 
     private ClusteredMediaDriver clusteredMediaDriver;
     private ClusteredServiceContainer container;
@@ -57,7 +57,7 @@ public class ClusterNodeTest
                 .errorHandler(ClusterTests.errorHandler(0))
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .threadingMode(ArchiveThreadingMode.SHARED)
                 .recordingEventsEnabled(false)
                 .deleteArchiveOnStart(true),

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClusterTimerTest
 {
-    private static final long MAX_CATALOG_ENTRIES = 128;
+    private static final long CATALOG_CAPACITY = 128 * 1024;
     private static final int INTERVAL_MS = 20;
 
     private ClusteredMediaDriver clusteredMediaDriver;
@@ -312,7 +312,7 @@ public class ClusterTimerTest
                 .errorHandler(ClusterTests.errorHandler(0))
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .threadingMode(ArchiveThreadingMode.SHARED)
                 .recordingEventsEnabled(false)
                 .deleteArchiveOnStart(initialLaunch),

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SlowTest
 public class StartFromTruncatedRecordingLogTest
 {
-    private static final long MAX_CATALOG_ENTRIES = 1024;
+    private static final long CATALOG_CAPACITY = 1024 * 1024;
     private static final int MEMBER_COUNT = 3;
     private static final int MESSAGE_COUNT = 10;
 
@@ -339,7 +339,7 @@ public class StartFromTruncatedRecordingLogTest
                 .dirDeleteOnShutdown(false)
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .archiveDir(new File(baseDirName, "archive"))
                 .controlChannel(archiveCtx.controlRequestChannel())
                 .controlStreamId(archiveCtx.controlRequestStreamId())

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestCluster.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class TestCluster implements AutoCloseable
 {
     private static final int SEGMENT_FILE_LENGTH = 16 * 1024 * 1024;
-    private static final long MAX_CATALOG_ENTRIES = 128;
+    private static final long CATALOG_CAPACITY = 128 * 1024;
     private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
     private static final String ARCHIVE_CONTROL_REQUEST_CHANNEL =
         "aeron:udp?term-length=64k|endpoint=localhost:8010";
@@ -260,7 +260,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnStart(true);
 
         context.archiveContext
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(context.aeronArchiveContext.controlRequestChannel())
             .controlStreamId(context.aeronArchiveContext.controlRequestStreamId())
@@ -328,7 +328,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnShutdown(false);
 
         context.archiveContext
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .segmentFileLength(SEGMENT_FILE_LENGTH)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(context.aeronArchiveContext.controlRequestChannel())
@@ -396,7 +396,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnStart(true);
 
         context.archiveContext
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(context.aeronArchiveContext.controlRequestChannel())
             .controlStreamId(context.aeronArchiveContext.controlRequestStreamId())
@@ -458,7 +458,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnShutdown(false);
 
         context.archiveContext
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .segmentFileLength(SEGMENT_FILE_LENGTH)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(context.aeronArchiveContext.controlRequestChannel())
@@ -519,7 +519,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnStart(true);
 
         context.archiveContext
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(context.aeronArchiveContext.controlRequestChannel())
             .controlStreamId(context.aeronArchiveContext.controlRequestStreamId())
@@ -1191,7 +1191,7 @@ public class TestCluster implements AutoCloseable
             .dirDeleteOnShutdown(false);
 
         nodeCtx.archiveCtx
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .segmentFileLength(256 * 1024)
             .archiveDir(new File(baseDirName, "archive"))
             .controlChannel(memberSpecificPort(ARCHIVE_CONTROL_REQUEST_CHANNEL, index))

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -625,11 +625,10 @@ void aeron_driver_conductor_on_available_image(
         source_identity_length +
         (2 * sizeof(int32_t));
 
-    const size_t static_buffer_length = sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH);
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH)];
     char *response_buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (response_length > static_buffer_length)
+    if (response_length > sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH))
     {
         if(aeron_alloc((void **) &dynamic_buffer, response_length) < 0)
         {
@@ -1648,11 +1647,10 @@ void aeron_driver_conductor_on_error(
 {
     const size_t response_length = sizeof(aeron_error_response_t) + length;
 
-    const size_t static_buffer_length = sizeof(aeron_error_response_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_error_response_t) + AERON_MAX_PATH];
     char *response_buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (response_length > static_buffer_length)
+    if (response_length > sizeof(aeron_error_response_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, response_length) < 0)
         {
@@ -1693,11 +1691,10 @@ void aeron_driver_conductor_on_publication_ready(
 {
     const size_t response_length = sizeof(aeron_publication_buffers_ready_t) + log_file_name_length;
 
-    const size_t static_buffer_length = sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH];
     char *response_buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (response_length > static_buffer_length)
+    if (response_length > sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, response_length) < 0)
         {
@@ -1803,11 +1800,10 @@ void aeron_driver_conductor_on_unavailable_image(
 {
     const size_t response_length = sizeof(aeron_image_message_t) + channel_length;
 
-    const size_t static_buffer_length = sizeof(aeron_image_message_t) + AERON_MAX_PATH;
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_image_message_t) + AERON_MAX_PATH];
     char *response_buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (response_length > static_buffer_length)
+    if (response_length > sizeof(aeron_image_message_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, response_length) < 0)
         {

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -625,8 +625,7 @@ void aeron_driver_conductor_on_available_image(
         source_identity_length +
         (2 * sizeof(int32_t));
 
-    char static_buffer[sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH)];
-    char *response_buffer = static_buffer;
+    char *response_buffer = NULL;
     char *dynamic_buffer = NULL;
     if (response_length > sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH))
     {
@@ -642,6 +641,11 @@ void aeron_driver_conductor_on_available_image(
             return;
         }
         response_buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_image_buffers_ready_t) + (2 * AERON_MAX_PATH)];
+        response_buffer = static_buffer;
     }
 
     aeron_image_buffers_ready_t *response = (aeron_image_buffers_ready_t *)response_buffer;
@@ -1647,8 +1651,7 @@ void aeron_driver_conductor_on_error(
 {
     const size_t response_length = sizeof(aeron_error_response_t) + length;
 
-    char static_buffer[sizeof(aeron_error_response_t) + AERON_MAX_PATH];
-    char *response_buffer = static_buffer;
+    char *response_buffer = NULL;
     char *dynamic_buffer = NULL;
     if (response_length > sizeof(aeron_error_response_t) + AERON_MAX_PATH)
     {
@@ -1664,6 +1667,11 @@ void aeron_driver_conductor_on_error(
             return;
         }
         response_buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_error_response_t) + AERON_MAX_PATH];
+        response_buffer = static_buffer;
     }
 
     aeron_error_response_t *response = (aeron_error_response_t *)response_buffer;
@@ -1691,8 +1699,7 @@ void aeron_driver_conductor_on_publication_ready(
 {
     const size_t response_length = sizeof(aeron_publication_buffers_ready_t) + log_file_name_length;
 
-    char static_buffer[sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH];
-    char *response_buffer = static_buffer;
+    char *response_buffer = NULL;
     char *dynamic_buffer = NULL;
     if (response_length > sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH)
     {
@@ -1708,6 +1715,11 @@ void aeron_driver_conductor_on_publication_ready(
             return;
         }
         response_buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_publication_buffers_ready_t) + AERON_MAX_PATH];
+        response_buffer = static_buffer;
     }
 
     aeron_publication_buffers_ready_t *response = (aeron_publication_buffers_ready_t *)response_buffer;
@@ -1800,8 +1812,7 @@ void aeron_driver_conductor_on_unavailable_image(
 {
     const size_t response_length = sizeof(aeron_image_message_t) + channel_length;
 
-    char static_buffer[sizeof(aeron_image_message_t) + AERON_MAX_PATH];
-    char *response_buffer = static_buffer;
+    char *response_buffer = NULL;
     char *dynamic_buffer = NULL;
     if (response_length > sizeof(aeron_image_message_t) + AERON_MAX_PATH)
     {
@@ -1817,6 +1828,11 @@ void aeron_driver_conductor_on_unavailable_image(
             return;
         }
         response_buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_image_message_t) + AERON_MAX_PATH];
+        response_buffer = static_buffer;
     }
 
     aeron_image_message_t *response = (aeron_image_message_t *)response_buffer;

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -236,11 +236,11 @@ int aeron_driver_agent_raw_log_map_interceptor(
     int result = aeron_raw_log_map(mapped_raw_log, path, use_sparse_files, term_length, page_size);
 
     const size_t path_len = strlen(path);
-    const size_t command_length = sizeof(aeron_driver_agent_map_raw_log_op_header_t) + path_len;
+    const size_t command_length = sizeof(aeron_driver_agent_raw_log_op_header_t) + path_len;
 
     char *buffer = NULL;
     char *dynamic_buffer = NULL;
-    if (command_length > sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH)
+    if (command_length > sizeof(aeron_driver_agent_raw_log_op_header_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -250,21 +250,21 @@ int aeron_driver_agent_raw_log_map_interceptor(
     }
     else
     {
-        char static_buffer[sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH];
+        char static_buffer[sizeof(aeron_driver_agent_raw_log_op_header_t) + AERON_MAX_PATH];
         buffer = static_buffer;
     }
 
-    aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+    aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)buffer;
 
     hdr->time_ms = aeron_epoch_clock();
-    hdr->map_raw.map_raw_log.path_len = (int32_t)path_len;
-    hdr->map_raw.map_raw_log.result = result;
-    hdr->map_raw.map_raw_log.addr = (uintptr_t)mapped_raw_log;
-    memcpy(&hdr->map_raw.map_raw_log.log, mapped_raw_log, sizeof(hdr->map_raw.map_raw_log.log));
-    memcpy(buffer + sizeof(aeron_driver_agent_map_raw_log_op_header_t), path, path_len);
+    hdr->raw_log.raw_log_map.path_len = (int32_t)path_len;
+    hdr->raw_log.raw_log_map.result = result;
+    hdr->raw_log.raw_log_map.addr = (uintptr_t)mapped_raw_log;
+    memcpy(&hdr->raw_log.raw_log_map.log, mapped_raw_log, sizeof(hdr->raw_log.raw_log_map.log));
+    memcpy(buffer + sizeof(aeron_driver_agent_raw_log_op_header_t), path, path_len);
 
     aeron_mpsc_rb_write(
-        &logging_mpsc_rb, AERON_RAW_LOG_MAP_OP, buffer, sizeof(aeron_driver_agent_map_raw_log_op_header_t) + path_len);
+        &logging_mpsc_rb, AERON_RAW_LOG_MAP_OP, buffer, sizeof(aeron_driver_agent_raw_log_op_header_t) + path_len);
     aeron_free(dynamic_buffer);
 
     return result;
@@ -272,34 +272,34 @@ int aeron_driver_agent_raw_log_map_interceptor(
 
 int aeron_driver_agent_raw_log_close_interceptor(aeron_mapped_raw_log_t *mapped_raw_log, const char *filename)
 {
-    uint8_t buffer[sizeof(aeron_driver_agent_map_raw_log_op_header_t)];
-    aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+    uint8_t buffer[sizeof(aeron_driver_agent_raw_log_op_header_t)];
+    aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)buffer;
 
     hdr->time_ms = aeron_epoch_clock();
-    hdr->map_raw.map_raw_log_close.addr = (uintptr_t)mapped_raw_log;
-    memcpy(&hdr->map_raw.map_raw_log_close.log, mapped_raw_log, sizeof(hdr->map_raw.map_raw_log.log));
-    hdr->map_raw.map_raw_log_close.result = aeron_raw_log_close(mapped_raw_log, filename);
+    hdr->raw_log.raw_log_close.addr = (uintptr_t)mapped_raw_log;
+    memcpy(&hdr->raw_log.raw_log_close.log, mapped_raw_log, sizeof(hdr->raw_log.raw_log_map.log));
+    hdr->raw_log.raw_log_close.result = aeron_raw_log_close(mapped_raw_log, filename);
 
     aeron_mpsc_rb_write(
-        &logging_mpsc_rb, AERON_RAW_LOG_CLOSE_OP, buffer, sizeof(aeron_driver_agent_map_raw_log_op_header_t));
+        &logging_mpsc_rb, AERON_RAW_LOG_CLOSE_OP, buffer, sizeof(aeron_driver_agent_raw_log_op_header_t));
 
-    return hdr->map_raw.map_raw_log_close.result;
+    return hdr->raw_log.raw_log_close.result;
 }
 
 bool aeron_driver_agent_raw_log_free_interceptor(aeron_mapped_raw_log_t *mapped_raw_log, const char *filename)
 {
-    uint8_t buffer[AERON_MAX_PATH + sizeof(aeron_driver_agent_map_raw_log_op_header_t)];
-    aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+    uint8_t buffer[AERON_MAX_PATH + sizeof(aeron_driver_agent_raw_log_op_header_t)];
+    aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)buffer;
 
     hdr->time_ms = aeron_epoch_clock();
-    hdr->map_raw.map_raw_log_free.addr = (uintptr_t)mapped_raw_log;
-    memcpy(&hdr->map_raw.map_raw_log_free.log, mapped_raw_log, sizeof(hdr->map_raw.map_raw_log_free.log));
-    hdr->map_raw.map_raw_log_free.result = aeron_raw_log_free(mapped_raw_log, filename);
+    hdr->raw_log.raw_log_free.addr = (uintptr_t)mapped_raw_log;
+    memcpy(&hdr->raw_log.raw_log_free.log, mapped_raw_log, sizeof(hdr->raw_log.raw_log_free.log));
+    hdr->raw_log.raw_log_free.result = aeron_raw_log_free(mapped_raw_log, filename);
 
     aeron_mpsc_rb_write(
-        &logging_mpsc_rb, AERON_RAW_LOG_FREE_OP, buffer, sizeof(aeron_driver_agent_map_raw_log_op_header_t));
+        &logging_mpsc_rb, AERON_RAW_LOG_FREE_OP, buffer, sizeof(aeron_driver_agent_raw_log_op_header_t));
 
-    return hdr->map_raw.map_raw_log_free.result;
+    return hdr->raw_log.raw_log_free.result;
 }
 
 void aeron_driver_agent_log_frame(
@@ -1281,43 +1281,43 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
 
         case AERON_RAW_LOG_MAP_OP:
         {
-            aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)message;
-            const char *pathname = (const char *)message + sizeof(aeron_driver_agent_map_raw_log_op_header_t);
+            aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)message;
+            const char *pathname = (const char *)message + sizeof(aeron_driver_agent_raw_log_op_header_t);
 
             fprintf(
                 logfp,
                 "[%s] RAW_LOG_MAP %p, \"%*s\" = %d\n",
                 aeron_driver_agent_dissect_timestamp(hdr->time_ms),
-                (void *)hdr->map_raw.map_raw_log.addr,
-                hdr->map_raw.map_raw_log.path_len,
+                (void *)hdr->raw_log.raw_log_map.addr,
+                hdr->raw_log.raw_log_map.path_len,
                 pathname,
-                hdr->map_raw.map_raw_log.result);
+                hdr->raw_log.raw_log_map.result);
             break;
         }
 
         case AERON_RAW_LOG_CLOSE_OP:
         {
-            aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)message;
+            aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)message;
 
             fprintf(
                 logfp,
                 "[%s] RAW_LOG_CLOSE %p = %d\n",
                 aeron_driver_agent_dissect_timestamp(hdr->time_ms),
-                (void *)hdr->map_raw.map_raw_log_close.addr,
-                hdr->map_raw.map_raw_log_close.result);
+                (void *)hdr->raw_log.raw_log_close.addr,
+                hdr->raw_log.raw_log_close.result);
             break;
         }
 
         case AERON_RAW_LOG_FREE_OP:
         {
-            aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)message;
+            aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)message;
 
             fprintf(
                 logfp,
                 "[%s] RAW_LOG_FREE %p = %s\n",
                 aeron_driver_agent_dissect_timestamp(hdr->time_ms),
-                (void *)hdr->map_raw.map_raw_log_free.addr,
-                hdr->map_raw.map_raw_log_free.result ? "true" : "false");
+                (void *)hdr->raw_log.raw_log_free.addr,
+                hdr->raw_log.raw_log_free.result ? "true" : "false");
             break;
         }
 

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -171,11 +171,10 @@ void aeron_driver_agent_conductor_to_driver_interceptor(
 {
     const size_t command_length = sizeof(aeron_driver_agent_cmd_log_header_t) + length;
 
-    const size_t static_buffer_length = MAX_CMD_LENGTH + sizeof(aeron_driver_agent_cmd_log_header_t);
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -198,11 +197,10 @@ void aeron_driver_agent_conductor_to_client_interceptor(
 {
     const size_t command_length = sizeof(aeron_driver_agent_cmd_log_header_t) + length;
 
-    const size_t static_buffer_length = MAX_CMD_LENGTH + sizeof(aeron_driver_agent_cmd_log_header_t);
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {
@@ -232,11 +230,10 @@ int aeron_driver_agent_raw_log_map_interceptor(
     const size_t path_len = strlen(path);
     const size_t command_length = sizeof(aeron_driver_agent_map_raw_log_op_header_t) + path_len;
 
-    const size_t static_buffer_length = AERON_MAX_PATH + sizeof(aeron_driver_agent_map_raw_log_op_header_t);
-    char static_buffer[static_buffer_length];
+    char static_buffer[sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH];
     char *buffer = static_buffer;
     char *dynamic_buffer = NULL;
-    if (command_length > static_buffer_length)
+    if (command_length > sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH)
     {
         if(aeron_alloc((void **) &dynamic_buffer, command_length) < 0)
         {

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -171,8 +171,7 @@ void aeron_driver_agent_conductor_to_driver_interceptor(
 {
     const size_t command_length = sizeof(aeron_driver_agent_cmd_log_header_t) + length;
 
-    char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH)
     {
@@ -181,6 +180,11 @@ void aeron_driver_agent_conductor_to_driver_interceptor(
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
+        buffer = static_buffer;
     }
 
     aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
@@ -197,8 +201,7 @@ void aeron_driver_agent_conductor_to_client_interceptor(
 {
     const size_t command_length = sizeof(aeron_driver_agent_cmd_log_header_t) + length;
 
-    char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH)
     {
@@ -207,6 +210,11 @@ void aeron_driver_agent_conductor_to_client_interceptor(
             return;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_driver_agent_cmd_log_header_t) + MAX_CMD_LENGTH];
+        buffer = static_buffer;
     }
 
     aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
@@ -230,8 +238,7 @@ int aeron_driver_agent_raw_log_map_interceptor(
     const size_t path_len = strlen(path);
     const size_t command_length = sizeof(aeron_driver_agent_map_raw_log_op_header_t) + path_len;
 
-    char static_buffer[sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH];
-    char *buffer = static_buffer;
+    char *buffer = NULL;
     char *dynamic_buffer = NULL;
     if (command_length > sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH)
     {
@@ -240,6 +247,11 @@ int aeron_driver_agent_raw_log_map_interceptor(
             return result;
         }
         buffer = dynamic_buffer;
+    }
+    else
+    {
+        char static_buffer[sizeof(aeron_driver_agent_map_raw_log_op_header_t) + AERON_MAX_PATH];
+        buffer = static_buffer;
     }
 
     aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -150,4 +150,22 @@ void aeron_driver_agent_untethered_subscription_state_change_interceptor(
     int32_t stream_id,
     int32_t session_id);
 
+void aeron_driver_agent_conductor_to_driver_interceptor(
+    int32_t msg_type_id, const void *message, size_t length, void *clientd);
+
+void aeron_driver_agent_conductor_to_client_interceptor(
+    aeron_driver_conductor_t *conductor, int32_t msg_type_id, const void *message, size_t length);
+
+int aeron_driver_agent_map_raw_log_interceptor(
+    aeron_mapped_raw_log_t *mapped_raw_log,
+    const char *path,
+    bool use_sparse_files,
+    uint64_t term_length,
+    uint64_t page_size);
+
+void aeron_driver_agent_log_frame(
+    int32_t msg_type_id, const struct msghdr *msghdr, int result, int32_t message_len);
+
+void aeron_driver_agent_log_dynamic_event(int64_t index, const void *message, size_t length);
+
 #endif //AERON_DRIVER_AGENT_H

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -56,39 +56,39 @@ typedef struct aeron_driver_agent_frame_log_header_stct
 }
 aeron_driver_agent_frame_log_header_t;
 
-typedef struct aeron_driver_agent_map_raw_log_op_header_stct
+typedef struct aeron_driver_agent_raw_log_op_header_stct
 {
     int64_t time_ms;
-    union map_raw_log_un
+    union raw_log_un
     {
-        struct map_raw_log_stct
+        struct raw_log_map_stct
         {
             aeron_mapped_raw_log_t log;
             int result;
             uintptr_t addr;
             int32_t path_len;
         }
-        map_raw_log;
+        raw_log_map;
 
-        struct map_raw_log_close_stct
+        struct raw_log_close_stct
         {
             aeron_mapped_raw_log_t log;
             int result;
             uintptr_t addr;
         }
-        map_raw_log_close;
+        raw_log_close;
 
-        struct map_raw_log_free_stct
+        struct raw_log_free_stct
         {
             aeron_mapped_raw_log_t log;
             bool result;
             uintptr_t addr;
         }
-        map_raw_log_free;
+        raw_log_free;
     }
-    map_raw;
+    raw_log;
 }
-aeron_driver_agent_map_raw_log_op_header_t;
+aeron_driver_agent_raw_log_op_header_t;
 
 typedef struct aeron_driver_agent_untethered_subscription_state_change_log_header_stct
 {
@@ -156,7 +156,7 @@ void aeron_driver_agent_conductor_to_driver_interceptor(
 void aeron_driver_agent_conductor_to_client_interceptor(
     aeron_driver_conductor_t *conductor, int32_t msg_type_id, const void *message, size_t length);
 
-int aeron_driver_agent_map_raw_log_interceptor(
+int aeron_driver_agent_raw_log_map_interceptor(
     aeron_mapped_raw_log_t *mapped_raw_log,
     const char *path,
     bool use_sparse_files,

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -313,7 +313,7 @@ TEST_F(DriverAgentTest, shouldLogMapRawLogCommand)
     aeron_mapped_raw_log_t mapped_raw_log = {};
     const char *path = ":unknown/path";
 
-    EXPECT_EQ(-1, aeron_driver_agent_map_raw_log_interceptor(&mapped_raw_log, path, false, 1024, 4096));
+    EXPECT_EQ(-1, aeron_driver_agent_raw_log_map_interceptor(&mapped_raw_log, path, false, 1024, 4096));
 
     auto message_handler =
             [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
@@ -321,16 +321,16 @@ TEST_F(DriverAgentTest, shouldLogMapRawLogCommand)
                 size_t *count = (size_t *)clientd;
                 (*count)++;
 
-                EXPECT_EQ(msg_type_id, AERON_MAP_RAW_LOG_OP);
+                EXPECT_EQ(msg_type_id, AERON_RAW_LOG_MAP_OP);
 
                 char *buffer = (char *)msg;
-                aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+                aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)buffer;
                 EXPECT_NE(hdr->time_ms, 0);
-                EXPECT_EQ(hdr->map_raw.map_raw_log.path_len, 13);
-                EXPECT_NE(hdr->map_raw.map_raw_log.addr, (uint64_t)0);
-                EXPECT_EQ(hdr->map_raw.map_raw_log.result, -1);
+                EXPECT_EQ(hdr->raw_log.raw_log_map.path_len, 13);
+                EXPECT_NE(hdr->raw_log.raw_log_map.addr, (uint64_t)0);
+                EXPECT_EQ(hdr->raw_log.raw_log_map.result, -1);
                 EXPECT_EQ(
-                        strcmp(":unknown/path", buffer + sizeof(aeron_driver_agent_map_raw_log_op_header_t)),
+                        strcmp(":unknown/path", buffer + sizeof(aeron_driver_agent_raw_log_op_header_t)),
                         0);
             };
 
@@ -352,7 +352,7 @@ TEST_F(DriverAgentTest, shouldLogMapRawLogCommandBigMessage)
     path[path_length - 1] = 'X';
     path[path_length] = '\0';
 
-    EXPECT_EQ(-1, aeron_driver_agent_map_raw_log_interceptor(&mapped_raw_log, path, false, 1024, 4096));
+    EXPECT_EQ(-1, aeron_driver_agent_raw_log_map_interceptor(&mapped_raw_log, path, false, 1024, 4096));
 
     auto message_handler =
             [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
@@ -360,16 +360,16 @@ TEST_F(DriverAgentTest, shouldLogMapRawLogCommandBigMessage)
                 size_t *count = (size_t *)clientd;
                 (*count)++;
 
-                EXPECT_EQ(msg_type_id, AERON_MAP_RAW_LOG_OP);
+                EXPECT_EQ(msg_type_id, AERON_RAW_LOG_MAP_OP);
 
                 char *buffer = (char *)msg;
-                aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+                aeron_driver_agent_raw_log_op_header_t *hdr = (aeron_driver_agent_raw_log_op_header_t *)buffer;
                 EXPECT_NE(hdr->time_ms, 0);
-                EXPECT_EQ(hdr->map_raw.map_raw_log.path_len, MAX_FRAME_LENGTH * 11);
-                EXPECT_NE(hdr->map_raw.map_raw_log.addr, (uint64_t)0);
-                EXPECT_EQ(hdr->map_raw.map_raw_log.result, -1);
+                EXPECT_EQ(hdr->raw_log.raw_log_map.path_len, MAX_FRAME_LENGTH * 11);
+                EXPECT_NE(hdr->raw_log.raw_log_map.addr, (uint64_t)0);
+                EXPECT_EQ(hdr->raw_log.raw_log_map.result, -1);
                 EXPECT_EQ(
-                        memcmp(":", buffer + sizeof(aeron_driver_agent_map_raw_log_op_header_t), 1),
+                        memcmp(":", buffer + sizeof(aeron_driver_agent_raw_log_op_header_t), 1),
                         0);
                 EXPECT_EQ(memcmp("X", buffer + length -1, 1), 0);
             };

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -113,3 +113,434 @@ TEST_F(DriverAgentTest, shouldLogUntetheredSubscriptionStateChange)
     EXPECT_EQ(messagesRead, (size_t)1);
     EXPECT_EQ(timesCalled, (size_t)1);
 }
+
+TEST_F(DriverAgentTest, shouldLogConductorToDriverCommand)
+{
+    aeron_init_logging_ring_buffer();
+
+    const size_t length = sizeof(aeron_publication_command_t) + 4;
+    char buffer[AERON_MAX_PATH];
+    aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
+    command->correlated.correlation_id = 11;
+    command->correlated.client_id = 42;
+    command->stream_id = 7;
+    command->channel_length = 4;
+    memcpy(buffer + sizeof(aeron_publication_command_t), "test", 4);
+
+    aeron_driver_agent_conductor_to_driver_interceptor(18, command, length, nullptr);
+
+    auto message_handler =
+        [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+        {
+            size_t *count = (size_t *)clientd;
+            (*count)++;
+
+            EXPECT_EQ(msg_type_id, AERON_CMD_IN);
+
+            char *buffer = (char *)msg;
+            aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
+            EXPECT_EQ(hdr->cmd_id, 18);
+            EXPECT_NE(hdr->time_ms, 0);
+
+            aeron_publication_command_t *payload =
+                    (aeron_publication_command_t *) (buffer + sizeof(aeron_driver_agent_cmd_log_header_t));
+            EXPECT_EQ(payload->correlated.correlation_id, 11);
+            EXPECT_EQ(payload->correlated.client_id, 42);
+            EXPECT_EQ(payload->stream_id, 7);
+            EXPECT_EQ(payload->channel_length, 4);
+            EXPECT_EQ(
+                    strcmp("test", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_publication_command_t)),
+                    0);
+        };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogConductorToDriverCommandBigMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    const size_t length = MAX_FRAME_LENGTH * 5;
+    char buffer[length];
+    aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
+    command->correlated.correlation_id = 118;
+    command->correlated.client_id = 9;
+    command->stream_id = 42;
+    command->channel_length = length - sizeof(aeron_publication_command_t);
+    memset(buffer + sizeof(aeron_publication_command_t), 'a', 1);
+    memset(buffer + length - 1, 'z', 1);
+
+    aeron_driver_agent_conductor_to_driver_interceptor(-10, command, length, nullptr);
+
+    auto message_handler =
+        [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+        {
+            size_t *count = (size_t *)clientd;
+            (*count)++;
+
+            EXPECT_EQ(msg_type_id, AERON_CMD_IN);
+
+
+            char *buffer = (char *)msg;
+            aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
+            EXPECT_EQ(hdr->cmd_id, -10);
+            EXPECT_NE(hdr->time_ms, 0);
+
+            const size_t payload_length = MAX_FRAME_LENGTH * 5;
+            aeron_publication_command_t *payload =
+                    (aeron_publication_command_t *) (buffer + sizeof(aeron_driver_agent_cmd_log_header_t));
+            EXPECT_EQ(payload->correlated.correlation_id, 118);
+            EXPECT_EQ(payload->correlated.client_id, 9);
+            EXPECT_EQ(payload->stream_id, 42);
+            EXPECT_EQ(payload->channel_length, (int32_t)(payload_length - sizeof(aeron_publication_command_t)));
+            EXPECT_EQ(
+                    memcmp("a", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_publication_command_t), 1),
+                    0);
+            EXPECT_EQ(memcmp("z", buffer + length -1, 1), 0);
+        };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogConductorToClientCommand)
+{
+    aeron_init_logging_ring_buffer();
+
+    const size_t length = sizeof(aeron_publication_command_t) + 4;
+    char buffer[AERON_MAX_PATH];
+    aeron_publication_command_t *command = (aeron_publication_command_t *)buffer;
+    command->correlated.correlation_id = 11;
+    command->correlated.client_id = 42;
+    command->stream_id = 7;
+    command->channel_length = 4;
+    memcpy(buffer + sizeof(aeron_publication_command_t), "test", 4);
+
+    aeron_driver_agent_conductor_to_client_interceptor(nullptr, 18, command, length);
+
+    auto message_handler =
+        [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+        {
+            size_t *count = (size_t *)clientd;
+            (*count)++;
+
+            EXPECT_EQ(msg_type_id, AERON_CMD_OUT);
+
+            char *buffer = (char *)msg;
+            aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
+            EXPECT_EQ(hdr->cmd_id, 18);
+            EXPECT_NE(hdr->time_ms, 0);
+
+            aeron_publication_command_t *payload =
+                    (aeron_publication_command_t *) (buffer + sizeof(aeron_driver_agent_cmd_log_header_t));
+            EXPECT_EQ(payload->correlated.correlation_id, 11);
+            EXPECT_EQ(payload->correlated.client_id, 42);
+            EXPECT_EQ(payload->stream_id, 7);
+            EXPECT_EQ(payload->channel_length, 4);
+            EXPECT_EQ(
+                    strcmp("test", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_publication_command_t)),
+                    0);
+        };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogConductorToClientCommandBigMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    const size_t length = MAX_FRAME_LENGTH * 15;
+    char buffer[length];
+    aeron_subscription_command_t *command = (aeron_subscription_command_t *)buffer;
+    command->correlated.correlation_id = 8;
+    command->correlated.client_id = 91;
+    command->stream_id = 142;
+    command->channel_length = length - sizeof(aeron_subscription_command_t);
+    memset(buffer + sizeof(aeron_subscription_command_t), 'a', 1);
+    memset(buffer + length - 1, 'z', 1);
+
+    aeron_driver_agent_conductor_to_client_interceptor(nullptr, 100, command, length);
+
+    auto message_handler =
+        [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+        {
+            size_t *count = (size_t *)clientd;
+            (*count)++;
+
+            EXPECT_EQ(msg_type_id, AERON_CMD_OUT);
+
+
+            char *buffer = (char *)msg;
+            aeron_driver_agent_cmd_log_header_t *hdr = (aeron_driver_agent_cmd_log_header_t *)buffer;
+            EXPECT_EQ(hdr->cmd_id, 100);
+            EXPECT_NE(hdr->time_ms, 0);
+
+            const size_t payload_length = MAX_FRAME_LENGTH * 15;
+            aeron_subscription_command_t *payload =
+                    (aeron_subscription_command_t *) (buffer + sizeof(aeron_driver_agent_cmd_log_header_t));
+            EXPECT_EQ(payload->correlated.correlation_id, 8);
+            EXPECT_EQ(payload->correlated.client_id, 91);
+            EXPECT_EQ(payload->stream_id, 142);
+            EXPECT_EQ(payload->channel_length, (int32_t)(payload_length - sizeof(aeron_subscription_command_t)));
+            EXPECT_EQ(
+                    memcmp("a", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_subscription_command_t), 1),
+                    0);
+            EXPECT_EQ(memcmp("z", buffer + length -1, 1), 0);
+        };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogMapRawLogCommand)
+{
+    aeron_init_logging_ring_buffer();
+
+    aeron_mapped_raw_log_t mapped_raw_log = {};
+    const char *path = ":unknown/path";
+
+    EXPECT_EQ(-1, aeron_driver_agent_map_raw_log_interceptor(&mapped_raw_log, path, false, 1024, 4096));
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, AERON_MAP_RAW_LOG_OP);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->map_raw.map_raw_log.path_len, 13);
+                EXPECT_NE(hdr->map_raw.map_raw_log.addr, (uint64_t)0);
+                EXPECT_EQ(hdr->map_raw.map_raw_log.result, -1);
+                EXPECT_EQ(
+                        strcmp(":unknown/path", buffer + sizeof(aeron_driver_agent_map_raw_log_op_header_t)),
+                        0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogMapRawLogCommandBigMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    aeron_mapped_raw_log_t mapped_raw_log = {};
+    const size_t path_length = MAX_FRAME_LENGTH * 11;
+    char path[path_length + 1];
+    memset(path, ':', path_length - 1);
+    path[path_length - 1] = 'X';
+    path[path_length] = '\0';
+
+    EXPECT_EQ(-1, aeron_driver_agent_map_raw_log_interceptor(&mapped_raw_log, path, false, 1024, 4096));
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, AERON_MAP_RAW_LOG_OP);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_map_raw_log_op_header_t *hdr = (aeron_driver_agent_map_raw_log_op_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->map_raw.map_raw_log.path_len, MAX_FRAME_LENGTH * 11);
+                EXPECT_NE(hdr->map_raw.map_raw_log.addr, (uint64_t)0);
+                EXPECT_EQ(hdr->map_raw.map_raw_log.result, -1);
+                EXPECT_EQ(
+                        memcmp(":", buffer + sizeof(aeron_driver_agent_map_raw_log_op_header_t), 1),
+                        0);
+                EXPECT_EQ(memcmp("X", buffer + length -1, 1), 0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogSmallAgentLogFrames)
+{
+    aeron_init_logging_ring_buffer();
+
+    struct sockaddr_storage addr {};
+    struct msghdr message;
+    struct iovec iov;
+
+    const int message_length = 100;
+    uint8_t buffer[message_length];
+    buffer[message_length - 1] = 'c';
+
+    iov.iov_base = buffer;
+    iov.iov_len = (uint32_t) message_length;
+    message.msg_iovlen = 1;
+    message.msg_iov = &iov;
+    message.msg_name = &addr;
+    message.msg_control = NULL;
+    message.msg_controllen = 0;
+    message.msg_namelen = sizeof(struct sockaddr_storage);
+
+    aeron_driver_agent_log_frame(22, &message, 500, message_length);
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, 22);
+                EXPECT_EQ(length,
+                          sizeof(aeron_driver_agent_frame_log_header_t) + sizeof(struct sockaddr_storage) + 100);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_frame_log_header_t *hdr = (aeron_driver_agent_frame_log_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->result, 500);
+                EXPECT_EQ(hdr->sockaddr_len, (int32_t)sizeof(struct sockaddr_storage));
+                EXPECT_EQ(memcmp(buffer + length - 1, "c", 1), 0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogAgentLogFramesAndCopyUpToMaxFrameLengthMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    struct sockaddr_storage addr {};
+    struct msghdr message;
+    struct iovec iov;
+
+    const int message_length = MAX_FRAME_LENGTH * 5;
+    uint8_t buffer[message_length];
+    memset(buffer, 'x', message_length);
+
+    iov.iov_base = buffer;
+    iov.iov_len = (uint32_t) message_length;
+    message.msg_iovlen = 1;
+    message.msg_iov = &iov;
+    message.msg_name = &addr;
+    message.msg_control = NULL;
+    message.msg_controllen = 0;
+    message.msg_namelen = sizeof(struct sockaddr_storage);
+
+    aeron_driver_agent_log_frame(13, &message, 1, message_length);
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, 13);
+                EXPECT_EQ(length,
+                          sizeof(aeron_driver_agent_frame_log_header_t) + sizeof(struct sockaddr_storage) + MAX_FRAME_LENGTH);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_frame_log_header_t *hdr = (aeron_driver_agent_frame_log_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->result, 1);
+                EXPECT_EQ(hdr->sockaddr_len, (int32_t)sizeof(struct sockaddr_storage));
+                char tmp[MAX_FRAME_LENGTH];
+                memset(tmp, 'x', MAX_FRAME_LENGTH);
+                EXPECT_EQ(memcmp(buffer + sizeof(aeron_driver_agent_frame_log_header_t) + sizeof(struct sockaddr_storage), tmp, MAX_FRAME_LENGTH), 0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogDynamicEventSmallMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    const int message_length = 200;
+    char message[message_length];
+    memset(message, 'x', message_length);
+
+    aeron_driver_agent_log_dynamic_event(111, &message, message_length);
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, AERON_DYNAMIC_DISSECTOR_EVENT);
+                EXPECT_EQ(length, sizeof(aeron_driver_agent_dynamic_event_header_t) + 200);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_dynamic_event_header_t *hdr = (aeron_driver_agent_dynamic_event_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->index, 111);
+                EXPECT_EQ(memcmp(buffer + length - 1, "x", 1), 0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}
+
+TEST_F(DriverAgentTest, shouldLogDynamicEventBigMessage)
+{
+    aeron_init_logging_ring_buffer();
+
+    const int message_length = MAX_FRAME_LENGTH * 3;
+    char message[message_length];
+    memset(message, 'z', message_length);
+
+    aeron_driver_agent_log_dynamic_event(5, &message, message_length);
+
+    auto message_handler =
+            [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)
+            {
+                size_t *count = (size_t *)clientd;
+                (*count)++;
+
+                EXPECT_EQ(msg_type_id, AERON_DYNAMIC_DISSECTOR_EVENT);
+                EXPECT_EQ(length, sizeof(aeron_driver_agent_dynamic_event_header_t) + MAX_FRAME_LENGTH);
+
+                char *buffer = (char *)msg;
+                aeron_driver_agent_dynamic_event_header_t *hdr = (aeron_driver_agent_dynamic_event_header_t *)buffer;
+                EXPECT_NE(hdr->time_ms, 0);
+                EXPECT_EQ(hdr->index, 5);
+                EXPECT_EQ(memcmp(buffer + length - 1, "z", 1), 0);
+            };
+
+    size_t timesCalled = 0;
+    size_t messagesRead = aeron_mpsc_rb_read(aeron_driver_agent_mpsc_rb(), message_handler, &timesCalled, 1);
+
+    EXPECT_EQ(messagesRead, (size_t)1);
+    EXPECT_EQ(timesCalled, (size_t)1);
+}

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/ArchiveCreator.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/ArchiveCreator.java
@@ -44,7 +44,7 @@ import static io.aeron.archive.Archive.Configuration.ARCHIVE_DIR_DEFAULT;
 public class ArchiveCreator
 {
     private static final String MESSAGE_PREFIX = "Message-Prefix-";
-    private static final int MAX_CATALOG_ENTRIES = 128;
+    private static final long CATALOG_CAPACITY = 128 * 1024;
     private static final int TERM_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
     private static final int SEGMENT_LENGTH = TERM_LENGTH * 2;
     private static final int STREAM_ID = 33;
@@ -66,7 +66,7 @@ public class ArchiveCreator
             .dirDeleteOnStart(true);
 
         final Archive.Context archiveContext = new Archive.Context()
-            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .catalogCapacity(CATALOG_CAPACITY)
             .segmentFileLength(SEGMENT_LENGTH)
             .deleteArchiveOnStart(true)
             .archiveDir(archiveDir)

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/IndexedReplicatedRecording.java
@@ -59,7 +59,7 @@ public class IndexedReplicatedRecording implements AutoCloseable
     static final int MESSAGE_BURST_COUNT = 10_000;
 
     private static final int TERM_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
-    private static final int MAX_CATALOG_ENTRIES = 64;
+    private static final long CATALOG_CAPACITY = 64 * 1024;
     private static final int SRC_CONTROL_STREAM_ID = AeronArchive.Configuration.CONTROL_STREAM_ID_DEFAULT;
     private static final String SRC_CONTROL_REQUEST_CHANNEL = "aeron:udp?endpoint=localhost:8090";
     private static final String SRC_CONTROL_RESPONSE_CHANNEL = "aeron:udp?endpoint=localhost:8091";
@@ -107,7 +107,7 @@ public class IndexedReplicatedRecording implements AutoCloseable
                 .dirDeleteOnShutdown(true)
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .controlChannel(SRC_CONTROL_REQUEST_CHANNEL)
                 .archiveClientContext(new AeronArchive.Context().controlResponseChannel(SRC_CONTROL_RESPONSE_CHANNEL))
                 .recordingEventsEnabled(false)
@@ -129,7 +129,7 @@ public class IndexedReplicatedRecording implements AutoCloseable
                 .dirDeleteOnShutdown(true)
                 .dirDeleteOnStart(true),
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .controlChannel(DST_CONTROL_REQUEST_CHANNEL)
                 .archiveClientContext(new AeronArchive.Context().controlResponseChannel(DST_CONTROL_RESPONSE_CHANNEL))
                 .recordingEventsEnabled(false)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
@@ -358,7 +358,7 @@ public class ArchiveAuthenticationTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(ArchiveSystemTests.MAX_CATALOG_ENTRIES)
+                .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
                 .aeronDirectoryName(aeronDirectoryName)
                 .deleteArchiveOnStart(true)
                 .archiveDir(new File(SystemUtil.tmpDirName(), "archive"))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
@@ -83,7 +83,7 @@ public class ArchiveDeleteAndRestartTest
             testWatcher);
 
         archiveContext = new Archive.Context()
-            .maxCatalogEntries(ArchiveSystemTests.MAX_CATALOG_ENTRIES)
+            .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
             .fileSyncLevel(SYNC_LEVEL)
             .deleteArchiveOnStart(true)
             .archiveDir(new File(SystemUtil.tmpDirName(), "archive-test"))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveSystemTests.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveSystemTests.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ArchiveSystemTests
 {
-    static final long MAX_CATALOG_ENTRIES = 128;
+    static final long CATALOG_CAPACITY = 128 * 1024;
     static final int TERM_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
     static final int FRAGMENT_LIMIT = 10;
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -147,7 +147,7 @@ public class ArchiveTest
             testWatcher);
 
         final Archive.Context archiveContext = new Archive.Context()
-            .maxCatalogEntries(ArchiveSystemTests.MAX_CATALOG_ENTRIES)
+            .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
             .fileSyncLevel(SYNC_LEVEL)
             .deleteArchiveOnStart(true)
             .archiveDir(new File(SystemUtil.tmpDirName(), "archive-test"))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -80,7 +80,7 @@ public class BasicArchiveTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(ArchiveSystemTests.MAX_CATALOG_ENTRIES)
+                .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
                 .aeronDirectoryName(aeronDirectoryName)
                 .deleteArchiveOnStart(true)
                 .archiveDir(new File(SystemUtil.tmpDirName(), "archive"))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -17,6 +17,7 @@ package io.aeron.archive;
 
 import io.aeron.*;
 import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
@@ -38,6 +39,8 @@ import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.archive.ArchiveSystemTests.*;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BasicArchiveTest
@@ -62,6 +65,7 @@ public class BasicArchiveTest
 
     @RegisterExtension
     public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+    private File archiveDir;
 
     @BeforeEach
     public void before()
@@ -78,12 +82,14 @@ public class BasicArchiveTest
                 .dirDeleteOnStart(true),
             testWatcher);
 
+        archiveDir = new File(SystemUtil.tmpDirName(), "archive");
+
         archive = Archive.launch(
             new Archive.Context()
                 .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
                 .aeronDirectoryName(aeronDirectoryName)
                 .deleteArchiveOnStart(true)
-                .archiveDir(new File(SystemUtil.tmpDirName(), "archive"))
+                .archiveDir(archiveDir)
                 .fileSyncLevel(0)
                 .errorHandler(Tests::onError)
                 .threadingMode(ArchiveThreadingMode.SHARED));
@@ -183,6 +189,211 @@ public class BasicArchiveTest
             sourceIdentity) -> assertEquals(startPosition, newStopPosition));
 
         assertEquals(1, count);
+    }
+
+    @Test
+    @Timeout(10)
+    public void purgeRecording()
+    {
+        final String messagePrefix = "Message-Prefix-";
+        final int messageCount = 10;
+        final long stopPosition;
+
+        final long subscriptionId = aeronArchive.startRecording(RECORDED_CHANNEL, RECORDED_STREAM_ID, LOCAL);
+        final long recordingIdFromCounter;
+        final int sessionId;
+
+        try (Subscription subscription = aeron.addSubscription(RECORDED_CHANNEL, RECORDED_STREAM_ID);
+            Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
+        {
+            sessionId = publication.sessionId();
+
+            final CountersReader counters = aeron.countersReader();
+            final int counterId = awaitRecordingCounterId(counters, sessionId);
+            recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
+
+            assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
+
+            offer(publication, messageCount, messagePrefix);
+            consume(subscription, messageCount, messagePrefix);
+
+            stopPosition = publication.position();
+            awaitPosition(counters, counterId, stopPosition);
+
+            final long joinPosition = subscription.imageBySessionId(sessionId).joinPosition();
+            assertEquals(joinPosition, aeronArchive.getStartPosition(recordingIdFromCounter));
+            assertEquals(stopPosition, aeronArchive.getRecordingPosition(recordingIdFromCounter));
+            assertEquals(NULL_VALUE, aeronArchive.getStopPosition(recordingIdFromCounter));
+        }
+
+        aeronArchive.stopRecording(subscriptionId);
+
+        final long recordingId = aeronArchive.findLastMatchingRecording(
+            0, "endpoint=localhost:3333", RECORDED_STREAM_ID, sessionId);
+        assertEquals(recordingIdFromCounter, recordingId);
+
+        assertFalse(aeronArchive.tryStopRecordingByIdentity(recordingId));
+
+        assertEquals(recordingIdFromCounter, recordingId);
+        assertEquals(stopPosition, aeronArchive.getStopPosition(recordingId));
+
+        final String[] segmentFiles = Catalog.listSegmentFiles(archiveDir, recordingId);
+        assertNotNull(segmentFiles);
+        assertNotEquals(0, segmentFiles.length);
+
+        aeronArchive.purgeRecording(recordingId);
+
+        final int count = aeronArchive.listRecording(
+            recordingId,
+            (controlSessionId,
+            correlationId,
+            recordingId1,
+            startTimestamp,
+            stopTimestamp,
+            startPosition,
+            newStopPosition,
+            initialTermId,
+            segmentFileLength,
+            termBufferLength,
+            mtuLength,
+            sessionId1,
+            streamId,
+            strippedChannel,
+            originalChannel,
+            sourceIdentity) -> assertEquals(startPosition, newStopPosition));
+
+        assertEquals(0, count);
+
+        assertArrayEquals(new String[0], Catalog.listSegmentFiles(archiveDir, recordingId));
+
+        for (final String segmentFile : segmentFiles)
+        {
+            assertFalse(new File(archiveDir, segmentFile).exists());
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void purgeRecordingFailsIfRecordingIsActive()
+    {
+        final String messagePrefix = "Message-Prefix-";
+        final int messageCount = 10;
+        final long stopPosition;
+
+        final long subscriptionId = aeronArchive.startRecording(RECORDED_CHANNEL, RECORDED_STREAM_ID, LOCAL);
+        try
+        {
+            final long recordingIdFromCounter;
+            final int sessionId;
+
+            try (Subscription subscription = aeron.addSubscription(RECORDED_CHANNEL, RECORDED_STREAM_ID);
+                Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
+            {
+                sessionId = publication.sessionId();
+
+                final CountersReader counters = aeron.countersReader();
+                final int counterId = awaitRecordingCounterId(counters, sessionId);
+                recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
+
+                assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
+
+                offer(publication, messageCount, messagePrefix);
+                consume(subscription, messageCount, messagePrefix);
+
+                stopPosition = publication.position();
+                awaitPosition(counters, counterId, stopPosition);
+
+                final long joinPosition = subscription.imageBySessionId(sessionId).joinPosition();
+                assertEquals(joinPosition, aeronArchive.getStartPosition(recordingIdFromCounter));
+                assertEquals(stopPosition, aeronArchive.getRecordingPosition(recordingIdFromCounter));
+                assertEquals(NULL_VALUE, aeronArchive.getStopPosition(recordingIdFromCounter));
+
+                final long recordingId = aeronArchive.findLastMatchingRecording(
+                    0, "endpoint=localhost:3333", RECORDED_STREAM_ID, sessionId);
+                assertEquals(recordingIdFromCounter, recordingId);
+
+                final ArchiveException exception = assertThrows(ArchiveException.class,
+                    () -> aeronArchive.purgeRecording(recordingId));
+                assertThat(exception.getMessage(), endsWith("error: cannot purge active recording " + recordingId));
+
+                final String[] segmentFiles = Catalog.listSegmentFiles(archiveDir, recordingId);
+                assertNotNull(segmentFiles);
+                assertNotEquals(0, segmentFiles.length);
+
+                for (final String segmentFile : segmentFiles)
+                {
+                    assertTrue(new File(archiveDir, segmentFile).exists());
+                }
+            }
+        }
+        finally
+        {
+            aeronArchive.stopRecording(subscriptionId);
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void purgeRecordingFailsIfThereAreActiveReplays()
+    {
+        final String messagePrefix = "Message-Prefix-";
+        final int messageCount = 10;
+        final long stopPosition;
+
+        final long subscriptionId = aeronArchive.startRecording(RECORDED_CHANNEL, RECORDED_STREAM_ID, LOCAL);
+        final long recordingIdFromCounter;
+        final int sessionId;
+
+        try (Subscription subscription = aeron.addSubscription(RECORDED_CHANNEL, RECORDED_STREAM_ID);
+            Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
+        {
+            sessionId = publication.sessionId();
+
+            final CountersReader counters = aeron.countersReader();
+            final int counterId = awaitRecordingCounterId(counters, sessionId);
+            recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
+
+            assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
+
+            offer(publication, messageCount, messagePrefix);
+            consume(subscription, messageCount, messagePrefix);
+
+            stopPosition = publication.position();
+            awaitPosition(counters, counterId, stopPosition);
+
+            final long joinPosition = subscription.imageBySessionId(sessionId).joinPosition();
+            assertEquals(joinPosition, aeronArchive.getStartPosition(recordingIdFromCounter));
+            assertEquals(stopPosition, aeronArchive.getRecordingPosition(recordingIdFromCounter));
+            assertEquals(NULL_VALUE, aeronArchive.getStopPosition(recordingIdFromCounter));
+        }
+
+        aeronArchive.stopRecording(subscriptionId);
+
+        final long recordingId = aeronArchive.findLastMatchingRecording(
+            0, "endpoint=localhost:3333", RECORDED_STREAM_ID, sessionId);
+        assertEquals(recordingIdFromCounter, recordingId);
+        assertEquals(stopPosition, aeronArchive.getStopPosition(recordingIdFromCounter));
+
+        final long position = 0L;
+        final long length = stopPosition - position;
+
+        try (Subscription subscription = aeronArchive.replay(
+            recordingId, position, length, REPLAY_CHANNEL, REPLAY_STREAM_ID))
+        {
+            final ArchiveException exception = assertThrows(ArchiveException.class,
+                () -> aeronArchive.purgeRecording(recordingId));
+            assertThat(exception.getMessage(),
+                endsWith("error: cannot purge recording with active replay " + recordingId));
+
+            final String[] segmentFiles = Catalog.listSegmentFiles(archiveDir, recordingId);
+            assertNotNull(segmentFiles);
+            assertNotEquals(0, segmentFiles.length);
+
+            for (final String segmentFile : segmentFiles)
+            {
+                assertTrue(new File(archiveDir, segmentFile).exists());
+            }
+        }
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.Aeron;
+import io.aeron.CommonContext;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.test.MediaDriverTestWatcher;
+import io.aeron.test.TestMediaDriver;
+import io.aeron.test.Tests;
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.EpochClock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.File;
+import java.util.stream.IntStream;
+
+import static io.aeron.archive.AbstractListRecordingsSession.MAX_SCANS_PER_WORK_CYCLE;
+import static io.aeron.archive.Catalog.PAGE_SIZE;
+import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
+import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
+import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
+import static io.aeron.test.Tests.generateStringWithSuffix;
+import static org.agrona.BitUtil.next;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CatalogWithJumboRecordingsAndGapsTest
+{
+    private static final int MTU_LENGTH = PAGE_SIZE * 4;
+    private static final int TERM_LENGTH = MTU_LENGTH * 8;
+    private static final int SEGMENT_LENGTH = TERM_LENGTH * 4;
+
+    private final File archiveDir = ArchiveTests.makeTestDirectory();
+    private final EpochClock epochClock = () -> 1;
+    private long[] recordingIds;
+
+    private TestMediaDriver mediaDriver;
+    private Archive archive;
+    private Aeron aeron;
+    private AeronArchive aeronArchive;
+
+    @RegisterExtension
+    public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
+
+    @BeforeEach
+    void before()
+    {
+        recordingIds = new long[MAX_SCANS_PER_WORK_CYCLE * 3];
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, 1024, epochClock, null, null))
+        {
+            for (int i = 0, current = 0; i < recordingIds.length; i++)
+            {
+                final String stippedChannel;
+                final String originalChannel;
+                final String sourceIdentity;
+                switch (current)
+                {
+                    case 0:
+                        stippedChannel = generateStringWithSuffix("ch", "1", 2000);
+                        originalChannel = "ch1?tag=OK";
+                        sourceIdentity = "src1";
+                        break;
+                    case 1:
+                        stippedChannel = "ch2";
+                        originalChannel = generateStringWithSuffix("ch1?tag=O", "K", 2500);
+                        sourceIdentity = "src2";
+                        break;
+                    case 2:
+                        stippedChannel = "ch3";
+                        originalChannel = "ch3?tag=OK|endpoint=localhost:8089";
+                        sourceIdentity = generateStringWithSuffix("src", "3", 1999);
+                        break;
+                    default:
+                        throw new Error();
+                }
+
+                recordingIds[i] = catalog.addNewRecording(i, NULL_POSITION, i * 100, NULL_TIMESTAMP, 0, SEGMENT_LENGTH,
+                    TERM_LENGTH, MTU_LENGTH, current, current, stippedChannel, originalChannel, sourceIdentity);
+
+                current = next(current, 3);
+            }
+
+            invalidateRecordings(catalog, 0, 3);
+            invalidateRecordings(catalog, 20, 30);
+            invalidateRecordings(catalog, 100, 111);
+            invalidateRecordings(catalog, recordingIds.length - 5, recordingIds.length);
+        }
+
+        final String aeronDirectoryName = CommonContext.generateRandomDirName();
+
+        mediaDriver = TestMediaDriver.launch(
+            new MediaDriver.Context()
+                .aeronDirectoryName(aeronDirectoryName)
+                .termBufferSparseFile(true)
+                .threadingMode(ThreadingMode.SHARED)
+                .errorHandler(Tests::onError)
+                .spiesSimulateConnection(false)
+                .publicationTermBufferLength(TERM_MIN_LENGTH)
+                .ipcTermBufferLength(TERM_MIN_LENGTH)
+                .dirDeleteOnStart(true),
+            testWatcher);
+
+        archive = Archive.launch(
+            new Archive.Context()
+                .catalogCapacity(Common.CATALOG_CAPACITY)
+                .aeronDirectoryName(aeronDirectoryName)
+                .errorHandler(Tests::onError)
+                .archiveDir(archiveDir)
+                .fileSyncLevel(0)
+                .threadingMode(ArchiveThreadingMode.SHARED));
+
+        aeron = Aeron.connect(
+            new Aeron.Context()
+                .aeronDirectoryName(aeronDirectoryName));
+
+        aeronArchive = AeronArchive.connect(
+            new AeronArchive.Context()
+                .aeron(aeron));
+    }
+
+    @AfterEach
+    void after()
+    {
+        CloseHelper.closeAll(aeronArchive, aeron, archive, mediaDriver);
+
+        archive.context().deleteDirectory();
+        mediaDriver.context().deleteDirectory();
+    }
+
+    @Test
+    @Timeout(10)
+    void listRecordingShouldHandleHugeRecordingDescriptors()
+    {
+        final int count = aeronArchive.listRecording(recordingIds[3],
+            (controlSessionId,
+            correlationId,
+            recordingId,
+            startTimestamp,
+            stopTimestamp,
+            startPosition,
+            stopPosition,
+            initialTermId,
+            segmentFileLength,
+            termBufferLength,
+            mtuLength,
+            sessionId,
+            streamId,
+            strippedChannel,
+            originalChannel,
+            sourceIdentity) ->
+            {
+                assertEquals(300, startTimestamp);
+                assertEquals("ch1?tag=OK", originalChannel);
+                assertEquals("src1", sourceIdentity);
+            });
+
+        assertEquals(1, count);
+    }
+
+    private void invalidateRecordings(final Catalog catalog, final int from, final int to)
+    {
+        IntStream.range(from, to).forEach(i -> catalog.invalidateRecording(recordingIds[i]));
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
@@ -24,14 +24,19 @@ import io.aeron.test.MediaDriverTestWatcher;
 import io.aeron.test.TestMediaDriver;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
+import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.EpochClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.util.List;
 import java.util.stream.IntStream;
 
 import static io.aeron.archive.AbstractListRecordingsSession.MAX_SCANS_PER_WORK_CYCLE;
@@ -40,14 +45,26 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.archive.client.AeronArchive.NULL_TIMESTAMP;
 import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
 import static io.aeron.test.Tests.generateStringWithSuffix;
+import static java.util.Arrays.asList;
 import static org.agrona.BitUtil.next;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class CatalogWithJumboRecordingsAndGapsTest
 {
     private static final int MTU_LENGTH = PAGE_SIZE * 4;
     private static final int TERM_LENGTH = MTU_LENGTH * 8;
     private static final int SEGMENT_LENGTH = TERM_LENGTH * 4;
+    private static final int NUM_RECORDINGS = MAX_SCANS_PER_WORK_CYCLE * 3;
+    private static final String[] STRIPPED_CHANNELS =
+        new String[]{ generateStringWithSuffix("ch", "1", 2000), "ch2", "ch3" };
+    private static final String[] ORIGINAL_CHANNELS =
+        new String[]{
+            "ch1?tag=OK",
+            generateStringWithSuffix("ch2?tag=O", "K", 2500),
+            "ch3?tag=OK|endpoint=localhost:8089" };
+    private static final String[] SOURCE_IDENTITIES =
+        new String[]{ "src1", "src2", generateStringWithSuffix("src", "3", 1999) };
 
     private final File archiveDir = ArchiveTests.makeTestDirectory();
     private final EpochClock epochClock = () -> 1;
@@ -64,37 +81,25 @@ class CatalogWithJumboRecordingsAndGapsTest
     @BeforeEach
     void before()
     {
-        recordingIds = new long[MAX_SCANS_PER_WORK_CYCLE * 3];
+        recordingIds = new long[NUM_RECORDINGS];
         try (Catalog catalog = new Catalog(archiveDir, null, 0, 1024, epochClock, null, null))
         {
             for (int i = 0, current = 0; i < recordingIds.length; i++)
             {
-                final String stippedChannel;
-                final String originalChannel;
-                final String sourceIdentity;
-                switch (current)
-                {
-                    case 0:
-                        stippedChannel = generateStringWithSuffix("ch", "1", 2000);
-                        originalChannel = "ch1?tag=OK";
-                        sourceIdentity = "src1";
-                        break;
-                    case 1:
-                        stippedChannel = "ch2";
-                        originalChannel = generateStringWithSuffix("ch1?tag=O", "K", 2500);
-                        sourceIdentity = "src2";
-                        break;
-                    case 2:
-                        stippedChannel = "ch3";
-                        originalChannel = "ch3?tag=OK|endpoint=localhost:8089";
-                        sourceIdentity = generateStringWithSuffix("src", "3", 1999);
-                        break;
-                    default:
-                        throw new Error();
-                }
-
-                recordingIds[i] = catalog.addNewRecording(i, NULL_POSITION, i * 100, NULL_TIMESTAMP, 0, SEGMENT_LENGTH,
-                    TERM_LENGTH, MTU_LENGTH, current, current, stippedChannel, originalChannel, sourceIdentity);
+                recordingIds[i] = catalog.addNewRecording(
+                    i,
+                    NULL_POSITION,
+                    i * 100,
+                    NULL_TIMESTAMP,
+                    0,
+                    SEGMENT_LENGTH,
+                    TERM_LENGTH,
+                    MTU_LENGTH,
+                    current,
+                    current,
+                    STRIPPED_CHANNELS[current],
+                    ORIGINAL_CHANNELS[current],
+                    SOURCE_IDENTITIES[current]);
 
                 current = next(current, 3);
             }
@@ -148,7 +153,7 @@ class CatalogWithJumboRecordingsAndGapsTest
 
     @Test
     @Timeout(10)
-    void listRecordingShouldHandleHugeRecordingDescriptors()
+    void listRecording()
     {
         final int count = aeronArchive.listRecording(recordingIds[3],
             (controlSessionId,
@@ -176,8 +181,104 @@ class CatalogWithJumboRecordingsAndGapsTest
         assertEquals(1, count);
     }
 
+    @ParameterizedTest
+    @Timeout(10)
+    @MethodSource("listRecordingsArguments")
+    void listRecordings(final long fromRecordingId, final int recordCount, final int expectedRecordCount)
+    {
+        final MutableInteger callCount = new MutableInteger();
+
+        final int count = aeronArchive.listRecordings(
+            fromRecordingId,
+            recordCount,
+            (controlSessionId,
+            correlationId,
+            recordingId,
+            startTimestamp,
+            stopTimestamp,
+            startPosition,
+            stopPosition,
+            initialTermId,
+            segmentFileLength,
+            termBufferLength,
+            mtuLength,
+            sessionId,
+            streamId,
+            strippedChannel,
+            originalChannel,
+            sourceIdentity) -> callCount.increment());
+
+        assertEquals(expectedRecordCount, count);
+        assertEquals(expectedRecordCount, callCount.get());
+    }
+
+    @ParameterizedTest
+    @Timeout(10)
+    @MethodSource("listRecordingsForUriArguments")
+    void listRecordingsForUri(
+        final long fromRecordingId,
+        final int recordCount,
+        final String channelFragment,
+        final int streamId,
+        final int expectedRecordCount)
+    {
+        final MutableInteger callCount = new MutableInteger();
+
+        final int count = aeronArchive.listRecordingsForUri(
+            fromRecordingId,
+            recordCount,
+            channelFragment,
+            streamId,
+            (controlSessionId,
+            correlationId,
+            recordingId,
+            startTimestamp,
+            stopTimestamp,
+            startPosition,
+            stopPosition,
+            initialTermId,
+            segmentFileLength,
+            termBufferLength,
+            mtuLength,
+            sessionId,
+            streamId1,
+            strippedChannel,
+            originalChannel,
+            sourceIdentity) -> callCount.increment());
+
+        assertEquals(expectedRecordCount, count);
+        assertEquals(expectedRecordCount, callCount.get());
+    }
+
     private void invalidateRecordings(final Catalog catalog, final int from, final int to)
     {
         IntStream.range(from, to).forEach(i -> catalog.invalidateRecording(recordingIds[i]));
+    }
+
+    private static List<Arguments> listRecordingsArguments()
+    {
+        return asList(
+            arguments(Long.MAX_VALUE, 5, 0),
+            arguments(-1, 10, 10),
+            arguments(2, 10, 10),
+            arguments(5, MAX_SCANS_PER_WORK_CYCLE, MAX_SCANS_PER_WORK_CYCLE),
+            arguments(25, 100, 100),
+            arguments(10, MAX_SCANS_PER_WORK_CYCLE * 2, MAX_SCANS_PER_WORK_CYCLE * 2),
+            arguments(NUM_RECORDINGS - 10, MAX_SCANS_PER_WORK_CYCLE, 5)
+        );
+    }
+
+    private static List<Arguments> listRecordingsForUriArguments()
+    {
+        return asList(
+            arguments(Long.MAX_VALUE, 5, ORIGINAL_CHANNELS[2], 2, 0),
+            arguments(-1, 10, ORIGINAL_CHANNELS[2], 2, 10),
+            arguments(2, 10, ORIGINAL_CHANNELS[2], 2, 10),
+            arguments(-1, 10, ORIGINAL_CHANNELS[2], 0, 0),
+            arguments(-1, 10, ORIGINAL_CHANNELS[1], 2, 0),
+            arguments(5, MAX_SCANS_PER_WORK_CYCLE, ORIGINAL_CHANNELS[2], 2, 245),
+            arguments(10, MAX_SCANS_PER_WORK_CYCLE * 2, ORIGINAL_CHANNELS[2], 2, 243),
+            arguments(NUM_RECORDINGS - 10, MAX_SCANS_PER_WORK_CYCLE, ORIGINAL_CHANNELS[2], 2, 2)
+        );
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
@@ -126,7 +126,7 @@ class CatalogWithJumboRecordingsAndGapsTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .catalogCapacity(Common.CATALOG_CAPACITY)
+                .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
                 .aeronDirectoryName(aeronDirectoryName)
                 .errorHandler(Tests::onError)
                 .archiveDir(archiveDir)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
@@ -114,7 +114,7 @@ public class ExtendRecordingTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(ArchiveSystemTests.MAX_CATALOG_ENTRIES)
+                .catalogCapacity(ArchiveSystemTests.CATALOG_CAPACITY)
                 .aeronDirectoryName(aeronDirectoryName)
                 .archiveDir(archiveDir)
                 .errorHandler(Tests::onError)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
@@ -77,7 +77,7 @@ public class ManageRecordingHistoryTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .segmentFileLength(SEGMENT_LENGTH)
                 .deleteArchiveOnStart(true)
                 .archiveDir(new File(SystemUtil.tmpDirName(), "archive"))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -138,7 +138,7 @@ public class ReplayMergeTest
 
         archive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .aeronDirectoryName(mediaDriverContext.aeronDirectoryName())
                 .errorHandler(Tests::onError)
                 .archiveDir(archiveDir)

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -100,7 +100,7 @@ public class ReplicateRecordingTest
 
         srcArchive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .aeronDirectoryName(srcAeronDirectoryName)
                 .controlChannel(SRC_CONTROL_REQUEST_CHANNEL)
                 .archiveClientContext(new AeronArchive.Context().controlResponseChannel(SRC_CONTROL_RESPONSE_CHANNEL))
@@ -124,7 +124,7 @@ public class ReplicateRecordingTest
 
         dstArchive = Archive.launch(
             new Archive.Context()
-                .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+                .catalogCapacity(CATALOG_CAPACITY)
                 .aeronDirectoryName(dstAeronDirectoryName)
                 .controlChannel(DST_CONTROL_REQUEST_CHANNEL)
                 .archiveClientContext(new AeronArchive.Context().controlResponseChannel(DST_CONTROL_RESPONSE_CHANNEL))

--- a/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/CTestMediaDriver.java
@@ -192,7 +192,7 @@ public final class CTestMediaDriver implements TestMediaDriver
 
     private static void setLogging(final Map<String, String> environment)
     {
-        environment.put("AERON_EVENT_LOG", "0x3");
+        environment.put("AERON_EVENT_LOG", "0xffff");
 
         final String driverAgentPath = System.getProperty(DRIVER_AGENT_PATH_PROP_NAME);
         if (null == driverAgentPath)

--- a/aeron-system-tests/src/test/java/io/aeron/test/MediaDriverTestWatcher.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/MediaDriverTestWatcher.java
@@ -50,8 +50,10 @@ public class MediaDriverTestWatcher implements TestWatcher, DriverOutputConsumer
                         System.out.println();
                         System.out.println("Media Driver: " + aeronDirectoryName + ", exit code: " + files.exitValue);
                         printEnvironment(files.environment, System.out);
+                        System.out.println();
                         System.out.println("*** STDOUT ***");
                         Files.copy(files.stdout.toPath(), System.out);
+                        System.out.println();
                         System.out.println("*** STDERR ***");
                         Files.copy(files.stderr.toPath(), System.out);
                         System.out.println("====");

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -15,7 +15,9 @@
  */
 package io.aeron.test;
 
-import io.aeron.*;
+import io.aeron.Aeron;
+import io.aeron.Publication;
+import io.aeron.Subscription;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.exceptions.TimeoutException;
@@ -180,6 +182,7 @@ public class Tests
 
     /**
      * Yield the thread then check for interrupt in a test.
+     *
      * @see #checkInterruptStatus()
      */
     public static void yield()
@@ -397,5 +400,17 @@ public class Tests
         {
             Tests.yield();
         }
+    }
+
+    public static String generateStringWithSuffix(
+        final String prefix, final String suffix, final int repeatSuffixTimes)
+    {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(prefix);
+        for (int i = 0; i < repeatSuffixTimes; i++)
+        {
+            builder.append(suffix);
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
This PR changes Archive recordings from being fixed length (1KB) to variable-length.

Summary:
- Recording descriptors are variable-length.
- No limitation on the length of the `strippedChannel`, `originalChannel` and `sourceIdentity` Strings.
- Ability to purge recordings (`io.aeron.archive.client.AeronArchive#purgeRecording`), i.e. mark recording as `INVALID` and delete the corresponding segment files.
- `max-entries` commands in ArchiveTool have been deprecated in favor of `capacity`, i.e. Catalog no longer has a max entries limit but has a capacity expressed in bytes. Catalog is auto-growing it's capacity when needed but an explicit command can be used as well.
- New command `ArchiveTool#compact` to compact the Catalog file, i.e. remove all recordings in state `INVALID` and delete the corresponding segment files.
- Add checksum to the `RecordingDescriptorHeader`. Now if the `io.aeron.archive.Archive.Context#recordChecksum()` is set the checksum of the entire `RecordingDescriptor` will be taken and stored in the header.
- `ArchiveTool#verify` - validate `RecordingDescriptor`  checksums.
- `ArchiveTool#checksum` - compute and persist `RecordingDescriptor`  checksums.
- Add support for jumbo `RecordingDescriptors`, i.e. allow `RecordingDescriptors` bigger than the `tryClaim` size by using `Publication#offer` API.
- Migration task to migrate from version `2` to version `3` of the Archive.