### PR TITLE
[C++] Use MMAP_POPULATE for faster prefaulting on Linux

### DIFF
--- a/aeron-client/src/main/cpp/LogBuffers.cpp
+++ b/aeron-client/src/main/cpp/LogBuffers.cpp
@@ -16,6 +16,10 @@
 
 #include "LogBuffers.h"
 
+#if defined(__linux__) || defined(_WIN32)
+#define AERON_NATIVE_PRETOUCH
+#endif
+
 namespace aeron
 {
 
@@ -47,7 +51,7 @@ LogBuffers::LogBuffers(const char *filename, bool preTouch)
         m_buffers[i].wrap(basePtr + (i * termLength), static_cast<std::size_t>(termLength));
     }
 
-#ifndef __linux__
+#ifndef AERON_NATIVE_PRETOUCH
     if (preTouch)
     {
         for (int i = 0; i < LogBufferDescriptor::PARTITION_COUNT; i++)

--- a/aeron-client/src/main/cpp/LogBuffers.cpp
+++ b/aeron-client/src/main/cpp/LogBuffers.cpp
@@ -26,7 +26,7 @@ LogBuffers::LogBuffers(const char *filename, bool preTouch)
 {
     const std::int64_t logLength = MemoryMappedFile::getFileSize(filename);
 
-    m_memoryMappedFiles = MemoryMappedFile::mapExisting(filename);
+    m_memoryMappedFiles = MemoryMappedFile::mapExisting(filename, false, preTouch);
 
     std::uint8_t *basePtr = m_memoryMappedFiles->getMemoryPtr();
 
@@ -47,6 +47,7 @@ LogBuffers::LogBuffers(const char *filename, bool preTouch)
         m_buffers[i].wrap(basePtr + (i * termLength), static_cast<std::size_t>(termLength));
     }
 
+#ifndef __linux__
     if (preTouch)
     {
         for (int i = 0; i < LogBufferDescriptor::PARTITION_COUNT; i++)
@@ -59,6 +60,7 @@ LogBuffers::LogBuffers(const char *filename, bool preTouch)
             }
         }
     }
+#endif
 }
 
 LogBuffers::LogBuffers(std::uint8_t *address, std::int64_t logLength, std::int32_t termLength)

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
@@ -257,6 +257,18 @@ MemoryMappedFile::MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_
         cleanUp();
         throw IOException(std::string("failed to Map Memory: ") + toString(GetLastError()), SOURCEINFO);
     }
+
+    if (preTouch)
+    {
+        WIN32_MEMORY_RANGE_ENTRY entry;
+        entry.NumberOfBytes = m_memorySize;
+        entry.VirtualAddress = m_memory ;
+        if (!PrefetchVirtualMemory(GetCurrentProcess(), 1, &entry, 0))
+        {
+            cleanUp();
+            throw IOException(std::string("failed to prefetch Memory: ") + toString(GetLastError()), SOURCEINFO);
+        }
+    }
 }
 
 void MemoryMappedFile::cleanUp()

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.cpp
@@ -66,7 +66,8 @@ bool MemoryMappedFile::fill(FileHandle fd, std::size_t size, std::uint8_t value)
     return true;
 }
 
-MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, std::size_t offset, std::size_t size)
+MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, std::size_t offset, std::size_t size,
+    bool preTouch)
 {
     FileHandle fd{};
     fd.handle = ::CreateFile(
@@ -98,14 +99,14 @@ MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, std::s
             std::string("failed to write to file: ") + filename + " " + toString(GetLastError()), SOURCEINFO);
     }
 
-    auto obj = MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, false));
+    auto obj = MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, false, preTouch));
     fd.handle = INVALID_HANDLE_VALUE;
 
     return obj;
 }
 
 MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(
-    const char *filename, std::size_t offset, std::size_t size, bool readOnly)
+    const char *filename, std::size_t offset, std::size_t size, bool readOnly, bool preTouch)
 {
     DWORD dwDesiredAccess = readOnly ? GENERIC_READ : (GENERIC_READ | GENERIC_WRITE);
     DWORD dwSharedMode = FILE_SHARE_READ | FILE_SHARE_WRITE;
@@ -134,7 +135,7 @@ MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(
             }
         });
 
-    auto obj = MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, readOnly));
+    auto obj = MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, readOnly, preTouch));
     fd.handle = INVALID_HANDLE_VALUE;
 
     return obj;
@@ -166,7 +167,8 @@ bool MemoryMappedFile::fill(FileHandle fd, std::size_t size, std::uint8_t value)
     return true;
 }
 
-MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, off_t offset, std::size_t size)
+MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, off_t offset, std::size_t size,
+    bool preTouch)
 {
     FileHandle fd{};
     fd.handle = ::open(filename, O_RDWR | O_CREAT, 0666);
@@ -187,11 +189,11 @@ MemoryMappedFile::ptr_t MemoryMappedFile::createNew(const char *filename, off_t 
         throw IOException(std::string("failed to write to file: ") + filename, SOURCEINFO);
     }
 
-    return MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, false));
+    return MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, size, false, preTouch));
 }
 
 MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(
-    const char *filename, off_t offset, std::size_t length, bool readOnly)
+    const char *filename, off_t offset, std::size_t length, bool readOnly, bool preTouch)
 {
     FileHandle fd{};
     fd.handle = ::open(filename, (readOnly ? O_RDONLY : O_RDWR), 0666);
@@ -207,13 +209,13 @@ MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(
             close(fd.handle);
         });
 
-    return MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, length, readOnly));
+    return MemoryMappedFile::ptr_t(new MemoryMappedFile(fd, offset, length, readOnly, preTouch));
 }
 #endif
 
-MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(const char *filename, bool readOnly)
+MemoryMappedFile::ptr_t MemoryMappedFile::mapExisting(const char *filename, bool readOnly, bool preTouch)
 {
-    return mapExisting(filename, 0, 0, readOnly);
+    return mapExisting(filename, 0, 0, readOnly, preTouch);
 }
 
 std::uint8_t *MemoryMappedFile::getMemoryPtr() const
@@ -229,7 +231,8 @@ std::size_t MemoryMappedFile::getMemorySize() const
 std::size_t MemoryMappedFile::m_page_size = getPageSize();
 
 #ifdef _WIN32
-MemoryMappedFile::MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_t length, bool readOnly)
+MemoryMappedFile::MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_t length, bool readOnly,
+    bool preTouch)
 {
     m_file = fd.handle;
 
@@ -247,7 +250,7 @@ MemoryMappedFile::MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_
     }
 
     m_memorySize = length;
-    m_memory = doMapping(m_memorySize, fd, offset, readOnly);
+    m_memory = doMapping(m_memorySize, fd, offset, readOnly, preTouch);
 
     if (!m_memory)
     {
@@ -282,7 +285,8 @@ MemoryMappedFile::~MemoryMappedFile()
     cleanUp();
 }
 
-uint8_t *MemoryMappedFile::doMapping(std::size_t size, FileHandle fd, std::size_t offset, bool readOnly)
+uint8_t *MemoryMappedFile::doMapping(std::size_t size, FileHandle fd, std::size_t offset, bool readOnly,
+    bool /* preTouch */)
 {
     DWORD flProtect = readOnly ? PAGE_READONLY : PAGE_READWRITE;
     m_mapping = ::CreateFileMapping(fd.handle, nullptr, flProtect, 0, static_cast<DWORD>(size), nullptr);
@@ -321,7 +325,7 @@ std::int64_t MemoryMappedFile::getFileSize(const char *filename)
 }
 
 #else
-MemoryMappedFile::MemoryMappedFile(FileHandle fd, off_t offset, std::size_t length, bool readOnly)
+MemoryMappedFile::MemoryMappedFile(FileHandle fd, off_t offset, std::size_t length, bool readOnly, bool preTouch)
 {
     if (0 == length && 0 == offset)
     {
@@ -331,7 +335,7 @@ MemoryMappedFile::MemoryMappedFile(FileHandle fd, off_t offset, std::size_t leng
     }
 
     m_memorySize = length;
-    m_memory = doMapping(m_memorySize, fd, static_cast<std::size_t>(offset), readOnly);
+    m_memory = doMapping(m_memorySize, fd, static_cast<std::size_t>(offset), readOnly, preTouch);
 }
 
 MemoryMappedFile::~MemoryMappedFile()
@@ -342,13 +346,26 @@ MemoryMappedFile::~MemoryMappedFile()
     }
 }
 
-std::uint8_t *MemoryMappedFile::doMapping(std::size_t length, FileHandle fd, std::size_t offset, bool readOnly)
+std::uint8_t *MemoryMappedFile::doMapping(std::size_t length, FileHandle fd, std::size_t offset, bool readOnly,
+    bool preTouch)
 {
+    int flags = MAP_SHARED;
+
+#ifdef __linux__
+    if (preTouch)
+    {
+        flags = flags | MAP_POPULATE;
+    }
+#else
+    (void) preTouch;
+#endif
+
+
     void *memory = ::mmap(
         nullptr,
         length,
         readOnly ? PROT_READ : (PROT_READ | PROT_WRITE),
-        MAP_SHARED,
+        flags,
         fd.handle,
         static_cast<off_t>(offset));
 

--- a/aeron-client/src/main/cpp/util/MemoryMappedFile.h
+++ b/aeron-client/src/main/cpp/util/MemoryMappedFile.h
@@ -36,18 +36,20 @@ public:
     typedef std::shared_ptr<MemoryMappedFile> ptr_t;
 
 #ifdef _WIN32
-    static ptr_t createNew(const char *filename, std::size_t offset, std::size_t length);
-    static ptr_t mapExisting(const char *filename, std::size_t offset, std::size_t length, bool readOnly = false);
+    static ptr_t createNew(const char *filename, std::size_t offset, std::size_t length, bool preTouch);
+    static ptr_t mapExisting(const char *filename, std::size_t offset, std::size_t length, bool readOnly = false,
+        bool preTouch = false);
 #else
-    static ptr_t createNew(const char *filename, off_t offset, std::size_t length);
-    static ptr_t mapExisting(const char *filename, off_t offset, std::size_t length, bool readOnly = false);
+    static ptr_t createNew(const char *filename, off_t offset, std::size_t length, bool preTouch);
+    static ptr_t mapExisting(const char *filename, off_t offset, std::size_t length, bool readOnly = false,
+        bool preTouch = false);
 #endif
 
-    static ptr_t mapExisting(const char *filename, bool readOnly = false);
+    static ptr_t mapExisting(const char *filename, bool readOnly = false, bool preTouch = false);
 
     inline static ptr_t mapExistingReadOnly(const char *filename)
     {
-        return mapExisting(filename, 0, 0, true);
+        return mapExisting(filename, 0, 0, true, false);
     }
 
     ~MemoryMappedFile();
@@ -72,12 +74,12 @@ private:
     };
 
 #ifdef _WIN32
-    MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_t length, bool readOnly);
+    MemoryMappedFile(FileHandle fd, std::size_t offset, std::size_t length, bool readOnly, bool preTouch);
 #else
-    MemoryMappedFile(FileHandle fd, off_t offset, std::size_t length, bool readOnly);
+    MemoryMappedFile(FileHandle fd, off_t offset, std::size_t length, bool readOnly, bool preTouch);
 #endif
 
-    std::uint8_t *doMapping(std::size_t size, FileHandle fd, std::size_t offset, bool readOnly);
+    std::uint8_t *doMapping(std::size_t size, FileHandle fd, std::size_t offset, bool readOnly, bool preTouch);
 
     std::uint8_t *m_memory = nullptr;
     std::size_t m_memorySize = 0;

--- a/aeron-client/src/test/cpp/ClientConductorTest.cpp
+++ b/aeron-client/src/test/cpp/ClientConductorTest.cpp
@@ -53,9 +53,9 @@ public:
         m_toDriver.fill(0);
         m_toClients.fill(0);
         MemoryMappedFile::ptr_t logbuffer1 = MemoryMappedFile::createNew(
-            m_logFileName.c_str(), 0, static_cast<size_t>(LOG_FILE_LENGTH));
+            m_logFileName.c_str(), 0, static_cast<size_t>(LOG_FILE_LENGTH), false);
         MemoryMappedFile::ptr_t logbuffer2 = MemoryMappedFile::createNew(
-            m_logFileName2.c_str(), 0, static_cast<size_t>(LOG_FILE_LENGTH));
+            m_logFileName2.c_str(), 0, static_cast<size_t>(LOG_FILE_LENGTH), false);
         m_manyToOneRingBuffer.consumerHeartbeatTime(m_currentTime);
 
         AtomicBuffer logMetaDataBuffer;

--- a/aeron-client/src/test/cpp/util/MemoryMappedFileTest.cpp
+++ b/aeron-client/src/test/cpp/util/MemoryMappedFileTest.cpp
@@ -42,7 +42,7 @@ TEST(mmfileTest, createCheck)
     const std::string name(makeTempFileName());
 
     ASSERT_NO_THROW({
-        m = MemoryMappedFile::createNew(name.c_str(), 0, size);
+        m = MemoryMappedFile::createNew(name.c_str(), 0, size, true);
     });
 
     ASSERT_EQ(m->getMemorySize(), size);
@@ -64,7 +64,7 @@ TEST(mmfileTest, writeReadCheck)
     std::string name = makeTempFileName();
 
     ASSERT_NO_THROW({
-        m = MemoryMappedFile::createNew(name.c_str(), 0, size);
+        m = MemoryMappedFile::createNew(name.c_str(), 0, size, true);
     });
 
     for (size_t n = 0; n < size; n++)


### PR DESCRIPTION
Prefaulting can be slow. MMAP_POPULATE speeds that up a bit as the
prefaulting happens directly in the kernel on creation and doesn't
require on demand interrupts and context switches.

I have left the windows version as is.