### PR TITLE
Flow control logging

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventDissector.java
@@ -418,11 +418,11 @@ final class ArchiveEventDissector
             HEADER_DECODER.version());
 
         builder.append(": controlSessionId=").append(CONTROL_RESPONSE_DECODER.controlSessionId())
-            .append(", correlationId=").append(CONTROL_RESPONSE_DECODER.correlationId())
-            .append(", relevantId=").append(CONTROL_RESPONSE_DECODER.relevantId())
-            .append(", code=").append(CONTROL_RESPONSE_DECODER.code())
-            .append(", version=").append(CONTROL_RESPONSE_DECODER.version())
-            .append(", errorMessage=");
+            .append(" correlationId=").append(CONTROL_RESPONSE_DECODER.correlationId())
+            .append(" relevantId=").append(CONTROL_RESPONSE_DECODER.relevantId())
+            .append(" code=").append(CONTROL_RESPONSE_DECODER.code())
+            .append(" version=").append(CONTROL_RESPONSE_DECODER.version())
+            .append(" errorMessage=");
 
         CONTROL_RESPONSE_DECODER.getErrorMessage(builder);
     }
@@ -437,7 +437,7 @@ final class ArchiveEventDissector
         absoluteOffset += SIZE_OF_LONG;
 
         builder.append(": replicationId=").append(replicationId);
-        builder.append(", ");
+        builder.append(" ");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -451,7 +451,7 @@ final class ArchiveEventDissector
         absoluteOffset += SIZE_OF_LONG;
 
         builder.append(": controlSessionId=").append(controlSessionId);
-        builder.append(", ");
+        builder.append(" ");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -468,8 +468,8 @@ final class ArchiveEventDissector
         absoluteOffset += SIZE_OF_LONG;
 
         builder.append(": sessionId=").append(sessionId);
-        builder.append(", recordingId=").append(recordingId);
-        builder.append(", errorMessage=");
+        builder.append(" recordingId=").append(recordingId);
+        builder.append(" errorMessage=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -497,9 +497,9 @@ final class ArchiveEventDissector
     private static void appendConnect(final StringBuilder builder)
     {
         builder.append(": correlationId=").append(CONNECT_REQUEST_DECODER.correlationId())
-            .append(", responseStreamId=").append(CONNECT_REQUEST_DECODER.responseStreamId())
-            .append(", version=").append(CONNECT_REQUEST_DECODER.version())
-            .append(", responseChannel=");
+            .append(" responseStreamId=").append(CONNECT_REQUEST_DECODER.responseStreamId())
+            .append(" version=").append(CONNECT_REQUEST_DECODER.version())
+            .append(" responseChannel=");
 
         CONNECT_REQUEST_DECODER.getResponseChannel(builder);
     }
@@ -507,13 +507,13 @@ final class ArchiveEventDissector
     private static void appendAuthConnect(final StringBuilder builder)
     {
         builder.append(": correlationId=").append(AUTH_CONNECT_REQUEST_DECODER.correlationId())
-            .append(", responseStreamId=").append(AUTH_CONNECT_REQUEST_DECODER.responseStreamId())
-            .append(", version=").append(AUTH_CONNECT_REQUEST_DECODER.version())
-            .append(", responseChannel=");
+            .append(" responseStreamId=").append(AUTH_CONNECT_REQUEST_DECODER.responseStreamId())
+            .append(" version=").append(AUTH_CONNECT_REQUEST_DECODER.version())
+            .append(" responseChannel=");
 
         AUTH_CONNECT_REQUEST_DECODER.getResponseChannel(builder);
 
-        builder.append(", encodedCredentialsLength=").append(AUTH_CONNECT_REQUEST_DECODER.encodedCredentialsLength());
+        builder.append(" encodedCredentialsLength=").append(AUTH_CONNECT_REQUEST_DECODER.encodedCredentialsLength());
     }
 
     private static void appendCloseSession(final StringBuilder builder)
@@ -524,10 +524,10 @@ final class ArchiveEventDissector
     private static void appendStartRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(START_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(START_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", streamId=").append(START_RECORDING_REQUEST_DECODER.streamId())
-            .append(", sourceLocation=").append(START_RECORDING_REQUEST_DECODER.sourceLocation())
-            .append(", channel=");
+            .append(" correlationId=").append(START_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" streamId=").append(START_RECORDING_REQUEST_DECODER.streamId())
+            .append(" sourceLocation=").append(START_RECORDING_REQUEST_DECODER.sourceLocation())
+            .append(" channel=");
 
         START_RECORDING_REQUEST_DECODER.getChannel(builder);
     }
@@ -535,11 +535,11 @@ final class ArchiveEventDissector
     private static void appendStartRecording2(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(START_RECORDING_REQUEST2_DECODER.controlSessionId())
-            .append(", correlationId=").append(START_RECORDING_REQUEST2_DECODER.correlationId())
-            .append(", streamId=").append(START_RECORDING_REQUEST2_DECODER.streamId())
-            .append(", sourceLocation=").append(START_RECORDING_REQUEST2_DECODER.sourceLocation())
-            .append(", autoStop=").append(START_RECORDING_REQUEST2_DECODER.autoStop())
-            .append(", channel=");
+            .append(" correlationId=").append(START_RECORDING_REQUEST2_DECODER.correlationId())
+            .append(" streamId=").append(START_RECORDING_REQUEST2_DECODER.streamId())
+            .append(" sourceLocation=").append(START_RECORDING_REQUEST2_DECODER.sourceLocation())
+            .append(" autoStop=").append(START_RECORDING_REQUEST2_DECODER.autoStop())
+            .append(" channel=");
 
         START_RECORDING_REQUEST2_DECODER.getChannel(builder);
     }
@@ -547,9 +547,9 @@ final class ArchiveEventDissector
     private static void appendStopRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", streamId=").append(STOP_RECORDING_REQUEST_DECODER.streamId())
-            .append(", channel=");
+            .append(" correlationId=").append(STOP_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" streamId=").append(STOP_RECORDING_REQUEST_DECODER.streamId())
+            .append(" channel=");
 
         STOP_RECORDING_REQUEST_DECODER.getChannel(builder);
     }
@@ -557,12 +557,12 @@ final class ArchiveEventDissector
     private static void appendReplay(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(REPLAY_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(REPLAY_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(REPLAY_REQUEST_DECODER.recordingId())
-            .append(", position=").append(REPLAY_REQUEST_DECODER.position())
-            .append(", length=").append(REPLAY_REQUEST_DECODER.length())
-            .append(", replayStreamId=").append(REPLAY_REQUEST_DECODER.replayStreamId())
-            .append(", replayChannel=");
+            .append(" correlationId=").append(REPLAY_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(REPLAY_REQUEST_DECODER.recordingId())
+            .append(" position=").append(REPLAY_REQUEST_DECODER.position())
+            .append(" length=").append(REPLAY_REQUEST_DECODER.length())
+            .append(" replayStreamId=").append(REPLAY_REQUEST_DECODER.replayStreamId())
+            .append(" replayChannel=");
 
         REPLAY_REQUEST_DECODER.getReplayChannel(builder);
     }
@@ -570,33 +570,33 @@ final class ArchiveEventDissector
     private static void appendStopReplay(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_REPLAY_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_REPLAY_REQUEST_DECODER.correlationId())
-            .append(", replaySessionId=").append(STOP_REPLAY_REQUEST_DECODER.replaySessionId());
+            .append(" correlationId=").append(STOP_REPLAY_REQUEST_DECODER.correlationId())
+            .append(" replaySessionId=").append(STOP_REPLAY_REQUEST_DECODER.replaySessionId());
     }
 
     private static void appendListRecordings(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(LIST_RECORDINGS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(LIST_RECORDINGS_REQUEST_DECODER.correlationId())
-            .append(", fromRecordingId=").append(LIST_RECORDINGS_REQUEST_DECODER.fromRecordingId())
-            .append(", recordCount=").append(LIST_RECORDINGS_REQUEST_DECODER.recordCount());
+            .append(" correlationId=").append(LIST_RECORDINGS_REQUEST_DECODER.correlationId())
+            .append(" fromRecordingId=").append(LIST_RECORDINGS_REQUEST_DECODER.fromRecordingId())
+            .append(" recordCount=").append(LIST_RECORDINGS_REQUEST_DECODER.recordCount());
     }
 
     private static void appendListRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(LIST_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(LIST_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(LIST_RECORDING_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(LIST_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(LIST_RECORDING_REQUEST_DECODER.recordingId());
     }
 
     private static void appendListRecordingsForUri(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.correlationId())
-            .append(", fromRecordingId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.fromRecordingId())
-            .append(", recordCount=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.recordCount())
-            .append(", streamId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.streamId())
-            .append(", channel=");
+            .append(" correlationId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.correlationId())
+            .append(" fromRecordingId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.fromRecordingId())
+            .append(" recordCount=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.recordCount())
+            .append(" streamId=").append(LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.streamId())
+            .append(" channel=");
 
         LIST_RECORDINGS_FOR_URI_REQUEST_DECODER.getChannel(builder);
     }
@@ -604,11 +604,11 @@ final class ArchiveEventDissector
     private static void appendExtendRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(EXTEND_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(EXTEND_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(EXTEND_RECORDING_REQUEST_DECODER.recordingId())
-            .append(", streamId=").append(EXTEND_RECORDING_REQUEST_DECODER.streamId())
-            .append(", sourceLocation=").append(EXTEND_RECORDING_REQUEST_DECODER.sourceLocation())
-            .append(", channel=");
+            .append(" correlationId=").append(EXTEND_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(EXTEND_RECORDING_REQUEST_DECODER.recordingId())
+            .append(" streamId=").append(EXTEND_RECORDING_REQUEST_DECODER.streamId())
+            .append(" sourceLocation=").append(EXTEND_RECORDING_REQUEST_DECODER.sourceLocation())
+            .append(" channel=");
 
         EXTEND_RECORDING_REQUEST_DECODER.getChannel(builder);
     }
@@ -616,12 +616,12 @@ final class ArchiveEventDissector
     private static void appendExtendRecording2(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(EXTEND_RECORDING_REQUEST2_DECODER.controlSessionId())
-            .append(", correlationId=").append(EXTEND_RECORDING_REQUEST2_DECODER.correlationId())
-            .append(", recordingId=").append(EXTEND_RECORDING_REQUEST2_DECODER.recordingId())
-            .append(", streamId=").append(EXTEND_RECORDING_REQUEST2_DECODER.streamId())
-            .append(", sourceLocation=").append(EXTEND_RECORDING_REQUEST2_DECODER.sourceLocation())
-            .append(", autoStop=").append(EXTEND_RECORDING_REQUEST2_DECODER.autoStop())
-            .append(", channel=");
+            .append(" correlationId=").append(EXTEND_RECORDING_REQUEST2_DECODER.correlationId())
+            .append(" recordingId=").append(EXTEND_RECORDING_REQUEST2_DECODER.recordingId())
+            .append(" streamId=").append(EXTEND_RECORDING_REQUEST2_DECODER.streamId())
+            .append(" sourceLocation=").append(EXTEND_RECORDING_REQUEST2_DECODER.sourceLocation())
+            .append(" autoStop=").append(EXTEND_RECORDING_REQUEST2_DECODER.autoStop())
+            .append(" channel=");
 
         EXTEND_RECORDING_REQUEST2_DECODER.getChannel(builder);
     }
@@ -629,47 +629,47 @@ final class ArchiveEventDissector
     private static void appendRecordingPosition(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(RECORDING_POSITION_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(RECORDING_POSITION_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(RECORDING_POSITION_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(RECORDING_POSITION_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(RECORDING_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendTruncateRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.recordingId())
-            .append(", position=").append(TRUNCATE_RECORDING_REQUEST_DECODER.position());
+            .append(" correlationId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(TRUNCATE_RECORDING_REQUEST_DECODER.recordingId())
+            .append(" position=").append(TRUNCATE_RECORDING_REQUEST_DECODER.position());
     }
 
     private static void appendStopRecordingSubscription(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.correlationId())
-            .append(", subscriptionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.subscriptionId());
+            .append(" correlationId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.correlationId())
+            .append(" subscriptionId=").append(STOP_RECORDING_SUBSCRIPTION_REQUEST_DECODER.subscriptionId());
     }
 
     private static void appendStopRecordingByIdentity(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(STOP_RECORDING_BY_IDENTITY_REQUEST_DECODER.recordingId());
     }
 
     private static void appendStopPosition(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_POSITION_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_POSITION_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(STOP_POSITION_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(STOP_POSITION_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(STOP_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendFindLastMatchingRecord(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", minRecordingId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.minRecordingId())
-            .append(", sessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.sessionId())
-            .append(", streamId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.streamId())
-            .append(", channel=");
+            .append(" correlationId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" minRecordingId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.minRecordingId())
+            .append(" sessionId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.sessionId())
+            .append(" streamId=").append(FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.streamId())
+            .append(" channel=");
 
         FIND_LAST_MATCHING_RECORDING_REQUEST_DECODER.getChannel(builder);
     }
@@ -677,12 +677,12 @@ final class ArchiveEventDissector
     private static void appendListRecordingSubscriptions(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.correlationId())
-            .append(", pseudoIndex=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.pseudoIndex())
-            .append(", applyStreamId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.applyStreamId())
-            .append(", subscriptionCount=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.subscriptionCount())
-            .append(", streamId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.streamId())
-            .append(", channel=");
+            .append(" correlationId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.correlationId())
+            .append(" pseudoIndex=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.pseudoIndex())
+            .append(" applyStreamId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.applyStreamId())
+            .append(" subscriptionCount=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.subscriptionCount())
+            .append(" streamId=").append(LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.streamId())
+            .append(" channel=");
 
         LIST_RECORDING_SUBSCRIPTIONS_REQUEST_DECODER.getChannel(builder);
     }
@@ -690,13 +690,13 @@ final class ArchiveEventDissector
     private static void appendStartBoundedReplay(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(BOUNDED_REPLAY_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(BOUNDED_REPLAY_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(BOUNDED_REPLAY_REQUEST_DECODER.recordingId())
-            .append(", position=").append(BOUNDED_REPLAY_REQUEST_DECODER.position())
-            .append(", length=").append(BOUNDED_REPLAY_REQUEST_DECODER.length())
-            .append(", limitCounterId=").append(BOUNDED_REPLAY_REQUEST_DECODER.limitCounterId())
-            .append(", replayStreamId=").append(BOUNDED_REPLAY_REQUEST_DECODER.replayStreamId())
-            .append(", replayChannel=");
+            .append(" correlationId=").append(BOUNDED_REPLAY_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(BOUNDED_REPLAY_REQUEST_DECODER.recordingId())
+            .append(" position=").append(BOUNDED_REPLAY_REQUEST_DECODER.position())
+            .append(" length=").append(BOUNDED_REPLAY_REQUEST_DECODER.length())
+            .append(" limitCounterId=").append(BOUNDED_REPLAY_REQUEST_DECODER.limitCounterId())
+            .append(" replayStreamId=").append(BOUNDED_REPLAY_REQUEST_DECODER.replayStreamId())
+            .append(" replayChannel=");
 
         BOUNDED_REPLAY_REQUEST_DECODER.getReplayChannel(builder);
     }
@@ -704,103 +704,103 @@ final class ArchiveEventDissector
     private static void appendStopAllReplays(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(STOP_ALL_REPLAYS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendReplicate(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(REPLICATE_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(REPLICATE_REQUEST_DECODER.correlationId())
-            .append(", srcRecordingId=").append(REPLICATE_REQUEST_DECODER.srcRecordingId())
-            .append(", dstRecordingId=").append(REPLICATE_REQUEST_DECODER.dstRecordingId())
-            .append(", srcControlStreamId=").append(REPLICATE_REQUEST_DECODER.srcControlStreamId())
-            .append(", srcControlChannel=");
+            .append(" correlationId=").append(REPLICATE_REQUEST_DECODER.correlationId())
+            .append(" srcRecordingId=").append(REPLICATE_REQUEST_DECODER.srcRecordingId())
+            .append(" dstRecordingId=").append(REPLICATE_REQUEST_DECODER.dstRecordingId())
+            .append(" srcControlStreamId=").append(REPLICATE_REQUEST_DECODER.srcControlStreamId())
+            .append(" srcControlChannel=");
 
         REPLICATE_REQUEST_DECODER.getSrcControlChannel(builder);
 
-        builder.append(", liveDestination=");
+        builder.append(" liveDestination=");
         REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
 
     private static void appendStopReplication(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(STOP_REPLICATION_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(STOP_REPLICATION_REQUEST_DECODER.correlationId())
-            .append(", replicationId=").append(STOP_REPLICATION_REQUEST_DECODER.replicationId());
+            .append(" correlationId=").append(STOP_REPLICATION_REQUEST_DECODER.correlationId())
+            .append(" replicationId=").append(STOP_REPLICATION_REQUEST_DECODER.replicationId());
     }
 
     private static void appendStartPosition(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(START_POSITION_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(START_POSITION_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(START_POSITION_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(START_POSITION_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(START_POSITION_REQUEST_DECODER.recordingId());
     }
 
     private static void appendDetachSegments(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(DETACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(DETACH_SEGMENTS_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(DETACH_SEGMENTS_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(DETACH_SEGMENTS_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(DETACH_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendDeleteDetachedSegments(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(DELETE_DETACHED_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendPurgeSegments(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(PURGE_SEGMENTS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(PURGE_SEGMENTS_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(PURGE_SEGMENTS_REQUEST_DECODER.recordingId())
-            .append(", newStartPosition=").append(PURGE_SEGMENTS_REQUEST_DECODER.newStartPosition());
+            .append(" correlationId=").append(PURGE_SEGMENTS_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(PURGE_SEGMENTS_REQUEST_DECODER.recordingId())
+            .append(" newStartPosition=").append(PURGE_SEGMENTS_REQUEST_DECODER.newStartPosition());
     }
 
     private static void appendAttachSegments(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(ATTACH_SEGMENTS_REQUEST_DECODER.recordingId());
     }
 
     private static void appendMigrateSegments(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.correlationId())
-            .append(", srcRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.srcRecordingId())
-            .append(", dstRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.dstRecordingId());
+            .append(" correlationId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.correlationId())
+            .append(" srcRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.srcRecordingId())
+            .append(" dstRecordingId=").append(MIGRATE_SEGMENTS_REQUEST_DECODER.dstRecordingId());
     }
 
     private static void appendKeepAlive(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(KEEP_ALIVE_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(KEEP_ALIVE_REQUEST_DECODER.correlationId());
+            .append(" correlationId=").append(KEEP_ALIVE_REQUEST_DECODER.correlationId());
     }
 
     private static void appendTaggedReplicate(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(TAGGED_REPLICATE_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(TAGGED_REPLICATE_REQUEST_DECODER.correlationId())
-            .append(", srcRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcRecordingId())
-            .append(", dstRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.dstRecordingId())
-            .append(", channelTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.channelTagId())
-            .append(", subscriptionTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.subscriptionTagId())
-            .append(", srcControlStreamId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcControlStreamId())
-            .append(", srcControlChannel=");
+            .append(" correlationId=").append(TAGGED_REPLICATE_REQUEST_DECODER.correlationId())
+            .append(" srcRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcRecordingId())
+            .append(" dstRecordingId=").append(TAGGED_REPLICATE_REQUEST_DECODER.dstRecordingId())
+            .append(" channelTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.channelTagId())
+            .append(" subscriptionTagId=").append(TAGGED_REPLICATE_REQUEST_DECODER.subscriptionTagId())
+            .append(" srcControlStreamId=").append(TAGGED_REPLICATE_REQUEST_DECODER.srcControlStreamId())
+            .append(" srcControlChannel=");
 
         TAGGED_REPLICATE_REQUEST_DECODER.getSrcControlChannel(builder);
 
-        builder.append(", liveDestination=");
+        builder.append(" liveDestination=");
         TAGGED_REPLICATE_REQUEST_DECODER.getLiveDestination(builder);
     }
 
     private static void appendPurgeRecording(final StringBuilder builder)
     {
         builder.append(": controlSessionId=").append(PURGE_RECORDING_REQUEST_DECODER.controlSessionId())
-            .append(", correlationId=").append(PURGE_RECORDING_REQUEST_DECODER.correlationId())
-            .append(", recordingId=").append(PURGE_RECORDING_REQUEST_DECODER.recordingId());
+            .append(" correlationId=").append(PURGE_RECORDING_REQUEST_DECODER.correlationId())
+            .append(" recordingId=").append(PURGE_RECORDING_REQUEST_DECODER.recordingId());
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventDissector.java
@@ -67,15 +67,15 @@ final class ClusterEventDissector
         final boolean isStartup = 1 == buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId)
-            .append(", logTruncatePosition=").append(logTruncatePosition)
-            .append(", leadershipTermId=").append(leadershipTermId)
-            .append(", termBaseLogPosition=").append(termBaseLogPosition)
-            .append(", logPosition=").append(logPosition)
-            .append(", leaderRecordingId=").append(leaderRecordingId)
-            .append(", timestamp=").append(timestamp)
-            .append(", leaderMemberId=").append(leaderMemberId)
-            .append(", logSessionId=").append(logSessionId)
-            .append(", isStartup=").append(isStartup);
+            .append(" logTruncatePosition=").append(logTruncatePosition)
+            .append(" leadershipTermId=").append(leadershipTermId)
+            .append(" termBaseLogPosition=").append(termBaseLogPosition)
+            .append(" logPosition=").append(logPosition)
+            .append(" leaderRecordingId=").append(leaderRecordingId)
+            .append(" timestamp=").append(timestamp)
+            .append(" leaderMemberId=").append(leaderMemberId)
+            .append(" logSessionId=").append(logSessionId)
+            .append(" isStartup=").append(isStartup);
     }
 
     static void dissectStateChange(
@@ -91,7 +91,7 @@ final class ClusterEventDissector
         absoluteOffset += SIZE_OF_INT;
 
         builder.append(": memberId=").append(memberId);
-        builder.append(", ");
+        builder.append(' ');
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -109,12 +109,11 @@ final class ClusterEventDissector
         final long logPosition = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
         absoluteOffset += SIZE_OF_LONG;
         final int followerMemberId = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
-        absoluteOffset += SIZE_OF_INT;
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId);
-        builder.append(", ");
+        builder.append(' ');
         builder.append(" logPosition=").append(logPosition);
-        builder.append(", ");
+        builder.append(' ');
         builder.append(" followerMemberId=").append(followerMemberId);
     }
 
@@ -134,14 +133,13 @@ final class ClusterEventDissector
         final long candidateTermId = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
         absoluteOffset += SIZE_OF_LONG;
         final int candidateId = buffer.getInt(absoluteOffset, LITTLE_ENDIAN);
-        absoluteOffset += SIZE_OF_INT;
 
         builder.append(": logLeadershipTermId=").append(logLeadershipTermId);
-        builder.append(", ");
+        builder.append(' ');
         builder.append(" logPosition=").append(logPosition);
-        builder.append(", ");
+        builder.append(' ');
         builder.append(" candidateTermId=").append(candidateTermId);
-        builder.append(", ");
+        builder.append(' ');
         builder.append(" candidateId=").append(candidateId);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -77,7 +77,10 @@ public enum DriverEventCode implements EventCode
         (code, buffer, offset, builder) -> dissectUntetheredSubscriptionStateChange(buffer, offset, builder)),
 
     NAME_RESOLUTION_NEIGHBOR_ADDED(46, DriverEventDissector::dissectAddress),
-    NAME_RESOLUTION_NEIGHBOR_REMOVED(47, DriverEventDissector::dissectAddress);
+    NAME_RESOLUTION_NEIGHBOR_REMOVED(47, DriverEventDissector::dissectAddress),
+
+    FLOW_CONTROL_RECEIVER_ADDED(48, DriverEventDissector::dissectFlowControlReceiver),
+    FLOW_CONTROL_RECEIVER_REMOVED(49, DriverEventDissector::dissectFlowControlReceiver);
 
     static final int EVENT_CODE_TYPE = EventCodeType.DRIVER.getTypeCode();
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -20,7 +20,8 @@ import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.*;
 import org.agrona.MutableDirectBuffer;
 
-import static io.aeron.agent.CommonEventDissector.*;
+import static io.aeron.agent.CommonEventDissector.dissectLogHeader;
+import static io.aeron.agent.CommonEventDissector.dissectSocketAddress;
 import static io.aeron.agent.DriverEventCode.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.BitUtil.SIZE_OF_INT;
@@ -301,6 +302,28 @@ final class DriverEventDissector
 
         builder.append(": ");
         dissectSocketAddress(buffer, absoluteOffset, builder);
+    }
+
+    static void dissectFlowControlReceiver(
+        final DriverEventCode code, final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, code, buffer, absoluteOffset, builder);
+
+        builder.append(": receiverCount=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" receiverId=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_LONG;
+
+        builder.append(" sessionId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" channel=");
+        buffer.getStringAscii(absoluteOffset, builder);
     }
 
     static int frameType(final MutableDirectBuffer buffer, final int termOffset)

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -232,10 +232,10 @@ final class DriverEventDissector
         builder.append(": sessionId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", channel=");
+        builder.append(" channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -248,10 +248,10 @@ final class DriverEventDissector
         builder.append(": streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_LONG;
 
-        builder.append(", channel=");
+        builder.append(" channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -264,13 +264,13 @@ final class DriverEventDissector
         builder.append(": sessionId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_LONG;
 
-        builder.append(", channel=");
+        builder.append(" channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -284,13 +284,13 @@ final class DriverEventDissector
         builder.append(": subscriptionId=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_LONG;
 
-        builder.append(", streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", sessionId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
+        builder.append(" sessionId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", ");
+        builder.append(" ");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -235,7 +235,7 @@ final class DriverEventDissector
         builder.append(", streamId=").append(buffer.getInt(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(", uri=");
+        builder.append(", channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -251,7 +251,7 @@ final class DriverEventDissector
         builder.append(", id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_LONG;
 
-        builder.append(", uri=");
+        builder.append(", channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
@@ -270,7 +270,7 @@ final class DriverEventDissector
         builder.append(", id=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
         absoluteOffset += SIZE_OF_LONG;
 
-        builder.append(", uri=");
+        builder.append(", channel=");
         buffer.getStringAscii(absoluteOffset, builder);
     }
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -98,7 +98,7 @@ final class DriverEventEncoder
         final int offset,
         final int captureLength,
         final int length,
-        final String uri,
+        final String channel,
         final int sessionId,
         final int streamId)
     {
@@ -110,7 +110,7 @@ final class DriverEventEncoder
         encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_INT;
 
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2, uri);
+        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2, channel);
     }
 
     static void encodeSubscriptionRemoval(
@@ -118,7 +118,7 @@ final class DriverEventEncoder
         final int offset,
         final int captureLength,
         final int length,
-        final String uri,
+        final String channel,
         final int streamId,
         final long id)
     {
@@ -130,7 +130,8 @@ final class DriverEventEncoder
         encodingBuffer.putLong(offset + relativeOffset, id, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_LONG;
 
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT - SIZE_OF_LONG, uri);
+        encodeTrailingString(
+            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT - SIZE_OF_LONG, channel);
     }
 
     static void encodeImageRemoval(
@@ -138,7 +139,7 @@ final class DriverEventEncoder
         final int offset,
         final int captureLength,
         final int length,
-        final String uri,
+        final String channel,
         final int sessionId,
         final int streamId,
         final long id)
@@ -155,7 +156,7 @@ final class DriverEventEncoder
         relativeOffset += SIZE_OF_LONG;
 
         encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG, uri);
+            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG, channel);
     }
 
     static <E extends Enum<E>> int untetheredSubscriptionStateChangeLength(final E from, final E to)

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -110,7 +110,7 @@ final class DriverEventEncoder
         encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_INT;
 
-        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - (SIZE_OF_INT * 2), uri);
+        encodeTrailingString(encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2, uri);
     }
 
     static void encodeSubscriptionRemoval(
@@ -155,7 +155,7 @@ final class DriverEventEncoder
         relativeOffset += SIZE_OF_LONG;
 
         encodeTrailingString(
-            encodingBuffer, offset + relativeOffset, captureLength - (SIZE_OF_INT * 2) - SIZE_OF_LONG, uri);
+            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG, uri);
     }
 
     static <E extends Enum<E>> int untetheredSubscriptionStateChangeLength(final E from, final E to)
@@ -193,5 +193,34 @@ final class DriverEventEncoder
         relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, fromName);
         relativeOffset += encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, STATE_SEPARATOR);
         encodingBuffer.putStringWithoutLengthAscii(offset + relativeOffset, toName);
+    }
+
+    static void encodeFlowControlReceiver(
+        final UnsafeBuffer encodingBuffer,
+        final int offset,
+        final int captureLength,
+        final int length,
+        final long receiverId,
+        final int sessionId,
+        final int streamId,
+        final String channel,
+        final int receiverCount)
+    {
+        int relativeOffset = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+
+        encodingBuffer.putInt(offset + relativeOffset, receiverCount, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putLong(offset + relativeOffset, receiverId, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_LONG;
+
+        encodingBuffer.putInt(offset + relativeOffset, sessionId, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodingBuffer.putInt(offset + relativeOffset, streamId, LITTLE_ENDIAN);
+        relativeOffset += SIZE_OF_INT;
+
+        encodeTrailingString(
+            encodingBuffer, offset + relativeOffset, captureLength - SIZE_OF_INT * 3 - SIZE_OF_LONG, channel);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -149,13 +149,13 @@ public final class DriverEventLogger
     /**
      * Log the removal of a publication.
      *
-     * @param uri       for the channel.
+     * @param channel   for the channel.
      * @param sessionId for the publication.
      * @param streamId  within the channel.
      */
-    public void logPublicationRemoval(final String uri, final int sessionId, final int streamId)
+    public void logPublicationRemoval(final String channel, final int sessionId, final int streamId)
     {
-        final int length = SIZE_OF_INT * 3 + uri.length();
+        final int length = SIZE_OF_INT * 3 + channel.length();
         final int captureLength = captureLength(length);
         final int encodedLength = encodedLength(captureLength);
 
@@ -166,7 +166,7 @@ public final class DriverEventLogger
             try
             {
                 final UnsafeBuffer buffer = (UnsafeBuffer)ringBuffer.buffer();
-                encodePublicationRemoval(buffer, index, captureLength, length, uri, sessionId, streamId);
+                encodePublicationRemoval(buffer, index, captureLength, length, channel, sessionId, streamId);
             }
             finally
             {
@@ -178,13 +178,13 @@ public final class DriverEventLogger
     /**
      * Log the removal of a subscription.
      *
-     * @param uri            for the channel.
+     * @param channel        for the channel.
      * @param streamId       within the channel.
      * @param subscriptionId for the subscription.
      */
-    public void logSubscriptionRemoval(final String uri, final int streamId, final long subscriptionId)
+    public void logSubscriptionRemoval(final String channel, final int streamId, final long subscriptionId)
     {
-        final int length = SIZE_OF_INT * 2 + SIZE_OF_LONG + uri.length();
+        final int length = SIZE_OF_INT * 2 + SIZE_OF_LONG + channel.length();
         final int captureLength = captureLength(length);
         final int encodedLength = encodedLength(captureLength);
 
@@ -195,7 +195,7 @@ public final class DriverEventLogger
             try
             {
                 final UnsafeBuffer buffer = (UnsafeBuffer)ringBuffer.buffer();
-                encodeSubscriptionRemoval(buffer, index, captureLength, length, uri, streamId, subscriptionId);
+                encodeSubscriptionRemoval(buffer, index, captureLength, length, channel, streamId, subscriptionId);
             }
             finally
             {
@@ -207,14 +207,14 @@ public final class DriverEventLogger
     /**
      * Log the removal of an image from the driver.
      *
-     * @param uri           for the channel.
+     * @param channel       for the channel.
      * @param sessionId     for the image.
      * @param streamId      for the image.
      * @param correlationId for the image.
      */
-    public void logImageRemoval(final String uri, final int sessionId, final int streamId, final long correlationId)
+    public void logImageRemoval(final String channel, final int sessionId, final int streamId, final long correlationId)
     {
-        final int length = SIZE_OF_INT * 3 + SIZE_OF_LONG + uri.length();
+        final int length = SIZE_OF_INT * 3 + SIZE_OF_LONG + channel.length();
         final int captureLength = captureLength(length);
         final int encodedLength = encodedLength(captureLength);
 
@@ -225,7 +225,7 @@ public final class DriverEventLogger
             try
             {
                 final UnsafeBuffer buffer = (UnsafeBuffer)ringBuffer.buffer();
-                encodeImageRemoval(buffer, index, captureLength, length, uri, sessionId, streamId, correlationId);
+                encodeImageRemoval(buffer, index, captureLength, length, channel, sessionId, streamId, correlationId);
             }
             finally
             {
@@ -331,11 +331,12 @@ public final class DriverEventLogger
 
     /**
      * Log the information about receiver for the corresponding flow control event.
-     *  @param code         flow control event type.
-     * @param receiverId   id of the receiver.
-     * @param sessionId    id of the session.
-     * @param streamId     id of the stream.
-     * @param channel      uri of the channel.
+     *
+     * @param code          flow control event type.
+     * @param receiverId    of the receiver.
+     * @param sessionId     of the image.
+     * @param streamId      of the image.
+     * @param channel       uri of the channel.
      * @param receiverCount number of the receivers after the event.
      */
     public void logFlowControlReceiver(

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -19,8 +19,7 @@ import net.bytebuddy.asm.Advice;
 
 import java.net.InetSocketAddress;
 
-import static io.aeron.agent.DriverEventCode.NAME_RESOLUTION_NEIGHBOR_ADDED;
-import static io.aeron.agent.DriverEventCode.NAME_RESOLUTION_NEIGHBOR_REMOVED;
+import static io.aeron.agent.DriverEventCode.*;
 import static io.aeron.agent.DriverEventLogger.LOGGER;
 
 class DriverInterceptor
@@ -35,18 +34,57 @@ class DriverInterceptor
         }
     }
 
-    static class Neighbour
+    static class NameResolution
     {
-        @Advice.OnMethodEnter
-        static void neighborAdded(final long nowMs, final InetSocketAddress address)
+        static class NeighborAdded
         {
-            LOGGER.logAddress(NAME_RESOLUTION_NEIGHBOR_ADDED, address);
+            @Advice.OnMethodEnter
+            static void neighborAdded(final long nowMs, final InetSocketAddress address)
+            {
+                LOGGER.logAddress(NAME_RESOLUTION_NEIGHBOR_ADDED, address);
+            }
         }
 
-        @Advice.OnMethodEnter
-        static void neighborRemoved(final long nowMs, final InetSocketAddress address)
+        static class NeighborRemoved
         {
-            LOGGER.logAddress(NAME_RESOLUTION_NEIGHBOR_REMOVED, address);
+            @Advice.OnMethodEnter
+            static void neighborRemoved(final long nowMs, final InetSocketAddress address)
+            {
+                LOGGER.logAddress(NAME_RESOLUTION_NEIGHBOR_REMOVED, address);
+            }
+        }
+    }
+
+    static class FlowControl
+    {
+        static class ReceiverAdded
+        {
+            @Advice.OnMethodEnter
+            static void receiverAdded(
+                final long receiverId,
+                final int sessionId,
+                final int streamId,
+                final String channel,
+                final int receiverCount)
+            {
+                LOGGER.logFlowControlReceiver(
+                    FLOW_CONTROL_RECEIVER_ADDED, receiverId, sessionId, streamId, channel, receiverCount);
+            }
+        }
+
+        static class ReceiverRemoved
+        {
+            @Advice.OnMethodEnter
+            static void receiverRemoved(
+                final long receiverId,
+                final int sessionId,
+                final int streamId,
+                final String channel,
+                final int receiverCount)
+            {
+                LOGGER.logFlowControlReceiver(
+                    FLOW_CONTROL_RECEIVER_REMOVED, receiverId, sessionId, streamId, channel, receiverCount);
+            }
         }
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventDissectorTest.java
@@ -54,11 +54,11 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.25] " + CONTEXT + ": " + CMD_OUT_RESPONSE.name() + " [100/100]: " +
             "controlSessionId=13" +
-            ", correlationId=42" +
-            ", relevantId=8" +
-            ", code=" + NULL_VAL +
-            ", version=111" +
-            ", errorMessage=the %ERR% msg",
+            " correlationId=42" +
+            " relevantId=8" +
+            " code=" + NULL_VAL +
+            " version=111" +
+            " errorMessage=the %ERR% msg",
             builder.toString());
     }
 
@@ -77,9 +77,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_CONNECT.name() + " [32/64]: " +
             "correlationId=88" +
-            ", responseStreamId=42" +
-            ", version=-10" +
-            ", responseChannel=call me maybe",
+            " responseStreamId=42" +
+            " version=-10" +
+            " responseChannel=call me maybe",
             builder.toString());
     }
 
@@ -113,10 +113,10 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_START_RECORDING.name() + " [32/64]:" +
             " controlSessionId=5" +
-            ", correlationId=13" +
-            ", streamId=7" +
-            ", sourceLocation=" + SourceLocation.REMOTE +
-            ", channel=foo",
+            " correlationId=13" +
+            " streamId=7" +
+            " sourceLocation=" + SourceLocation.REMOTE +
+            " channel=foo",
             builder.toString());
     }
 
@@ -137,11 +137,11 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_START_RECORDING2.name() + " [32/64]:" +
             " controlSessionId=5" +
-            ", correlationId=13" +
-            ", streamId=7" +
-            ", sourceLocation=" + SourceLocation.REMOTE +
-            ", autoStop=" + BooleanType.TRUE +
-            ", channel=foo",
+            " correlationId=13" +
+            " streamId=7" +
+            " sourceLocation=" + SourceLocation.REMOTE +
+            " autoStop=" + BooleanType.TRUE +
+            " channel=foo",
             builder.toString());
     }
 
@@ -160,9 +160,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.6] " + CONTEXT + ": " + CMD_IN_STOP_RECORDING.name() + " [32/64]:" +
             " controlSessionId=5" +
-            ", correlationId=42" +
-            ", streamId=7" +
-            ", channel=bar",
+            " correlationId=42" +
+            " streamId=7" +
+            " channel=bar",
             builder.toString());
     }
 
@@ -184,12 +184,12 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_REPLAY.name() + " [90/90]:" +
             " controlSessionId=5" +
-            ", correlationId=42" +
-            ", recordingId=178" +
-            ", position=" + Long.MAX_VALUE +
-            ", length=2000" +
-            ", replayStreamId=99" +
-            ", replayChannel=replay channel",
+            " correlationId=42" +
+            " recordingId=178" +
+            " position=" + Long.MAX_VALUE +
+            " length=2000" +
+            " replayStreamId=99" +
+            " replayChannel=replay channel",
             builder.toString());
     }
 
@@ -207,8 +207,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_STOP_REPLAY.name() + " [90/90]:" +
             " controlSessionId=5" +
-            ", correlationId=42" +
-            ", replaySessionId=66",
+            " correlationId=42" +
+            " replaySessionId=66",
             builder.toString());
     }
 
@@ -227,9 +227,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDINGS.name() + " [32/32]:" +
             " controlSessionId=9" +
-            ", correlationId=78" +
-            ", fromRecordingId=45" +
-            ", recordCount=10",
+            " correlationId=78" +
+            " fromRecordingId=45" +
+            " recordCount=10",
             builder.toString());
     }
 
@@ -250,11 +250,11 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDINGS_FOR_URI.name() + " [32/32]:" +
             " controlSessionId=9" +
-            ", correlationId=78" +
-            ", fromRecordingId=45" +
-            ", recordCount=10" +
-            ", streamId=200" +
-            ", channel=CH",
+            " correlationId=78" +
+            " fromRecordingId=45" +
+            " recordCount=10" +
+            " streamId=200" +
+            " channel=CH",
             builder.toString());
     }
 
@@ -272,8 +272,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.1] " + CONTEXT + ": " + CMD_IN_LIST_RECORDING.name() + " [32/32]:" +
             " controlSessionId=19" +
-            ", correlationId=178" +
-            ", recordingId=1010101",
+            " correlationId=178" +
+            " recordingId=1010101",
             builder.toString());
     }
 
@@ -294,11 +294,11 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_EXTEND_RECORDING.name() + " [12/32]:" +
             " controlSessionId=9" +
-            ", correlationId=78" +
-            ", recordingId=1010101" +
-            ", streamId=43" +
-            ", sourceLocation=" + SourceLocation.LOCAL +
-            ", channel=extend me",
+            " correlationId=78" +
+            " recordingId=1010101" +
+            " streamId=43" +
+            " sourceLocation=" + SourceLocation.LOCAL +
+            " channel=extend me",
             builder.toString());
     }
 
@@ -320,12 +320,12 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_EXTEND_RECORDING2.name() + " [12/32]:" +
             " controlSessionId=9" +
-            ", correlationId=78" +
-            ", recordingId=1010101" +
-            ", streamId=43" +
-            ", sourceLocation=" + SourceLocation.LOCAL +
-            ", autoStop=" + BooleanType.TRUE +
-            ", channel=extend me",
+            " correlationId=78" +
+            " recordingId=1010101" +
+            " streamId=43" +
+            " sourceLocation=" + SourceLocation.LOCAL +
+            " autoStop=" + BooleanType.TRUE +
+            " channel=extend me",
             builder.toString());
     }
 
@@ -343,8 +343,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_RECORDING_POSITION.name() + " [12/32]:" +
             " controlSessionId=2" +
-            ", correlationId=3" +
-            ", recordingId=6",
+            " correlationId=3" +
+            " recordingId=6",
             builder.toString());
     }
 
@@ -363,9 +363,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_TRUNCATE_RECORDING.name() + " [12/32]:" +
             " controlSessionId=2" +
-            ", correlationId=3" +
-            ", recordingId=8" +
-            ", position=1000000",
+            " correlationId=3" +
+            " recordingId=8" +
+            " position=1000000",
             builder.toString());
     }
 
@@ -383,8 +383,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_STOP_RECORDING_SUBSCRIPTION.name() + " [12/32]:" +
             " controlSessionId=22" +
-            ", correlationId=33" +
-            ", subscriptionId=888",
+            " correlationId=33" +
+            " subscriptionId=888",
             builder.toString());
     }
 
@@ -402,8 +402,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_STOP_RECORDING_BY_IDENTITY.name() + " [12/32]:" +
             " controlSessionId=22" +
-            ", correlationId=33" +
-            ", recordingId=777",
+            " correlationId=33" +
+            " recordingId=777",
             builder.toString());
     }
 
@@ -421,8 +421,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.0] " + CONTEXT + ": " + CMD_IN_STOP_POSITION.name() + " [12/32]:" +
             " controlSessionId=22" +
-            ", correlationId=33" +
-            ", recordingId=44",
+            " correlationId=33" +
+            " recordingId=44",
             builder.toString());
     }
 
@@ -443,11 +443,11 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_FIND_LAST_MATCHING_RECORD.name() + " [90/90]:" +
             " controlSessionId=1" +
-            ", correlationId=2" +
-            ", minRecordingId=3" +
-            ", sessionId=4" +
-            ", streamId=5" +
-            ", channel=this is a channel",
+            " correlationId=2" +
+            " minRecordingId=3" +
+            " sessionId=4" +
+            " streamId=5" +
+            " channel=this is a channel",
             builder.toString());
     }
 
@@ -469,12 +469,12 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_LIST_RECORDING_SUBSCRIPTIONS.name() + " [90/90]:" +
             " controlSessionId=1" +
-            ", correlationId=2" +
-            ", pseudoIndex=1111111" +
-            ", applyStreamId=" + BooleanType.TRUE +
-            ", subscriptionCount=777" +
-            ", streamId=555" +
-            ", channel=ch2",
+            " correlationId=2" +
+            " pseudoIndex=1111111" +
+            " applyStreamId=" + BooleanType.TRUE +
+            " subscriptionCount=777" +
+            " streamId=555" +
+            " channel=ch2",
             builder.toString());
     }
 
@@ -497,13 +497,13 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_START_BOUNDED_REPLAY.name() + " [90/90]:" +
             " controlSessionId=10" +
-            ", correlationId=20" +
-            ", recordingId=30" +
-            ", position=40" +
-            ", length=50" +
-            ", limitCounterId=-123" +
-            ", replayStreamId=14" +
-            ", replayChannel=rep ch",
+            " correlationId=20" +
+            " recordingId=30" +
+            " position=40" +
+            " length=50" +
+            " limitCounterId=-123" +
+            " replayStreamId=14" +
+            " replayChannel=rep ch",
             builder.toString());
     }
 
@@ -521,8 +521,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[10.325] " + CONTEXT + ": " + CMD_IN_STOP_ALL_REPLAYS.name() + " [90/90]:" +
             " controlSessionId=10" +
-            ", correlationId=20" +
-            ", recordingId=30",
+            " correlationId=20" +
+            " recordingId=30",
             builder.toString());
     }
 
@@ -544,12 +544,12 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_REPLICATE.name() + " [1000/1000]:" +
             " controlSessionId=2" +
-            ", correlationId=5" +
-            ", srcRecordingId=17" +
-            ", dstRecordingId=2048" +
-            ", srcControlStreamId=10" +
-            ", srcControlChannel=CTRL ch" +
-            ", liveDestination=live destination",
+            " correlationId=5" +
+            " srcRecordingId=17" +
+            " dstRecordingId=2048" +
+            " srcControlStreamId=10" +
+            " srcControlChannel=CTRL ch" +
+            " liveDestination=live destination",
             builder.toString());
     }
 
@@ -567,8 +567,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_STOP_REPLICATION.name() + " [1000/1000]:" +
             " controlSessionId=-2" +
-            ", correlationId=-5" +
-            ", replicationId=-999",
+            " correlationId=-5" +
+            " replicationId=-999",
             builder.toString());
     }
 
@@ -586,8 +586,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_START_POSITION.name() + " [1000/1000]:" +
             " controlSessionId=3" +
-            ", correlationId=16" +
-            ", recordingId=1",
+            " correlationId=16" +
+            " recordingId=1",
             builder.toString());
     }
 
@@ -605,8 +605,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_DETACH_SEGMENTS.name() + " [1000/1000]:" +
             " controlSessionId=3" +
-            ", correlationId=16" +
-            ", recordingId=1",
+            " correlationId=16" +
+            " recordingId=1",
             builder.toString());
     }
 
@@ -624,8 +624,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_DELETE_DETACHED_SEGMENTS.name() + " [1000/1000]:" +
             " controlSessionId=53" +
-            ", correlationId=516" +
-            ", recordingId=51",
+            " correlationId=516" +
+            " recordingId=51",
             builder.toString());
     }
 
@@ -644,9 +644,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_PURGE_SEGMENTS.name() + " [1000/1000]:" +
             " controlSessionId=3" +
-            ", correlationId=56" +
-            ", recordingId=15" +
-            ", newStartPosition=100",
+            " correlationId=56" +
+            " recordingId=15" +
+            " newStartPosition=100",
             builder.toString());
     }
 
@@ -664,8 +664,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_ATTACH_SEGMENTS.name() + " [1000/1000]:" +
             " controlSessionId=30" +
-            ", correlationId=560" +
-            ", recordingId=50",
+            " correlationId=560" +
+            " recordingId=50",
             builder.toString());
     }
 
@@ -684,9 +684,9 @@ class ArchiveEventDissectorTest
 
         assertEquals("[0.5] " + CONTEXT + ": " + CMD_IN_MIGRATE_SEGMENTS.name() + " [1000/1000]:" +
             " controlSessionId=7" +
-            ", correlationId=6" +
-            ", srcRecordingId=1" +
-            ", dstRecordingId=21902",
+            " correlationId=6" +
+            " srcRecordingId=1" +
+            " dstRecordingId=21902",
             builder.toString());
     }
 
@@ -706,10 +706,10 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_AUTH_CONNECT.name() + " [3/6]:" +
             " correlationId=16" +
-            ", responseStreamId=19" +
-            ", version=2" +
-            ", responseChannel=English Channel" +
-            ", encodedCredentialsLength=5",
+            " responseStreamId=19" +
+            " version=2" +
+            " responseChannel=English Channel" +
+            " encodedCredentialsLength=5",
             builder.toString());
     }
 
@@ -726,7 +726,7 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_KEEP_ALIVE.name() + " [3/6]:" +
             " controlSessionId=31" +
-            ", correlationId=119",
+            " correlationId=119",
             builder.toString());
     }
 
@@ -750,14 +750,14 @@ class ArchiveEventDissectorTest
 
         assertEquals("[5.5] " + CONTEXT + ": " + CMD_IN_TAGGED_REPLICATE.name() + " [3/6]:" +
             " controlSessionId=1" +
-            ", correlationId=-10" +
-            ", srcRecordingId=9" +
-            ", dstRecordingId=31" +
-            ", channelTagId=4" +
-            ", subscriptionTagId=7" +
-            ", srcControlStreamId=15" +
-            ", srcControlChannel=src" +
-            ", liveDestination=alive and well",
+            " correlationId=-10" +
+            " srcRecordingId=9" +
+            " dstRecordingId=31" +
+            " channelTagId=4" +
+            " subscriptionTagId=7" +
+            " srcControlStreamId=15" +
+            " srcControlChannel=src" +
+            " liveDestination=alive and well",
             builder.toString());
     }
 
@@ -784,7 +784,7 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.5] " + CONTEXT + ": " + REPLICATION_SESSION_STATE_CHANGE.name() + " [10/20]:" +
             " replicationId=10000000000" +
-            ", x -> y",
+            " x -> y",
             builder.toString());
     }
 
@@ -799,7 +799,7 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.5] " + CONTEXT + ": " + CONTROL_SESSION_STATE_CHANGE.name() + " [10/20]:" +
             " controlSessionId=-10000000000" +
-            ", x -> y",
+            " x -> y",
             builder.toString());
     }
 
@@ -814,7 +814,7 @@ class ArchiveEventDissectorTest
         dissectReplaySessionError(buffer, 0, builder);
 
         assertEquals("[5.6] " + CONTEXT + ": " + REPLAY_SESSION_ERROR.name() + " [6/100]:" +
-            " sessionId=-8, recordingId=42, errorMessage=something went wrong",
+            " sessionId=-8 recordingId=42 errorMessage=something went wrong",
             builder.toString());
     }
 
@@ -848,8 +848,8 @@ class ArchiveEventDissectorTest
 
         assertEquals("[1.125] " + CONTEXT + ": " + CMD_IN_PURGE_RECORDING.name() + " [56/901]:" +
             " controlSessionId=15" +
-            ", correlationId=421" +
-            ", recordingId=6",
+            " correlationId=421" +
+            " recordingId=6",
             builder.toString());
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventDissectorTest.java
@@ -50,9 +50,9 @@ class ClusterEventDissectorTest
 
         ClusterEventDissector.dissectNewLeadershipTerm(buffer, 0, builder);
 
-        assertEquals("[33.0] " + CONTEXT + ": " + NEW_LEADERSHIP_TERM.name() + " [8/9]: logLeadershipTermId=1," +
-            " logTruncatePosition=2, leadershipTermId=3, termBaseLogPosition=4, logPosition=5, leaderRecordingId=6, " +
-            "timestamp=7, leaderMemberId=100, logSessionId=200, isStartup=true",
+        assertEquals("[33.0] " + CONTEXT + ": " + NEW_LEADERSHIP_TERM.name() +
+            " [8/9]: logLeadershipTermId=1 logTruncatePosition=2 leadershipTermId=3 termBaseLogPosition=4 " +
+            "logPosition=5 leaderRecordingId=6 timestamp=7 leaderMemberId=100 logSessionId=200 isStartup=true",
             builder.toString());
     }
 
@@ -65,7 +65,7 @@ class ClusterEventDissectorTest
 
         ClusterEventDissector.dissectStateChange(ELECTION_STATE_CHANGE, buffer, 0, builder);
 
-        assertEquals("[-1.0] " + CONTEXT + ": " + ELECTION_STATE_CHANGE.name() + " [100/200]: memberId=42, a -> b",
+        assertEquals("[-1.0] " + CONTEXT + ": " + ELECTION_STATE_CHANGE.name() + " [100/200]: memberId=42 a -> b",
             builder.toString());
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -54,7 +54,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemovePublicationCleanup(buffer, offset, builder);
 
         assertEquals("[2.5] " + CONTEXT + ": " + REMOVE_PUBLICATION_CLEANUP.name() +
-            " [22/88]: sessionId=42, streamId=11, uri=channel uri",
+            " [22/88]: sessionId=42, streamId=11, channel=channel uri",
             builder.toString());
     }
 
@@ -70,7 +70,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemoveSubscriptionCleanup(buffer, offset, builder);
 
         assertEquals("[0.1] " + CONTEXT + ": " + REMOVE_SUBSCRIPTION_CLEANUP.name() +
-            " [100/100]: streamId=33, id=111111111111, uri=test",
+            " [100/100]: streamId=33, id=111111111111, channel=test",
             builder.toString());
     }
 
@@ -87,7 +87,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemoveImageCleanup(buffer, offset, builder);
 
         assertEquals("[12.3456789] " + CONTEXT + ": " + REMOVE_IMAGE_CLEANUP.name() +
-            " [66/99]: sessionId=77, streamId=55, id=1000000, uri=URI",
+            " [66/99]: sessionId=77, streamId=55, id=1000000, channel=URI",
             builder.toString());
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -594,6 +594,24 @@ class DriverEventDissectorTest
             " [17/27]: 127.0.0.1:4848", builder.toString());
     }
 
+    @Test
+    void dissectFlowControlReceiver()
+    {
+        final int offset = 24;
+        internalEncodeLogHeader(buffer, offset, 42, 48, () -> 2_500_000_000L);
+        buffer.putInt(offset + LOG_HEADER_LENGTH, 5, LITTLE_ENDIAN);
+        buffer.putLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, -45754449919191L, LITTLE_ENDIAN);
+        buffer.putInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, 11, LITTLE_ENDIAN);
+        buffer.putInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, 4, LITTLE_ENDIAN);
+        buffer.putStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 3 + SIZE_OF_LONG, "ABC");
+
+        DriverEventDissector.dissectFlowControlReceiver(FLOW_CONTROL_RECEIVER_ADDED, buffer, offset, builder);
+
+        assertEquals("[2.5] " + CONTEXT + ": " + FLOW_CONTROL_RECEIVER_ADDED.name() +
+            " [42/48]: receiverCount=5 receiverId=-45754449919191 sessionId=11 streamId=4 channel=ABC",
+            builder.toString());
+    }
+
     private DirectBuffer newBuffer(final byte[] bytes)
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(allocate(bytes.length));

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -54,7 +54,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemovePublicationCleanup(buffer, offset, builder);
 
         assertEquals("[2.5] " + CONTEXT + ": " + REMOVE_PUBLICATION_CLEANUP.name() +
-            " [22/88]: sessionId=42, streamId=11, channel=channel uri",
+            " [22/88]: sessionId=42 streamId=11 channel=channel uri",
             builder.toString());
     }
 
@@ -70,7 +70,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemoveSubscriptionCleanup(buffer, offset, builder);
 
         assertEquals("[0.1] " + CONTEXT + ": " + REMOVE_SUBSCRIPTION_CLEANUP.name() +
-            " [100/100]: streamId=33, id=111111111111, channel=test",
+            " [100/100]: streamId=33 id=111111111111 channel=test",
             builder.toString());
     }
 
@@ -87,7 +87,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectRemoveImageCleanup(buffer, offset, builder);
 
         assertEquals("[12.3456789] " + CONTEXT + ": " + REMOVE_IMAGE_CLEANUP.name() +
-            " [66/99]: sessionId=77, streamId=55, id=1000000, channel=URI",
+            " [66/99]: sessionId=77 streamId=55 id=1000000 channel=URI",
             builder.toString());
     }
 
@@ -576,7 +576,7 @@ class DriverEventDissectorTest
         DriverEventDissector.dissectUntetheredSubscriptionStateChange(buffer, offset, builder);
 
         assertEquals("[1.5] " + CONTEXT + ": " + UNTETHERED_SUBSCRIPTION_STATE_CHANGE.name() +
-            " [22/88]: subscriptionId=88, streamId=123, sessionId=777, state changed",
+            " [22/88]: subscriptionId=88 streamId=123 sessionId=777 state changed",
             builder.toString());
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventEncoderTest.java
@@ -36,99 +36,99 @@ class DriverEventEncoderTest
     private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[MAX_EVENT_LENGTH * 10]);
 
     @Test
-    void encodePublicationRemovalShouldWriteUriLast()
+    void encodePublicationRemovalShouldWriteChannelLast()
     {
         final int offset = 10;
-        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final String channel = "aeron:udp?endpoint=224.10.9.8";
         final int sessionId = 42;
         final int streamId = 5;
-        final int captureLength = 3 * SIZE_OF_INT + uri.length();
+        final int captureLength = 3 * SIZE_OF_INT + channel.length();
 
-        encodePublicationRemoval(buffer, offset, captureLength, captureLength, uri, sessionId, streamId);
+        encodePublicationRemoval(buffer, offset, captureLength, captureLength, channel, sessionId, streamId);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
         assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
         assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri, buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
+        assertEquals(channel, buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
     }
 
     @Test
-    void encodePublicationRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    void encodePublicationRemovalShouldTruncateChannelIfItExceedsMaxMessageLength()
     {
         final int offset = 121;
         final char[] data = new char[MAX_EVENT_LENGTH];
         fill(data, 'z');
-        final String uri = new String(data);
+        final String channel = new String(data);
         final int length = data.length + 3 * SIZE_OF_INT;
         final int captureLength = captureLength(length);
 
-        encodePublicationRemoval(buffer, offset, captureLength, length, uri, 1, -1);
+        encodePublicationRemoval(buffer, offset, captureLength, length, channel, 1, -1);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
         assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
         assertEquals(1, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(-1, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, captureLength - 3 * SIZE_OF_INT - 3) + "...",
+        assertEquals(channel.substring(0, captureLength - 3 * SIZE_OF_INT - 3) + "...",
             buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
     }
 
     @Test
-    void encodeSubscriptionRemovalShouldWriteUriLast()
+    void encodeSubscriptionRemovalShouldWriteChannelLast()
     {
         final int offset = 0;
-        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final String channel = "aeron:udp?endpoint=224.10.9.8";
         final int streamId = 13;
         final long id = Long.MAX_VALUE;
-        final int captureLength = 2 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+        final int captureLength = 2 * SIZE_OF_INT + SIZE_OF_LONG + channel.length();
 
-        encodeSubscriptionRemoval(buffer, offset, captureLength, captureLength, uri, streamId, id);
+        encodeSubscriptionRemoval(buffer, offset, captureLength, captureLength, channel, streamId, id);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
         assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
         assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri,
+        assertEquals(channel,
             buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
-    void encodeSubscriptionRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    void encodeSubscriptionRemovalShouldTruncateChannelIfItExceedsMaxMessageLength()
     {
         final char[] data = new char[MAX_EVENT_LENGTH * 3 + 5];
         fill(data, 'a');
         final int offset = 0;
         final int length = SIZE_OF_INT * 2 + SIZE_OF_LONG + data.length;
         final int captureLength = captureLength(length);
-        final String uri = new String(data);
+        final String channel = new String(data);
         final int streamId = 1;
         final long id = -1;
 
-        encodeSubscriptionRemoval(buffer, offset, captureLength, length, uri, streamId, id);
+        encodeSubscriptionRemoval(buffer, offset, captureLength, length, channel, streamId, id);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
         assertNotEquals(0, buffer.getLong(offset + SIZE_OF_INT * 2, LITTLE_ENDIAN));
         assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG - 3) + "...",
+        assertEquals(channel.substring(0, captureLength - SIZE_OF_INT * 2 - SIZE_OF_LONG - 3) + "...",
             buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
-    void encodeImageRemovalShouldWriteUriLast()
+    void encodeImageRemovalShouldWriteChannelLast()
     {
         final int offset = 0;
-        final String uri = "aeron:udp?endpoint=224.10.9.8";
+        final String channel = "aeron:udp?endpoint=224.10.9.8";
         final int sessionId = 13;
         final int streamId = 42;
         final long id = Long.MAX_VALUE;
-        final int captureLength = 3 * SIZE_OF_INT + SIZE_OF_LONG + uri.length();
+        final int captureLength = 3 * SIZE_OF_INT + SIZE_OF_LONG + channel.length();
 
-        encodeImageRemoval(buffer, offset, captureLength, captureLength, uri, sessionId, streamId, id);
+        encodeImageRemoval(buffer, offset, captureLength, captureLength, channel, sessionId, streamId, id);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(captureLength, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
@@ -136,24 +136,24 @@ class DriverEventEncoderTest
         assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
         assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(uri,
+        assertEquals(channel,
             buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
     @Test
-    void encodeImageRemovalShouldTruncateUriIfItExceedsMaxMessageLength()
+    void encodeImageRemovalShouldTruncateChannelIfItExceedsMaxMessageLength()
     {
         final char[] data = new char[MAX_EVENT_LENGTH + 8];
         fill(data, 'a');
         final int offset = 0;
         final int length = data.length + SIZE_OF_LONG + SIZE_OF_INT * 3;
         final int captureLength = captureLength(length);
-        final String uri = new String(data);
+        final String channel = new String(data);
         final int sessionId = -1;
         final int streamId = 1;
         final long id = 0;
 
-        encodeImageRemoval(buffer, offset, captureLength, length, uri, sessionId, streamId, id);
+        encodeImageRemoval(buffer, offset, captureLength, length, channel, sessionId, streamId, id);
 
         assertEquals(captureLength, buffer.getInt(offset, LITTLE_ENDIAN));
         assertEquals(length, buffer.getInt(offset + SIZE_OF_INT, LITTLE_ENDIAN));
@@ -161,7 +161,7 @@ class DriverEventEncoderTest
         assertEquals(sessionId, buffer.getInt(offset + LOG_HEADER_LENGTH, LITTLE_ENDIAN));
         assertEquals(streamId, buffer.getInt(offset + LOG_HEADER_LENGTH + SIZE_OF_INT, LITTLE_ENDIAN));
         assertEquals(id, buffer.getLong(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2, LITTLE_ENDIAN));
-        assertEquals(uri.substring(0, captureLength - SIZE_OF_LONG - SIZE_OF_INT * 3 - 3) + "...",
+        assertEquals(channel.substring(0, captureLength - SIZE_OF_LONG - SIZE_OF_INT * 3 - 3) + "...",
             buffer.getStringAscii(offset + LOG_HEADER_LENGTH + SIZE_OF_INT * 2 + SIZE_OF_LONG, LITTLE_ENDIAN));
     }
 
@@ -228,17 +228,17 @@ class DriverEventEncoderTest
     }
 
     @Test
-    void encodeFlowControlReceiverShouldTruncateChannelUriIfTooLong()
+    void encodeFlowControlReceiverShouldTruncateChannelChannelIfTooLong()
     {
-        final char[] uri = new char[MAX_EVENT_LENGTH + 11];
-        fill(uri, 'x');
+        final char[] data = new char[MAX_EVENT_LENGTH + 11];
+        fill(data, 'x');
         final int offset = 16;
         final long receiverId = Long.MIN_VALUE;
         final int sessionId = 42;
         final int streamId = 0;
-        final String channel = new String(uri);
+        final String channel = new String(data);
         final int receiverCount = 0;
-        final int length = 4 * SIZE_OF_INT + SIZE_OF_LONG + uri.length;
+        final int length = 4 * SIZE_OF_INT + SIZE_OF_LONG + data.length;
         final int captureLength = captureLength(length);
 
         encodeFlowControlReceiver(

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -958,6 +958,9 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->name_resolution_on_neighbor_added_func = aeron_driver_conductor_name_resolver_on_neighbor_change_null;
     _context->name_resolution_on_neighbor_removed_func = aeron_driver_conductor_name_resolver_on_neighbor_change_null;
 
+    _context->flow_control_on_receiver_added_func = NULL;
+    _context->flow_control_on_receiver_removed_func = NULL;
+
     if ((_context->termination_validator_func = aeron_driver_termination_validator_load(
         AERON_CONFIG_GETENV_OR_DEFAULT(AERON_DRIVER_TERMINATION_VALIDATOR_ENV_VAR, "deny"))) == NULL)
     {

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -64,6 +64,14 @@ aeron_driver_context_bindings_clientd_entry_t;
 
 typedef void (*aeron_driver_name_resolver_on_neighbor_change_func_t)(const struct sockaddr_storage *addr);
 
+typedef void (*aeron_driver_flow_control_strategy_on_receiver_change_func_t)(
+    int64_t receiver_id,
+    int32_t session_id,
+    int32_t stream_id,
+    size_t channel_length,
+    const char *channel,
+    size_t receiver_count);
+
 typedef struct aeron_driver_context_stct
 {
     char *aeron_dir;                                        /* aeron.dir */
@@ -213,6 +221,9 @@ typedef struct aeron_driver_context_stct
 
     aeron_driver_name_resolver_on_neighbor_change_func_t name_resolution_on_neighbor_added_func;
     aeron_driver_name_resolver_on_neighbor_change_func_t name_resolution_on_neighbor_removed_func;
+
+    aeron_driver_flow_control_strategy_on_receiver_change_func_t flow_control_on_receiver_added_func;
+    aeron_driver_flow_control_strategy_on_receiver_change_func_t flow_control_on_receiver_removed_func;
 
     aeron_driver_termination_validator_func_t termination_validator_func;
     void *termination_validator_state;

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -78,8 +78,9 @@ int64_t aeron_min_flow_control_strategy_on_idle(
 {
     aeron_min_flow_control_strategy_state_t *strategy_state = (aeron_min_flow_control_strategy_state_t *)state;
     int64_t min_limit_position = INT64_MAX;
+    size_t receiver_count = strategy_state->receivers.length;
 
-    for (int last_index = (int)strategy_state->receivers.length - 1, i = last_index; i >= 0; i--)
+    for (int last_index = (int)receiver_count - 1, i = last_index; i >= 0; i--)
     {
         aeron_min_flow_control_strategy_receiver_t *receiver = &strategy_state->receivers.array[i];
 
@@ -91,7 +92,8 @@ int64_t aeron_min_flow_control_strategy_on_idle(
                 (size_t)i,
                 (size_t)last_index);
             last_index--;
-            aeron_min_flow_control_strategy_state_set_length(strategy_state, strategy_state->receivers.length - 1);
+            receiver_count--;
+            aeron_min_flow_control_strategy_state_set_length(strategy_state, receiver_count);
         }
         else
         {

--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -36,6 +36,8 @@ typedef struct aeron_min_flow_control_strategy_receiver_stct
     int64_t last_position_plus_window;
     int64_t time_of_last_status_message_ns;
     int64_t receiver_id;
+    int32_t session_id;
+    int32_t stream_id;
     uint8_t padding_after[AERON_CACHE_LINE_LENGTH];
 }
 aeron_min_flow_control_strategy_receiver_t;
@@ -53,7 +55,12 @@ typedef struct aeron_min_flow_control_strategy_state_stct
     int64_t receiver_timeout_ns;
     int32_t group_min_size;
     int64_t group_tag;
+    char channel[AERON_MAX_PATH];
+    size_t channel_length;
     aeron_distinct_error_log_t *error_log;
+
+    aeron_driver_flow_control_strategy_on_receiver_change_func_t receiver_added;
+    aeron_driver_flow_control_strategy_on_receiver_change_func_t receiver_removed;
 }
 aeron_min_flow_control_strategy_state_t;
 
@@ -94,6 +101,17 @@ int64_t aeron_min_flow_control_strategy_on_idle(
             last_index--;
             receiver_count--;
             aeron_min_flow_control_strategy_state_set_length(strategy_state, receiver_count);
+            aeron_driver_flow_control_strategy_on_receiver_change_func_t receiver_removed = strategy_state->receiver_removed;
+            if (NULL != receiver_removed)
+            {
+                receiver_removed(
+                    receiver->receiver_id,
+                    receiver->session_id,
+                    receiver->stream_id,
+                    strategy_state->channel_length,
+                    strategy_state->channel,
+                    receiver_count);
+            }
         }
         else
         {
@@ -148,7 +166,7 @@ int64_t aeron_min_flow_control_strategy_process_sm(
     {
         int ensure_capacity_result = 0;
         AERON_ARRAY_ENSURE_CAPACITY(
-            ensure_capacity_result,strategy_state->receivers, aeron_min_flow_control_strategy_receiver_t);
+            ensure_capacity_result, strategy_state->receivers, aeron_min_flow_control_strategy_receiver_t);
 
         if (ensure_capacity_result >= 0)
         {
@@ -160,8 +178,22 @@ int64_t aeron_min_flow_control_strategy_process_sm(
             receiver->last_position_plus_window = position + window_length;
             receiver->time_of_last_status_message_ns = now_ns;
             receiver->receiver_id = receiver_id;
+            receiver->session_id = status_message_header->session_id;
+            receiver->stream_id = status_message_header->stream_id;
 
             min_position = (position + window_length) < min_position ? (position + window_length) : min_position;
+
+            aeron_driver_flow_control_strategy_on_receiver_change_func_t receiver_added = strategy_state->receiver_added;
+            if (NULL != receiver_added)
+            {
+                receiver_added(
+                    receiver->receiver_id,
+                    receiver->session_id,
+                    receiver->stream_id,
+                    strategy_state->channel_length,
+                    strategy_state->channel,
+                    receivers_length + 1);
+            }
         }
         else
         {
@@ -299,6 +331,9 @@ int aeron_tagged_flow_control_strategy_supplier_init(
     state->receivers.capacity = 0;
     aeron_min_flow_control_strategy_state_set_length(state, 0);
 
+    state->channel_length = channel->uri_length;
+    strncpy(state->channel, channel->original_uri, state->channel_length);
+
     state->receiver_timeout_ns = options.timeout_ns.is_present ?
         options.timeout_ns.value : context->flow_control.receiver_timeout_ns;
     state->group_min_size = options.group_min_size.is_present ?
@@ -306,6 +341,9 @@ int aeron_tagged_flow_control_strategy_supplier_init(
     state->group_tag = options.group_tag.is_present ? options.group_tag.value : context->flow_control.group_tag;
 
     state->error_log = context->error_log;
+
+    state->receiver_added = context->flow_control_on_receiver_added_func;
+    state->receiver_removed = context->flow_control_on_receiver_removed_func;
 
     *strategy = _strategy;
 

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -1615,7 +1615,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: sessionId=%d, streamId=%d, channel=%.*s\n",
+                "%s: sessionId=%d streamId=%d channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->session_id,
                 hdr->stream_id,
@@ -1630,7 +1630,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: streamId=%d, id=%" PRId64 ", channel=%.*s\n",
+                "%s: streamId=%d id=%" PRId64 " channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->stream_id,
                 hdr->id,
@@ -1645,7 +1645,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: sessionId=%d, streamId=%d, id=%" PRId64 ", channel=%.*s\n",
+                "%s: sessionId=%d streamId=%d id=%" PRId64 " channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->session_id,
                 hdr->stream_id,
@@ -1678,7 +1678,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
 
             fprintf(
                 logfp,
-                "%s: subscriptionId=%" PRId64 ", streamId=%d, sessionId=%d, %s -> %s\n",
+                "%s: subscriptionId=%" PRId64 " streamId=%d sessionId=%d %s -> %s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->subscription_id,
                 hdr->stream_id,

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -1615,7 +1615,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: sessionId=%d, streamId=%d, uri=%.*s\n",
+                "%s: sessionId=%d, streamId=%d, channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->session_id,
                 hdr->stream_id,
@@ -1630,7 +1630,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: streamId=%d, id=%" PRId64 ", uri=%.*s\n",
+                "%s: streamId=%d, id=%" PRId64 ", channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->stream_id,
                 hdr->id,
@@ -1645,7 +1645,7 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
             const char *channel = (const char *)message + sizeof(aeron_driver_agent_remove_resource_cleanup_t);
             fprintf(
                 logfp,
-                "%s: sessionId=%d, streamId=%d, id=%" PRId64 ", uri=%.*s\n",
+                "%s: sessionId=%d, streamId=%d, id=%" PRId64 ", channel=%.*s\n",
                 aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
                 hdr->session_id,
                 hdr->stream_id,

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -123,6 +123,8 @@ static struct aeron_driver_agent_log_event_stct log_events[AERON_DRIVER_EVENT_NU
         { "UNTETHERED_SUBSCRIPTION_STATE_CHANGE", AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
         { "NAME_RESOLUTION_NEIGHBOR_ADDED",       AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
         { "NAME_RESOLUTION_NEIGHBOR_REMOVED",     AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
+        { "FLOW_CONTROL_RECEIVER_ADDED",          AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
+        { "FLOW_CONTROL_RECEIVER_REMOVED",        AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
         { "ADD_DYNAMIC_DISSECTOR",                AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
         { "DYNAMIC_DISSECTOR_EVENT",              AERON_DRIVER_AGENT_EVENT_TYPE_OTHER,   false },
     };
@@ -816,6 +818,74 @@ void aeron_driver_agent_name_resolution_on_neighbor_removed(const struct sockadd
     log_name_resolution_neighbor_change(AERON_DRIVER_EVENT_NAME_RESOLUTION_NEIGHBOR_REMOVED, addr);
 }
 
+void log_flow_control_on_receiver_change(
+    const aeron_driver_agent_event_t event_id,
+    const int64_t receiver_id,
+    const int32_t session_id,
+    const int32_t stream_id,
+    const size_t channel_length,
+    const char *channel,
+    const size_t receiver_count)
+{
+    int32_t offset = aeron_mpsc_rb_try_claim(
+        &logging_mpsc_rb,
+        event_id,
+        sizeof(aeron_driver_agent_flow_control_receiver_change_log_header_t) + channel_length);
+    if (offset > 0)
+    {
+        uint8_t *ptr = (logging_mpsc_rb.buffer + offset);
+        aeron_driver_agent_flow_control_receiver_change_log_header_t *hdr =
+            (aeron_driver_agent_flow_control_receiver_change_log_header_t *)ptr;
+
+        hdr->time_ns = aeron_nano_clock();
+        hdr->receiver_id = receiver_id;
+        hdr->session_id = session_id;
+        hdr->stream_id = stream_id;
+        hdr->channel_length = (int32_t)channel_length;
+        hdr->receiver_count = (int32_t)receiver_count;
+
+        memcpy(ptr + sizeof(aeron_driver_agent_flow_control_receiver_change_log_header_t), channel, channel_length);
+
+        aeron_mpsc_rb_commit(&logging_mpsc_rb, offset);
+    }
+}
+
+void aeron_driver_agent_flow_control_on_receiver_added(
+    int64_t receiver_id,
+    int32_t session_id,
+    int32_t stream_id,
+    size_t channel_length,
+    const char *channel,
+    size_t receiver_count)
+{
+    log_flow_control_on_receiver_change(
+        AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_ADDED,
+        receiver_id,
+        session_id,
+        stream_id,
+        channel_length,
+        channel,
+        receiver_count);
+}
+
+void aeron_driver_agent_flow_control_on_receiver_removed(
+    int64_t receiver_id,
+    int32_t session_id,
+    int32_t stream_id,
+    size_t channel_length,
+    const char *channel,
+    size_t receiver_count)
+{
+    log_flow_control_on_receiver_change(
+        AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_REMOVED,
+        receiver_id,
+        session_id,
+        stream_id,
+        channel_length,
+        channel,
+        receiver_count);
+}
+
 int aeron_driver_agent_interceptor_init(
     void **interceptor_state, aeron_driver_context_t *context, aeron_udp_channel_transport_affinity_t affinity)
 {
@@ -960,6 +1030,16 @@ int aeron_driver_agent_init_logging_events_interceptors(aeron_driver_context_t *
     if (aeron_driver_agent_is_event_enabled(AERON_DRIVER_EVENT_NAME_RESOLUTION_NEIGHBOR_REMOVED))
     {
         context->name_resolution_on_neighbor_removed_func = aeron_driver_agent_name_resolution_on_neighbor_removed;
+    }
+
+    if (aeron_driver_agent_is_event_enabled(AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_ADDED))
+    {
+        context->flow_control_on_receiver_added_func = aeron_driver_agent_flow_control_on_receiver_added;
+    }
+
+    if (aeron_driver_agent_is_event_enabled(AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_REMOVED))
+    {
+        context->flow_control_on_receiver_removed_func = aeron_driver_agent_flow_control_on_receiver_removed;
     }
 
     return 0;
@@ -1703,6 +1783,25 @@ void aeron_driver_agent_log_dissector(int32_t msg_type_id, const void *message, 
                 dissect_sockaddr(addr));
             break;
         }
+
+        case AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_ADDED:
+        case AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_REMOVED:
+        {
+            aeron_driver_agent_flow_control_receiver_change_log_header_t *hdr = (aeron_driver_agent_flow_control_receiver_change_log_header_t *)message;
+            const char *channel = (const char *)message + sizeof(aeron_driver_agent_flow_control_receiver_change_log_header_t);
+            fprintf(
+                logfp,
+                "%s: receiverCount=%d receiverId=%" PRId64 " sessionId=%d streamId=%d channel=%.*s\n",
+                aeron_driver_agent_dissect_log_header(hdr->time_ns, msg_type_id, length, length),
+                hdr->receiver_count,
+                hdr->receiver_id,
+                hdr->session_id,
+                hdr->stream_id,
+                hdr->channel_length,
+                channel);
+            break;
+        }
+
         case AERON_DRIVER_EVENT_ADD_DYNAMIC_DISSECTOR:
         {
             aeron_driver_agent_add_dissector_header_t *hdr = (aeron_driver_agent_add_dissector_header_t *)message;

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -70,6 +70,8 @@ typedef enum aeron_driver_agent_event_enum
     AERON_DRIVER_EVENT_UNTETHERED_SUBSCRIPTION_STATE_CHANGE = 45,
     AERON_DRIVER_EVENT_NAME_RESOLUTION_NEIGHBOR_ADDED = 46,
     AERON_DRIVER_EVENT_NAME_RESOLUTION_NEIGHBOR_REMOVED = 47,
+    AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_ADDED = 48,
+    AERON_DRIVER_EVENT_FLOW_CONTROL_RECEIVER_REMOVED = 49,
 
     // C-specific events. Note: event IDs are dynamic to avoid gaps in the sparse arrays.
     AERON_DRIVER_EVENT_ADD_DYNAMIC_DISSECTOR,
@@ -150,6 +152,17 @@ typedef struct aeron_driver_agent_dynamic_event_header_stct
 }
 aeron_driver_agent_dynamic_event_header_t;
 
+typedef struct aeron_driver_agent_flow_control_receiver_change_log_header_stct
+{
+    int64_t time_ns;
+    int64_t receiver_id;
+    int32_t session_id;
+    int32_t stream_id;
+    int32_t channel_length;
+    int32_t receiver_count;
+}
+aeron_driver_agent_flow_control_receiver_change_log_header_t;
+
 aeron_mpsc_rb_t *aeron_driver_agent_mpsc_rb();
 
 typedef int (*aeron_driver_context_init_t)(aeron_driver_context_t **);
@@ -220,5 +233,21 @@ void aeron_driver_agent_receiver_proxy_on_remove_endpoint(const void *channel);
 int64_t aeron_driver_agent_add_dynamic_dissector(aeron_driver_agent_generic_dissector_func_t func);
 
 void aeron_driver_agent_log_dynamic_event(int64_t index, const void *message, size_t length);
+
+void aeron_driver_agent_flow_control_on_receiver_added(
+    int64_t receiver_id,
+    int32_t session_id,
+    int32_t stream_id,
+    size_t channel_length,
+    const char *channel,
+    size_t receiver_count);
+
+void aeron_driver_agent_flow_control_on_receiver_removed(
+    int64_t receiver_id,
+    int32_t session_id,
+    int32_t stream_id,
+    size_t channel_length,
+    const char *channel,
+    size_t receiver_count);
 
 #endif //AERON_DRIVER_AGENT_H

--- a/aeron-driver/src/main/java/io/aeron/driver/AbstractMinMulticastFlowControl.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/AbstractMinMulticastFlowControl.java
@@ -38,10 +38,11 @@ public abstract class AbstractMinMulticastFlowControl implements FlowControl
 {
     static final Receiver[] EMPTY_RECEIVERS = new Receiver[0];
 
+    private final boolean isGroupTagAware;
     private long receiverTimeoutNs;
     private long groupTag;
     private int groupMinSize;
-    private final boolean isGroupTagAware;
+    private String channel;
     private volatile Receiver[] receivers = EMPTY_RECEIVERS;
 
     /**
@@ -66,6 +67,7 @@ public abstract class AbstractMinMulticastFlowControl implements FlowControl
         receiverTimeoutNs = context.flowControlReceiverTimeoutNs();
         groupTag = isGroupTagAware ? context.flowControlGroupTag() : 0;
         groupMinSize = context.flowControlGroupMinSize();
+        channel = udpChannel.originalUriString();
 
         parseUriParam(udpChannel.channelUri().get(CommonContext.FLOW_CONTROL_PARAM_NAME));
     }
@@ -89,6 +91,8 @@ public abstract class AbstractMinMulticastFlowControl implements FlowControl
                     receivers[i] = receivers[lastIndex--];
                 }
                 removed++;
+                receiverRemoved(
+                    receiver.receiverId, receiver.sessionId, receiver.streamId, channel, receivers.length - removed);
             }
             else
             {
@@ -163,10 +167,12 @@ public abstract class AbstractMinMulticastFlowControl implements FlowControl
 
         if (matchesTag && !isExisting)
         {
-            final Receiver receiver = new Receiver(position, lastPositionPlusWindow, timeNs, receiverId);
+            final Receiver receiver = new Receiver(
+                receiverId, flyweight.sessionId(), flyweight.streamId(), position, lastPositionPlusWindow, timeNs);
             receivers = add(receivers, receiver);
             this.receivers = receivers;
             minPosition = Math.min(minPosition, lastPositionPlusWindow);
+            receiverAdded(receiver.receiverId, receiver.sessionId, receiver.streamId, channel, receivers.length);
         }
 
         if (receivers.length < groupMinSize)
@@ -268,19 +274,45 @@ public abstract class AbstractMinMulticastFlowControl implements FlowControl
         }
     }
 
+    private void receiverAdded(
+        final long receiverId, final int sessionId, final int streamId, final String channel, final int receiverCount)
+    {
+//        System.out.println("Receiver added: receiverCount=" + receiverCount +
+//            ", receiverId=" + receiverId + ", sessionId=" + sessionId + ", streamId=" + streamId +
+//            ", channel=" + channel);
+    }
+
+    private void receiverRemoved(
+        final long receiverId, final int sessionId, final int streamId, final String channel, final int receiverCount)
+    {
+//        System.out.println("Receiver removed: receiverCount=" + receiverCount +
+//            ", receiverId=" + receiverId + ", sessionId=" + sessionId + ", streamId=" + streamId +
+//            ", channel=" + channel);
+    }
+
     static class Receiver
     {
+        final long receiverId;
+        final int sessionId;
+        final int streamId;
         long lastPosition;
         long lastPositionPlusWindow;
         long timeOfLastStatusMessageNs;
-        final long receiverId;
 
-        Receiver(final long lastPosition, final long lastPositionPlusWindow, final long timeNs, final long receiverId)
+        Receiver(
+            final long receiverId,
+            final int sessionId,
+            final int streamId,
+            final long lastPosition,
+            final long lastPositionPlusWindow,
+            final long timeNs)
         {
+            this.receiverId = receiverId;
+            this.sessionId = sessionId;
+            this.streamId = streamId;
             this.lastPosition = lastPosition;
             this.lastPositionPlusWindow = lastPositionPlusWindow;
             this.timeOfLastStatusMessageNs = timeNs;
-            this.receiverId = receiverId;
         }
     }
 }

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -545,7 +545,7 @@ TEST_F(DriverAgentTest, shouldLogConductorToDriverCommandBigMessage)
             EXPECT_EQ(
                 memcmp("a", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_publication_command_t), 1),
                 0);
-            EXPECT_EQ(memcmp("z", buffer + length -1, 1), 0);
+            EXPECT_EQ(memcmp("z", buffer + length - 1, 1), 0);
         };
 
     size_t timesCalled = 0;
@@ -642,7 +642,7 @@ TEST_F(DriverAgentTest, shouldLogConductorToClientCommandBigMessage)
             EXPECT_EQ(
                 memcmp("a", buffer + sizeof(aeron_driver_agent_cmd_log_header_t) + sizeof(aeron_subscription_command_t), 1),
                 0);
-            EXPECT_EQ(memcmp("z", buffer + length -1, 1), 0);
+            EXPECT_EQ(memcmp("z", buffer + length - 1, 1), 0);
         };
 
     size_t timesCalled = 0;
@@ -870,7 +870,7 @@ TEST_F(DriverAgentTest, shouldLogRemovePublicationCleanup)
 {
     aeron_driver_agent_logging_ring_buffer_init();
 
-    aeron_driver_agent_remove_publication_cleanup(42, 10, 5,"channel");
+    aeron_driver_agent_remove_publication_cleanup(42, 10, 5, "channel");
 
     auto message_handler =
         [](int32_t msg_type_id, const void *msg, size_t length, void *clientd)


### PR DESCRIPTION
This PR adds agent logging for min/group flow control strategies when a receiver is added or removed.
It also has other changes:
- [C] Fix receivers array length assignment upon remove.
- [Java] Fix logging configuration of name resolution when both add and remove are logged.
- [C/Java] Remove commas as field separators.