### PR TITLE
Topology tests & allow multicast for log channel

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Supplier;
 
+import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static io.aeron.cluster.ConsensusModule.Configuration.*;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SNAPSHOT_CHANNEL_PROP_NAME;
 import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.SNAPSHOT_STREAM_ID_PROP_NAME;
@@ -1080,6 +1081,7 @@ public final class ConsensusModule implements AutoCloseable
         private AuthenticatorSupplier authenticatorSupplier;
         private LogPublisher logPublisher;
         private EgressPublisher egressPublisher;
+        private boolean logChannelIsMultiDestination;
 
         /**
          * Perform a shallow copy of the object.
@@ -1305,6 +1307,9 @@ public final class ConsensusModule implements AutoCloseable
             {
                 egressPublisher = new EgressPublisher();
             }
+
+            final ChannelUri channelUri = ChannelUri.parse(logChannel());
+            logChannelIsMultiDestination = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);
 
             concludeMarkFile();
         }
@@ -2948,6 +2953,11 @@ public final class ConsensusModule implements AutoCloseable
         EgressPublisher egressPublisher()
         {
             return egressPublisher;
+        }
+
+        boolean logChannelIsMultiDestination()
+        {
+            return logChannelIsMultiDestination;
         }
 
         private void concludeMarkFile()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1081,7 +1081,7 @@ public final class ConsensusModule implements AutoCloseable
         private AuthenticatorSupplier authenticatorSupplier;
         private LogPublisher logPublisher;
         private EgressPublisher egressPublisher;
-        private boolean logChannelIsMultiDestination;
+        private boolean isLogChannelMultiDestination;
 
         /**
          * Perform a shallow copy of the object.
@@ -1309,7 +1309,7 @@ public final class ConsensusModule implements AutoCloseable
             }
 
             final ChannelUri channelUri = ChannelUri.parse(logChannel());
-            logChannelIsMultiDestination = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);
+            isLogChannelMultiDestination = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);
 
             concludeMarkFile();
         }
@@ -2955,9 +2955,9 @@ public final class ConsensusModule implements AutoCloseable
             return egressPublisher;
         }
 
-        boolean logChannelIsMultiDestination()
+        boolean isLogChannelMultiDestination()
         {
-            return logChannelIsMultiDestination;
+            return isLogChannelMultiDestination;
         }
 
         private void concludeMarkFile()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -641,7 +641,7 @@ class ConsensusModuleAgent implements Agent
                     ClusterMember.addConsensusPublication(
                         newMember, ChannelUri.parse(ctx.consensusChannel()), ctx.consensusStreamId(), aeron);
 
-                    logPublisher.addPassiveFollower(ctx.logChannelIsMultiDestination(), newMember.logEndpoint());
+                    logPublisher.addPassiveFollower(ctx.isLogChannelMultiDestination(), newMember.logEndpoint());
                 }
             }
             else if (Cluster.Role.FOLLOWER == role)
@@ -700,7 +700,7 @@ class ConsensusModuleAgent implements Agent
                     final int streamId = ctx.consensusStreamId();
                     ClusterMember.addConsensusPublication(member, consensusUri, streamId, aeron);
 
-                    logPublisher.addPassiveFollower(ctx.logChannelIsMultiDestination(), member.logEndpoint());
+                    logPublisher.addPassiveFollower(ctx.isLogChannelMultiDestination(), member.logEndpoint());
                 }
 
                 member.hasRequestedJoin(true);
@@ -796,7 +796,7 @@ class ConsensusModuleAgent implements Agent
                     passiveMembers = ClusterMember.removeMember(passiveMembers, memberId);
                     member.closePublication(ctx.countedErrorHandler());
 
-                    logPublisher.removePassiveFollower(ctx.logChannelIsMultiDestination(), member.logEndpoint());
+                    logPublisher.removePassiveFollower(ctx.isLogChannelMultiDestination(), member.logEndpoint());
 
                     clusterMemberByIdMap.remove(memberId);
                     clusterMemberByIdMap.compact();
@@ -1288,7 +1288,7 @@ class ConsensusModuleAgent implements Agent
                 channelUri.put(FLOW_CONTROL_PARAM_NAME, "min,t:" + timeout + "s");
             }
 
-            if (ctx.logChannelIsMultiDestination())
+            if (ctx.isLogChannelMultiDestination())
             {
                 channelUri.put(MDC_CONTROL_MODE_PARAM_NAME, MDC_CONTROL_MODE_MANUAL);
             }
@@ -1306,7 +1306,7 @@ class ConsensusModuleAgent implements Agent
         final String channel = channelUri.toString();
         final ExclusivePublication publication = aeron.addExclusivePublication(channel, ctx.logStreamId());
 
-        if (ctx.logChannelIsMultiDestination())
+        if (ctx.isLogChannelMultiDestination())
         {
             for (final ClusterMember member : clusterMembers)
             {
@@ -2437,7 +2437,7 @@ class ConsensusModuleAgent implements Agent
 
                 member.closePublication(ctx.countedErrorHandler());
 
-                logPublisher.removePassiveFollower(ctx.logChannelIsMultiDestination(), member.logEndpoint());
+                logPublisher.removePassiveFollower(ctx.isLogChannelMultiDestination(), member.logEndpoint());
                 pendingMemberRemovals--;
             }
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -16,15 +16,17 @@
 package io.aeron.cluster;
 
 import io.aeron.*;
-import io.aeron.archive.client.*;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.ArchiveException;
+import io.aeron.archive.client.ControlResponsePoller;
 import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.archive.codecs.SourceLocation;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.cluster.client.AeronCluster;
-import io.aeron.cluster.service.ClusterClock;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.Cluster;
+import io.aeron.cluster.service.ClusterClock;
 import io.aeron.cluster.service.ClusterMarkFile;
 import io.aeron.cluster.service.RecoveryState;
 import io.aeron.exceptions.AeronException;
@@ -38,7 +40,6 @@ import org.agrona.concurrent.status.CountersReader;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.CommonContext.*;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -15,7 +15,10 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.ChannelUriStringBuilder;
+import io.aeron.CommonContext;
+import io.aeron.Image;
+import io.aeron.Subscription;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.ChangeType;
 import io.aeron.cluster.service.Cluster;
@@ -833,8 +836,9 @@ class Election
 
     private void addLiveLogDestination()
     {
-        // TODO: Handle multicast case
-        final String destination = "aeron:udp?endpoint=" + thisMember.logEndpoint();
+        final String destination = ctx.logChannelIsMultiDestination() ?
+            "aeron:udp?endpoint=" + thisMember.logEndpoint() : ctx.logChannel();
+
         logSubscription.asyncAddDestination(destination);
         consensusModuleAgent.liveLogDestination(destination);
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -836,7 +836,7 @@ class Election
 
     private void addLiveLogDestination()
     {
-        final String destination = ctx.logChannelIsMultiDestination() ?
+        final String destination = ctx.isLogChannelMultiDestination() ?
             "aeron:udp?endpoint=" + thisMember.logEndpoint() : ctx.logChannel();
 
         logSubscription.asyncAddDestination(destination);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogPublisher.java
@@ -97,17 +97,17 @@ final class LogPublisher
         return publication.sessionId();
     }
 
-    void addPassiveFollower(final String followerLogEndpoint)
+    void addPassiveFollower(final boolean logChannelIsMultiDestination, final String followerLogEndpoint)
     {
-        if (null != publication)
+        if (logChannelIsMultiDestination && null != publication)
         {
             publication.asyncAddDestination("aeron:udp?endpoint=" + followerLogEndpoint);
         }
     }
 
-    void removePassiveFollower(final String followerLogEndpoint)
+    void removePassiveFollower(final boolean logChannelIsMultiDestination, final String followerLogEndpoint)
     {
-        if (null != publication)
+        if (logChannelIsMultiDestination && null != publication)
         {
             publication.asyncRemoveDestination("aeron:udp?endpoint=" + followerLogEndpoint);
         }

--- a/aeron-samples/scripts/cluster/agent-ns
+++ b/aeron-samples/scripts/cluster/agent-ns
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -euo pipefail
+
+source ./script-common
+
+mkdir -p logs
+
+# tag::start_jvm[]
+function startNode() {
+
+    namespace=ns_cluster$1
+
+    sudo ip netns exec ${namespace} su - ${USER} -c "cd ${PWD} && \
+    ${JAVA_HOME}/bin/java \
+        -cp ../../../aeron-all/build/libs/aeron-all-${VERSION}.jar:../../../aeron-test-support/build/libs/aeron-test-support-${VERSION}.jar \
+        -javaagent:../../../aeron-agent/build/libs/aeron-agent-${VERSION}.jar \
+        -XX:+UseBiasedLocking \
+        -XX:BiasedLockingStartupDelay=0 \
+        -XX:+UnlockExperimentalVMOptions \
+        -XX:+TrustFinalNonStaticFields \
+        -XX:+UnlockDiagnosticVMOptions \
+        -XX:GuaranteedSafepointInterval=300000 \
+        -XX:+UseParallelOldGC \
+        ${JVM_OPTS:-} ${ADD_OPENS} \
+        io.aeron.test.launcher.RemoteLaunchServer > logs/launch-$1.log" &
+}
+
+function startAll() {
+  startNode 0
+  startNode 1
+  startNode 2
+
+  tail -n 100 -F logs/launch-*.log
+}
+# end::start_jvm[]
+
+if [[ $# -lt 1 ]]; then
+  startAll
+elif [[ $1 == 0 ]] || [[ $1 == 1 ]] || [[ $1 == 2 ]]; then
+  echo "starting node $1"
+  startNode $1
+else
+  echo "Usage: ./basic-auction-cluster [0,1,2]"
+  exit 1
+fi
+
+

--- a/aeron-samples/scripts/cluster/basic-auction-client-ns
+++ b/aeron-samples/scripts/cluster/basic-auction-client-ns
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -euo pipefail
+
+source ./script-common
+
+# tag::start_jvm[]
+function startNode() {
+    ${JAVA_HOME}/bin/java \
+        -cp ../../../aeron-all/build/libs/aeron-all-${VERSION}.jar \
+        -XX:+UseBiasedLocking \
+        -XX:BiasedLockingStartupDelay=0 \
+        -XX:+UnlockExperimentalVMOptions \
+        -XX:+TrustFinalNonStaticFields \
+        -XX:+UnlockDiagnosticVMOptions \
+        -XX:GuaranteedSafepointInterval=300000 \
+        -XX:+UseParallelOldGC \
+        -Daeron.cluster.tutorial.customerId="$1" \
+        -Daeron.cluster.tutorial.numOfBids="$2" \
+        -Daeron.cluster.tutorial.bidIntervalMs="$3" \
+        -Daeron.cluster.tutorial.hostnames=10.42.0.10,10.42.0.11,10.42.0.12 \
+        ${JVM_OPTS:-} ${ADD_OPENS} \
+        io.aeron.samples.cluster.tutorial.BasicAuctionClusterClient
+}
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: ./basic-action-client <customer id> [number of bids (default 10)] [bid interval ms (default 1000)]"
+  exit 1
+fi
+
+CUSTOMER_ID=${1}
+NUM_OF_BIDS=${2:-10}
+BID_INTERVAL_MS=${3:-1000}
+
+startNode ${CUSTOMER_ID} ${NUM_OF_BIDS} ${BID_INTERVAL_MS}
+# end::start_jvm[]
+

--- a/aeron-samples/scripts/cluster/basic-auction-cluster
+++ b/aeron-samples/scripts/cluster/basic-auction-cluster
@@ -52,7 +52,7 @@ elif [[ $1 == 0 ]] || [[ $1 == 1 ]] || [[ $1 == 2 ]]; then
   echo "starting node $1"
   startNode $1
 else
-  echo "Usage: ./basic-auction-cluster [1,2,3]"
+  echo "Usage: ./basic-auction-cluster [0,1,2]"
   exit 1
 fi
 

--- a/aeron-samples/scripts/cluster/basic-auction-cluster-ns
+++ b/aeron-samples/scripts/cluster/basic-auction-cluster-ns
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -euo pipefail
+
+source ./script-common
+
+mkdir -p logs
+
+# tag::start_jvm[]
+function startNode() {
+
+    namespace=ns_cluster$1
+
+    sudo ip netns exec ${namespace} su - ${USER} -c "cd ${PWD} && \
+    ${JAVA_HOME}/bin/java \
+        -cp ../../../aeron-all/build/libs/aeron-all-${VERSION}.jar \
+        -javaagent:../../../aeron-agent/build/libs/aeron-agent-${VERSION}.jar \
+        -XX:+UseBiasedLocking \
+        -XX:BiasedLockingStartupDelay=0 \
+        -XX:+UnlockExperimentalVMOptions \
+        -XX:+TrustFinalNonStaticFields \
+        -XX:+UnlockDiagnosticVMOptions \
+        -XX:GuaranteedSafepointInterval=300000 \
+        -XX:+UseParallelOldGC \
+        -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.ssl.need.client.auth=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false \
+        -Daeron.event.cluster.log=all \
+        -Daeron.cluster.tutorial.hostnames=10.42.0.10,10.42.0.11,10.42.0.12 \
+        -Daeron.cluster.tutorial.nodeId=$1 \
+        ${JVM_OPTS:-} ${ADD_OPENS} \
+        io.aeron.samples.cluster.tutorial.BasicAuctionClusteredServiceNode > logs/cluster-$1.log" &
+}
+
+function startAll() {
+  startNode 0
+  startNode 1
+  startNode 2
+
+  tail -n 100 -F logs/cluster-*.log
+}
+# end::start_jvm[]
+
+if [[ $# -lt 1 ]]; then
+  startAll
+elif [[ $1 == 0 ]] || [[ $1 == 1 ]] || [[ $1 == 2 ]]; then
+  echo "starting node $1"
+  startNode $1
+else
+  echo "Usage: ./basic-auction-cluster [0,1,2]"
+  exit 1
+fi
+
+

--- a/aeron-samples/scripts/cluster/remove-namespaces
+++ b/aeron-samples/scripts/cluster/remove-namespaces
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+sudo ip -all netns delete
+sudo ip link delete br_c
+

--- a/aeron-samples/scripts/cluster/setup-namespaces
+++ b/aeron-samples/scripts/cluster/setup-namespaces
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2020 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+set -euox pipefail
+
+sudo ip netns add ns_cluster0
+sudo ip netns add ns_cluster1
+sudo ip netns add ns_cluster2
+
+sudo ip link add name br_c type bridge
+sudo ip link set br_c up
+
+sudo ip link add veth_cluster0 type veth peer name br_cluster0
+sudo ip link set veth_cluster0 netns ns_cluster0
+sudo ip netns exec ns_cluster0 ip addr add 10.42.0.10/24 dev veth_cluster0
+sudo ip netns exec ns_cluster0 ip link set veth_cluster0 up
+sudo ip link set br_cluster0 up
+
+sudo ip link add veth_cluster1 type veth peer name br_cluster1
+sudo ip link set veth_cluster1 netns ns_cluster1
+sudo ip netns exec ns_cluster1 ip addr add 10.42.0.11/24 dev veth_cluster1
+sudo ip netns exec ns_cluster1 ip link set veth_cluster1 up
+sudo ip link set br_cluster1 up
+
+sudo ip link add veth_cluster2 type veth peer name br_cluster2
+sudo ip link set veth_cluster2 netns ns_cluster2
+sudo ip netns exec ns_cluster2 ip addr add 10.42.0.12/24 dev veth_cluster2
+sudo ip netns exec ns_cluster2 ip link set veth_cluster2 up
+sudo ip link set br_cluster2 up
+
+sudo ip link set br_cluster0 master br_c
+sudo ip link set br_cluster1 master br_c
+sudo ip link set br_cluster2 master br_c
+sudo ip addr add 10.42.0.1/24 brd + dev br_c
+

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoService.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoService.java
@@ -1,0 +1,63 @@
+package io.aeron.samples.cluster;
+
+import io.aeron.ExclusivePublication;
+import io.aeron.Image;
+import io.aeron.cluster.codecs.CloseReason;
+import io.aeron.cluster.service.ClientSession;
+import io.aeron.cluster.service.Cluster;
+import io.aeron.cluster.service.ClusteredService;
+import io.aeron.logbuffer.Header;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdleStrategy;
+
+public class EchoService implements ClusteredService
+{
+    protected Cluster cluster;
+    protected IdleStrategy idleStrategy;
+
+    public void onStart(final Cluster cluster, final Image snapshotImage)
+    {
+        this.cluster = cluster;
+        this.idleStrategy = cluster.idleStrategy();
+    }
+
+    public void onSessionOpen(final ClientSession session, final long timestamp)
+    {
+    }
+
+    public void onSessionClose(final ClientSession session, final long timestamp, final CloseReason closeReason)
+    {
+    }
+
+    public void onSessionMessage(
+        final ClientSession session,
+        final long timestamp,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length,
+        final Header header)
+    {
+        System.out.println("Echoing: " + length + " bytes");
+        idleStrategy.reset();
+        while (session.offer(buffer, offset, length) < 0)
+        {
+            idleStrategy.idle();
+        }
+    }
+
+    public void onTimerEvent(final long correlationId, final long timestamp)
+    {
+    }
+
+    public void onTakeSnapshot(final ExclusivePublication snapshotPublication)
+    {
+    }
+
+    public void onRoleChange(final Cluster.Role newRole)
+    {
+    }
+
+    public void onTerminate(final Cluster cluster)
+    {
+    }
+}

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoServiceNode.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoServiceNode.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.samples.cluster;
+
+import io.aeron.ChannelUriStringBuilder;
+import io.aeron.CommonContext;
+import io.aeron.archive.Archive;
+import io.aeron.archive.ArchiveThreadingMode;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.cluster.ClusteredMediaDriver;
+import io.aeron.cluster.ConsensusModule;
+import io.aeron.cluster.service.ClusteredServiceContainer;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.MinMulticastFlowControlSupplier;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.samples.cluster.tutorial.BasicAuctionClusteredService;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.NoOpLock;
+import org.agrona.concurrent.ShutdownSignalBarrier;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Integer.parseInt;
+
+/**
+ * Node that launches the service for the {@link BasicAuctionClusteredService}.
+ */
+// tag::new_service[]
+public class EchoServiceNode
+// end::new_service[]
+{
+    private static ErrorHandler errorHandler(final String context)
+    {
+        return
+            (Throwable throwable) ->
+            {
+                System.err.println(context);
+                throwable.printStackTrace(System.err);
+            };
+    }
+
+    // tag::ports[]
+    private static final int PORT_BASE = 9000;
+    private static final int PORTS_PER_NODE = 100;
+    private static final int ARCHIVE_CONTROL_REQUEST_PORT_OFFSET = 1;
+    static final int CLIENT_FACING_PORT_OFFSET = 2;
+    private static final int MEMBER_FACING_PORT_OFFSET = 3;
+    private static final int LOG_PORT_OFFSET = 4;
+    private static final int TRANSFER_PORT_OFFSET = 5;
+    private static final int LOG_CONTROL_PORT_OFFSET = 6;
+    private static final int TERM_LENGTH = 64 * 1024;
+
+    static int calculatePort(final int nodeId, final int offset)
+    {
+        return PORT_BASE + (nodeId * PORTS_PER_NODE) + offset;
+    }
+    // end::ports[]
+
+    // tag::udp_channel[]
+    private static String udpChannel(final int nodeId, final String hostname, final int portOffset)
+    {
+        final int port = calculatePort(nodeId, portOffset);
+        return new ChannelUriStringBuilder()
+            .media("udp")
+            .termLength(TERM_LENGTH)
+            .endpoint(hostname + ":" + port)
+            .build();
+    }
+    // end::udp_channel[]
+
+    private static String logControlChannel(final int nodeId, final String hostname, final int portOffset)
+    {
+        final int port = calculatePort(nodeId, portOffset);
+        return new ChannelUriStringBuilder()
+            .media("udp")
+            .termLength(TERM_LENGTH)
+            .controlMode("manual")
+            .controlEndpoint(hostname + ":" + port)
+            .build();
+    }
+
+    public static String clusterMembers(final List<String> hostnames)
+    {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < hostnames.size(); i++)
+        {
+            sb.append(i);
+            sb.append(',').append(hostnames.get(i)).append(':').append(calculatePort(i, CLIENT_FACING_PORT_OFFSET));
+            sb.append(',').append(hostnames.get(i)).append(':').append(calculatePort(i, MEMBER_FACING_PORT_OFFSET));
+            sb.append(',').append(hostnames.get(i)).append(':').append(calculatePort(i, LOG_PORT_OFFSET));
+            sb.append(',').append(hostnames.get(i)).append(':').append(calculatePort(i, TRANSFER_PORT_OFFSET));
+            sb.append(',').append(hostnames.get(i)).append(':')
+                .append(calculatePort(i, ARCHIVE_CONTROL_REQUEST_PORT_OFFSET));
+            sb.append('|');
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Main method for launching the process.
+     *
+     * @param args passed to the process.
+     */
+    // tag::main[]
+    public static void main(final String[] args)
+    {
+        final int nodeId = parseInt(System.getProperty("aeron.cluster.tutorial.nodeId"));               // <1>
+        final String[] hostnames = System.getProperty(
+            "aeron.cluster.tutorial.hostnames", "localhost,localhost,localhost").split(",");            // <2>
+        final String hostname = hostnames[nodeId];
+
+        final File baseDir = new File(System.getProperty("user.dir"), "node" + nodeId);                 // <3>
+        final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + nodeId + "-driver";
+
+        final ShutdownSignalBarrier barrier = new ShutdownSignalBarrier();                              // <4>
+        // end::main[]
+
+        // tag::media_driver[]
+        final MediaDriver.Context mediaDriverContext = new MediaDriver.Context()
+            .aeronDirectoryName(aeronDirName)
+            .threadingMode(ThreadingMode.SHARED)
+            .termBufferSparseFile(true)
+            .multicastFlowControlSupplier(new MinMulticastFlowControlSupplier())
+            .terminationHook(barrier::signal)
+            .errorHandler(EchoServiceNode.errorHandler("Media Driver"));
+        // end::media_driver[]
+
+        // tag::archive[]
+        final Archive.Context archiveContext = new Archive.Context()
+            .aeronDirectoryName(aeronDirName)
+            .archiveDir(new File(baseDir, "archive"))
+            .controlChannel(udpChannel(nodeId, hostname, ARCHIVE_CONTROL_REQUEST_PORT_OFFSET))
+            .localControlChannel("aeron:ipc?term-length=64k")
+            .recordingEventsEnabled(false)
+            .threadingMode(ArchiveThreadingMode.SHARED);
+        // end::archive[]
+
+        // tag::archive_client[]
+        final AeronArchive.Context aeronArchiveContext = new AeronArchive.Context()
+            .lock(NoOpLock.INSTANCE)
+            .controlRequestChannel(archiveContext.localControlChannel())
+            .controlRequestStreamId(archiveContext.localControlStreamId())
+            .controlResponseChannel(archiveContext.localControlChannel())
+            .aeronDirectoryName(aeronDirName);
+        // end::archive_client[]
+
+        // tag::consensus_module[]
+        final ConsensusModule.Context consensusModuleContext = new ConsensusModule.Context()
+            .errorHandler(errorHandler("Consensus Module"))
+            .clusterMemberId(nodeId)                                                                     // <1>
+            .clusterMembers(clusterMembers(Arrays.asList(hostnames)))                                    // <2>
+            .clusterDir(new File(baseDir, "consensus-module"))                                           // <3>
+            .logChannel(logControlChannel(nodeId, hostname, LOG_CONTROL_PORT_OFFSET))                    // <5>
+            .archiveContext(aeronArchiveContext.clone());                                                // <6>
+        // end::consensus_module[]
+
+        // tag::clustered_service[]
+        final ClusteredServiceContainer.Context clusteredServiceContext =
+            new ClusteredServiceContainer.Context()
+            .aeronDirectoryName(aeronDirName)                                                            // <1>
+            .archiveContext(aeronArchiveContext.clone())                                                 // <2>
+            .clusterDir(new File(baseDir, "service"))
+            .clusteredService(new EchoService())                                                         // <3>
+            .errorHandler(errorHandler("Clustered Service"));
+        // end::clustered_service[]
+
+        // tag::running[]
+        try (
+            ClusteredMediaDriver clusteredMediaDriver = ClusteredMediaDriver.launch(
+                mediaDriverContext, archiveContext, consensusModuleContext);                             // <1>
+            ClusteredServiceContainer container = ClusteredServiceContainer.launch(
+                clusteredServiceContext))                                                                // <2>
+        {
+            System.out.println("[" + nodeId + "] Started Cluster Node on " + hostname + "...");
+            barrier.await();                                                                             // <3>
+            System.out.println("[" + nodeId + "] Exiting");
+        }
+        // end::running[]
+    }
+}

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoServiceNode.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/EchoServiceNode.java
@@ -166,7 +166,6 @@ public class EchoServiceNode
             .clusterMemberId(nodeId)                                                                     // <1>
             .clusterMembers(clusterMembers(Arrays.asList(hostnames)))                                    // <2>
             .clusterDir(new File(baseDir, "consensus-module"))                                           // <3>
-            .logChannel(logControlChannel(nodeId, hostname, LOG_CONTROL_PORT_OFFSET))                    // <5>
             .archiveContext(aeronArchiveContext.clone());                                                // <6>
         // end::consensus_module[]
 

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusterClient.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusterClient.java
@@ -191,7 +191,10 @@ public class BasicAuctionClusterClient implements EgressListener
         final int numOfBids = Integer.parseInt(System.getProperty("aeron.cluster.tutorial.numOfBids"));         // <2>
         final int bidIntervalMs = Integer.parseInt(System.getProperty("aeron.cluster.tutorial.bidIntervalMs")); // <3>
 
-        final String ingressEndpoints = ingressEndpoints(Arrays.asList("localhost", "localhost", "localhost"));
+        final String[] hostnames = System.getProperty(
+            "aeron.cluster.tutorial.hostnames", "localhost,localhost,localhost").split(",");
+        final String ingressEndpoints = ingressEndpoints(Arrays.asList(hostnames));
+
         final BasicAuctionClusterClient client = new BasicAuctionClusterClient(customerId, numOfBids, bidIntervalMs);
 
         // tag::connect[]

--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredServiceNode.java
@@ -119,15 +119,15 @@ public class BasicAuctionClusteredServiceNode
     // tag::main[]
     public static void main(final String[] args)
     {
-        final int nodeId = parseInt(System.getProperty("aeron.cluster.tutorial.nodeId"));                // <1>
+        final int nodeId = parseInt(System.getProperty("aeron.cluster.tutorial.nodeId"));               // <1>
+        final String[] hostnames = System.getProperty(
+            "aeron.cluster.tutorial.hostnames", "localhost,localhost,localhost").split(",");            // <2>
+        final String hostname = hostnames[nodeId];
 
-        final List<String> hostnames = Arrays.asList("localhost", "localhost", "localhost");             // <2>
-        final String hostname = hostnames.get(nodeId);
-
-        final File baseDir = new File(System.getProperty("user.dir"), "node" + nodeId);            // <3>
+        final File baseDir = new File(System.getProperty("user.dir"), "node" + nodeId);                 // <3>
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + nodeId + "-driver";
 
-        final ShutdownSignalBarrier barrier = new ShutdownSignalBarrier();                               // <4>
+        final ShutdownSignalBarrier barrier = new ShutdownSignalBarrier();                              // <4>
         // end::main[]
 
         // tag::media_driver[]
@@ -144,7 +144,7 @@ public class BasicAuctionClusteredServiceNode
         final Archive.Context archiveContext = new Archive.Context()
             .aeronDirectoryName(aeronDirName)
             .archiveDir(new File(baseDir, "archive"))
-            .controlChannel(udpChannel(nodeId, "localhost", ARCHIVE_CONTROL_REQUEST_PORT_OFFSET))
+            .controlChannel(udpChannel(nodeId, hostname, ARCHIVE_CONTROL_REQUEST_PORT_OFFSET))
             .localControlChannel("aeron:ipc?term-length=64k")
             .recordingEventsEnabled(false)
             .threadingMode(ArchiveThreadingMode.SHARED);
@@ -163,8 +163,8 @@ public class BasicAuctionClusteredServiceNode
         final ConsensusModule.Context consensusModuleContext = new ConsensusModule.Context()
             .errorHandler(errorHandler("Consensus Module"))
             .clusterMemberId(nodeId)                                                                     // <1>
-            .clusterMembers(clusterMembers(hostnames))                                                   // <2>
-            .clusterDir(new File(baseDir, "consensus-module"))                                     // <3>
+            .clusterMembers(clusterMembers(Arrays.asList(hostnames)))                                    // <2>
+            .clusterDir(new File(baseDir, "consensus-module"))                                           // <3>
             .ingressChannel("aeron:udp?term-length=64k")                                                 // <4>
             .logChannel(logControlChannel(nodeId, hostname, LOG_CONTROL_PORT_OFFSET))                    // <5>
             .archiveContext(aeronArchiveContext.clone());                                                // <6>

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -1,0 +1,348 @@
+package io.aeron.cluster;
+
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.VirtualMachineDescriptor;
+import io.aeron.cluster.client.AeronCluster;
+import io.aeron.cluster.client.EgressListener;
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.ThreadingMode;
+import io.aeron.samples.cluster.EchoServiceNode;
+import io.aeron.samples.cluster.tutorial.BasicAuctionClusterClient;
+import io.aeron.test.Tests;
+import io.aeron.test.TopologyTest;
+import io.aeron.test.launcher.FileResolveUtil;
+import io.aeron.test.launcher.RemoteLaunchClient;
+import org.agrona.IoUtil;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.MutableReference;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TopologyTest
+public class ClusterNetworkTopologyTest
+{
+    private static final int REMOTE_LAUNCH_PORT = 11112;
+    private static final String NODE_0_HOST = "10.42.0.10";
+    private static final String NODE_1_HOST = "10.42.0.11";
+    private static final String NODE_2_HOST = "10.42.0.12";
+    private static final String INGRESS_ENDPOINTS = BasicAuctionClusterClient.ingressEndpoints(
+        Arrays.asList(NODE_0_HOST, NODE_1_HOST, NODE_2_HOST));
+
+    @BeforeEach
+    void setUp()
+    {
+        Tests.await(
+            () ->
+            {
+                final List<VirtualMachineDescriptor> list = VirtualMachine.list();
+                final List<VirtualMachineDescriptor> echoServices = list.stream()
+                    .filter(vm -> EchoServiceNode.class.getName().equals(vm.displayName()))
+                    .collect(Collectors.toList());
+
+                if (!echoServices.isEmpty())
+                {
+                    System.out.println(echoServices);
+                    Tests.sleep(200);
+                }
+
+                return echoServices.isEmpty();
+            },
+            SECONDS.toNanos(5)
+        );
+
+        final File scriptDir = FileResolveUtil.resolveClusterScriptDir();
+        IoUtil.delete(new File(scriptDir, "node0"), true);
+        IoUtil.delete(new File(scriptDir, "node1"), true);
+        IoUtil.delete(new File(scriptDir, "node2"), true);
+    }
+
+    @Test
+    void shouldGetNetworkInformationFromAgentNodes() throws IOException
+    {
+        RemoteLaunchClient.connect(NODE_0_HOST, REMOTE_LAUNCH_PORT).executeBlocking(System.out, "/usr/sbin/ip", "a");
+        RemoteLaunchClient.connect(NODE_1_HOST, REMOTE_LAUNCH_PORT).executeBlocking(System.out, "/usr/sbin/ip", "a");
+        RemoteLaunchClient.connect(NODE_2_HOST, REMOTE_LAUNCH_PORT).executeBlocking(System.out, "/usr/sbin/ip", "a");
+    }
+
+    private static Stream<Arguments> provideTopologyConfigurations()
+    {
+        return Stream.of(
+            Arguments.of("aeron:udp", INGRESS_ENDPOINTS),
+            Arguments.of("aeron:udp?endpoint=239.20.90.11:9152|interface=10.42.0.0/24", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTopologyConfigurations")
+    void shouldGetEchoFromCluster(final String ingressChannel, final String ingressEndpoints) throws Exception
+    {
+        try (
+            RemoteLaunchClient remote0 = RemoteLaunchClient.connect(NODE_0_HOST, REMOTE_LAUNCH_PORT);
+            RemoteLaunchClient remote1 = RemoteLaunchClient.connect(NODE_1_HOST, REMOTE_LAUNCH_PORT);
+            RemoteLaunchClient remote2 = RemoteLaunchClient.connect(NODE_2_HOST, REMOTE_LAUNCH_PORT))
+        {
+            final String hostnames = NODE_0_HOST + "," + NODE_1_HOST + "," + NODE_2_HOST;
+            final String[] command0 = deriveCommand(hostnames, 0, ingressChannel);
+            final String[] command1 = deriveCommand(hostnames, 1, ingressChannel);
+            final String[] command2 = deriveCommand(hostnames, 2, ingressChannel);
+
+            final SocketChannel execute0 = remote0.execute(false, command0);
+            final SocketChannel execute1 = remote1.execute(false, command1);
+            final SocketChannel execute2 = remote2.execute(false, command2);
+
+            final Node node0 = new Node("Node 0");
+            final Node node1 = new Node("Node 1");
+            final Node node2 = new Node("Node 2");
+
+            final Selector selector = Selector.open();
+            execute0.register(selector, SelectionKey.OP_READ, node0);
+            execute1.register(selector, SelectionKey.OP_READ, node1);
+            execute2.register(selector, SelectionKey.OP_READ, node2);
+
+            boolean node0Started = false;
+            boolean node1Started = false;
+            boolean node2Started = false;
+
+            while (!node0Started || !node1Started || !node2Started)
+            {
+                pollSelector(selector);
+                node0Started = node0Started || node0.checkOutput("Started Cluster Node");
+                node1Started = node1Started || node1.checkOutput("Started Cluster Node");
+                node2Started = node2Started || node2.checkOutput("Started Cluster Node");
+            }
+
+            final String message = "Hello World!";
+            final MutableDirectBuffer messageBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(128));
+            final int length = messageBuffer.putStringAscii(0, message);
+            final MutableReference<String> egressResponse = new MutableReference<>();
+
+            final EgressListener egressListener = (clusterSessionId, timestamp, buffer, offset, length1, header) ->
+            {
+                final String stringAscii = buffer.getStringAscii(offset);
+                System.out.println("Response: " + stringAscii);
+                egressResponse.set(stringAscii);
+            };
+
+            try (
+                MediaDriver mediaDriver = MediaDriver.launchEmbedded(new MediaDriver.Context()
+                    .threadingMode(ThreadingMode.SHARED)
+                    .dirDeleteOnStart(true)
+                    .dirDeleteOnShutdown(true));
+                AeronCluster aeronCluster = AeronCluster.connect(
+                    new AeronCluster.Context()
+                    .egressListener(egressListener)
+                    .egressChannel("aeron:udp?endpoint=10.42.0.1:0")
+                    .aeronDirectoryName(mediaDriver.aeronDirectoryName())
+                    .ingressChannel(ingressChannel)
+                    .ingressEndpoints(ingressEndpoints)))
+            {
+                Tests.await(
+                    () ->
+                    {
+                        final long position = aeronCluster.offer(messageBuffer, 0, length);
+                        pollSelector(selector);
+                        return 0 < position;
+                    },
+                    SECONDS.toNanos(5)
+                );
+
+                Tests.await(
+                    () ->
+                    {
+                        aeronCluster.pollEgress();
+                        pollSelector(selector);
+                        return message.equals(egressResponse.get());
+                    },
+                    SECONDS.toNanos(5)
+                );
+            }
+        }
+    }
+
+    @Test
+    void shouldMatchPatternSplitAcrossReads()
+    {
+        final Node n = new Node("Node");
+        final String s = "Some text first: \u1F600";
+        final byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+
+        final ByteBuffer allocate = ByteBuffer.allocate(1024);
+        allocate.put(bytes, 0, 19);
+        n.applyResponseData(allocate);
+        allocate.put(bytes, 19, bytes.length - 19);
+        n.applyResponseData(allocate);
+
+        assertTrue(n.checkOutput(s));
+    }
+
+    @Test
+    void shouldMatchPatternSplitAcrossBufferBoundary()
+    {
+        final Node n = new Node("Node");
+        final String s = "Some text first: \u1F600";
+        final byte[] toMatch = s.getBytes(StandardCharsets.UTF_8);
+        final byte[] bytes = new byte[4096];
+        Arrays.fill(bytes, (byte)'a');
+
+        final ByteBuffer allocate = ByteBuffer.allocate(4096);
+
+        allocate.put(bytes);
+        n.applyResponseData(allocate);
+
+        System.arraycopy(toMatch, 0, bytes, bytes.length - (toMatch.length / 2), toMatch.length / 2);
+        allocate.put(bytes);
+        n.applyResponseData(allocate);
+
+        Arrays.fill(bytes, (byte)'a');
+        System.arraycopy(toMatch, (toMatch.length / 2), bytes, 0, toMatch.length - (toMatch.length / 2));
+        allocate.put(bytes);
+        n.applyResponseData(allocate);
+
+        assertTrue(n.checkOutput(s));
+    }
+
+    private static final class Node
+    {
+        private final String name;
+        private final CharBuffer textOutput = CharBuffer.allocate(8192);
+        private final ByteBuffer binaryOutput = ByteBuffer.allocateDirect(textOutput.capacity() / 2);
+        private final CharBuffer textOutputDup = textOutput.duplicate();
+        private final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+
+        Node(final String name)
+        {
+            this.name = name;
+        }
+
+        public void readChannel(final ReadableByteChannel channel) throws IOException
+        {
+            final int read = channel.read(binaryOutput);
+            if (read <= 0)
+            {
+                return;
+            }
+
+            int initialTextPosition = textOutput.position();
+            applyResponseData(binaryOutput);
+            final int resultTextPosition = textOutput.position();
+
+            if (resultTextPosition < initialTextPosition)
+            {
+                initialTextPosition -= textOutput.capacity() / 2;
+            }
+
+            assert initialTextPosition <= resultTextPosition;
+
+            textOutputDup.clear().position(initialTextPosition).limit(resultTextPosition);
+            System.out.print(name);
+            System.out.print(": ");
+            System.out.print(textOutputDup);
+        }
+
+        private void applyResponseData(final ByteBuffer data)
+        {
+            data.flip();
+            final CoderResult result = decoder.decode(data, textOutput, false);
+            if (CoderResult.OVERFLOW == result)
+            {
+                textOutput.limit(textOutput.capacity());
+                textOutput.position(textOutput.capacity() / 2);
+                textOutput.compact();
+                decoder.decode(data, textOutput, false);
+            }
+            data.compact();
+        }
+
+        public boolean checkOutput(final String regexToMatch)
+        {
+            final Pattern pattern = Pattern.compile(regexToMatch);
+            final CharBuffer duplicate = textOutput.duplicate();
+            duplicate.flip();
+            final Matcher matcher = pattern.matcher(duplicate);
+            return matcher.find();
+        }
+    }
+
+    private void pollSelector(final Selector selector)
+    {
+        try
+        {
+            final int select = selector.selectNow();
+            if (select < 1)
+            {
+                return;
+            }
+
+            final Set<SelectionKey> selectionKeys = selector.selectedKeys();
+            for (final SelectionKey selectionKey : selectionKeys)
+            {
+                final Node node = (Node)selectionKey.attachment();
+                final ReadableByteChannel toReadFrom = (ReadableByteChannel)selectionKey.channel();
+                node.readChannel(toReadFrom);
+            }
+            selectionKeys.clear();
+        }
+        catch (final IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String[] deriveCommand(
+        final String hostnames,
+        final int nodeId,
+        final String ingressChannel)
+    {
+        final List<String> command = new ArrayList<>();
+        command.add(FileResolveUtil.resolveJavaBinary().getAbsolutePath());
+        if (isVersionAfterJdk8())
+        {
+            command.add("--add-opens");
+            command.add("java.base/sun.nio.ch=ALL-UNNAMED");
+        }
+        command.add("-cp");
+        command.add(FileResolveUtil.resolveAeronAllJar().getAbsolutePath());
+        command.add("-Daeron.dir.delete.on.start=true");
+        command.add("-Daeron.print.configuration=true");
+        command.add("-Daeron.cluster.ingress.channel=" + ingressChannel);
+        command.add("-Daeron.cluster.tutorial.hostnames=" + hostnames);
+        command.add("-Daeron.cluster.tutorial.nodeId=" + nodeId);
+        command.add(EchoServiceNode.class.getName());
+
+        return command.toArray(new String[0]);
+    }
+
+    private static boolean isVersionAfterJdk8()
+    {
+        String versionString = System.getProperty("java.specification.version");
+        versionString = versionString.startsWith("1.") ? versionString.substring(2) : versionString;
+        return Integer.parseInt(versionString) > 8;
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -237,6 +237,29 @@ public class ClusterTest
 
     @Test
     @Timeout(40)
+    public void shouldEchoMessages(final TestInfo testInfo)
+    {
+        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        try
+        {
+            cluster.awaitLeader();
+            cluster.connectClient();
+
+            final int expectedCount = 10;
+
+            cluster.sendMessages(expectedCount);
+            cluster.awaitResponseMessageCount(expectedCount);
+            cluster.awaitServicesMessageCount(expectedCount);
+        }
+        catch (final Throwable ex)
+        {
+            cluster.dumpData(testInfo);
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+    @Test
+    @Timeout(40)
     public void shouldEchoMessagesThenContinueOnNewLeader(final TestInfo testInfo)
     {
         cluster = startThreeNodeStaticCluster(NULL_VALUE);

--- a/aeron-test-support/src/main/java/io/aeron/test/TopologyTest.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/TopologyTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("topology")
+public @interface TopologyTest
+{
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -60,9 +60,11 @@ public class TestCluster implements AutoCloseable
 {
     private static final int SEGMENT_FILE_LENGTH = 16 * 1024 * 1024;
     private static final long CATALOG_CAPACITY = 128 * 1024;
-//    private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
-    private static final String LOG_CHANNEL =
-        "aeron:udp?term-length=512k|endpoint=224.20.30.39:24326|interface=localhost";
+    private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
+    // Use for testing cluster with multicast
+    // TODO: Parameterise tests with this.
+//    private static final String LOG_CHANNEL =
+//        "aeron:udp?term-length=512k|endpoint=224.20.30.39:24326|interface=localhost";
     private static final String ARCHIVE_CONTROL_REQUEST_CHANNEL =
         "aeron:udp?term-length=64k|endpoint=localhost:8010";
     private static final String ARCHIVE_CONTROL_RESPONSE_CHANNEL =

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -60,7 +60,9 @@ public class TestCluster implements AutoCloseable
 {
     private static final int SEGMENT_FILE_LENGTH = 16 * 1024 * 1024;
     private static final long CATALOG_CAPACITY = 128 * 1024;
-    private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
+//    private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";
+    private static final String LOG_CHANNEL =
+        "aeron:udp?term-length=512k|endpoint=224.20.30.39:24326|interface=localhost";
     private static final String ARCHIVE_CONTROL_REQUEST_CHANNEL =
         "aeron:udp?term-length=64k|endpoint=localhost:8010";
     private static final String ARCHIVE_CONTROL_RESPONSE_CHANNEL =

--- a/aeron-test-support/src/main/java/io/aeron/test/launcher/FileResolveUtil.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/launcher/FileResolveUtil.java
@@ -1,0 +1,75 @@
+package io.aeron.test.launcher;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class FileResolveUtil
+{
+    public static File resolveProjectRoot()
+    {
+        final File workingDir = new File(System.getProperty("user.dir"));
+        File parent = workingDir;
+
+        do
+        {
+            final String[] versionTxtFile = parent.list((dir, name) -> "version.txt".equals(name));
+            if (null != versionTxtFile && 1 == versionTxtFile.length)
+            {
+                return parent;
+            }
+
+            parent = workingDir.getParentFile();
+        }
+        while (null != parent);
+
+        throw new RuntimeException("Unable to find project root directory from: " + workingDir);
+    }
+
+    public static File resolveAeronAllJar()
+    {
+        final File projectRoot = resolveProjectRoot();
+        final File allBuildLibs = new File(projectRoot, "aeron-all/build/libs");
+        if (!allBuildLibs.exists())
+        {
+            throw new RuntimeException("Directory: " + allBuildLibs + " does not exist");
+        }
+
+        final File[] aeronAllJarFiles = allBuildLibs.listFiles(
+            (dir, name) -> name.startsWith("aeron-all-") && name.endsWith(".jar"));
+
+        if (null == aeronAllJarFiles || 0 == aeronAllJarFiles.length)
+        {
+            throw new RuntimeException("Unable to find aeron jar files in directory: " + allBuildLibs);
+        }
+
+        if (1 != aeronAllJarFiles.length)
+        {
+            throw new RuntimeException(
+                "Multiple libs found, run './gradlew clean': " + Arrays.toString(aeronAllJarFiles));
+        }
+
+        return aeronAllJarFiles[0];
+    }
+
+    public static File resolveJavaBinary()
+    {
+        final File javaHome = new File(System.getProperty("java.home"));
+        if (!javaHome.exists())
+        {
+            throw new RuntimeException("java.home: " + javaHome + " does not exist??");
+        }
+
+        final File javaBinary = new File(javaHome, "bin/java");
+        if (!javaBinary.exists())
+        {
+            throw new RuntimeException("java binary: " + javaBinary + " does not exist??");
+        }
+
+        return javaBinary;
+    }
+
+    public static File resolveClusterScriptDir()
+    {
+        return new File(resolveProjectRoot(), "aeron-samples/scripts/cluster");
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/launcher/RemoteLaunchClient.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/launcher/RemoteLaunchClient.java
@@ -1,0 +1,75 @@
+package io.aeron.test.launcher;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SocketChannel;
+
+public final class RemoteLaunchClient implements AutoCloseable
+{
+    private final String host;
+    private final int port;
+    private SocketChannel clientChannel;
+
+    private RemoteLaunchClient(final String host, final int port)
+    {
+        this.host = host;
+        this.port = port;
+    }
+
+    public static RemoteLaunchClient connect(final String host, final int port) throws IOException
+    {
+        final RemoteLaunchClient remoteLaunchClient = new RemoteLaunchClient(host, port);
+        remoteLaunchClient.init();
+        return remoteLaunchClient;
+    }
+
+    private void init() throws IOException
+    {
+        clientChannel = SocketChannel.open(new InetSocketAddress(host, port));
+    }
+
+    public ReadableByteChannel execute(final String... command) throws IOException
+    {
+        return execute(true, command);
+    }
+
+    public SocketChannel execute(final boolean usingBlockingIo, final String... command) throws IOException
+    {
+        final ObjectOutputStream out = new ObjectOutputStream(Channels.newOutputStream(clientChannel));
+        out.writeObject(command);
+        out.flush();
+        clientChannel.configureBlocking(usingBlockingIo);
+        return clientChannel;
+    }
+
+    public void executeBlocking(final OutputStream out, final String... command) throws IOException
+    {
+        try (ReadableByteChannel commandResponse = execute(command))
+        {
+            final ByteBuffer buffer = ByteBuffer.allocate(4096);
+            while (commandResponse.isOpen())
+            {
+                final int read = commandResponse.read(buffer);
+                if (read < 0)
+                {
+                    break;
+                }
+
+                buffer.flip();
+                out.write(buffer.array(), buffer.position(), buffer.limit());
+                buffer.clear();
+            }
+        }
+    }
+
+    public void close() throws Exception
+    {
+        clientChannel.close();
+    }
+}
+

--- a/aeron-test-support/src/main/java/io/aeron/test/launcher/RemoteLaunchServer.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/launcher/RemoteLaunchServer.java
@@ -1,0 +1,331 @@
+package io.aeron.test.launcher;
+
+import org.agrona.CloseHelper;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousCloseException;
+import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RemoteLaunchServer
+{
+
+    private final ServerSocketChannel serverChannel;
+    private final Collection<Connection> connections = new ConcurrentLinkedDeque<>();
+
+    public static void main(final String[] args) throws IOException
+    {
+        final String host = System.getProperty("aeron.test.launch.host", "0.0.0.0");
+        final int port = Integer.getInteger("aeron.test.launch.port", 11112);
+
+        final RemoteLaunchServer server = new RemoteLaunchServer(host, port);
+        Runtime.getRuntime().addShutdownHook(new Thread(server::close));
+
+        server.run();
+    }
+
+    public RemoteLaunchServer(final String host, final int port) throws IOException
+    {
+        serverChannel = ServerSocketChannel.open();
+        final InetSocketAddress local = new InetSocketAddress(host, port);
+        serverChannel.bind(local);
+    }
+
+    public void run()
+    {
+        Thread.setDefaultUncaughtExceptionHandler((t, e) ->
+        {
+            System.err.println("Uncaught exception on: " + t);
+            e.printStackTrace(System.err);
+        });
+
+        try
+        {
+            while (!Thread.currentThread().isInterrupted())
+            {
+                final SocketChannel connectionChannel = serverChannel.accept();
+                final Connection connection = new Connection(connectionChannel);
+                connection.start();
+                connections.add(connection);
+            }
+        }
+        catch (final AsynchronousCloseException e)
+        {
+            // Normal close
+        }
+        catch (final IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close()
+    {
+        try
+        {
+            serverChannel.close();
+        }
+        catch (final IOException e)
+        {
+            e.printStackTrace();
+        }
+
+        connections.forEach(Connection::stop);
+    }
+
+    static class Connection
+    {
+        private final SocketChannel connectionChannel;
+        private final AtomicReference<State> currentState = new AtomicReference<>(State.CREATED);
+        private volatile ProcessResponseReader responseReader;
+        private volatile Thread requestThread;
+        private volatile Thread responseThread;
+        private Process process = null;
+
+        private enum State
+        {
+            CREATED,
+            STARTING,
+            PENDING,
+            RUNNING,
+            CLOSING
+        }
+
+        Connection(final SocketChannel connectionChannel)
+        {
+            this.connectionChannel = connectionChannel;
+        }
+
+        public void start()
+        {
+            requestThread = new Thread(this::runRequests);
+            if (currentState.compareAndSet(State.CREATED, State.STARTING))
+            {
+                requestThread.start();
+            }
+        }
+
+        public void stop()
+        {
+            final State state = this.currentState.get();
+            do
+            {
+                switch (state)
+                {
+                    case CREATED:
+                        if (currentState.compareAndSet(State.CREATED, State.CLOSING))
+                        {
+                            return;
+                        }
+                        break;
+
+                    case STARTING:
+                        break;
+
+                    case PENDING:
+                        if (currentState.compareAndSet(State.PENDING, State.CLOSING))
+                        {
+                            try
+                            {
+                                connectionChannel.close();
+                            }
+                            catch (final IOException e)
+                            {
+                                e.printStackTrace();
+                            }
+                            return;
+                        }
+                        break;
+
+                    case RUNNING:
+                        if (currentState.compareAndSet(State.RUNNING, State.CLOSING))
+                        {
+                            responseReader.markClosed();
+                            try
+                            {
+                                connectionChannel.close();
+                            }
+                            catch (final IOException e)
+                            {
+                                e.printStackTrace();
+                            }
+                            process.destroy();
+                            return;
+                        }
+                        break;
+
+                    case CLOSING:
+                        return;
+                }
+            }
+            while (true);
+        }
+
+        private void runRequests()
+        {
+            try
+            {
+                if (!currentState.compareAndSet(State.STARTING, State.PENDING))
+                {
+                    throw new IllegalStateException("Should not happen");
+                }
+
+                final ObjectInputStream requestIn = new ObjectInputStream(Channels.newInputStream(connectionChannel));
+                while (!Thread.currentThread().isInterrupted())
+                {
+                    final Object o = requestIn.readObject();
+                    if (o instanceof String[])
+                    {
+                        final State state = currentState.get();
+                        switch (state)
+                        {
+                            case PENDING:
+                                if (!currentState.compareAndSet(State.PENDING, State.STARTING))
+                                {
+                                    return;
+                                }
+                                currentState.set(startProcess((String[])o));
+
+                                break;
+
+                            case STARTING:
+                                throw new IllegalStateException("Should not happen");
+
+                            case RUNNING:
+                                // Allow submission of more commands???
+                                break;
+
+                            case CLOSING:
+                                return;
+                        }
+                    }
+                    else
+                    {
+                        if (currentState.compareAndSet(State.RUNNING, State.CLOSING) && null != process)
+                        {
+                            responseReader.markClosed();
+                            CloseHelper.close(connectionChannel);
+                            process.destroy();
+                        }
+                    }
+                }
+            }
+            catch (final EOFException e)
+            {
+                if (currentState.compareAndSet(State.RUNNING, State.CLOSING) && null != process)
+                {
+                    responseReader.markClosed();
+                    CloseHelper.close(connectionChannel);
+                    process.destroy();
+                }
+            }
+            catch (final AsynchronousCloseException e)
+            {
+                if (currentState.compareAndSet(State.RUNNING, State.CLOSING) && null != process)
+                {
+                    responseReader.markClosed();
+                    process.destroy();
+                }
+            }
+            catch (final IOException | ClassNotFoundException e)
+            {
+                System.err.println("Error occurred");
+                e.printStackTrace();
+
+                if (currentState.compareAndSet(State.RUNNING, State.CLOSING) && null != process)
+                {
+                    responseReader.markClosed();
+                    CloseHelper.close(connectionChannel);
+                    process.destroy();
+                }
+            }
+        }
+
+        private State startProcess(final String[] command) throws IOException
+        {
+            try
+            {
+                final Process p = new ProcessBuilder(command)
+                    .redirectErrorStream(true)
+                    .start();
+
+                process = p;
+
+                responseReader = new ProcessResponseReader(connectionChannel);
+                responseThread = new Thread(() -> responseReader.runResponses(p.getInputStream()));
+                responseThread.start();
+
+                return State.RUNNING;
+            }
+            catch (final IOException e)
+            {
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                e.printStackTrace(new PrintStream(baos));
+                connectionChannel.write(ByteBuffer.wrap(baos.toByteArray()));
+                connectionChannel.close();
+
+                if (!currentState.compareAndSet(State.STARTING, State.CLOSING))
+                {
+                    throw new IllegalStateException("Should not happen");
+                }
+
+                return State.CLOSING;
+            }
+        }
+    }
+
+    private static final class ProcessResponseReader
+    {
+        private final SocketChannel connectionChannel;
+        private volatile boolean isClosed = false;
+
+        private ProcessResponseReader(final SocketChannel connectionChannel)
+        {
+            this.connectionChannel = connectionChannel;
+        }
+
+        private void runResponses(final InputStream processOutput)
+        {
+            final ByteBuffer data = ByteBuffer.allocate(1024);
+            try
+            {
+                while (!isClosed)
+                {
+                    final int read = processOutput.read(data.array());
+                    if (-1 != read)
+                    {
+                        data.position(0).limit(read);
+                        connectionChannel.write(data);
+                    }
+                    else
+                    {
+                        connectionChannel.close();
+                        break;
+                    }
+                }
+            }
+            catch (final IOException e)
+            {
+                if (!isClosed)
+                {
+                    throw new RuntimeException(e);
+                }
+                else
+                {
+                    System.out.println("Process closed");
+                }
+            }
+        }
+
+        public void markClosed()
+        {
+            isClosed = true;
+        }
+    }
+}

--- a/aeron-test-support/src/test/java/io/aeron/test/launcher/RemoteLauncherTest.java
+++ b/aeron-test-support/src/test/java/io/aeron/test/launcher/RemoteLauncherTest.java
@@ -1,0 +1,53 @@
+package io.aeron.test.launcher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnabledOnOs(OS.LINUX)
+public class RemoteLauncherTest
+{
+    @Test
+    void shouldLaunchShortLivedCommand() throws IOException, InterruptedException
+    {
+        final RemoteLaunchServer server = new RemoteLaunchServer("localhost", 11112);
+        final Thread t = new Thread(server::run);
+        t.start();
+        final RemoteLaunchClient client = RemoteLaunchClient.connect("localhost", 11112);
+        try
+        {
+            final String message = "helloworld";
+            assertTimeoutPreemptively(
+                Duration.ofMillis(5_000),
+                () ->
+                {
+                    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    client.executeBlocking(out, "/usr/bin/echo", message);
+
+                    final byte[] expectedBytes = message.getBytes(StandardCharsets.UTF_8);
+                    final byte[] actualBytes = Arrays.copyOf(out.toByteArray(), expectedBytes.length);
+                    assertArrayEquals(expectedBytes, actualBytes);
+                }
+            );
+        }
+        finally
+        {
+            server.close();
+            t.join();
+        }
+    }
+
+    @Test
+    void shouldResolveAeronAllJar()
+    {
+        assertNotNull(FileResolveUtil.resolveAeronAllJar());
+    }
+}

--- a/aeron-test-support/src/test/java/io/aeron/test/launcher/RemoteLauncherTest.java
+++ b/aeron-test-support/src/test/java/io/aeron/test/launcher/RemoteLauncherTest.java
@@ -30,11 +30,12 @@ public class RemoteLauncherTest
                 () ->
                 {
                     final ByteArrayOutputStream out = new ByteArrayOutputStream();
-                    client.executeBlocking(out, "/usr/bin/echo", message);
+                    client.executeBlocking(out, "echo", message);
 
                     final byte[] expectedBytes = message.getBytes(StandardCharsets.UTF_8);
                     final byte[] actualBytes = Arrays.copyOf(out.toByteArray(), expectedBytes.length);
-                    assertArrayEquals(expectedBytes, actualBytes);
+                    assertArrayEquals(
+                        expectedBytes, actualBytes, out.toString() + " vs " + new String(actualBytes));
                 }
             );
         }

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ subprojects {
         }
 
         useJUnitPlatform {
-            excludeTags 'slow'
+            excludeTags 'slow', 'topology'
         }
 
         testLogging {
@@ -770,6 +770,7 @@ project(':aeron-system-tests') {
     dependencies {
         testImplementation project(':aeron-archive')
         testImplementation project(':aeron-test-support')
+        testImplementation project(':aeron-samples')
         testImplementation project(path: ':aeron-client', configuration: 'tests')
         testImplementation project(path: ':aeron-archive', configuration: 'tests')
         testImplementation project(path: ':aeron-cluster')

--- a/build.gradle
+++ b/build.gradle
@@ -774,6 +774,7 @@ project(':aeron-system-tests') {
         testImplementation project(path: ':aeron-client', configuration: 'tests')
         testImplementation project(path: ':aeron-archive', configuration: 'tests')
         testImplementation project(path: ':aeron-cluster')
+        testCompile files("${System.properties['java.home']}/../lib/tools.jar")
     }
 
     test {


### PR DESCRIPTION
There is still one outstanding test failure as result of this change.  In `shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne` it appears that when extending the recording the image does not become available to the archive's subscription therefore it never constructs the recording counter and ConsensusModule's conductor times out.