### PR TITLE
[Java] Out of order RecordingLog

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
@@ -19,6 +19,7 @@ import io.aeron.Aeron;
 import io.aeron.CncFileDescriptor;
 import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
+import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.BooleanType;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
 import io.aeron.cluster.service.ClusterMarkFile;
@@ -26,25 +27,33 @@ import io.aeron.cluster.service.ClusterNodeControlProperties;
 import io.aeron.cluster.service.ConsensusModuleProxy;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
+import org.agrona.LangUtil;
 import org.agrona.SystemUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.collections.MutableBoolean;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.EpochClock;
 import org.agrona.concurrent.SystemEpochClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static io.aeron.Aeron.NULL_VALUE;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.file.StandardOpenOption.*;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.agrona.SystemUtil.getDurationInNanos;
 
@@ -56,6 +65,7 @@ import static org.agrona.SystemUtil.getDurationInNanos;
  *                         pid: prints PID of cluster component.
  *               recovery-plan: [service count] prints recovery plan of cluster component.
  *               recording-log: prints recording log of cluster component.
+ *          sort-recording-log: re-arranges entries in the recording log to match the order in memory.
  *                      errors: prints Aeron and cluster component error logs.
  *                list-members: print leader memberId, active members list, and passive members list.
  *               remove-member: [memberId] requests removal of a member specified in memberId.
@@ -127,6 +137,10 @@ public class ClusterTool
 
             case "recording-log":
                 recordingLog(System.out, clusterDir);
+                break;
+
+            case "sort-recording-log":
+                sortRecordingLog(System.out, clusterDir);
                 break;
 
             case "errors":
@@ -274,6 +288,71 @@ public class ClusterTool
         {
             out.println(recordingLog.toString());
         }
+    }
+
+    /**
+     * Print out the {@link RecordingLog} for the cluster.
+     *
+     * @param out        to print the output to.
+     * @param clusterDir where the cluster is running.
+     * @return {@code true} if file contents was changed or {@code false} if it was already in the correct order.
+     */
+    public static boolean sortRecordingLog(final PrintStream out, final File clusterDir)
+    {
+        final List<RecordingLog.Entry> entries;
+        try (RecordingLog recordingLog = new RecordingLog(clusterDir))
+        {
+            entries = recordingLog.entries();
+            if (recordingLogSorted(entries))
+            {
+                return false;
+            }
+        }
+
+        final int size = entries.size();
+        final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096).order(LITTLE_ENDIAN);
+        final UnsafeBuffer buffer = new UnsafeBuffer(byteBuffer);
+        final File newLogFile = new File(clusterDir, RecordingLog.RECORDING_LOG_FILE_NAME + ".sorted");
+        try
+        {
+            try (FileChannel fileChannel = FileChannel.open(newLogFile.toPath(), CREATE, READ, WRITE))
+            {
+                long position = 0;
+                for (int i = 0; i < size; i++)
+                {
+                    RecordingLog.writeEntryToBuffer(entries.get(0), buffer);
+                    byteBuffer.limit(RecordingLog.ENTRY_LENGTH).position(0);
+
+                    if (RecordingLog.ENTRY_LENGTH != fileChannel.write(byteBuffer, position))
+                    {
+                        throw new ClusterException("failed to write recording");
+                    }
+                    position += RecordingLog.ENTRY_LENGTH;
+                }
+            }
+
+            final Path logFile = clusterDir.toPath().resolve(RecordingLog.RECORDING_LOG_FILE_NAME);
+            Files.delete(logFile);
+            Files.move(newLogFile.toPath(), logFile);
+        }
+        catch (final IOException e)
+        {
+            LangUtil.rethrowUnchecked(e);
+        }
+
+        return true;
+    }
+
+    private static boolean recordingLogSorted(final List<RecordingLog.Entry> entries)
+    {
+        for (int i = entries.size() - 1; i >= 0; i--)
+        {
+            if (entries.get(i).entryIndex != i)
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -1035,6 +1114,7 @@ public class ClusterTool
             "                        pid: prints PID of cluster component%n" +
             "              recovery-plan: [service count] prints recovery plan of cluster component%n" +
             "              recording-log: prints recording log of cluster component%n" +
+            "         sort-recording-log: re-arranges entries in the recording log to match the order in memory%n" +
             "                     errors: prints Aeron and cluster component error logs%n" +
             "               list-members: print leader memberId, active members list, and passive members list%n" +
             "              remove-member: [memberId] requests removal of a member specified in memberId%n" +

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -568,8 +568,8 @@ public final class RecordingLog implements AutoCloseable
 
     private static final Comparator<Entry> ENTRY_COMPARATOR =
         comparingLong((Entry o) -> o.leadershipTermId)
-        .thenComparingInt(o -> o.type)
-        .thenComparingLong(o -> o.logPosition);
+            .thenComparingInt(o -> o.type)
+            .thenComparingLong(o -> o.logPosition);
 
     private long recordingId = NULL_VALUE;
     private int nextEntryIndex;
@@ -989,6 +989,11 @@ public final class RecordingLog implements AutoCloseable
         long logPosition = NULL_POSITION;
         if (size > 0)
         {
+            if (cacheIndexByLeadershipTermIdMap.containsKey(leadershipTermId))
+            {
+                throw new ClusterException("duplicate term entry for leadershipTermId=" + leadershipTermId);
+            }
+
             final long previousLeadershipTermId = leadershipTermId - 1;
             if (NULL_VALUE != cacheIndexByLeadershipTermIdMap.get(previousLeadershipTermId))
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -1009,13 +1009,6 @@ public final class RecordingLog implements AutoCloseable
         if (!restoreInvalidSnapshot(
             recordingId, leadershipTermId, termBaseLogPosition, logPosition, timestamp, serviceId))
         {
-            final Entry entry = findLastTerm();
-            if (null != entry && entry.leadershipTermId != leadershipTermId)
-            {
-                throw new ClusterException("snapshot not for current leadership term=" + entry.leadershipTermId +
-                    " snapshot=" + leadershipTermId);
-            }
-
             append(
                 ENTRY_TYPE_SNAPSHOT,
                 recordingId,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -568,8 +568,8 @@ public final class RecordingLog implements AutoCloseable
 
     private static final Comparator<Entry> ENTRY_COMPARATOR =
         comparingLong((Entry o) -> o.leadershipTermId)
-            .thenComparingInt(o -> o.type)
-            .thenComparingLong(o -> o.logPosition);
+        .thenComparingInt(o -> o.type)
+        .thenComparingLong(o -> o.logPosition);
 
     private long recordingId = NULL_VALUE;
     private int nextEntryIndex;
@@ -992,6 +992,24 @@ public final class RecordingLog implements AutoCloseable
             if (cacheIndexByLeadershipTermIdMap.containsKey(leadershipTermId))
             {
                 throw new ClusterException("duplicate term entry for leadershipTermId=" + leadershipTermId);
+            }
+
+            for (int i = size - 1; i >= 0; i--)
+            {
+                final Entry entry = entriesCache.get(i);
+                if (leadershipTermId == entry.leadershipTermId)
+                {
+                    if (ENTRY_TYPE_SNAPSHOT == entry.type)
+                    {
+                        throw new ClusterException("term cannot be added for leadershipTermId=" + leadershipTermId +
+                            ", because a snapshot already exists");
+                    }
+                    break;
+                }
+                else if (entry.leadershipTermId < leadershipTermId)
+                {
+                    break;
+                }
             }
 
             final long previousLeadershipTermId = leadershipTermId - 1;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -1233,7 +1233,8 @@ public final class RecordingLog implements AutoCloseable
         for (int i = size - 1; i >= 0; i--)
         {
             final Entry e = entries.get(i);
-            if (e.leadershipTermId > leadershipTermId)
+            if (e.leadershipTermId > leadershipTermId ||
+                leadershipTermId == e.leadershipTermId && e.logPosition > logPosition)
             {
                 index--;
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -184,6 +184,64 @@ public final class RecordingLog implements AutoCloseable
                 entryIndex);
         }
 
+        Entry logPosition(final long logPosition)
+        {
+            return new Entry(
+                recordingId,
+                leadershipTermId,
+                termBaseLogPosition,
+                logPosition,
+                timestamp,
+                serviceId,
+                type,
+                isValid,
+                entryIndex);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public boolean equals(final Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+
+            final Entry entry = (Entry)o;
+
+            return recordingId == entry.recordingId &&
+                leadershipTermId == entry.leadershipTermId &&
+                termBaseLogPosition == entry.termBaseLogPosition &&
+                logPosition == entry.logPosition &&
+                timestamp == entry.timestamp &&
+                serviceId == entry.serviceId &&
+                type == entry.type &&
+                entryIndex == entry.entryIndex &&
+                isValid == entry.isValid;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public int hashCode()
+        {
+            int result = (int)(recordingId ^ (recordingId >>> 32));
+            result = 31 * result + (int)(leadershipTermId ^ (leadershipTermId >>> 32));
+            result = 31 * result + (int)(termBaseLogPosition ^ (termBaseLogPosition >>> 32));
+            result = 31 * result + (int)(logPosition ^ (logPosition >>> 32));
+            result = 31 * result + (int)(timestamp ^ (timestamp >>> 32));
+            result = 31 * result + serviceId;
+            result = 31 * result + type;
+            result = 31 * result + entryIndex;
+            result = 31 * result + (isValid ? 1 : 0);
+            return result;
+        }
+
         /**
          * {@inheritDoc}
          */
@@ -506,7 +564,6 @@ public final class RecordingLog implements AutoCloseable
      */
     private static final int ENTRY_LENGTH = BitUtil.align(ENTRY_TYPE_OFFSET + SIZE_OF_INT, CACHE_LINE_LENGTH);
 
-    private long filePosition = 0;
     private int nextEntryIndex;
     private final FileChannel fileChannel;
     private final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(4096).order(LITTLE_ENDIAN);
@@ -597,7 +654,6 @@ public final class RecordingLog implements AutoCloseable
      */
     public void reload()
     {
-        filePosition = 0;
         entriesCache.clear();
         cacheIndexByLeadershipTermIdMap.clear();
         invalidSnapshots.clear();
@@ -608,6 +664,7 @@ public final class RecordingLog implements AutoCloseable
 
         try
         {
+            long filePosition = 0;
             while (true)
             {
                 final int bytesRead = fileChannel.read(byteBuffer, filePosition);
@@ -798,8 +855,8 @@ public final class RecordingLog implements AutoCloseable
      * Create a recovery plan for the cluster so that when the steps are replayed the plan will bring the cluster
      * back to the latest stable state.
      *
-     * @param archive      to lookup recording descriptors.
-     * @param serviceCount of services that may have snapshots.
+     * @param archive               to lookup recording descriptors.
+     * @param serviceCount          of services that may have snapshots.
      * @param replicatedRecordingId leader's recordingId used for replicating
      * @return a new {@link RecoveryPlan} for the cluster.
      */
@@ -903,32 +960,32 @@ public final class RecordingLog implements AutoCloseable
         final long recordingId, final long leadershipTermId, final long termBaseLogPosition, final long timestamp)
     {
         final int size = entriesCache.size();
+        long logPosition = NULL_POSITION;
         if (size > 0)
         {
-            final Entry entry = findLastTerm();
-            if (null != entry && entry.leadershipTermId >= leadershipTermId)
-            {
-                throw new ClusterException("leadershipTermId out of sequence: last=" +
-                    entry.leadershipTermId + " appending=" + leadershipTermId);
-            }
-
             final long previousLeadershipTermId = leadershipTermId - 1;
             if (NULL_VALUE != cacheIndexByLeadershipTermIdMap.get(previousLeadershipTermId))
             {
                 commitLogPosition(previousLeadershipTermId, termBaseLogPosition);
             }
+
+            final Entry nextTermEntry = findTermEntry(leadershipTermId + 1);
+            if (null != nextTermEntry)
+            {
+                logPosition = nextTermEntry.termBaseLogPosition;
+            }
         }
 
-        append(
+        final int index = append(
             ENTRY_TYPE_TERM,
             recordingId,
             leadershipTermId,
             termBaseLogPosition,
-            NULL_POSITION,
+            logPosition,
             timestamp,
             NULL_VALUE);
 
-        cacheIndexByLeadershipTermIdMap.put(leadershipTermId, entriesCache.size() - 1);
+        cacheIndexByLeadershipTermIdMap.put(leadershipTermId, index);
     }
 
     /**
@@ -989,16 +1046,7 @@ public final class RecordingLog implements AutoCloseable
         {
             commitEntryLogPosition(entry.entryIndex, logPosition);
 
-            entriesCache.set(index, new Entry(
-                entry.recordingId,
-                entry.leadershipTermId,
-                entry.termBaseLogPosition,
-                logPosition,
-                entry.timestamp,
-                entry.serviceId,
-                entry.type,
-                entry.isValid,
-                entry.entryIndex));
+            entriesCache.set(index, entry.logPosition(logPosition));
         }
     }
 
@@ -1039,20 +1087,7 @@ public final class RecordingLog implements AutoCloseable
 
         final int invalidEntryType = ENTRY_TYPE_INVALID_FLAG | invalidEntry.type;
         buffer.putInt(0, invalidEntryType, LITTLE_ENDIAN);
-        byteBuffer.limit(SIZE_OF_INT).position(0);
-        final long position = (invalidEntry.entryIndex * (long)ENTRY_LENGTH) + ENTRY_TYPE_OFFSET;
-
-        try
-        {
-            if (SIZE_OF_INT != fileChannel.write(byteBuffer, position))
-            {
-                throw new ClusterException("failed to write field atomically");
-            }
-        }
-        catch (final Exception ex)
-        {
-            LangUtil.rethrowUnchecked(ex);
-        }
+        writeToDisc(entryIndex, ENTRY_TYPE_OFFSET, SIZE_OF_INT);
     }
 
     /**
@@ -1080,22 +1115,9 @@ public final class RecordingLog implements AutoCloseable
         }
 
         buffer.putInt(0, NULL_VALUE, LITTLE_ENDIAN);
-        byteBuffer.limit(SIZE_OF_INT).position(0);
-        final long position = (index * (long)ENTRY_LENGTH) + ENTRY_TYPE_OFFSET;
+        writeToDisc(index, ENTRY_TYPE_OFFSET, SIZE_OF_INT);
 
-        try
-        {
-            if (SIZE_OF_INT != fileChannel.write(byteBuffer, position))
-            {
-                throw new ClusterException("failed to write field atomically");
-            }
-
-            reload();
-        }
-        catch (final Exception ex)
-        {
-            LangUtil.rethrowUnchecked(ex);
-        }
+        reload();
     }
 
     /**
@@ -1175,18 +1197,7 @@ public final class RecordingLog implements AutoCloseable
                     entry.entryIndex);
 
                 writeEntryToBuffer(validatedEntry, buffer, byteBuffer);
-                final long position = (entry.entryIndex * (long)ENTRY_LENGTH);
-                try
-                {
-                    if (ENTRY_LENGTH != fileChannel.write(byteBuffer, position))
-                    {
-                        throw new ClusterException("failed to write entry atomically");
-                    }
-                }
-                catch (final IOException ex)
-                {
-                    LangUtil.rethrowUnchecked(ex);
-                }
+                writeToDisc(entry.entryIndex, 0, ENTRY_LENGTH);
 
                 entriesCache.set(entryCacheIndex, validatedEntry);
                 invalidSnapshots.fastUnorderedRemove(i);
@@ -1198,7 +1209,7 @@ public final class RecordingLog implements AutoCloseable
         return false;
     }
 
-    private void append(
+    private int append(
         final int entryType,
         final long recordingId,
         final long leadershipTermId,
@@ -1219,22 +1230,64 @@ public final class RecordingLog implements AutoCloseable
             nextEntryIndex);
 
         writeEntryToBuffer(entry, buffer, byteBuffer);
-        try
-        {
-            final int bytesWritten = fileChannel.write(byteBuffer, filePosition);
-            if (ENTRY_LENGTH != bytesWritten)
-            {
-                throw new ClusterException("failed to write entry atomically");
-            }
-            filePosition += bytesWritten;
-        }
-        catch (final IOException ex)
-        {
-            LangUtil.rethrowUnchecked(ex);
-        }
+        writeToDisc(entry.entryIndex, 0, ENTRY_LENGTH);
 
         nextEntryIndex++;
-        entriesCache.add(entry);
+
+        final ArrayList<Entry> entries = this.entriesCache;
+        final int size = entries.size();
+        int index = size;
+        for (int i = size - 1; i >= 0; i--)
+        {
+            final Entry e = entries.get(i);
+            if (e.leadershipTermId > leadershipTermId)
+            {
+                index--;
+            }
+            else
+            {
+                break;
+            }
+        }
+        if (index < size)
+        {
+            entries.add(null);
+            for (int i = size - 1; i >= index; i--)
+            {
+                entries.set(i + 1, entries.get(i));
+            }
+            entries.set(index, entry);
+
+            // Update entries in the cache
+            final Long2LongHashMap.EntryIterator entryIterator = cacheIndexByLeadershipTermIdMap.entrySet().iterator();
+            while (entryIterator.hasNext())
+            {
+                entryIterator.next();
+                if (entryIterator.getLongKey() > leadershipTermId)
+                {
+                    entryIterator.setValue(entryIterator.getLongValue() + 1);
+                }
+            }
+
+            // Update invalid snapshot indices that could have shifted
+            for (int i = invalidSnapshots.size() - 1; i >= 0; i--)
+            {
+                final int snapshotIndex = invalidSnapshots.getInt(i);
+                if (snapshotIndex >= index)
+                {
+                    invalidSnapshots.set(i, snapshotIndex + 1);
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        else
+        {
+            entries.add(entry);
+        }
+        return index;
     }
 
     private void writeEntryToBuffer(final Entry entry, final UnsafeBuffer buffer, final ByteBuffer byteBuffer)
@@ -1246,8 +1299,24 @@ public final class RecordingLog implements AutoCloseable
         buffer.putLong(TIMESTAMP_OFFSET, entry.timestamp, LITTLE_ENDIAN);
         buffer.putInt(SERVICE_ID_OFFSET, entry.serviceId, LITTLE_ENDIAN);
         buffer.putInt(ENTRY_TYPE_OFFSET, entry.type, LITTLE_ENDIAN);
+    }
 
-        byteBuffer.limit(ENTRY_LENGTH).position(0);
+    private void writeToDisc(final int entryIndex, final int offset, final int length)
+    {
+        byteBuffer.limit(length).position(0);
+        final long position = (entryIndex * (long)ENTRY_LENGTH) + offset;
+
+        try
+        {
+            if (length != fileChannel.write(byteBuffer, position))
+            {
+                throw new ClusterException("failed to write field atomically");
+            }
+        }
+        catch (final Exception ex)
+        {
+            LangUtil.rethrowUnchecked(ex);
+        }
     }
 
     private void captureEntriesFromBuffer(
@@ -1304,20 +1373,7 @@ public final class RecordingLog implements AutoCloseable
     private void commitEntryLogPosition(final int entryIndex, final long value)
     {
         buffer.putLong(0, value, LITTLE_ENDIAN);
-        byteBuffer.limit(SIZE_OF_LONG).position(0);
-        final long position = (entryIndex * (long)ENTRY_LENGTH) + LOG_POSITION_OFFSET;
-
-        try
-        {
-            if (SIZE_OF_LONG != fileChannel.write(byteBuffer, position))
-            {
-                throw new ClusterException("failed to write field atomically");
-            }
-        }
-        catch (final IOException ex)
-        {
-            LangUtil.rethrowUnchecked(ex);
-        }
+        writeToDisc(entryIndex, LOG_POSITION_OFFSET, SIZE_OF_LONG);
     }
 
     private static void planRecovery(

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingLog.java
@@ -564,7 +564,7 @@ public final class RecordingLog implements AutoCloseable
     /**
      * The length of each entry in the recording log (not the recordings in the archive).
      */
-    private static final int ENTRY_LENGTH = BitUtil.align(ENTRY_TYPE_OFFSET + SIZE_OF_INT, CACHE_LINE_LENGTH);
+    static final int ENTRY_LENGTH = BitUtil.align(ENTRY_TYPE_OFFSET + SIZE_OF_INT, CACHE_LINE_LENGTH);
 
     private static final Comparator<Entry> ENTRY_COMPARATOR =
         comparingLong((Entry o) -> o.leadershipTermId)
@@ -1359,7 +1359,7 @@ public final class RecordingLog implements AutoCloseable
         return index;
     }
 
-    private void writeEntryToBuffer(final Entry entry, final UnsafeBuffer buffer)
+    static void writeEntryToBuffer(final Entry entry, final UnsafeBuffer buffer)
     {
         buffer.putLong(RECORDING_ID_OFFSET, entry.recordingId, LITTLE_ENDIAN);
         buffer.putLong(LEADERSHIP_TERM_ID_OFFSET, entry.leadershipTermId, LITTLE_ENDIAN);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
@@ -100,8 +100,8 @@ public class RecordingLogTest
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
             recordingLog.appendSnapshot(1L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(1L, 1L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(1L, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(2L, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(3L, 1L, 0, 777L, 0, 0);
         }
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
@@ -113,7 +113,7 @@ public class RecordingLogTest
                 Aeron.NULL_VALUE);
             assertEquals(2, recoveryPlan.snapshots.size());
             assertEquals(SERVICE_ID, recoveryPlan.snapshots.get(0).serviceId);
-            assertEquals(1L, recoveryPlan.snapshots.get(0).recordingId);
+            assertEquals(2L, recoveryPlan.snapshots.get(0).recordingId);
             assertEquals(0, recoveryPlan.snapshots.get(1).serviceId);
             assertEquals(1L, recoveryPlan.snapshots.get(1).recordingId);
         }
@@ -126,10 +126,10 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(-5L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(-5L, 1L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(-5L, 1L, 0, 888L, 0, 0);
-            recordingLog.appendSnapshot(-5L, 1L, 0, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(1L, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(2L, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(3L, 1L, 0, 888L, 0, 0);
+            recordingLog.appendSnapshot(4L, 1L, 0, 888L, 0, SERVICE_ID);
 
             recordingLog.invalidateLatestSnapshot();
         }
@@ -141,7 +141,9 @@ public class RecordingLogTest
                 Aeron.NULL_VALUE);
             assertEquals(2, recoveryPlan.snapshots.size());
             assertEquals(SERVICE_ID, recoveryPlan.snapshots.get(0).serviceId);
+            assertEquals(2L, recoveryPlan.snapshots.get(0).recordingId);
             assertEquals(0, recoveryPlan.snapshots.get(1).serviceId);
+            assertEquals(1L, recoveryPlan.snapshots.get(1).recordingId);
         }
     }
 
@@ -152,12 +154,12 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(777L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(777L, 1L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(777L, 1L, 0, 888L, 0, 0);
-            recordingLog.appendSnapshot(777L, 1L, 0, 888L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(777L, 1L, 0, 999L, 0, 0);
-            recordingLog.appendSnapshot(777L, 1L, 0, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(1, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(2, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(3, 1L, 0, 888L, 0, 0);
+            recordingLog.appendSnapshot(4, 1L, 0, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(5, 1L, 0, 999L, 0, 0);
+            recordingLog.appendSnapshot(6, 1L, 0, 999L, 0, SERVICE_ID);
 
             recordingLog.invalidateEntry(1L, 2);
             recordingLog.invalidateEntry(1L, 3);
@@ -170,7 +172,9 @@ public class RecordingLogTest
                 Aeron.NULL_VALUE);
             assertEquals(2, recoveryPlan.snapshots.size());
             assertEquals(SERVICE_ID, recoveryPlan.snapshots.get(0).serviceId);
+            assertEquals(6L, recoveryPlan.snapshots.get(0).recordingId);
             assertEquals(0, recoveryPlan.snapshots.get(1).serviceId);
+            assertEquals(5L, recoveryPlan.snapshots.get(1).recordingId);
         }
     }
 
@@ -184,10 +188,10 @@ public class RecordingLogTest
         {
             recordingLog.appendTerm(0L, 9L, 444, 0);
             recordingLog.appendTerm(0L, 10L, 666, 0);
-            recordingLog.appendSnapshot(0L, 10L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(0L, 10L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(0L, 10L, 0, 888L, 0, 0);
-            recordingLog.appendSnapshot(0L, 10L, 0, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(1L, 10L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(2L, 10L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(3L, 10L, 0, 888L, 0, 0);
+            recordingLog.appendSnapshot(4L, 10L, 0, 888L, 0, SERVICE_ID);
             recordingLog.appendTerm(0L, removedLeadershipTerm, 555, 0);
 
             final RecordingLog.Entry lastTerm = recordingLog.findLastTerm();
@@ -295,7 +299,6 @@ public class RecordingLogTest
     @Test
     public void shouldInvalidateLatestSnapshot()
     {
-        final long recordingId = 1L;
         final long termBaseLogPosition = 0L;
         final long logIncrement = 640L;
         long leadershipTermId = 7L;
@@ -304,26 +307,26 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendTerm(recordingId, leadershipTermId, termBaseLogPosition, timestamp);
+            recordingLog.appendTerm(1, leadershipTermId, termBaseLogPosition, timestamp);
 
             timestamp += 1;
             logPosition += logIncrement;
 
             recordingLog.appendSnapshot(
-                recordingId, leadershipTermId, termBaseLogPosition, logPosition, timestamp, 0);
+                2, leadershipTermId, termBaseLogPosition, logPosition, timestamp, 0);
             recordingLog.appendSnapshot(
-                recordingId, leadershipTermId, termBaseLogPosition, logPosition, timestamp, SERVICE_ID);
+                3, leadershipTermId, termBaseLogPosition, logPosition, timestamp, SERVICE_ID);
 
             timestamp += 1;
             logPosition += logIncrement;
 
             recordingLog.appendSnapshot(
-                recordingId, leadershipTermId, termBaseLogPosition, logPosition, timestamp, 0);
+                4, leadershipTermId, termBaseLogPosition, logPosition, timestamp, 0);
             recordingLog.appendSnapshot(
-                recordingId, leadershipTermId, termBaseLogPosition, logPosition, timestamp, SERVICE_ID);
+                5, leadershipTermId, termBaseLogPosition, logPosition, timestamp, SERVICE_ID);
 
             leadershipTermId++;
-            recordingLog.appendTerm(recordingId, leadershipTermId, logPosition, timestamp);
+            recordingLog.appendTerm(1, leadershipTermId, logPosition, timestamp);
 
             assertTrue(recordingLog.invalidateLatestSnapshot());
             assertEquals(6, recordingLog.entries().size());
@@ -371,12 +374,12 @@ public class RecordingLogTest
     {
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(3L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(3L, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(1L, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(2L, 1L, 0, 777L, 0, SERVICE_ID);
             recordingLog.appendSnapshot(3L, 1L, 10, 888L, 0, 0);
-            recordingLog.appendSnapshot(3L, 1L, 10, 888L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(3L, 1L, 20, 999L, 0, 0);
-            recordingLog.appendSnapshot(3L, 1L, 20, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(4L, 1L, 10, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(5L, 1L, 20, 999L, 0, 0);
+            recordingLog.appendSnapshot(6L, 1L, 20, 999L, 0, SERVICE_ID);
 
             recordingLog.invalidateEntry(1L, 2);
             recordingLog.invalidateEntry(1L, 3);
@@ -384,23 +387,23 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(3L, 1L, 10, 888L, 555, 0);
-            recordingLog.appendSnapshot(3L, 1L, 10, 888L, -999, SERVICE_ID);
+            recordingLog.appendSnapshot(7L, 1L, 10, 888L, 555, 0);
+            recordingLog.appendSnapshot(8L, 1L, 10, 888L, -999, SERVICE_ID);
 
             assertEquals(6, recordingLog.entries().size());
             assertTrue(recordingLog.entries().get(2).isValid);
-            assertEquals(555, recordingLog.entries().get(2).timestamp);
+            assertEquals(7L, recordingLog.entries().get(2).recordingId);
             assertTrue(recordingLog.entries().get(3).isValid);
-            assertEquals(-999, recordingLog.entries().get(3).timestamp);
+            assertEquals(8L, recordingLog.entries().get(3).recordingId);
         }
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
             assertEquals(6, recordingLog.entries().size());
             assertTrue(recordingLog.entries().get(2).isValid);
-            assertEquals(555, recordingLog.entries().get(2).timestamp);
+            assertEquals(7L, recordingLog.entries().get(2).recordingId);
             assertTrue(recordingLog.entries().get(3).isValid);
-            assertEquals(-999, recordingLog.entries().get(3).timestamp);
+            assertEquals(8L, recordingLog.entries().get(3).recordingId);
         }
     }
 
@@ -409,12 +412,12 @@ public class RecordingLogTest
     {
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(5L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(5L, 1L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(5L, 1L, 10, 888L, 0, 0);
-            recordingLog.appendSnapshot(5L, 1L, 10, 888L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(5L, 1L, 20, 999L, 0, 0);
-            recordingLog.appendSnapshot(5L, 1L, 20, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(-10, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(-11, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(-12, 1L, 10, 888L, 0, 0);
+            recordingLog.appendSnapshot(-13, 1L, 10, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(-14, 1L, 20, 999L, 0, 0);
+            recordingLog.appendSnapshot(-15, 1L, 20, 999L, 0, SERVICE_ID);
 
             recordingLog.invalidateLatestSnapshot();
             recordingLog.invalidateLatestSnapshot();
@@ -422,20 +425,20 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(5L, 1L, 20, 999L, 0, 0);
-            recordingLog.appendSnapshot(5L, 1L, 20, 999L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(5L, 1L, 10, 888L, 0, 0);
-            recordingLog.appendSnapshot(5L, 1L, 10, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(1, 1L, 20, 999L, 0, 0);
+            recordingLog.appendSnapshot(2, 1L, 20, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(3, 1L, 10, 888L, 0, 0);
+            recordingLog.appendSnapshot(4, 1L, 10, 888L, 0, SERVICE_ID);
 
             assertEquals(6, recordingLog.entries().size());
             assertTrue(recordingLog.entries().get(2).isValid);
-            assertEquals(5L, recordingLog.entries().get(2).recordingId);
+            assertEquals(3L, recordingLog.entries().get(2).recordingId);
             assertTrue(recordingLog.entries().get(3).isValid);
-            assertEquals(5L, recordingLog.entries().get(3).recordingId);
+            assertEquals(4L, recordingLog.entries().get(3).recordingId);
             assertTrue(recordingLog.entries().get(4).isValid);
-            assertEquals(5L, recordingLog.entries().get(4).recordingId);
+            assertEquals(1L, recordingLog.entries().get(4).recordingId);
             assertTrue(recordingLog.entries().get(5).isValid);
-            assertEquals(5L, recordingLog.entries().get(5).recordingId);
+            assertEquals(2L, recordingLog.entries().get(5).recordingId);
         }
     }
 
@@ -446,12 +449,12 @@ public class RecordingLogTest
         {
             recordingLog.appendTerm(10L, 0L, 0, 0);
             recordingLog.appendTerm(10L, 1L, 1000, 0);
-            recordingLog.appendSnapshot(10L, 1L, 0, 777L, 0, 0);
-            recordingLog.appendSnapshot(10L, 1L, 0, 777L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(10L, 1L, 10, 888L, 0, 0);
-            recordingLog.appendSnapshot(10L, 1L, 10, 888L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(10L, 1L, 20, 999L, 0, 0);
-            recordingLog.appendSnapshot(10L, 1L, 20, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(0, 1L, 0, 777L, 0, 0);
+            recordingLog.appendSnapshot(1, 1L, 0, 777L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(2, 1L, 10, 888L, 0, 0);
+            recordingLog.appendSnapshot(3, 1L, 10, 888L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(4, 1L, 20, 999L, 0, 0);
+            recordingLog.appendSnapshot(5, 1L, 20, 999L, 0, SERVICE_ID);
             recordingLog.appendTerm(10L, 2L, 1000, 5);
 
             assertTrue(recordingLog.invalidateLatestSnapshot());
@@ -459,28 +462,28 @@ public class RecordingLogTest
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
-            recordingLog.appendSnapshot(10L, 2L, 20, 999L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(10L, 1L, 21, 999L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(10L, 1L, 20, 998L, 0, SERVICE_ID);
-            recordingLog.appendSnapshot(10L, 1L, 20, 999L, 0, 42);
+            recordingLog.appendSnapshot(6, 2L, 20, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(7, 1L, 21, 999L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(8, 1L, 20, 998L, 0, SERVICE_ID);
+            recordingLog.appendSnapshot(9, 1L, 20, 999L, 0, 42);
 
-            assertEquals(new RecordingLog.Entry(10, 1, 20, 998, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 11),
+            assertEquals(new RecordingLog.Entry(8, 1, 20, 998, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 11),
                 recordingLog.entries().get(6));
-            assertEquals(new RecordingLog.Entry(10, 1, 20, 999, 0, 0, ENTRY_TYPE_SNAPSHOT, false, 6),
+            assertEquals(new RecordingLog.Entry(4, 1, 20, 999, 0, 0, ENTRY_TYPE_SNAPSHOT, false, 6),
                 recordingLog.entries().get(7));
-            assertEquals(new RecordingLog.Entry(10, 1, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, false, 7),
+            assertEquals(new RecordingLog.Entry(5, 1, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, false, 7),
                 recordingLog.entries().get(8));
-            assertEquals(new RecordingLog.Entry(10, 1, 21, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 10),
+            assertEquals(new RecordingLog.Entry(7, 1, 21, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 10),
                 recordingLog.entries().get(9));
-            assertEquals(new RecordingLog.Entry(10, 1, 20, 999, 0, 42, ENTRY_TYPE_SNAPSHOT, true, 12),
+            assertEquals(new RecordingLog.Entry(9, 1, 20, 999, 0, 42, ENTRY_TYPE_SNAPSHOT, true, 12),
                 recordingLog.entries().get(10));
             assertEquals(new RecordingLog.Entry(10, 2, 1000, NULL_POSITION, 5, NULL_VALUE, ENTRY_TYPE_TERM, true, 8),
                 recordingLog.entries().get(11));
-            assertEquals(new RecordingLog.Entry(10, 2, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 9),
+            assertEquals(new RecordingLog.Entry(6, 2, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 9),
                 recordingLog.entries().get(12));
             final RecordingLog.Entry latestSnapshot = recordingLog.getLatestSnapshot(SERVICE_ID);
             assertNotNull(latestSnapshot);
-            assertEquals(2, latestSnapshot.leadershipTermId);
+            assertEquals(6L, latestSnapshot.recordingId);
         }
     }
 
@@ -521,22 +524,22 @@ public class RecordingLogTest
     {
         final List<RecordingLog.Entry> sortedEntries = asList(
             new RecordingLog.Entry(3, 0, 0, NULL_POSITION, 0, NULL_VALUE, ENTRY_TYPE_TERM, true, 0),
-            new RecordingLog.Entry(3, 1, 100, 0, 42, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 1),
+            new RecordingLog.Entry(10, 1, 100, 0, 42, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 1),
             new RecordingLog.Entry(3, 2, 0, 2048, 555, NULL_VALUE, ENTRY_TYPE_TERM, true, 2),
-            new RecordingLog.Entry(3, 2, 200, 300, 100, 26, ENTRY_TYPE_SNAPSHOT, true, 5),
-            new RecordingLog.Entry(3, 2, 1000, 1256, 21, -19, ENTRY_TYPE_SNAPSHOT, true, 4),
+            new RecordingLog.Entry(100, 2, 200, 300, 100, 26, ENTRY_TYPE_SNAPSHOT, true, 5),
+            new RecordingLog.Entry(1, 2, 1000, 1256, 21, -19, ENTRY_TYPE_SNAPSHOT, true, 4),
             new RecordingLog.Entry(3, 3, 2048, NULL_POSITION, 0, NULL_VALUE, ENTRY_TYPE_TERM, true, 3));
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
             recordingLog.appendTerm(3, 0, 0, 0);
-            recordingLog.appendSnapshot(3, 1, 100, 0, 42, SERVICE_ID);
+            recordingLog.appendSnapshot(300, 1, 100, 0, 42, SERVICE_ID);
             recordingLog.invalidateEntry(1, 1);
             recordingLog.appendTerm(3, 2, 0, 555);
             recordingLog.appendTerm(3, 3, 2048, 0);
-            recordingLog.appendSnapshot(3, 2, 1000, 1256, 21, -19);
-            recordingLog.appendSnapshot(3, 1, 100, 0, 42, SERVICE_ID);
-            recordingLog.appendSnapshot(3, 2, 200, 300, 100, 26);
+            recordingLog.appendSnapshot(1, 2, 1000, 1256, 21, -19);
+            recordingLog.appendSnapshot(10, 1, 100, 0, 42, SERVICE_ID);
+            recordingLog.appendSnapshot(100, 2, 200, 300, 100, 26);
 
             assertEquals(6, recordingLog.nextEntryIndex());
             final List<RecordingLog.Entry> entries = recordingLog.entries();
@@ -588,7 +591,7 @@ public class RecordingLogTest
 
             final ClusterException exception = assertThrows(ClusterException.class,
                 () -> recordingLog.appendTerm(21, 1, 0, 0));
-            assertEquals("ERROR - invalid recordingId=21, expected recordingId=42", exception.getMessage());
+            assertEquals("ERROR - invalid TERM recordingId=21, expected recordingId=42", exception.getMessage());
             assertEquals(1, recordingLog.entries().size());
         }
 
@@ -596,35 +599,13 @@ public class RecordingLogTest
         {
             final ClusterException exception = assertThrows(ClusterException.class,
                 () -> recordingLog.appendTerm(-5, -5, -5, -5));
-            assertEquals("ERROR - invalid recordingId=-5, expected recordingId=42", exception.getMessage());
+            assertEquals("ERROR - invalid TERM recordingId=-5, expected recordingId=42", exception.getMessage());
             assertEquals(1, recordingLog.entries().size());
         }
     }
 
     @Test
-    void appendSnapshotShouldNotAcceptDifferentRecordingIds()
-    {
-        try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
-        {
-            recordingLog.appendSnapshot(19, 0, 0, 0, 0, SERVICE_ID);
-
-            final ClusterException exception = assertThrows(ClusterException.class,
-                () -> recordingLog.appendSnapshot(17, 0, 0, 100, 100, SERVICE_ID));
-            assertEquals("ERROR - invalid recordingId=17, expected recordingId=19", exception.getMessage());
-            assertEquals(1, recordingLog.entries().size());
-        }
-
-        try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
-        {
-            final ClusterException exception = assertThrows(ClusterException.class,
-                () -> recordingLog.appendSnapshot(333, 1, 1, 1, 1, 1));
-            assertEquals("ERROR - invalid recordingId=333, expected recordingId=19", exception.getMessage());
-            assertEquals(1, recordingLog.entries().size());
-        }
-    }
-
-    @Test
-    void appendTermShouldSecondValidTermForTheSameLeadershipTermId()
+    void appendTermShouldOnlyAllowASingleValidTermForTheSameLeadershipTermId()
     {
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
         {
@@ -636,7 +617,7 @@ public class RecordingLogTest
 
             final ClusterException exception = assertThrows(ClusterException.class,
                 () -> recordingLog.appendTerm(8, 1, 5, 5));
-            assertEquals("ERROR - duplicate term entry for leadershipTermId=1", exception.getMessage());
+            assertEquals("ERROR - duplicate TERM entry for leadershipTermId=1", exception.getMessage());
             assertEquals(3, recordingLog.entries().size());
         }
     }
@@ -652,7 +633,7 @@ public class RecordingLogTest
 
             final ClusterException exception = assertThrows(ClusterException.class,
                 () -> recordingLog.appendTerm(4, 1, 0, 5000));
-            assertEquals("ERROR - term cannot be added for leadershipTermId=1, because a snapshot already exists",
+            assertEquals("ERROR - TERM cannot be added for leadershipTermId=1, because a snapshot already exists",
                 exception.getMessage());
             assertEquals(3, recordingLog.entries().size());
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/RecordingLogTest.java
@@ -88,7 +88,7 @@ public class RecordingLogTest
 
             final RecordingLog.Entry snapshot = recordingLog.getLatestSnapshot(SERVICE_ID);
             assertNotNull(snapshot);
-            assertEquals(entry.toString(), snapshot.toString());
+            assertEquals(entry, snapshot);
         }
     }
 
@@ -368,7 +368,7 @@ public class RecordingLogTest
             assertTrue(recordingLog.entries().get(5).isValid);
 
             assertFalse(recordingLog.invalidateLatestSnapshot());
-            assertEquals(leadershipTermId, recordingLog.getTermEntry(leadershipTermId).leadershipTermId);
+            assertEquals(recordingId, recordingLog.getTermEntry(leadershipTermId).recordingId);
         }
     }
 
@@ -460,7 +460,7 @@ public class RecordingLogTest
             recordingLog.appendSnapshot(6L, 1L, 20, 999L, 0, SERVICE_ID);
             recordingLog.appendTerm(0L, 2L, 1000, 5);
 
-            recordingLog.invalidateLatestSnapshot();
+            assertTrue(recordingLog.invalidateLatestSnapshot());
         }
 
         try (RecordingLog recordingLog = new RecordingLog(TEMP_DIR))
@@ -470,11 +470,13 @@ public class RecordingLogTest
             recordingLog.appendSnapshot(9L, 1L, 20, 998L, 0, SERVICE_ID);
             recordingLog.appendSnapshot(10L, 1L, 20, 999L, 0, 42);
 
-            assertEquals(new RecordingLog.Entry(6, 1, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, false, 7),
-                recordingLog.entries().get(7));
-            assertEquals(new RecordingLog.Entry(8, 1, 21, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 10),
-                recordingLog.entries().get(8));
             assertEquals(new RecordingLog.Entry(9, 1, 20, 998, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 11),
+                recordingLog.entries().get(6));
+            assertEquals(new RecordingLog.Entry(5, 1, 20, 999, 0, 0, ENTRY_TYPE_SNAPSHOT, false, 6),
+                recordingLog.entries().get(7));
+            assertEquals(new RecordingLog.Entry(6, 1, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, false, 7),
+                recordingLog.entries().get(8));
+            assertEquals(new RecordingLog.Entry(8, 1, 21, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 10),
                 recordingLog.entries().get(9));
             assertEquals(new RecordingLog.Entry(10, 1, 20, 999, 0, 42, ENTRY_TYPE_SNAPSHOT, true, 12),
                 recordingLog.entries().get(10));
@@ -482,7 +484,9 @@ public class RecordingLogTest
                 recordingLog.entries().get(11));
             assertEquals(new RecordingLog.Entry(7, 2, 20, 999, 0, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 9),
                 recordingLog.entries().get(12));
-            assertEquals(7, recordingLog.getLatestSnapshot(SERVICE_ID).recordingId);
+            final RecordingLog.Entry latestSnapshot = recordingLog.getLatestSnapshot(SERVICE_ID);
+            assertNotNull(latestSnapshot);
+            assertEquals(7, latestSnapshot.recordingId);
         }
     }
 
@@ -521,26 +525,28 @@ public class RecordingLogTest
         {
             recordingLog.appendTerm(0, 0, 0, 0);
             recordingLog.appendSnapshot(1, 1, 100, 0, 42, SERVICE_ID);
-            recordingLog.appendTerm(0, 3, 2048, 0);
             recordingLog.invalidateEntry(1, 1);
+            recordingLog.appendTerm(0, 3, 2048, 0);
             recordingLog.appendSnapshot(0, 2, 1000, 1256, 21, -19);
-            recordingLog.appendTerm(1, 3, 4096, 200);
             recordingLog.appendSnapshot(2, 1, 100, 0, 42, SERVICE_ID);
+            recordingLog.appendSnapshot(1, 2, 200, 300, 100, 26);
 
             assertEquals(5, recordingLog.nextEntryIndex());
             final List<RecordingLog.Entry> entries = recordingLog.entries();
             assertEquals(asList(
                 new RecordingLog.Entry(0, 0, 0, NULL_POSITION, 0, NULL_VALUE, ENTRY_TYPE_TERM, true, 0),
                 new RecordingLog.Entry(2, 1, 100, 0, 42, SERVICE_ID, ENTRY_TYPE_SNAPSHOT, true, 1),
+                new RecordingLog.Entry(1, 2, 200, 300, 100, 26, ENTRY_TYPE_SNAPSHOT, true, 4),
                 new RecordingLog.Entry(0, 2, 1000, 1256, 21, -19, ENTRY_TYPE_SNAPSHOT, true, 3),
-                new RecordingLog.Entry(0, 3, 2048, NULL_POSITION, 0, NULL_VALUE, ENTRY_TYPE_TERM, true, 2),
-                new RecordingLog.Entry(1, 3, 4096, NULL_POSITION, 200, NULL_VALUE, ENTRY_TYPE_TERM, true, 4)),
+                new RecordingLog.Entry(0, 3, 2048, NULL_POSITION, 0, NULL_VALUE, ENTRY_TYPE_TERM, true, 2)),
                 entries);
             assertEquals(0, recordingLog.getTermEntry(0).recordingId);
             assertNull(recordingLog.findTermEntry(1));
             assertNull(recordingLog.findTermEntry(2));
-            assertEquals(1, recordingLog.getTermEntry(3).recordingId);
-            assertEquals(2, recordingLog.getLatestSnapshot(SERVICE_ID).recordingId);
+            assertEquals(0, recordingLog.getTermEntry(3).recordingId);
+            final RecordingLog.Entry latestSnapshot = recordingLog.getLatestSnapshot(SERVICE_ID);
+            assertNotNull(latestSnapshot);
+            assertEquals(2, latestSnapshot.recordingId);
         }
     }
 


### PR DESCRIPTION
This PR changes `RecordingLog` to allow term and snapshot entries to be added out of order.
- A TERM can be added out of order with other terms.
- A snapshot can be added out of order with other entries.
- A TERM must be added before a snapshot for the same `leadershipTermId` (validation).
- `NULL_VALUE` is not allowed as `recordingId` (validation).
- All TERM entries must added with the same `recordingId` (validation).
- ClusterTool now has command `sort-recording-log` which re-arranges entries on disc to match the in-memory order.