### PR TITLE
Leader heartbeat timeout for custom NameResolver

### DIFF
--- a/aeron-cluster/src/test/java/io/aeron/cluster/CustomNameResolverTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/CustomNameResolverTest.java
@@ -1,0 +1,47 @@
+package io.aeron.cluster;
+
+import org.agrona.CloseHelper;
+import org.agrona.LangUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class CustomNameResolverTest
+{
+
+    private TestClusterWithNameResolver cluster;
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.close(cluster);
+    }
+
+    @Test
+    void test(final TestInfo testInfo)
+    {
+        final int messageCount = 300;
+        cluster = TestClusterWithNameResolver.startThreeNodeStaticCluster();
+        try
+        {
+            cluster.awaitLeader();
+            cluster.connectClient();
+
+            final int iterations = 30000;
+            for (int i = 0; i < iterations; i++)
+            {
+                cluster.sendMessages(messageCount);
+                final int expectedMessageCount = (i * messageCount) + messageCount;
+                cluster.awaitResponseMessageCount(expectedMessageCount);
+                // System.out.println("sent " + expectedMessageCount + "/" + (iterations * messageCount));
+            }
+
+        }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+}
+

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestClusterWithNameResolver.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestClusterWithNameResolver.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.aeron.CommonContext;
+import io.aeron.Publication;
+import io.aeron.archive.ArchiveThreadingMode;
+import io.aeron.cluster.TestNode.TestService;
+import io.aeron.cluster.client.AeronCluster;
+import io.aeron.cluster.client.ClusterException;
+import io.aeron.cluster.client.EgressListener;
+import io.aeron.cluster.codecs.EventCode;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.logbuffer.Header;
+import io.aeron.test.DataCollector;
+import io.aeron.test.Tests;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.agrona.BitUtil;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.EpochClock;
+import org.agrona.concurrent.NoOpLock;
+import org.junit.jupiter.api.TestInfo;
+
+public class TestClusterWithNameResolver implements AutoCloseable
+{
+
+    private static final long MAX_CATALOG_ENTRIES = 128;
+    private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
+    private static final String ARCHIVE_LOCAL_CONTROL_CHANNEL = "aeron:ipc?term-length=64k";
+    private static final String INGRESS_CHANNEL = "aeron:udp?term-length=128k";
+
+    private final DataCollector dataCollector = new DataCollector();
+    private final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
+    private final MutableInteger responseCount = new MutableInteger();
+    private final MutableInteger newLeaderEvent = new MutableInteger();
+    private final EgressListener egressMessageListener = new EgressListener()
+    {
+        public void onMessage(
+            final long clusterSessionId,
+            final long timestamp,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length,
+            final Header header)
+        {
+            responseCount.increment();
+        }
+
+        public void onSessionEvent(
+            final long correlationId,
+            final long clusterSessionId,
+            final long leadershipTermId,
+            final int leaderMemberId,
+            final EventCode code,
+            final String detail)
+        {
+            if (EventCode.ERROR == code)
+            {
+                throw new ClusterException(detail);
+            }
+            else if (EventCode.CLOSED == code)
+            {
+                System.out.println("session closed due to " + detail);
+            }
+        }
+
+        public void onNewLeader(
+            final long clusterSessionId,
+            final long leadershipTermId,
+            final int leaderMemberId,
+            final String ingressEndpoints)
+        {
+            newLeaderEvent.increment();
+        }
+    };
+    private final TestNameResolver nameResolver = new TestNameResolver();
+
+    private final TestNode[] nodes;
+    private final String staticClusterMembers;
+    private final String staticClusterMemberEndpoints;
+    private final int appointedLeaderId;
+
+    private MediaDriver clientMediaDriver;
+    private AeronCluster client;
+
+    TestClusterWithNameResolver(final int staticMemberCount, final int dynamicMemberCount,
+        final int appointedLeaderId)
+    {
+        final int memberCount = staticMemberCount + dynamicMemberCount;
+        if ((memberCount + 1) >= 10)
+        {
+            throw new IllegalArgumentException("max members exceeded: max=9 count=" + memberCount);
+        }
+
+        this.nodes = new TestNode[memberCount + 1];
+        this.staticClusterMembers = clusterMembers(0, staticMemberCount);
+        this.staticClusterMemberEndpoints = ingressEndpoints(0, staticMemberCount);
+        this.appointedLeaderId = appointedLeaderId;
+    }
+
+    public void close()
+    {
+        final boolean isInterrupted = Thread.interrupted();
+        try
+        {
+            CloseHelper.closeAll(
+                client,
+                clientMediaDriver,
+                null != clientMediaDriver ? () -> clientMediaDriver.context().deleteDirectory() : null,
+                () -> CloseHelper.closeAll(Stream.of(nodes).map(TestCluster::closeAndDeleteNode).collect(toList())));
+        }
+        finally
+        {
+            if (isInterrupted)
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        ClusterTests.failOnClusterError();
+    }
+
+    static AutoCloseable closeAndDeleteNode(final TestNode node)
+    {
+        if (node == null)
+        {
+            return null;
+        }
+
+        return node::closeAndDelete;
+    }
+
+    static TestClusterWithNameResolver startThreeNodeStaticCluster()
+    {
+        final TestClusterWithNameResolver testCluster = new TestClusterWithNameResolver(3, 0,
+            NULL_VALUE);
+        for (int i = 0; i < 3; i++)
+        {
+            testCluster.startStaticNode(i, TestNode.TestService::new);
+        }
+
+        return testCluster;
+    }
+
+    TestNode startStaticNode(
+        final int index,
+        final Supplier<? extends TestService> serviceSupplier)
+    {
+        nameResolver.populate("local-" + index, "localhost");
+        final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
+        final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final TestNode.Context context = new TestNode.Context(serviceSupplier.get().index(index));
+
+        context.aeronArchiveContext
+            .lock(NoOpLock.INSTANCE)
+            .controlRequestChannel(memberSpecificPort(archiveControlRequestChannel(index), index))
+            .controlRequestStreamId(100)
+            .controlResponseChannel(memberSpecificPort(archiveControlResponseChannel(index), index))
+            .controlResponseStreamId(110 + index)
+            .aeronDirectoryName(baseDirName)
+            .errorHandler(th ->
+            {
+                System.err.println("[aeronArchiveContext-" + index + "]");
+                th.printStackTrace(System.err);
+            });
+
+        context.mediaDriverContext
+            .nameResolver(nameResolver)
+            .aeronDirectoryName(aeronDirName)
+            .threadingMode(ThreadingMode.SHARED)
+            .termBufferSparseFile(true)
+            .errorHandler(ClusterTests.errorHandler(index))
+            .dirDeleteOnShutdown(false)
+            .dirDeleteOnStart(true)
+            .errorHandler(th ->
+            {
+                System.err.println("[mediaDriverContext-" + index + "]");
+                th.printStackTrace(System.err);
+            });
+
+        context.archiveContext
+            .maxCatalogEntries(MAX_CATALOG_ENTRIES)
+            .archiveDir(new File(baseDirName, "archive"))
+            .controlChannel(context.aeronArchiveContext.controlRequestChannel())
+            .controlStreamId(context.aeronArchiveContext.controlRequestStreamId())
+            .localControlChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
+            .recordingEventsEnabled(false)
+            .localControlStreamId(context.aeronArchiveContext.controlRequestStreamId())
+            .recordingEventsEnabled(false)
+            .threadingMode(ArchiveThreadingMode.SHARED)
+            .deleteArchiveOnStart(true)
+            .errorHandler(th ->
+            {
+                System.err.println("[archiveContext-" + index + "]");
+                th.printStackTrace(System.err);
+            });
+
+        context.consensusModuleContext
+            .errorHandler(ClusterTests.errorHandler(index))
+            .clusterMemberId(index)
+            .clusterMembers(staticClusterMembers)
+            .startupCanvassTimeoutNs(TimeUnit.SECONDS.toNanos(5))
+            .appointedLeaderId(appointedLeaderId)
+            .clusterDir(new File(baseDirName, "consensus-module"))
+            .ingressChannel(INGRESS_CHANNEL)
+            .logChannel(LOG_CHANNEL)
+            .archiveContext(context.aeronArchiveContext.clone()
+            .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
+            .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
+            .deleteDirOnStart(true)
+            .errorHandler(th ->
+            {
+                System.err.println("[consensusModuleContext-" + index + "]");
+                th.printStackTrace(System.err);
+            });
+
+        context.serviceContainerContext
+            .aeronDirectoryName(aeronDirName)
+            .archiveContext(context.aeronArchiveContext.clone()
+            .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
+            .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
+            .clusterDir(new File(baseDirName, "service"))
+            .clusteredService(context.service)
+            .errorHandler(th ->
+            {
+                System.err.println("[serviceContainerContext-" + index + "]");
+                th.printStackTrace(System.err);
+            });
+
+        nodes[index] = new TestNode(context, dataCollector);
+
+        return nodes[index];
+    }
+
+    void stopNode(final TestNode testNode)
+    {
+        testNode.close();
+    }
+
+    void stopAllNodes()
+    {
+        CloseHelper.closeAll(nodes);
+    }
+
+    AeronCluster connectClient()
+    {
+        return connectClient(
+            new AeronCluster.Context()
+                .ingressChannel(INGRESS_CHANNEL)
+                .egressChannel(egressChannel(0)));
+    }
+
+    AeronCluster connectClient(final AeronCluster.Context clientCtx)
+    {
+        final String aeronDirName = CommonContext.getAeronDirectoryName();
+
+        if (null == clientMediaDriver)
+        {
+            dataCollector.add(Paths.get(aeronDirName));
+
+            clientMediaDriver = MediaDriver.launch(
+                new MediaDriver.Context()
+                    .nameResolver(nameResolver)
+                    .threadingMode(ThreadingMode.SHARED)
+                    .dirDeleteOnStart(true)
+                    .dirDeleteOnShutdown(false)
+                    .aeronDirectoryName(aeronDirName)
+                    .errorHandler(th ->
+                    {
+                        System.err.println("[clientMediaDriver-]");
+                        th.printStackTrace(System.err);
+                    }));
+        }
+
+        CloseHelper.close(client);
+        client = AeronCluster.connect(
+            clientCtx
+                .aeronDirectoryName(aeronDirName)
+                .egressListener(egressMessageListener)
+                .ingressEndpoints(staticClusterMemberEndpoints)
+                .errorHandler(th ->
+                {
+                    System.err.println("[client-]");
+                    th.printStackTrace(System.err);
+                }));
+
+        return client;
+    }
+
+    void closeClient()
+    {
+        CloseHelper.close(client);
+    }
+
+    void sendMessages(final int messageCount)
+    {
+        for (int i = 0; i < messageCount; i++)
+        {
+            msgBuffer.putInt(0, i);
+            try
+            {
+                pollUntilMessageSent(BitUtil.SIZE_OF_INT);
+            }
+            catch (final Throwable ex)
+            {
+                throw new ClusterException("failed to send message " + i + " of " + messageCount,
+                    ex);
+            }
+        }
+    }
+
+    void pollUntilMessageSent(final int messageLength)
+    {
+        while (true)
+        {
+            client.pollEgress();
+
+            final long result = client.offer(msgBuffer, 0, messageLength);
+            if (result > 0)
+            {
+                return;
+            }
+
+            if (Publication.ADMIN_ACTION == result)
+            {
+                continue;
+            }
+
+            if (Publication.CLOSED == result)
+            {
+                throw new ClusterException("client publication is closed");
+            }
+
+            if (Publication.MAX_POSITION_EXCEEDED == result)
+            {
+                throw new ClusterException("max position exceeded");
+            }
+
+            Tests.sleep(1);
+        }
+    }
+
+    void awaitResponseMessageCount(final int messageCount)
+    {
+        final EpochClock epochClock = client.context().aeron().context().epochClock();
+        long heartbeatDeadlineMs = epochClock.time() + TimeUnit.SECONDS.toMillis(1);
+        long count;
+
+        while ((count = responseCount.get()) < messageCount)
+        {
+            Thread.yield();
+            if (Thread.interrupted())
+            {
+                final String message = "count=" + count + " awaiting=" + messageCount;
+                Tests.unexpectedInterruptStackTrace(message);
+                fail(message);
+            }
+
+            client.pollEgress();
+
+            final long nowMs = epochClock.time();
+            if (nowMs > heartbeatDeadlineMs)
+            {
+                client.sendKeepAlive();
+                heartbeatDeadlineMs = nowMs + TimeUnit.SECONDS.toMillis(1);
+            }
+        }
+    }
+
+    TestNode findLeader(final int skipIndex)
+    {
+        for (int i = 0; i < nodes.length; i++)
+        {
+            final TestNode node = nodes[i];
+            if (i == skipIndex || null == node || node.isClosed())
+            {
+                continue;
+            }
+
+            if (node.isLeader() && ElectionState.CLOSED == node.electionState())
+            {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
+    TestNode findLeader()
+    {
+        return findLeader(NULL_VALUE);
+    }
+
+    TestNode awaitLeader(final int skipIndex)
+    {
+        TestNode leaderNode;
+        while (null == (leaderNode = findLeader(skipIndex)))
+        {
+            Tests.sleep(10);
+        }
+
+        return leaderNode;
+    }
+
+    TestNode awaitLeader()
+    {
+        return awaitLeader(NULL_VALUE);
+    }
+
+    static String memberSpecificPort(final String channel, final int memberId)
+    {
+        return channel.substring(0, channel.length() - 1) + memberId;
+    }
+
+    static String clusterMembers(final int clusterId, final int memberCount)
+    {
+        final StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < memberCount; i++)
+        {
+            builder
+                .append(i).append(',')
+                .append("local-").append(i).append(":2").append(clusterId).append("11").append(i)
+                .append(',')
+                .append("local-").append(i).append(":2").append(clusterId).append("22").append(i)
+                .append(',')
+                .append("local-").append(i).append(":2").append(clusterId).append("33").append(i)
+                .append(',')
+                .append("local-").append(i).append(":2").append(clusterId).append("44").append(i)
+                .append(',')
+                .append("local-").append(i).append(":801").append(i).append('|');
+        }
+
+        builder.setLength(builder.length() - 1);
+
+        return builder.toString();
+    }
+
+    static String ingressEndpoints(final int clusterId, final int memberCount)
+    {
+        final StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < memberCount; i++)
+        {
+            builder.append(i).append('=').append("local-").append(i).append(":2").append(clusterId)
+                .append("11").append(i).append(',');
+        }
+
+        builder.setLength(builder.length() - 1);
+
+        return builder.toString();
+    }
+
+    private static String archiveControlRequestChannel(final int index)
+    {
+        return "aeron:udp?term-length=64k|endpoint=local-" + index + ":8010";
+    }
+
+    private static String archiveControlResponseChannel(final int index)
+    {
+        return "aeron:udp?term-length=64k|endpoint=local-" + index + ":8020";
+    }
+
+    private static String egressChannel(final int index)
+    {
+        return "aeron:udp?term-length=128k|endpoint=local-" + index + ":9020";
+    }
+
+    public void dumpData(final TestInfo testInfo)
+    {
+        dataCollector.dumpData(testInfo);
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/TestNameResolver.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/TestNameResolver.java
@@ -1,0 +1,46 @@
+package io.aeron.cluster;
+
+import io.aeron.driver.DefaultNameResolver;
+import io.aeron.driver.NameResolver;
+import java.net.InetAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public final class TestNameResolver implements NameResolver
+{
+
+    private static final String NULL_ADDRESS = "localhost:7";
+
+    private final ConcurrentMap<String, String> addressByMember = new ConcurrentHashMap<>();
+
+    public void populate(final String name, final String address)
+    {
+        addressByMember.put(name, address);
+    }
+
+    @Override
+    public InetAddress resolve(final String name, final String uriParams, final boolean isReResolve)
+    {
+        return DefaultNameResolver.INSTANCE.resolve(name, uriParams, isReResolve);
+    }
+
+    @Override
+    public String lookup(final String name, final String uriParamName, final boolean isReLookup)
+    {
+        final String[] split = name.split(":");
+        final String key = split[0];
+        final int port = Integer.parseInt(split[1]);
+
+        final String address = addressByMember.get(key);
+
+        if (address == null)
+        {
+            // return name; -> fail immediately by java.net.UnknownHostException:
+            //   Unresolved - endpoint=local-1:20221, name-and-port=local-1:20221
+            return NULL_ADDRESS;
+        }
+
+        return address + ":" + port;
+    }
+}
+

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -26,6 +26,7 @@ import io.aeron.protocol.StatusMessageFlyweight;
 import io.aeron.status.LocalSocketAddressStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.concurrent.CachedNanoClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -57,6 +58,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
     private final AtomicCounter statusMessagesReceived;
     private final AtomicCounter nakMessagesReceived;
     private final AtomicCounter statusIndicator;
+    private final CachedNanoClock cachedNanoClock;
     private AtomicCounter localSocketAddressIndicator;
 
     public SendChannelEndpoint(
@@ -72,6 +74,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
         nakMessagesReceived = context.systemCounters().get(NAK_MESSAGES_RECEIVED);
         statusMessagesReceived = context.systemCounters().get(STATUS_MESSAGES_RECEIVED);
         this.statusIndicator = statusIndicator;
+        this.cachedNanoClock = context.cachedNanoClock();
 
         MultiSndDestination multiSndDestination = null;
         if (udpChannel.isManualControlMode())
@@ -288,6 +291,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
                 publication.onStatusMessage(msg, srcAddress);
             }
 
+            timeOfLastResolutionNs = cachedNanoClock.nanoTime();
             statusMessagesReceived.incrementOrdered();
         }
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -26,7 +26,6 @@ import io.aeron.protocol.StatusMessageFlyweight;
 import io.aeron.status.LocalSocketAddressStatus;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.collections.Long2ObjectHashMap;
-import org.agrona.concurrent.CachedNanoClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -58,7 +57,6 @@ public class SendChannelEndpoint extends UdpChannelTransport
     private final AtomicCounter statusMessagesReceived;
     private final AtomicCounter nakMessagesReceived;
     private final AtomicCounter statusIndicator;
-    private final CachedNanoClock cachedNanoClock;
     private AtomicCounter localSocketAddressIndicator;
 
     public SendChannelEndpoint(
@@ -74,7 +72,6 @@ public class SendChannelEndpoint extends UdpChannelTransport
         nakMessagesReceived = context.systemCounters().get(NAK_MESSAGES_RECEIVED);
         statusMessagesReceived = context.systemCounters().get(STATUS_MESSAGES_RECEIVED);
         this.statusIndicator = statusIndicator;
-        this.cachedNanoClock = context.cachedNanoClock();
 
         MultiSndDestination multiSndDestination = null;
         if (udpChannel.isManualControlMode())
@@ -288,7 +285,6 @@ public class SendChannelEndpoint extends UdpChannelTransport
                 publication.onStatusMessage(msg, srcAddress);
             }
 
-            timeOfLastResolutionNs = cachedNanoClock.nanoTime();
             statusMessagesReceived.incrementOrdered();
         }
     }


### PR DESCRIPTION
Hi all
I tried to update the Aeron version from `1.29.0` to the latest and faced with an issue kinda `io.aeron.cluster.client.ClusterException: leader heartbeat timeout` and it reproduced on Linux machines only (Windows and MacOS work properly).
I work with a custom implementation of the `NameResolver ` and during starting cluster nodes they can not always know the right IPs other members and if my `NameResolver` was not updated yet it returns `localhost:7` to avoid immediate failure by `java.net.UnknownHostException` (have no ability return `null`). And such workaround worked till `1.30.0`.
Then I found the commit that broke the previous behavior -> https://github.com/real-logic/aeron/commit/58e7dbb2f5b07ebafabf24252734eff44075a3a6 and after reverting of `timeOfLastResolutionNs` updating in  `SendChannelEndpoint#onStatusMessage` it works again. 
Also, I added my test scenario with a shared `NameResolver` implementation and it's populated each time when a cluster node is starting `TestClusterWithNameResolver:174` to simulate dynamic populating addresses by names.

I am still not sure that is a bug and why it is reproduced on Linux machines only.
