### PR TITLE
[Java] More cluster tutorial fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ hs_err_pid*
 /aeron-archive/*.dat
 /aeron-cluster/*.dat
 /aeron-cluster/recording.log
+
+aeron-samples/scripts/cluster/logs/
+aeron-samples/scripts/cluster/node*/

--- a/aeron-samples/scripts/cluster/script-common
+++ b/aeron-samples/scripts/cluster/script-common
@@ -16,7 +16,7 @@
 ## limitations under the License.
 ##
 
-if [[ ! -v JAVA_HOME ]]; then
+if [ -z "$JAVA_HOME" ]; then
   echo "Please set the JAVA_HOME environment variable"
   exit 1
 fi

--- a/aeron-samples/src/docs/asciidoc/Cluster-Tutorial.asciidoc
+++ b/aeron-samples/src/docs/asciidoc/Cluster-Tutorial.asciidoc
@@ -380,8 +380,8 @@ include::{sampleSourceDir}/io/aeron/samples/cluster/tutorial/BasicAuctionCluster
 ----
 
 Because Cluster's Consensus Module requires that we write a log file to support the Raft protocol, we need a client for
-the constructed Archive for it to use. The client needs a channel to receive responses back from the cluster, so again
-we are using the node specific port to prevent collisions.
+the constructed Archive for it to use. The client needs a channel to receive responses back from the cluster, so we are
+using port 0 to prevent collisions and have the port to be assigned by the OS from the ephemeral port range.
 
 ==== Consensus Module
 

--- a/aeron-samples/src/docs/asciidoc/Cluster-Tutorial.asciidoc
+++ b/aeron-samples/src/docs/asciidoc/Cluster-Tutorial.asciidoc
@@ -540,9 +540,9 @@ also avoiding using the media drivers that each of the cluster nodes are using.
 cluster events (e.g. new elected leaders).
 
 <3> Specify the channel to receive egress responses back from the cluster. In our case we are using a UDP unicast
-response, which will limit responses to the session that sent the ingress message. We are adjusting the port per client
-to allow for multiple clients on the same machine with multiple media drivers. For a single media driver this would not
-be necessary.
+response, which will limit responses to the session that sent the ingress message. We are using port 0 to allow for
+multiple clients on the same machine with multiple media drivers and to avoid having to specify an actual port per
+client.
 
 +
 

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusterClient.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusterClient.java
@@ -190,8 +190,6 @@ public class BasicAuctionClusterClient implements EgressListener
         final BasicAuctionClusterClient client = new BasicAuctionClusterClient(customerId, numOfBids, bidIntervalMs);
 
         // tag::connect[]
-        final int egressPort = 19000 + customerId;
-
         try (
             MediaDriver mediaDriver = MediaDriver.launchEmbedded(new MediaDriver.Context()                      // <1>
                 .threadingMode(ThreadingMode.SHARED)
@@ -200,7 +198,7 @@ public class BasicAuctionClusterClient implements EgressListener
             AeronCluster aeronCluster = AeronCluster.connect(
                 new AeronCluster.Context()
                 .egressListener(client)                                                                         // <2>
-                .egressChannel("aeron:udp?endpoint=localhost:" + egressPort)                                    // <3>
+                .egressChannel("aeron:udp?endpoint=localhost:0")                                                // <3>
                 .aeronDirectoryName(mediaDriver.aeronDirectoryName())
                 .ingressChannel("aeron:udp")                                                                    // <4>
                 .ingressEndpoints(ingressEndpoints)))                                                           // <5>

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
@@ -54,12 +54,12 @@ public class BasicAuctionClusteredServiceNode
     private static final int PORT_BASE = 9000;
     private static final int PORTS_PER_NODE = 100;
     private static final int ARCHIVE_CONTROL_REQUEST_PORT_OFFSET = 1;
-    private static final int ARCHIVE_CONTROL_RESPONSE_PORT_OFFSET = 2;
-    static final int CLIENT_FACING_PORT_OFFSET = 3;
-    private static final int MEMBER_FACING_PORT_OFFSET = 4;
-    private static final int LOG_PORT_OFFSET = 5;
-    private static final int TRANSFER_PORT_OFFSET = 6;
-    private static final int LOG_CONTROL_PORT_OFFSET = 7;
+    static final int CLIENT_FACING_PORT_OFFSET = 2;
+    private static final int MEMBER_FACING_PORT_OFFSET = 3;
+    private static final int LOG_PORT_OFFSET = 4;
+    private static final int TRANSFER_PORT_OFFSET = 5;
+    private static final int LOG_CONTROL_PORT_OFFSET = 6;
+    private static final int TERM_LENGTH = 64 * 1024;
 
     static int calculatePort(final int nodeId, final int offset)
     {
@@ -73,7 +73,7 @@ public class BasicAuctionClusteredServiceNode
         final int port = calculatePort(nodeId, portOffset);
         return new ChannelUriStringBuilder()
             .media("udp")
-            .termLength(64 * 1024)
+            .termLength(TERM_LENGTH)
             .endpoint(hostname + ":" + port)
             .build();
     }
@@ -84,7 +84,7 @@ public class BasicAuctionClusteredServiceNode
         final int port = calculatePort(nodeId, portOffset);
         return new ChannelUriStringBuilder()
             .media("udp")
-            .termLength(64 * 1024)
+            .termLength(TERM_LENGTH)
             .controlMode("manual")
             .controlEndpoint(hostname + ":" + port)
             .build();
@@ -147,7 +147,7 @@ public class BasicAuctionClusteredServiceNode
             .lock(NoOpLock.INSTANCE)
             .controlRequestChannel(archiveContext.controlChannel())
             .controlRequestStreamId(archiveContext.controlStreamId())
-            .controlResponseChannel(udpChannel(nodeId, "localhost", ARCHIVE_CONTROL_RESPONSE_PORT_OFFSET))
+            .controlResponseChannel("aeron:udp?endpoint=localhost:0|term-length=64k")
             .aeronDirectoryName(aeronDirName);
         // end::archive_client[]
 

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
@@ -134,6 +134,7 @@ public class BasicAuctionClusteredServiceNode
 
         // tag::archive[]
         final Archive.Context archiveContext = new Archive.Context()
+            .aeronDirectoryName(aeronDirName)
             .archiveDir(new File(baseDir, "archive"))
             .controlChannel(udpChannel(nodeId, "localhost", ARCHIVE_CONTROL_REQUEST_PORT_OFFSET))
             .localControlChannel("aeron:ipc?term-length=64k")

--- a/buildSrc/src/main/java/io/aeron/build/AsciidoctorPreprocessTask.java
+++ b/buildSrc/src/main/java/io/aeron/build/AsciidoctorPreprocessTask.java
@@ -37,21 +37,51 @@ import static java.util.stream.Collectors.joining;
 
 public class AsciidoctorPreprocessTask extends DefaultTask
 {
-    @Input
-    public final String sampleBaseDir = getProject().getProjectDir().getAbsolutePath();
+    private final String sampleBaseDir = getProject().getProjectDir().getAbsolutePath();
 
-    @Input
-    public final String sampleSourceDir = sampleBaseDir + "/src/main/java";
+    private final String sampleSourceDir = sampleBaseDir + "/src/main/java";
 
-    @InputDirectory
-    public final File source = new File(sampleBaseDir, "/src/docs/asciidoc");
+    private final File source = new File(sampleBaseDir, "/src/docs/asciidoc");
 
-    @OutputDirectory
-    public final File target = new File(getProject().getBuildDir(), "/asciidoc/asciidoc");
+    private final File target = new File(getProject().getBuildDir(), "/asciidoc/asciidoc");
 
     // Has a slightly silly name to avoid name clashes in the build script.
+    private String versionText;
+
     @Input
-    public String versionText;
+    public String getSampleBaseDir()
+    {
+        return sampleBaseDir;
+    }
+
+    @Input
+    public String getSampleSourceDir()
+    {
+        return sampleSourceDir;
+    }
+
+    @InputDirectory
+    public File getSource()
+    {
+        return source;
+    }
+
+    @OutputDirectory
+    public File getTarget()
+    {
+        return target;
+    }
+
+    @Input
+    public String getVersionText()
+    {
+        return versionText;
+    }
+
+    public void setVersionText(final String versionText)
+    {
+        this.versionText = versionText;
+    }
 
     @TaskAction
     public void preprocess() throws Exception


### PR DESCRIPTION
- Fix Gradle deprecation warnings.
- Use port 0 for egress and control response channels.
- Assign Aeron dir name to Archive.Context.
- Ignore cluster tutorial output files/dirs in Git.