### PR TITLE
[C] Lower CMake requirement to 3.5.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.6.1 FATAL_ERROR)
-cmake_policy(VERSION 3.6.1)
+cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_policy(VERSION 3.5.1)
 
 file(STRINGS version.txt AERON_VERSION_TXT LIMIT_COUNT 1 REGEX "^[0-9]+(\\.[0-9]+)+")
 string(REGEX REPLACE "^([0-9]+(\\.[0-9]+)+).*$" "\\1" AERON_VERSION_FROM_FILE "${AERON_VERSION_TXT}")

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Full clean and build of all modules
 
 You require the following to build the C++ API for Aeron:
 
-* 3.6.1 or higher of [CMake](http://www.cmake.org/)
+* 3.5.1 or higher of [CMake](http://www.cmake.org/)
 * C++11 supported compiler for the supported platform
 * C11 supported compiler for the supported platform
 * Requirements to build [HdrHistogram_c](https://github.com/HdrHistogram/HdrHistogram_c). 


### PR DESCRIPTION
Although CMake 3.6.1 is currently required, the build appears to work well with CMake 3.5.1. As Ubuntu 16.04 ships with that version, lower the CMake requirement to 3.5.1.