### PR TITLE
[Java] Actually check for cluster archive client errors in ClusterBackupAgent

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -455,7 +455,7 @@ public class ClusterBackupAgent implements Agent
 
             if (null != clusterArchive)
             {
-                clusterArchive.pollForErrorResponse();
+                clusterArchive.checkForErrorResponse();
             }
         }
 


### PR DESCRIPTION
ClusterBackupAgent polls for cluster archive client errors, but doesn't do anything with the returned value, so they become silently ignored. We should check instead, like for the backup archive.