### PR TITLE
[Java] Fix AeronStat arguments in help

### DIFF
--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -235,8 +235,8 @@ public class AeronStat
                     "filter by optional regex patterns:%n" +
                     "\t[type=<pattern>]%n" +
                     "\t[identity=<pattern>]%n" +
-                    "\t[sessionId=<pattern>]%n" +
-                    "\t[streamId=<pattern>]%n" +
+                    "\t[session=<pattern>]%n" +
+                    "\t[stream=<pattern>]%n" +
                     "\t[channel=<pattern>]%n");
 
                 System.exit(0);


### PR DESCRIPTION
Addresses minor typos in the help displayed with `-h`:

- `streamId` should be `stream`
- `sessionId` should be `session`