### PR TITLE
check tag when reusing send channel endpoint 

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -1552,6 +1552,13 @@ aeron_send_channel_endpoint_t *aeron_driver_conductor_get_or_add_send_channel_en
 
         endpoint = aeron_str_to_ptr_hash_map_get(
             &conductor->send_channel_endpoint_by_channel_map, channel->canonical_form, channel->canonical_length);
+        if (NULL != endpoint &&
+            AERON_URI_INVALID_TAG != endpoint->conductor_fields.udp_channel->tag_id &&
+            AERON_URI_INVALID_TAG != channel->tag_id &&
+            channel->tag_id != endpoint->conductor_fields.udp_channel->tag_id)
+        {
+            endpoint = NULL;
+        }
     }
 
     if (aeron_driver_conductor_update_and_check_ats_status(

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1346,7 +1346,14 @@ public final class DriverConductor implements Agent
             }
         }
 
-        return sendChannelEndpointByChannelMap.get(udpChannel.canonicalForm());
+        SendChannelEndpoint endpoint = sendChannelEndpointByChannelMap.get(udpChannel.canonicalForm());
+        if (null != endpoint && endpoint.udpChannel().hasTag() && udpChannel.hasTag() &&
+            endpoint.udpChannel().tag() != udpChannel.tag())
+        {
+            endpoint = null;
+        }
+
+        return endpoint;
     }
 
     private void checkForClashingSubscription(


### PR DESCRIPTION
Currently when a publication is created, endpoint from an old one can be reused. However, the tag is not checked and as a result publication and endpoint have different tags. Spy subscriptions then may hang waiting for image.

I have added a test - if removed publication has not been cleaned up by timeout, then the endpoint is reused and the test does not pass.