### PR TITLE
Event log disable

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
@@ -52,10 +52,10 @@ final class EventConfiguration
 
     /**
      * Disabled Driver Event tags system property name. Follows the format specified for
-     * {@link EventConfiguration#ENABLED_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the set
-     * specified there.  Defined on its own has no effect.
+     * {@link EventConfiguration#ENABLED_EVENT_CODES_PROP_NAME}. This property will disable any codes in the set
+     * specified there. Defined on its own has no effect.
      */
-    public static final String DISABLED_EVENT_CODES_PROP_NAME = "aeron.event.log.disabled";
+    public static final String DISABLED_EVENT_CODES_PROP_NAME = "aeron.event.log.disable";
 
     /**
      * Archive Event tags system property name. This is either:
@@ -68,10 +68,10 @@ final class EventConfiguration
 
     /**
      * Disabled Archive Event tags system property name. Follows the format specified for
-     * {@link EventConfiguration#ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the
-     * set specified there.  Defined on its own has no effect.
+     * {@link EventConfiguration#ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME}. This property will disable any codes in the
+     * set specified there. Defined on its own has no effect.
      */
-    public static final String DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME = "aeron.event.archive.log.disabled";
+    public static final String DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME = "aeron.event.archive.log.disable";
 
     /**
      * Cluster Event tags system property name. This is either:
@@ -84,10 +84,10 @@ final class EventConfiguration
 
     /**
      * Disabled Cluster Event tags system property name. Follows the format specified for
-     * {@link EventConfiguration#ENABLED_CLUSTER_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the
-     * set specified there.  Defined on its own has no effect.
+     * {@link EventConfiguration#ENABLED_CLUSTER_EVENT_CODES_PROP_NAME}. This property will disable any codes in the
+     * set specified there. Defined on its own has no effect.
      */
-    public static final String DISABLED_CLUSTER_EVENT_CODES_PROP_NAME = "aeron.event.cluster.log.disabled";
+    public static final String DISABLED_CLUSTER_EVENT_CODES_PROP_NAME = "aeron.event.cluster.log.disable";
 
     /**
      * Event codes for admin events within the driver, i.e. does not include frame capture and name resolution

--- a/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
@@ -51,6 +51,13 @@ final class EventConfiguration
     public static final String ENABLED_EVENT_CODES_PROP_NAME = "aeron.event.log";
 
     /**
+     * Disabled Driver Event tags system property name. Follows the format specified for
+     * {@link EventConfiguration#ENABLED_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the set
+     * specified there.  Defined on its own has no effect.
+     */
+    public static final String DISABLED_EVENT_CODES_PROP_NAME = "aeron.event.log.disabled";
+
+    /**
      * Archive Event tags system property name. This is either:
      * <ul>
      * <li>A comma separated list of {@link ArchiveEventCode}s to enable</li>
@@ -60,6 +67,13 @@ final class EventConfiguration
     public static final String ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME = "aeron.event.archive.log";
 
     /**
+     * Disabled Archive Event tags system property name. Follows the format specified for
+     * {@link EventConfiguration#ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the
+     * set specified there.  Defined on its own has no effect.
+     */
+    public static final String DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME = "aeron.event.archive.log.disabled";
+
+    /**
      * Cluster Event tags system property name. This is either:
      * <ul>
      * <li>A comma separated list of {@link ClusterEventCode}s to enable</li>
@@ -67,6 +81,13 @@ final class EventConfiguration
      * </ul>
      */
     public static final String ENABLED_CLUSTER_EVENT_CODES_PROP_NAME = "aeron.event.cluster.log";
+
+    /**
+     * Disabled Cluster Event tags system property name. Follows the format specified for
+     * {@link EventConfiguration#ENABLED_CLUSTER_EVENT_CODES_PROP_NAME}.  This property will disable any codes in the
+     * set specified there.  Defined on its own has no effect.
+     */
+    public static final String DISABLED_CLUSTER_EVENT_CODES_PROP_NAME = "aeron.event.cluster.log.disabled";
 
     /**
      * Event codes for admin events within the driver, i.e. does not include frame capture and name resolution
@@ -115,13 +136,16 @@ final class EventConfiguration
     static void init()
     {
         DRIVER_EVENT_CODES.clear();
-        DRIVER_EVENT_CODES.addAll(getEnabledDriverEventCodes(getProperty(ENABLED_EVENT_CODES_PROP_NAME)));
+        DRIVER_EVENT_CODES.addAll(getDriverEventCodes(getProperty(ENABLED_EVENT_CODES_PROP_NAME)));
+        DRIVER_EVENT_CODES.removeAll(getDriverEventCodes(getProperty(DISABLED_EVENT_CODES_PROP_NAME)));
 
         ARCHIVE_EVENT_CODES.clear();
-        ARCHIVE_EVENT_CODES.addAll(getEnabledArchiveEventCodes(getProperty(ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME)));
+        ARCHIVE_EVENT_CODES.addAll(getArchiveEventCodes(getProperty(ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME)));
+        ARCHIVE_EVENT_CODES.removeAll(getArchiveEventCodes(getProperty(DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME)));
 
         CLUSTER_EVENT_CODES.clear();
-        CLUSTER_EVENT_CODES.addAll(getEnabledClusterEventCodes(getProperty(ENABLED_CLUSTER_EVENT_CODES_PROP_NAME)));
+        CLUSTER_EVENT_CODES.addAll(getClusterEventCodes(getProperty(ENABLED_CLUSTER_EVENT_CODES_PROP_NAME)));
+        CLUSTER_EVENT_CODES.removeAll(getClusterEventCodes(getProperty(DISABLED_CLUSTER_EVENT_CODES_PROP_NAME)));
     }
 
     /**
@@ -141,7 +165,7 @@ final class EventConfiguration
      * @param enabledEventCodes that can be "all" or a comma separated list of Event Code ids or names.
      * @return the {@link Set} of {@link ArchiveEventCode}s that are enabled for the logger.
      */
-    static EnumSet<ArchiveEventCode> getEnabledArchiveEventCodes(final String enabledEventCodes)
+    static EnumSet<ArchiveEventCode> getArchiveEventCodes(final String enabledEventCodes)
     {
         if (Strings.isEmpty(enabledEventCodes))
         {
@@ -160,7 +184,7 @@ final class EventConfiguration
      * @param enabledEventCodes that can be "all" or a comma separated list of Event Code ids or names.
      * @return the {@link Set} of {@link ClusterEventCode}s that are enabled for the logger.
      */
-    static Set<ClusterEventCode> getEnabledClusterEventCodes(final String enabledEventCodes)
+    static Set<ClusterEventCode> getClusterEventCodes(final String enabledEventCodes)
     {
         if (Strings.isEmpty(enabledEventCodes))
         {
@@ -179,7 +203,7 @@ final class EventConfiguration
      * @param enabledEventCodes that can be "all", "admin", or a comma separated list of Event Code ids or names.
      * @return the {@link Set} of {@link DriverEventCode}s that are enabled for the logger.
      */
-    static EnumSet<DriverEventCode> getEnabledDriverEventCodes(final String enabledEventCodes)
+    static EnumSet<DriverEventCode> getDriverEventCodes(final String enabledEventCodes)
     {
         if (Strings.isEmpty(enabledEventCodes))
         {

--- a/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventConfiguration.java
@@ -69,36 +69,14 @@ final class EventConfiguration
     public static final String ENABLED_CLUSTER_EVENT_CODES_PROP_NAME = "aeron.event.cluster.log";
 
     /**
-     * Event codes for admin events within the driver, i.e. does not include frame capture.
+     * Event codes for admin events within the driver, i.e. does not include frame capture and name resolution
+     * events.
      */
-    public static final Set<DriverEventCode> ADMIN_ONLY_EVENT_CODES = EnumSet.of(
-        CMD_IN_ADD_PUBLICATION,
-        CMD_IN_ADD_SUBSCRIPTION,
-        CMD_IN_KEEPALIVE_CLIENT,
-        CMD_IN_REMOVE_PUBLICATION,
-        CMD_IN_REMOVE_SUBSCRIPTION,
-        CMD_IN_ADD_COUNTER,
-        CMD_IN_REMOVE_COUNTER,
-        CMD_IN_CLIENT_CLOSE,
-        CMD_IN_ADD_RCV_DESTINATION,
-        CMD_IN_REMOVE_RCV_DESTINATION,
-        REMOVE_IMAGE_CLEANUP,
-        REMOVE_PUBLICATION_CLEANUP,
-        REMOVE_SUBSCRIPTION_CLEANUP,
-        CMD_OUT_PUBLICATION_READY,
-        CMD_OUT_AVAILABLE_IMAGE,
-        CMD_OUT_ON_UNAVAILABLE_IMAGE,
-        CMD_OUT_ON_OPERATION_SUCCESS,
-        CMD_OUT_ERROR,
-        CMD_OUT_SUBSCRIPTION_READY,
-        CMD_OUT_COUNTER_READY,
-        CMD_OUT_ON_UNAVAILABLE_COUNTER,
-        CMD_OUT_ON_CLIENT_TIMEOUT,
-        CMD_IN_TERMINATE_DRIVER,
-        SEND_CHANNEL_CREATION,
-        RECEIVE_CHANNEL_CREATION,
-        SEND_CHANNEL_CLOSE,
-        RECEIVE_CHANNEL_CLOSE);
+    public static final Set<DriverEventCode> ADMIN_ONLY_EVENT_CODES = EnumSet.complementOf(EnumSet.of(
+        FRAME_IN,
+        FRAME_OUT,
+        NAME_RESOLUTION_NEIGHBOR_ADDED,
+        NAME_RESOLUTION_NEIGHBOR_REMOVED));
 
     /**
      * Event Buffer default length (in bytes).

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -26,6 +26,7 @@ import static io.aeron.agent.EventConfiguration.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class EventConfigurationTest
 {
@@ -98,5 +99,42 @@ public class EventConfigurationTest
     {
         assertEquals(EnumSet.of(ArchiveEventCode.CATALOG_RESIZE, ArchiveEventCode.CMD_IN_TAGGED_REPLICATE),
             getArchiveEventCodes("CATALOG_RESIZE,CMD_IN_TAGGED_REPLICATE,"));
+    }
+
+    @Test
+    void shouldDisableSpecificDriverEvents()
+    {
+        System.setProperty("aeron.event.log", "all");
+        System.setProperty("aeron.event.log.disabled", "FRAME_IN,FRAME_OUT");
+        EventConfiguration.init();
+        assertEquals(DriverEventCode.values().length - 2, DRIVER_EVENT_CODES.size());
+        assertFalse(DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_IN));
+        assertFalse(DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_OUT));
+    }
+
+    @Test
+    void shouldDisableSpecificArchiverEvents()
+    {
+        System.setProperty("aeron.event.archive.log", "all");
+        System.setProperty(
+            "aeron.event.archive.log.disabled",
+            ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS.name() + "," + ArchiveEventCode.CMD_IN_CONNECT);
+        EventConfiguration.init();
+        assertEquals(ArchiveEventCode.values().length - 2, ARCHIVE_EVENT_CODES.size());
+        assertFalse(ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS));
+        assertFalse(ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CMD_IN_CONNECT));
+    }
+
+    @Test
+    void shouldDisableSpecificClusterEvents()
+    {
+        System.setProperty("aeron.event.cluster.log", "all");
+        System.setProperty(
+            "aeron.event.cluster.log.disabled",
+            ClusterEventCode.ROLE_CHANGE.name() + "," + ClusterEventCode.ELECTION_STATE_CHANGE);
+        EventConfiguration.init();
+        assertEquals(ClusterEventCode.values().length - 2, CLUSTER_EVENT_CODES.size());
+        assertFalse(CLUSTER_EVENT_CODES.contains(ClusterEventCode.ROLE_CHANGE));
+        assertFalse(CLUSTER_EVENT_CODES.contains(ClusterEventCode.ELECTION_STATE_CHANGE));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -32,7 +32,7 @@ public class EventConfigurationTest
     @Test
     public void nullValueMeansNoEventsEnabled()
     {
-        assertEquals(getEnabledDriverEventCodes(null), EnumSet.noneOf(DriverEventCode.class));
+        assertEquals(getDriverEventCodes(null), EnumSet.noneOf(DriverEventCode.class));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class EventConfigurationTest
         System.setErr(new PrintStream(stderr));
         try
         {
-            final Set<DriverEventCode> enabledEventCodes = getEnabledDriverEventCodes("list of invalid options");
+            final Set<DriverEventCode> enabledEventCodes = getDriverEventCodes("list of invalid options");
             assertEquals(EnumSet.noneOf(DriverEventCode.class), enabledEventCodes);
             assertThat(stderr.toString(), startsWith("unknown event code: list of invalid options"));
         }
@@ -56,7 +56,7 @@ public class EventConfigurationTest
     @Test
     public void allDriverEventsShouldBeEnabled()
     {
-        assertEquals(EnumSet.allOf(DriverEventCode.class), getEnabledDriverEventCodes("all"));
+        assertEquals(EnumSet.allOf(DriverEventCode.class), getDriverEventCodes("all"));
     }
 
     @Test
@@ -68,13 +68,13 @@ public class EventConfigurationTest
             DriverEventCode.CMD_IN_CLIENT_CLOSE,
             DriverEventCode.UNTETHERED_SUBSCRIPTION_STATE_CHANGE);
         assertEquals(expectedCodes,
-            getEnabledDriverEventCodes("FRAME_OUT,FRAME_IN,CMD_IN_CLIENT_CLOSE,UNTETHERED_SUBSCRIPTION_STATE_CHANGE,"));
+            getDriverEventCodes("FRAME_OUT,FRAME_IN,CMD_IN_CLIENT_CLOSE,UNTETHERED_SUBSCRIPTION_STATE_CHANGE,"));
     }
 
     @Test
     public void allClusterEventsShouldBeEnabled()
     {
-        assertEquals(EnumSet.allOf(ClusterEventCode.class), getEnabledClusterEventCodes("all"));
+        assertEquals(EnumSet.allOf(ClusterEventCode.class), getClusterEventCodes("all"));
     }
 
     @Test
@@ -84,19 +84,19 @@ public class EventConfigurationTest
             ClusterEventCode.STATE_CHANGE,
             ClusterEventCode.NEW_LEADERSHIP_TERM,
             ClusterEventCode.ROLE_CHANGE),
-            getEnabledClusterEventCodes("STATE_CHANGE,NEW_LEADERSHIP_TERM,ROLE_CHANGE,"));
+            getClusterEventCodes("STATE_CHANGE,NEW_LEADERSHIP_TERM,ROLE_CHANGE,"));
     }
 
     @Test
     public void allArchiveEventsShouldBeEnabled()
     {
-        assertEquals(EnumSet.allOf(ArchiveEventCode.class), getEnabledArchiveEventCodes("all"));
+        assertEquals(EnumSet.allOf(ArchiveEventCode.class), getArchiveEventCodes("all"));
     }
 
     @Test
     public void archiveEventsShouldBeParsedAsListOfEventCodes()
     {
         assertEquals(EnumSet.of(ArchiveEventCode.CATALOG_RESIZE, ArchiveEventCode.CMD_IN_TAGGED_REPLICATE),
-            getEnabledArchiveEventCodes("CATALOG_RESIZE,CMD_IN_TAGGED_REPLICATE,"));
+            getArchiveEventCodes("CATALOG_RESIZE,CMD_IN_TAGGED_REPLICATE,"));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -104,8 +104,8 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificDriverEvents()
     {
-        System.setProperty("aeron.event.log", "all");
-        System.setProperty("aeron.event.log.disabled", "FRAME_IN,FRAME_OUT");
+        System.setProperty(ENABLED_EVENT_CODES_PROP_NAME, "all");
+        System.setProperty(DISABLED_EVENT_CODES_PROP_NAME, "FRAME_IN,FRAME_OUT");
         EventConfiguration.init();
         assertEquals(DriverEventCode.values().length - 2, DRIVER_EVENT_CODES.size());
         assertFalse(DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_IN));
@@ -115,9 +115,9 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificArchiverEvents()
     {
-        System.setProperty("aeron.event.archive.log", "all");
+        System.setProperty(ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME, "all");
         System.setProperty(
-            "aeron.event.archive.log.disabled",
+            DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME,
             ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS.name() + "," + ArchiveEventCode.CMD_IN_CONNECT);
         EventConfiguration.init();
         assertEquals(ArchiveEventCode.values().length - 2, ARCHIVE_EVENT_CODES.size());
@@ -128,9 +128,9 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificClusterEvents()
     {
-        System.setProperty("aeron.event.cluster.log", "all");
+        System.setProperty(ENABLED_CLUSTER_EVENT_CODES_PROP_NAME, "all");
         System.setProperty(
-            "aeron.event.cluster.log.disabled",
+            DISABLED_CLUSTER_EVENT_CODES_PROP_NAME,
             ClusterEventCode.ROLE_CHANGE.name() + "," + ClusterEventCode.ELECTION_STATE_CHANGE);
         EventConfiguration.init();
         assertEquals(ClusterEventCode.values().length - 2, CLUSTER_EVENT_CODES.size());


### PR DESCRIPTION
Adds:
- `aeron.event.log.disabled`
- `aeron.event.archive.log.disabled`
- `aeron.event.cluster.log.disabled`

That allows disabling of specific events from the logging, e.g. `-Daeron.event.log=all` `-Daeron.event.log.disabled=FRAME_IN,FRAME_OUT` is everything except frames.