### PR TITLE
Add support for outputting in influxdb data_format for use with Telegraf exec plugin

### DIFF
--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.StringJoiner;
 
 import static io.aeron.driver.status.PerImageIndicator.PER_IMAGE_TYPE_ID;
 import static io.aeron.driver.status.PublisherLimit.PUBLISHER_LIMIT_TYPE_ID;
@@ -186,7 +187,7 @@ public class AeronStat
         }
         else if (telegraf)
         {
-            final StringBuilder telegrafMetric = new StringBuilder();
+            final StringJoiner telegrafMetric = new StringJoiner(",", " ", "");
             telegrafOutput(cncFileReader, telegrafMetric);
         }
         else
@@ -210,10 +211,9 @@ public class AeronStat
         while (running.get());
     }
 
-    private static void telegrafOutput(final CncFileReader cncFileReader, final StringBuilder telegrafMetric)
+    private static void telegrafOutput(final CncFileReader cncFileReader, final StringJoiner telegrafMetric)
     {
         final CountersReader counters = cncFileReader.countersReader();
-        telegrafMetric.append("aeron");
         counters.forEach(
             (counterId, typeId, keyBuffer, label) ->
             {
@@ -221,12 +221,12 @@ public class AeronStat
                 {
                     final long cv = counters.getCounterValue(counterId);
                     final String cl = counters.getCounterLabel(counterId).replaceAll("( |,|\\.|-)", "_").toLowerCase();
-                    final String o = String.format(",%s=%s", cl, cv);
-                    telegrafMetric.append(o);
+                    final String o = String.format("%s=%s", cl, cv);
+                    telegrafMetric.add(o);
                 }
             }
         );
-        System.out.println(telegrafMetric);
+        System.out.println("aeron" + telegrafMetric);
     }
 
     private static void printOutput(final CncFileReader cncFileReader, final CounterFilter counterFilter)

--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -112,7 +112,7 @@ public class AeronStat
     {
         long delayMs = 1000L;
         boolean watch = true;
-        boolean telegraf = true;
+        boolean telegraf = false;
         Pattern typeFilter = null;
         Pattern identityFilter = null;
         Pattern sessionFilter = null;

--- a/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/AeronStat.java
@@ -214,14 +214,18 @@ public class AeronStat
     private static void telegrafOutput(final CncFileReader cncFileReader, final StringJoiner telegrafMetric)
     {
         final CountersReader counters = cncFileReader.countersReader();
+        final String replaceRegex = "( |,|\\.|-)";
+        final Pattern pattern = Pattern.compile(replaceRegex);
+
         counters.forEach(
             (counterId, typeId, keyBuffer, label) ->
             {
                 if (counterId <= 24)
                 {
                     final long cv = counters.getCounterValue(counterId);
-                    final String cl = counters.getCounterLabel(counterId).replaceAll("( |,|\\.|-)", "_").toLowerCase();
-                    final String o = String.format("%s=%s", cl, cv);
+                    final String cl = pattern.matcher(counters.getCounterLabel(counterId)
+                        .toLowerCase()).replaceAll("_");
+                    final String o = cl + "=" + cv;
                     telegrafMetric.add(o);
                 }
             }


### PR DESCRIPTION
Details on Telegraf Exec plugin: https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec

Here is in example for telegraf.conf:
```
# Get metrics from aeron
[[inputs.exec]]
  ## Commands array
  commands = [
    "java -cp /opt/telegraf/aeron-all-1.25.1-telegraf.jar -Xmx8m -Daeron.dir=/dev/shm/aeron io.aeron.samples.AeronStat watch=false telegraf=true"
  ]

  ## Timeout for each command to complete.
  timeout = "5s"
  data_format = "influx"
  data_type = "string" 
```