### PR TITLE
[C++] Archive client shared library addition

### DIFF
--- a/aeron-archive/src/main/cpp/CMakeLists.txt
+++ b/aeron-archive/src/main/cpp/CMakeLists.txt
@@ -96,9 +96,11 @@ SET(HEADERS
 
 # static library
 add_library(aeron_archive_client STATIC ${SOURCE} ${HEADERS})
+add_library(aeron_archive_client_shared SHARED ${SOURCE} ${HEADERS})
 add_library(aeron_archive_client_wrapper STATIC ${SOURCE} ${HEADERS})
 
 add_dependencies(aeron_archive_client codecs)
+add_dependencies(aeron_archive_client_shared codecs)
 add_dependencies(aeron_archive_client_wrapper codecs)
 
 target_include_directories(aeron_archive_client
@@ -106,6 +108,10 @@ target_include_directories(aeron_archive_client
     PRIVATE ${ARCHIVE_CODEC_TARGET_DIR})
 
 target_include_directories(aeron_archive_client_wrapper
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${ARCHIVE_CODEC_TARGET_DIR})
+
+target_include_directories(aeron_archive_client_shared
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${ARCHIVE_CODEC_TARGET_DIR})
 
@@ -118,11 +124,17 @@ target_link_libraries(aeron_archive_client
     PRIVATE aeron_client
     INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 
+target_link_libraries(aeron_archive_client_shared
+    PRIVATE aeron_client_shared
+    INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+
 target_link_libraries(aeron_archive_client_wrapper
     PRIVATE aeron_client_wrapper aeron
     INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 
 if (AERON_INSTALL_TARGETS)
-    install(TARGETS aeron_archive_client ARCHIVE DESTINATION lib)
+    install(TARGETS aeron_archive_client_shared aeron_archive_client 
+        LIBRARY DESTINATION lib 
+        ARCHIVE DESTINATION lib)
     install(DIRECTORY . DESTINATION include FILES_MATCHING PATTERN "*.h")
 endif ()


### PR DESCRIPTION
Created additional shared lib version of aeron_archive_client.a (ie aeron_archive_client_shared.so).

This is similar to previous changes made to aeron_client.a were there was an addition to generate aeron_client_shared.so ( https://github.com/real-logic/aeron/commit/0e716c5cdee513e2f051606b7ee4ce73e89608fe#diff-751998d20f15036aea603a63c5dae00781bdc2258315bc2269a1698dd6fff51d )