### PR TITLE
Event log dump on test failure

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
@@ -113,12 +113,9 @@ final class ClusterEventDissector
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId);
         builder.append(", ");
-        buffer.getStringAscii(absoluteOffset, builder);
         builder.append(" logPosition=").append(logPosition);
         builder.append(", ");
-        buffer.getStringAscii(absoluteOffset, builder);
         builder.append(" followerMemberId=").append(followerMemberId);
-        buffer.getStringAscii(absoluteOffset, builder);
     }
 
     public static void dissectRequestVote(
@@ -141,14 +138,10 @@ final class ClusterEventDissector
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId);
         builder.append(", ");
-        buffer.getStringAscii(absoluteOffset, builder);
         builder.append(" logPosition=").append(logPosition);
         builder.append(", ");
-        buffer.getStringAscii(absoluteOffset, builder);
         builder.append(" candidateTermId=").append(candidateTermId);
         builder.append(", ");
-        buffer.getStringAscii(absoluteOffset, builder);
         builder.append(" candidateId=").append(candidateId);
-        buffer.getStringAscii(absoluteOffset, builder);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgent.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.LangUtil;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.Agent;
+import org.agrona.concurrent.MessageHandler;
+import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
+
+import javax.management.*;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
+import static io.aeron.agent.EventLogReaderAgent.decodeLogEvent;
+import static java.nio.channels.FileChannel.open;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+
+/**
+ * Simple reader of {@link EventConfiguration#EVENT_RING_BUFFER} that is useful for testing.  It will register
+ * itself into JMX and allow users to switch on and off capture of log events in memory and allows the user
+ * to periodically write them to a file.
+ */
+public final class CollectingEventLogReaderAgent implements Agent, CollectingEventLogReaderAgentMBean
+{
+    private static final String LOGGING_MBEAN_NAME = "io.aeron:type=logging";
+
+    private enum State { COLLECTING, IGNORING, RESET }
+    private final ManyToOneRingBuffer ringBuffer = EventConfiguration.EVENT_RING_BUFFER;
+    private final ExpandableArrayBuffer collectingBuffer = new ExpandableArrayBuffer();
+    private final MessageHandler messageHandler = this::onMessage;
+    private final Object mutex = new Object();
+
+    private volatile State state = State.IGNORING;
+    private int bufferPosition = 0;
+
+    CollectingEventLogReaderAgent()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void onStart()
+    {
+        try
+        {
+            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            ObjectName oName = new ObjectName(LOGGING_MBEAN_NAME);
+            mBeanServer.registerMBean(this, oName);
+        }
+        catch (
+            MalformedObjectNameException |
+            InstanceAlreadyExistsException |
+            MBeanRegistrationException |
+            NotCompliantMBeanException ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String roleName()
+    {
+        return "inmemory-event-log-reader";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int doWork()
+    {
+        synchronized (mutex)
+        {
+            return ringBuffer.read(messageHandler, EVENT_READER_FRAME_LIMIT);
+        }
+    }
+
+    private void onMessage(final int msgTypeId, final MutableDirectBuffer buffer, final int index, final int length)
+    {
+        if (state == State.IGNORING)
+        {
+            return;
+        }
+        else if (state == State.RESET)
+        {
+            bufferPosition = 0;
+            state = State.IGNORING;
+            return;
+        }
+
+        int position = bufferPosition;
+
+        collectingBuffer.putInt(position, msgTypeId);
+        position += SIZE_OF_INT;
+        collectingBuffer.putInt(position, length);
+        position += SIZE_OF_INT;
+        collectingBuffer.putBytes(position, buffer, index, length);
+        position += length;
+
+        bufferPosition = position;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setCollecting(boolean isCollecting)
+    {
+        this.state = isCollecting ? State.COLLECTING : State.IGNORING;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void reset()
+    {
+        this.state = State.RESET;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isCollecting()
+    {
+        return state == State.COLLECTING;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void writeToFile(final String filename)
+    {
+        synchronized (mutex) {
+            doOutputToFile(filename);
+        }
+    }
+
+    private void doOutputToFile(final String filename)
+    {
+        System.out.println("Dumping to file: " + filename);
+
+        final StringBuilder builder = new StringBuilder();
+
+        try (PrintStream out = new PrintStream(filename))
+        {
+            final int terminalPosition = bufferPosition;
+
+            int readingPosition = 0;
+            while (readingPosition < terminalPosition)
+            {
+                int msgTypeId = collectingBuffer.getInt(readingPosition);
+                readingPosition += SIZE_OF_INT;
+                int length = collectingBuffer.getInt(readingPosition);
+                readingPosition += SIZE_OF_INT;
+
+                final int eventCodeTypeId = msgTypeId >> 16;
+                final int eventCodeId = msgTypeId & 0xFFFF;
+
+                builder.setLength(0);
+                decodeLogEvent(collectingBuffer, readingPosition, eventCodeTypeId, eventCodeId, builder);
+                readingPosition += length;
+
+                out.print(builder);
+            }
+
+            bufferPosition = 0;
+        }
+        catch (final IOException ex)
+        {
+            System.err.println("Failed to write to output log: " + ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgent.java
@@ -26,11 +26,9 @@ import javax.management.*;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventLogReaderAgent.decodeLogEvent;
-import static java.nio.channels.FileChannel.open;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 
 /**
@@ -42,7 +40,11 @@ public final class CollectingEventLogReaderAgent implements Agent, CollectingEve
 {
     private static final String LOGGING_MBEAN_NAME = "io.aeron:type=logging";
 
-    private enum State { COLLECTING, IGNORING, RESET }
+    private enum State
+    {
+        COLLECTING, IGNORING, RESET
+    }
+
     private final ManyToOneRingBuffer ringBuffer = EventConfiguration.EVENT_RING_BUFFER;
     private final ExpandableArrayBuffer collectingBuffer = new ExpandableArrayBuffer();
     private final MessageHandler messageHandler = this::onMessage;
@@ -62,12 +64,11 @@ public final class CollectingEventLogReaderAgent implements Agent, CollectingEve
     {
         try
         {
-            MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
-            ObjectName oName = new ObjectName(LOGGING_MBEAN_NAME);
+            final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            final ObjectName oName = new ObjectName(LOGGING_MBEAN_NAME);
             mBeanServer.registerMBean(this, oName);
         }
-        catch (
-            MalformedObjectNameException |
+        catch (final MalformedObjectNameException |
             InstanceAlreadyExistsException |
             MBeanRegistrationException |
             NotCompliantMBeanException ex)
@@ -123,7 +124,7 @@ public final class CollectingEventLogReaderAgent implements Agent, CollectingEve
     /**
      * {@inheritDoc}
      */
-    public void setCollecting(boolean isCollecting)
+    public void setCollecting(final boolean isCollecting)
     {
         this.state = isCollecting ? State.COLLECTING : State.IGNORING;
     }
@@ -149,7 +150,8 @@ public final class CollectingEventLogReaderAgent implements Agent, CollectingEve
      */
     public void writeToFile(final String filename)
     {
-        synchronized (mutex) {
+        synchronized (mutex)
+        {
             doOutputToFile(filename);
         }
     }
@@ -167,9 +169,9 @@ public final class CollectingEventLogReaderAgent implements Agent, CollectingEve
             int readingPosition = 0;
             while (readingPosition < terminalPosition)
             {
-                int msgTypeId = collectingBuffer.getInt(readingPosition);
+                final int msgTypeId = collectingBuffer.getInt(readingPosition);
                 readingPosition += SIZE_OF_INT;
-                int length = collectingBuffer.getInt(readingPosition);
+                final int length = collectingBuffer.getInt(readingPosition);
                 readingPosition += SIZE_OF_INT;
 
                 final int eventCodeTypeId = msgTypeId >> 16;

--- a/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgentMBean.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgentMBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.agent;
 
 /**
@@ -32,5 +47,5 @@ public interface CollectingEventLogReaderAgentMBean
      * @param filename file to write to.
      *
      */
-    void writeToFile(final String filename);
+    void writeToFile(String filename);
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgentMBean.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CollectingEventLogReaderAgentMBean.java
@@ -1,0 +1,36 @@
+package io.aeron.agent;
+
+/**
+ * MBean interface for a logging agent that stores events in memory and allows them to be periodically written
+ * out.  Useful within tests.
+ */
+public interface CollectingEventLogReaderAgentMBean
+{
+    /**
+     * Enable or disable the collection of logs.
+     *
+     * @param isCollecting whether logs should be collected or not.
+     */
+    void setCollecting(boolean isCollecting);
+
+    /**
+     * Shows whether logs are being collected or not.
+     *
+     * @return true to indicate logs are being collected in memory.
+     */
+    boolean isCollecting();
+
+    /**
+     * Reset the internal positions within the collector discarding all previous logs.  Should be called periodically,
+     * so to avoid consuming all available memory.
+     */
+    void reset();
+
+    /**
+     * Output the collected logs to file.
+     *
+     * @param filename file to write to.
+     *
+     */
+    void writeToFile(final String filename);
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogReaderAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogReaderAgent.java
@@ -126,8 +126,27 @@ public final class EventLogReaderAgent implements Agent
         final int eventCodeTypeId = msgTypeId >> 16;
         final int eventCodeId = msgTypeId & 0xFFFF;
 
-        builder.setLength(0);
+        this.builder.setLength(0);
 
+        decodeLogEvent(buffer, index, eventCodeTypeId, eventCodeId, this.builder);
+
+        if (null == fileChannel)
+        {
+            out.print(this.builder);
+        }
+        else
+        {
+            appendEvent(this.builder, byteBuffer, fileChannel);
+        }
+    }
+
+    static void decodeLogEvent(
+        final MutableDirectBuffer buffer,
+        final int index,
+        final int eventCodeTypeId,
+        final int eventCodeId,
+        final StringBuilder builder)
+    {
         if (DriverEventCode.EVENT_CODE_TYPE == eventCodeTypeId)
         {
             DriverEventCode.get(eventCodeId).decode(buffer, index, builder);
@@ -146,15 +165,6 @@ public final class EventLogReaderAgent implements Agent
         }
 
         builder.append(lineSeparator());
-
-        if (null == fileChannel)
-        {
-            out.print(builder);
-        }
-        else
-        {
-            appendEvent(builder, byteBuffer, fileChannel);
-        }
     }
 
     private static void appendEvent(final StringBuilder builder, final ByteBuffer buffer, final FileChannel fileChannel)

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -42,10 +42,17 @@ public class ClusterTest
 {
     private TestCluster cluster = null;
 
+    @BeforeEach
+    void before()
+    {
+        Tests.startLogCollecting();
+    }
+
     @AfterEach
     void after()
     {
         CloseHelper.close(cluster);
+        Tests.resetLogCollecting();
     }
 
     @Test

--- a/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
@@ -151,6 +151,8 @@ public final class DataCollector
 
             final Path threadDump = destination.resolve(THREAD_DUMP_FILE_NAME);
             Files.write(threadDump, SystemUtil.threadDump().getBytes(UTF_8));
+            Tests.dumpCollectedLogs(destination.resolve("events.log").toString());
+
             return destination;
         }
         catch (final IOException ex)

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -463,12 +463,12 @@ public class Tests
             {
                 mBeanServer.setAttribute(loggingName, new Attribute("Collecting", true));
             }
-            catch (InstanceNotFoundException ex)
+            catch (final InstanceNotFoundException ex)
             {
                 // It must not have been set up for the test.  Expected in many cases.
             }
         }
-        catch (Exception ex)
+        catch (final Exception ex)
         {
             LangUtil.rethrowUnchecked(ex);
         }
@@ -485,12 +485,12 @@ public class Tests
             {
                 mBeanServer.invoke(loggingName, "reset", new Object[0], new String[0]);
             }
-            catch (InstanceNotFoundException ex)
+            catch (final InstanceNotFoundException ex)
             {
                 // It must not have been set up for the test.  Expected in many cases.
             }
         }
-        catch (Exception ex)
+        catch (final Exception ex)
         {
             LangUtil.rethrowUnchecked(ex);
         }
@@ -506,14 +506,14 @@ public class Tests
             try
             {
                 mBeanServer.invoke(
-                    loggingName, "writeToFile", new Object[] { filename }, new String[] { "java.lang.String" } );
+                    loggingName, "writeToFile", new Object[] { filename }, new String[] { "java.lang.String" });
             }
-            catch (InstanceNotFoundException ex)
+            catch (final InstanceNotFoundException ex)
             {
                 // It must not have been set up for the test.  Expected in many cases.
             }
         }
-        catch (Exception ex)
+        catch (final Exception ex)
         {
             LangUtil.rethrowUnchecked(ex);
         }

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -29,6 +29,8 @@ import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 
+import javax.management.*;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.doAnswer;
 public class Tests
 {
     public static final IdleStrategy SLEEP_1_MS = new SleepingMillisIdleStrategy(1);
+    private static final String LOGGING_MBEAN_NAME = "io.aeron:type=logging";
 
     /**
      * Set a private field in a class for testing.
@@ -447,5 +450,72 @@ public class Tests
         }
 
         return builder.toString();
+    }
+
+    public static void startLogCollecting()
+    {
+        try
+        {
+            final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            final ObjectName loggingName = new ObjectName(LOGGING_MBEAN_NAME);
+
+            try
+            {
+                mBeanServer.setAttribute(loggingName, new Attribute("Collecting", true));
+            }
+            catch (InstanceNotFoundException ex)
+            {
+                // It must not have been set up for the test.  Expected in many cases.
+            }
+        }
+        catch (Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+    public static void resetLogCollecting()
+    {
+        try
+        {
+            final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            final ObjectName loggingName = new ObjectName("io.aeron:type=logging");
+
+            try
+            {
+                mBeanServer.invoke(loggingName, "reset", new Object[0], new String[0]);
+            }
+            catch (InstanceNotFoundException ex)
+            {
+                // It must not have been set up for the test.  Expected in many cases.
+            }
+        }
+        catch (Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
+    }
+
+    public static void dumpCollectedLogs(final String filename)
+    {
+        try
+        {
+            final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            final ObjectName loggingName = new ObjectName("io.aeron:type=logging");
+
+            try
+            {
+                mBeanServer.invoke(
+                    loggingName, "writeToFile", new Object[] { filename }, new String[] { "java.lang.String" } );
+            }
+            catch (InstanceNotFoundException ex)
+            {
+                // It must not have been set up for the test.  Expected in many cases.
+            }
+        }
+        catch (Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -232,10 +232,22 @@ subprojects {
     }
 
     task slowTest(type: Test) {
+        dependsOn ":aeron-agent:jar"
+
         maxParallelForks = 1
         useJUnitPlatform {
             includeTags 'slow'
         }
+
+        ext.agentFilename = {
+            project.file("../aeron-agent/build/libs/aeron-agent-${aeronVersion}.jar").absolutePath
+        }
+
+        jvmArgs '-javaagent:' + agentFilename()
+        systemProperty "aeron.event.cluster.log", "all"
+        systemProperty "aeron.event.cluster.log.disable", "CANVASS_POSITION"
+        systemProperty "aeron.debug.timeout", "3600s"
+        systemProperty "aeron.event.log.reader.classname", "io.aeron.agent.CollectingEventLogReaderAgent"
     }
 
     task topologyTest(type: Test) {


### PR DESCRIPTION
- Captures the configure Aeron event logs in memory, when requested and dumps them into an `events.log` in the failure output if the test fails.
- Currently only configured to work on the `slowTest` task and with ClusterTest specifically.