### PR TITLE
[Java] Dynamic logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ GTAGS
 GRTAGS
 GPATH
 prop
-out
-classes
-bin
+out/
+classes/
+bin/
 
 # OS X
 .DS_Store
@@ -19,7 +19,8 @@ bin
 *.iml
 *.ipr
 *.iws
-.idea
+.idea/
+.run/
 
 # editors
 *.sublime-project
@@ -28,7 +29,7 @@ bin
 
 # the build
 build-local.properties
-.gradle
+.gradle/
 build*
 cmake-build-debug/
 cmake-build-release/

--- a/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ArchiveEventCode.java
@@ -143,7 +143,18 @@ public enum ArchiveEventCode implements EventCode
 
     static ArchiveEventCode get(final int id)
     {
-        return id >= 0 && id < EVENT_CODE_BY_ID.length ? EVENT_CODE_BY_ID[id] : null;
+        if (id < 0 || id >= EVENT_CODE_BY_ID.length)
+        {
+            throw new IllegalArgumentException("no ArchiveEventCode for id: " + id);
+        }
+
+        final ArchiveEventCode code = EVENT_CODE_BY_ID[id];
+        if (null == code)
+        {
+            throw new IllegalArgumentException("no ArchiveEventCode for id: " + id);
+        }
+
+        return code;
     }
 
     static ArchiveEventCode getByTemplateId(final int templateId)

--- a/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ClusterEventCode.java
@@ -88,7 +88,18 @@ public enum ClusterEventCode implements EventCode
 
     static ClusterEventCode get(final int id)
     {
-        return id >= 0 && id < EVENT_CODE_BY_ID.length ? EVENT_CODE_BY_ID[id] : null;
+        if (id < 0 || id >= EVENT_CODE_BY_ID.length)
+        {
+            throw new IllegalArgumentException("no ClusterEventCode for id: " + id);
+        }
+
+        final ClusterEventCode code = EVENT_CODE_BY_ID[id];
+        if (null == code)
+        {
+            throw new IllegalArgumentException("no ClusterEventCode for id: " + id);
+        }
+
+        return code;
     }
 
     /**

--- a/aeron-agent/src/main/java/io/aeron/agent/ConfigOption.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ConfigOption.java
@@ -86,7 +86,6 @@ enum ConfigOption
      */
     DISABLED_CLUSTER_EVENT_CODES("aeron.event.cluster.log.disable");
 
-    static final String READER_CLASSNAME_DEFAULT = "io.aeron.agent.EventLogReaderAgent";
     static final String START_COMMAND = "start";
     static final String STOP_COMMAND = "stop";
 

--- a/aeron-agent/src/main/java/io/aeron/agent/ConfigOption.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ConfigOption.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.Strings;
+import org.agrona.concurrent.Agent;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * A set of configuration options.
+ */
+enum ConfigOption
+{
+    /**
+     * Event Buffer log file name system property. If not set then output will default to {@link System#out}.
+     */
+    LOG_FILENAME("aeron.event.log.filename"),
+
+    /**
+     * Event reader {@link Agent} which consumes the {@link EventConfiguration#EVENT_RING_BUFFER} to output log events.
+     */
+    READER_CLASSNAME("aeron.event.log.reader.classname"),
+
+    /**
+     * Driver Event tags system property. This is either:
+     * <ul>
+     * <li>A comma separated list of {@link DriverEventCode}s to enable</li>
+     * <li>"all" which enables all the codes</li>
+     * <li>"admin" which enables the codes specified by {@link EventConfiguration#ADMIN_ONLY_EVENT_CODES} which
+     * is the admin commands</li>
+     * </ul>
+     */
+    ENABLED_DRIVER_EVENT_CODES("aeron.event.log"),
+
+    /**
+     * Disabled Driver Event tags system property. Follows the format specified for
+     * {@link #ENABLED_DRIVER_EVENT_CODES}. This property will disable any codes in the set
+     * specified there. Defined on its own has no effect.
+     */
+    DISABLED_DRIVER_EVENT_CODES("aeron.event.log.disable"),
+
+    /**
+     * Archive Event tags system property. This is either:
+     * <ul>
+     * <li>A comma separated list of {@link ArchiveEventCode}s to enable</li>
+     * <li>"all" which enables all the codes</li>
+     * </ul>
+     */
+    ENABLED_ARCHIVE_EVENT_CODES("aeron.event.archive.log"),
+
+    /**
+     * Disabled Archive Event tags system property. Follows the format specified for
+     * {@link #ENABLED_ARCHIVE_EVENT_CODES}. This property will disable any codes in the
+     * set specified there. Defined on its own has no effect.
+     */
+    DISABLED_ARCHIVE_EVENT_CODES("aeron.event.archive.log.disable"),
+
+    /**
+     * Cluster Event tags system property. This is either:
+     * <ul>
+     * <li>A comma separated list of {@link ClusterEventCode}s to enable</li>
+     * <li>"all" which enables all the codes</li>
+     * </ul>
+     */
+    ENABLED_CLUSTER_EVENT_CODES("aeron.event.cluster.log"),
+
+    /**
+     * Disabled Cluster Event tags system property name. Follows the format specified for
+     * {@link #ENABLED_CLUSTER_EVENT_CODES}. This property will disable any codes in the
+     * set specified there. Defined on its own has no effect.
+     */
+    DISABLED_CLUSTER_EVENT_CODES("aeron.event.cluster.log.disable");
+
+    static final String READER_CLASSNAME_DEFAULT = "io.aeron.agent.EventLogReaderAgent";
+    static final String START_COMMAND = "start";
+    static final String STOP_COMMAND = "stop";
+
+    private static final char VALUE_SEPARATOR = '=';
+    private static final char OPTION_SEPARATOR = '|';
+    private static final ConfigOption[] OPTIONS = values();
+
+    private final String propertyName;
+
+    ConfigOption(final String propertyName)
+    {
+        this.propertyName = propertyName;
+    }
+
+    String propertyName()
+    {
+        return propertyName;
+    }
+
+    static EnumMap<ConfigOption, String> fromSystemProperties()
+    {
+        final EnumMap<ConfigOption, String> values = new EnumMap<>(ConfigOption.class);
+        for (final ConfigOption option : OPTIONS)
+        {
+            final String value = System.getProperty(option.propertyName());
+            if (null != value)
+            {
+                values.put(option, value);
+            }
+        }
+        return values;
+    }
+
+    static String buildAgentArgs(final EnumMap<ConfigOption, String> configOptions)
+    {
+        if (configOptions.isEmpty())
+        {
+            return null;
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        for (final Map.Entry<ConfigOption, String> entry : configOptions.entrySet())
+        {
+            builder.append(entry.getKey())
+                .append(VALUE_SEPARATOR)
+                .append(entry.getValue())
+                .append(OPTION_SEPARATOR);
+        }
+        if (builder.length() > 0)
+        {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+        return builder.toString();
+    }
+
+    static EnumMap<ConfigOption, String> parseAgentArgs(final String agentArgs)
+    {
+        if (Strings.isEmpty(agentArgs))
+        {
+            throw new IllegalArgumentException("cannot parse empty value");
+        }
+
+        final EnumMap<ConfigOption, String> values = new EnumMap<>(ConfigOption.class);
+
+        int optionIndex = -1;
+        do
+        {
+            final int valueIndex = agentArgs.indexOf(VALUE_SEPARATOR, optionIndex);
+            if (valueIndex <= 0)
+            {
+                break;
+            }
+
+            int nameIndex = -1;
+            while (optionIndex < valueIndex)
+            {
+                nameIndex = optionIndex;
+                optionIndex = agentArgs.indexOf(OPTION_SEPARATOR, optionIndex + 1);
+                if (optionIndex < 0)
+                {
+                    break;
+                }
+            }
+
+            final String optionName = agentArgs.substring(nameIndex + 1, valueIndex);
+            final ConfigOption option = valueOf(optionName);
+            final String value = agentArgs.substring(
+                valueIndex + 1,
+                optionIndex > 0 ? optionIndex : agentArgs.length());
+            values.put(option, value);
+        }
+        while (optionIndex > 0);
+
+        return values;
+    }
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/DynamicLoggingAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DynamicLoggingAgent.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.agrona.PropertyAction;
+import org.agrona.Strings;
+import org.agrona.SystemUtil;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.EnumMap;
+
+import static io.aeron.agent.ConfigOption.*;
+
+/**
+ * Attach/detach logging agent dynamically to a running process.
+ */
+public class DynamicLoggingAgent
+{
+    /**
+     * Attach logging agent jar to a running process.
+     *
+     * @param args program arguments.
+     */
+    public static void main(final String[] args)
+    {
+        if (args.length < 3)
+        {
+            printHelp();
+            System.exit(-1);
+        }
+
+        final File agentJar = Paths.get(args[0]).toAbsolutePath().toFile();
+        if (!agentJar.exists())
+        {
+            throw new IllegalArgumentException(agentJar + " does not exist!");
+        }
+
+        final String processId = args[1];
+        if (Strings.isEmpty(processId))
+        {
+            throw new IllegalArgumentException("no processId provided!");
+        }
+
+        final String command = args[2];
+        for (int i = 3; i < args.length; i++)
+        {
+            SystemUtil.loadPropertiesFile(PropertyAction.PRESERVE, args[i]);
+        }
+
+        switch (command)
+        {
+            case START_COMMAND:
+            {
+                final EnumMap<ConfigOption, String> configOptions = fromSystemProperties();
+                String logFile = configOptions.get(LOG_FILENAME);
+                if (Strings.isEmpty(logFile))
+                {
+                    final String baseDir;
+                    if (SystemUtil.isLinux() && Files.exists(Paths.get("/dev/shm")))
+                    {
+                        baseDir = "/dev/shm/";
+                    }
+                    else
+                    {
+                        baseDir = SystemUtil.tmpDirName();
+                    }
+
+                    logFile = baseDir + "agent-log-pid-" + processId + ".log";
+                    configOptions.put(LOG_FILENAME, logFile);
+                }
+
+                if (Strings.isEmpty(configOptions.get(READER_CLASSNAME)))
+                {
+                    configOptions.put(READER_CLASSNAME, READER_CLASSNAME_DEFAULT);
+                }
+
+                final String agentArgs = buildAgentArgs(configOptions);
+                ByteBuddyAgent.attach(agentJar, processId, agentArgs);
+                break;
+            }
+
+            case STOP_COMMAND:
+            {
+                ByteBuddyAgent.attach(agentJar, processId, command);
+                break;
+            }
+
+            default:
+                throw new IllegalArgumentException("invalid command: " + command);
+        }
+    }
+
+    private static void printHelp()
+    {
+        System.out.println("Usage: <agent-jar> <java-process-id> <command> [property files...]");
+        System.out.println("  <agent-jar> - fully qualified path to the agent jar");
+        System.out.println("  <java-process-id> - PID of the Java process to attach an agent to");
+        System.out.println("  <command> - either '" + START_COMMAND + "' or '" + STOP_COMMAND + "'");
+        System.out
+            .println("  [property files...] - an optional list of property files to configure logging options");
+    }
+
+}

--- a/aeron-agent/src/main/java/io/aeron/agent/DynamicLoggingAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DynamicLoggingAgent.java
@@ -55,7 +55,7 @@ public class DynamicLoggingAgent
         final String processId = args[1];
         if (Strings.isEmpty(processId))
         {
-            throw new IllegalArgumentException("no processId provided!");
+            throw new IllegalArgumentException("no PID provided!");
         }
 
         final String command = args[2];
@@ -94,7 +94,7 @@ public class DynamicLoggingAgent
         out.println("  <java-process-id> - PID of the Java process to attach an agent to");
         out.println("  <command> - either '" + START_COMMAND + "' or '" + STOP_COMMAND + "'");
         out.println("  [property files...] - an optional list of property files to configure logging options");
-        out.println("Note: logging options can be specified either via system properties of the property files.");
+        out.println("Note: logging options can be specified either via system properties or the property files.");
     }
 
     private static void attachAgent(final File agentJar, final String processId, final String agentArgs)
@@ -126,7 +126,7 @@ public class DynamicLoggingAgent
         {
             out.printf(
                 "Cannot start logging as it is already running.%n" +
-                "To stop logging use a '%s' command.%n%n",
+                "To stop logging use the '%s' command.%n%n",
                 STOP_COMMAND);
         }
         else

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -42,11 +42,17 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 /**
  * A Java agent which when attached to a JVM will weave byte code to intercept events as defined by
  * {@link DriverEventCode}. Events are recorded to an in-memory {@link org.agrona.concurrent.ringbuffer.RingBuffer}
- * which is consumed and appended asynchronous to a log as defined by the class {@link ConfigOption#READER_CLASSNAME}
+ * which is consumed and appended asynchronous to a log as defined by the class {@link #READER_CLASSNAME_PROP_NAME}
  * which defaults to {@link EventLogReaderAgent}.
  */
 public final class EventLogAgent
 {
+    /**
+     * Event reader {@link Agent} which consumes the {@link EventConfiguration#EVENT_RING_BUFFER} to output log events.
+     */
+    public static final String READER_CLASSNAME_PROP_NAME = READER_CLASSNAME.propertyName();
+    public static final String READER_CLASSNAME_DEFAULT = "io.aeron.agent.EventLogReaderAgent";
+
     private static final long SLEEP_PERIOD_MS = 1L;
 
     private static AgentRunner readerAgentRunner;
@@ -91,6 +97,15 @@ public final class EventLogAgent
                 instrumentation,
                 ConfigOption.parseAgentArgs(agentArgs));
         }
+    }
+
+    /**
+     * Remove the transformer and close the agent runner for the event log reader.
+     */
+    @Deprecated
+    public static synchronized void removeTransformer()
+    {
+        stopLogging();
     }
 
     /**

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogReaderAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogReaderAgent.java
@@ -40,10 +40,15 @@ import static org.agrona.BufferUtil.allocateDirectAligned;
 
 /**
  * Simple reader of {@link EventConfiguration#EVENT_RING_BUFFER} that appends to {@link System#out} by default
- * or to file if {@link ConfigOption#LOG_FILENAME} system property is set.
+ * or to file if {@link #LOG_FILENAME_PROP_NAME} System property is set.
  */
 public final class EventLogReaderAgent implements Agent
 {
+    /**
+     * Event Buffer length system property name. If not set then output will default to {@link System#out}.
+     */
+    public static final String LOG_FILENAME_PROP_NAME = ConfigOption.LOG_FILENAME.propertyName();
+
     private final ManyToOneRingBuffer ringBuffer = EventConfiguration.EVENT_RING_BUFFER;
     private final StringBuilder builder = new StringBuilder();
     private final MessageHandler messageHandler = this::onMessage;

--- a/aeron-agent/src/test/java/io/aeron/agent/AgentTests.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/AgentTests.java
@@ -15,33 +15,42 @@
  */
 package io.aeron.agent;
 
+import io.aeron.test.Tests;
 import net.bytebuddy.agent.ByteBuddyAgent;
+import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.aeron.agent.CommonEventEncoder.LOG_HEADER_LENGTH;
+import static io.aeron.agent.ConfigOption.*;
+import static io.aeron.agent.EventConfiguration.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class AgentTests
+final class AgentTests
 {
-    public static void beforeAgent()
+    static void startLogging(final EnumMap<ConfigOption, String> configOptions)
     {
-        EventLogAgent.agentmain("", ByteBuddyAgent.install());
+        EventLogAgent.agentmain(buildAgentArgs(configOptions), ByteBuddyAgent.install());
     }
 
-    public static void afterAgent()
+    static void stopLogging()
     {
-        EventLogAgent.removeTransformer();
-        System.clearProperty(EventConfiguration.ENABLED_EVENT_CODES_PROP_NAME);
-        System.clearProperty(EventConfiguration.ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME);
-        System.clearProperty(EventConfiguration.ENABLED_CLUSTER_EVENT_CODES_PROP_NAME);
-        System.clearProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME);
-        EventConfiguration.reset();
+        EventLogAgent.stopLogging();
     }
 
-    public static void verifyLogHeader(
+    static void verifyLogHeader(
         final UnsafeBuffer logBuffer,
         final int recordOffset,
         final int eventCodeId,
@@ -54,5 +63,172 @@ public class AgentTests
         assertEquals(captureLength, logBuffer.getInt(encodedMsgOffset(recordOffset), LITTLE_ENDIAN));
         assertEquals(length, logBuffer.getInt(encodedMsgOffset(recordOffset + SIZE_OF_INT), LITTLE_ENDIAN));
         assertNotEquals(0, logBuffer.getLong(encodedMsgOffset(recordOffset + SIZE_OF_INT * 2), LITTLE_ENDIAN));
+    }
+
+    @AfterEach
+    void afterEach()
+    {
+        stopLogging();
+        TestLoggingAgent.INSTANCE_COUNT.set(0);
+        TestLoggingAgent.onStartCalled = false;
+        TestLoggingAgent.onStopCalled = false;
+        TestLoggingAgentWithFileName.LOG_FILE_NAME.set(null);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void agentmainShouldUseSystemPropertiesWhenAgentsArgsIsEmpty(final String agentArgs)
+    {
+        System.setProperty(ENABLED_DRIVER_EVENT_CODES.propertyName(), "admin");
+        System.setProperty(
+            ENABLED_ARCHIVE_EVENT_CODES.propertyName(),
+            "CMD_IN_EXTEND_RECORDING,REPLICATION_SESSION_STATE_CHANGE,CATALOG_RESIZE");
+        System.setProperty(DISABLED_ARCHIVE_EVENT_CODES.propertyName(), "REPLICATION_SESSION_STATE_CHANGE");
+        System.setProperty(ENABLED_CLUSTER_EVENT_CODES.propertyName(), "all");
+        System.setProperty(DISABLED_CLUSTER_EVENT_CODES.propertyName(), "ROLE_CHANGE");
+        System.setProperty(READER_CLASSNAME.propertyName(), TestLoggingAgent.class.getName());
+        final int instanceCount = TestLoggingAgent.INSTANCE_COUNT.get();
+        try
+        {
+            EventLogAgent.agentmain(agentArgs, ByteBuddyAgent.install());
+
+            assertEquals(instanceCount + 1, TestLoggingAgent.INSTANCE_COUNT.get());
+            assertEquals(ADMIN_ONLY_EVENT_CODES, DRIVER_EVENT_CODES);
+            assertEquals(
+                EnumSet.of(ArchiveEventCode.CMD_IN_EXTEND_RECORDING, ArchiveEventCode.CATALOG_RESIZE),
+                ARCHIVE_EVENT_CODES);
+            assertEquals(
+                EnumSet.complementOf(EnumSet.of(ClusterEventCode.ROLE_CHANGE)),
+                CLUSTER_EVENT_CODES);
+        }
+        finally
+        {
+            for (final ConfigOption option : ConfigOption.values())
+            {
+                System.clearProperty(option.propertyName());
+            }
+        }
+    }
+
+    @Test
+    void shouldFailToStartLoggingIfAgentAlreadyRunning()
+    {
+        final int instanceCount = TestLoggingAgent.INSTANCE_COUNT.get();
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(READER_CLASSNAME, TestLoggingAgent.class.getName());
+
+        startLogging(configOptions); // logging is not started as no events are configured
+        assertEquals(instanceCount, TestLoggingAgent.INSTANCE_COUNT.get());
+
+        configOptions.put(ENABLED_DRIVER_EVENT_CODES, "admin");
+        startLogging(configOptions); // logging is running now
+        assertEquals(instanceCount + 1, TestLoggingAgent.INSTANCE_COUNT.get());
+
+        final IllegalStateException exception =
+            assertThrows(IllegalStateException.class, () -> startLogging(configOptions));
+        assertEquals("agent already instrumented", exception.getMessage());
+    }
+
+    @Test
+    void shouldStartLoggingAfterItWasStopped()
+    {
+        final int instanceCount = TestLoggingAgent.INSTANCE_COUNT.get();
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(READER_CLASSNAME, TestLoggingAgent.class.getName());
+        configOptions.put(ENABLED_ARCHIVE_EVENT_CODES, ArchiveEventCode.CMD_IN_AUTH_CONNECT.name());
+
+        startLogging(configOptions);
+        assertEquals(instanceCount + 1, TestLoggingAgent.INSTANCE_COUNT.get());
+
+        stopLogging();
+        assertEquals(EnumSet.noneOf(DriverEventCode.class), DRIVER_EVENT_CODES);
+        assertEquals(EnumSet.noneOf(ArchiveEventCode.class), ARCHIVE_EVENT_CODES);
+        assertEquals(EnumSet.noneOf(ClusterEventCode.class), CLUSTER_EVENT_CODES);
+
+        startLogging(configOptions);
+        assertEquals(instanceCount + 2, TestLoggingAgent.INSTANCE_COUNT.get());
+    }
+
+    @Test
+    void shouldInitializeLoggingAgentWithAFileName()
+    {
+        assertNull(TestLoggingAgentWithFileName.LOG_FILE_NAME.get());
+        final String logFileName = "/dev/shm/my-file.txt";
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(READER_CLASSNAME, TestLoggingAgentWithFileName.class.getName());
+        configOptions.put(LOG_FILENAME, logFileName);
+        configOptions.put(ENABLED_ARCHIVE_EVENT_CODES, "all");
+
+        startLogging(configOptions);
+        assertEquals(logFileName, TestLoggingAgentWithFileName.LOG_FILE_NAME.get());
+    }
+
+    @Test
+    @Timeout(10)
+    void shouldStartAndStopLoggingAgent()
+    {
+        final int instanceCount = TestLoggingAgent.INSTANCE_COUNT.get();
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(READER_CLASSNAME, TestLoggingAgent.class.getName());
+        configOptions.put(ENABLED_ARCHIVE_EVENT_CODES, "all");
+
+        startLogging(configOptions);
+        assertEquals(instanceCount + 1, TestLoggingAgent.INSTANCE_COUNT.get());
+        Tests.await(() -> TestLoggingAgent.onStartCalled);
+
+        stopLogging();
+        Tests.await(() -> TestLoggingAgent.onStopCalled);
+    }
+
+    private static class TestLoggingAgent implements Agent
+    {
+        static final AtomicInteger INSTANCE_COUNT = new AtomicInteger();
+        static volatile boolean onStartCalled = false;
+        static volatile boolean onStopCalled = false;
+
+        TestLoggingAgent()
+        {
+            INSTANCE_COUNT.getAndIncrement();
+        }
+
+        public int doWork() throws Exception
+        {
+            return 0;
+        }
+
+        public String roleName()
+        {
+            return "test-logging-agent";
+        }
+
+        public void onStart()
+        {
+            onStartCalled = true;
+        }
+
+        public void onClose()
+        {
+            onStopCalled = true;
+        }
+    }
+
+    private static class TestLoggingAgentWithFileName implements Agent
+    {
+        static final AtomicReference<String> LOG_FILE_NAME = new AtomicReference<>();
+
+        TestLoggingAgentWithFileName(final String logFileName)
+        {
+            LOG_FILE_NAME.set(logFileName);
+        }
+
+        public int doWork() throws Exception
+        {
+            return 0;
+        }
+
+        public String roleName()
+        {
+            return "test-logging-agent-with-file-name";
+        }
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventCodeTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveEventCodeTest.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.aeron.agent.ArchiveEventCode.EVENT_CODE_TYPE;
-import static io.aeron.agent.ArchiveEventCode.fromEventCodeId;
+import static io.aeron.agent.ArchiveEventCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ArchiveEventCodeTest
@@ -29,7 +28,29 @@ public class ArchiveEventCodeTest
     @EnumSource(ArchiveEventCode.class)
     void getCodeById(final ArchiveEventCode code)
     {
-        assertSame(code, ArchiveEventCode.get(code.id()));
+        assertSame(code, get(code.id()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, 101, Integer.MIN_VALUE, Integer.MAX_VALUE })
+    void getShouldThrowIllegalArgumentExceptionIfIdIsUnknown(final int id)
+    {
+        assertThrows(IllegalArgumentException.class, () -> get(id));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ArchiveEventCode.class)
+    void getCodeByTemplateId(final ArchiveEventCode code)
+    {
+        final int templateId = code.templateId();
+        if (templateId < 0)
+        {
+            assertNull(getByTemplateId(templateId));
+        }
+        else
+        {
+            assertSame(code, getByTemplateId(templateId));
+        }
     }
 
     @ParameterizedTest
@@ -48,8 +69,8 @@ public class ArchiveEventCodeTest
 
     @ParameterizedTest
     @ValueSource(ints = { 0, -1, 13, Integer.MIN_VALUE, Integer.MAX_VALUE })
-    void fromEventCodeIdReturnNullForUnknownCode(final int eventCodeId)
+    void fromEventCodeIdThrowsIllegalArgumentExceptionIfCodeIsInvalid(final int eventCodeId)
     {
-        assertNull(fromEventCodeId(eventCodeId));
+        assertThrows(IllegalArgumentException.class, () -> fromEventCodeId(eventCodeId));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -49,7 +50,7 @@ public class ArchiveLoggingAgentTest
     @AfterEach
     public void after()
     {
-        AgentTests.afterAgent();
+        AgentTests.stopLogging();
 
         if (testDir != null && testDir.exists())
         {
@@ -116,9 +117,10 @@ public class ArchiveLoggingAgentTest
 
     private void before(final String enabledEvents, final EnumSet<ArchiveEventCode> expectedEvents)
     {
-        System.setProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME, StubEventLogReaderAgent.class.getName());
-        System.setProperty(EventConfiguration.ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME, enabledEvents);
-        AgentTests.beforeAgent();
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(ConfigOption.READER_CLASSNAME, StubEventLogReaderAgent.class.getName());
+        configOptions.put(ConfigOption.ENABLED_ARCHIVE_EVENT_CODES, enabledEvents);
+        AgentTests.startLogging(configOptions);
 
         WAIT_LIST.clear();
         WAIT_LIST.addAll(expectedEvents);

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterEventCodeTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterEventCodeTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.aeron.agent.ClusterEventCode.fromEventCodeId;
+import static io.aeron.agent.ClusterEventCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ClusterEventCodeTest
@@ -28,14 +28,21 @@ public class ClusterEventCodeTest
     @EnumSource(ClusterEventCode.class)
     void getCodeById(final ClusterEventCode code)
     {
-        assertSame(code, ClusterEventCode.get(code.id()));
+        assertSame(code, get(code.id()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, -1, 77, Integer.MIN_VALUE, Integer.MAX_VALUE })
+    void getCodeByIdShouldThrowIllegalArgumentExceptionForUnknownId(final int id)
+    {
+        assertThrows(IllegalArgumentException.class, () -> get(id));
     }
 
     @ParameterizedTest
     @EnumSource(ClusterEventCode.class)
     void toEventCodeIdComputesEventId(final ClusterEventCode eventCode)
     {
-        assertEquals(ClusterEventCode.EVENT_CODE_TYPE << 16 | (eventCode.id() & 0xFFFF), eventCode.toEventCodeId());
+        assertEquals(EVENT_CODE_TYPE << 16 | (eventCode.id() & 0xFFFF), eventCode.toEventCodeId());
     }
 
     @ParameterizedTest
@@ -47,8 +54,8 @@ public class ClusterEventCodeTest
 
     @ParameterizedTest
     @ValueSource(ints = { 0, -1, 13, Integer.MIN_VALUE, Integer.MAX_VALUE })
-    void fromEventCodeIdReturnNullForUnknownCode(final int eventCodeId)
+    void fromEventCodeIdShouldThrowIllegalArgumentExceptionForUnknownCodeId(final int eventCodeId)
     {
-        assertNull(fromEventCodeId(eventCodeId));
+        assertThrows(IllegalArgumentException.class, () -> fromEventCodeId(eventCodeId));
     }
 }

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
+import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -62,7 +63,7 @@ public class ClusterLoggingAgentTest
     public void after()
     {
         CloseHelper.closeAll(clusteredMediaDriver.consensusModule(), container, clusteredMediaDriver);
-        AgentTests.afterAgent();
+        AgentTests.stopLogging();
 
         if (testDir != null && testDir.exists())
         {
@@ -154,9 +155,10 @@ public class ClusterLoggingAgentTest
 
     private void before(final String enabledEvents, final EnumSet<ClusterEventCode> expectedEvents)
     {
-        System.setProperty(EventLogAgent.READER_CLASSNAME_PROP_NAME, StubEventLogReaderAgent.class.getName());
-        System.setProperty(EventConfiguration.ENABLED_CLUSTER_EVENT_CODES_PROP_NAME, enabledEvents);
-        AgentTests.beforeAgent();
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(ConfigOption.READER_CLASSNAME, StubEventLogReaderAgent.class.getName());
+        configOptions.put(ConfigOption.ENABLED_CLUSTER_EVENT_CODES, enabledEvents);
+        AgentTests.startLogging(configOptions);
 
         WAIT_LIST.clear();
         WAIT_LIST.addAll(expectedEvents);

--- a/aeron-agent/src/test/java/io/aeron/agent/ConfigOptionTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ConfigOptionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.agent;
+
+import org.agrona.collections.ObjectHashSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static io.aeron.agent.ConfigOption.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigOptionTest
+{
+    @Test
+    void propertyNameShouldBeUnique()
+    {
+        final ObjectHashSet<String> properties = new ObjectHashSet<>();
+        for (final ConfigOption option : values())
+        {
+            assertTrue(properties.add(option.propertyName()));
+        }
+    }
+
+    @Test
+    void shouldReadSystemProperties()
+    {
+        final EnumMap<ConfigOption, String> expectedValues = new EnumMap<>(ConfigOption.class);
+        try
+        {
+            expectedValues.put(DISABLED_ARCHIVE_EVENT_CODES, "abc");
+            expectedValues.put(LOG_FILENAME, "");
+            expectedValues.put(ENABLED_CLUSTER_EVENT_CODES, "1,2,3");
+            for (final Map.Entry<ConfigOption, String> entry : expectedValues.entrySet())
+            {
+                System.setProperty(entry.getKey().propertyName(), entry.getValue());
+            }
+            System.setProperty("ignore me", "1000");
+
+            final EnumMap<ConfigOption, String> values = fromSystemProperties();
+
+            assertEquals(expectedValues, values);
+        }
+        finally
+        {
+            System.clearProperty(DISABLED_ARCHIVE_EVENT_CODES.propertyName());
+            System.clearProperty(LOG_FILENAME.propertyName());
+            System.clearProperty(ENABLED_CLUSTER_EVENT_CODES.propertyName());
+            System.clearProperty("ignore me");
+        }
+    }
+
+    @Test
+    void shouldReturnAnEmptyMapIfNoSystemPropertiesAreSet()
+    {
+        final EnumMap<ConfigOption, String> expectedValues = new EnumMap<>(ConfigOption.class);
+
+        final EnumMap<ConfigOption, String> values = fromSystemProperties();
+
+        assertEquals(expectedValues, values);
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionIfConfigOptionsMapIsNull()
+    {
+        assertThrows(NullPointerException.class, () -> buildAgentArgs(null));
+    }
+
+    @Test
+    void shouldReturnNullIfConfigOptionsMapIsEmpty()
+    {
+        assertNull(buildAgentArgs(new EnumMap<>(ConfigOption.class)));
+    }
+
+    @Test
+    void shouldCombineConfigOptionsIntoAnAgentArgsString()
+    {
+        final EnumMap<ConfigOption, String> configOptions = new EnumMap<>(ConfigOption.class);
+        configOptions.put(READER_CLASSNAME, "reader class");
+        configOptions.put(DISABLED_CLUSTER_EVENT_CODES, "CANVASS_POSITION");
+        configOptions.put(ENABLED_DRIVER_EVENT_CODES, "all");
+        configOptions.put(LOG_FILENAME, "file.txt");
+        configOptions.put(DISABLED_DRIVER_EVENT_CODES, "admin");
+
+        final String agentArgs = buildAgentArgs(configOptions);
+
+        assertEquals("LOG_FILENAME=file.txt|" +
+            "READER_CLASSNAME=reader class|" +
+            "ENABLED_DRIVER_EVENT_CODES=all|" +
+            "DISABLED_DRIVER_EVENT_CODES=admin|" +
+            "DISABLED_CLUSTER_EVENT_CODES=CANVASS_POSITION",
+            agentArgs);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowExceptionIfNullOrEmptyAgentArgs(final String agentArgs)
+    {
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> parseAgentArgs(agentArgs));
+        assertEquals("cannot parse empty value", exception.getMessage());
+    }
+
+    @Test
+    void shouldParseAgentArgsAsAConfigOptionsMap()
+    {
+        final EnumMap<ConfigOption, String> expectedOptions = new EnumMap<>(ConfigOption.class);
+        expectedOptions.put(LOG_FILENAME, "log.out");
+        expectedOptions.put(READER_CLASSNAME, "my reader");
+        expectedOptions.put(ENABLED_DRIVER_EVENT_CODES, "all");
+        expectedOptions.put(DISABLED_DRIVER_EVENT_CODES, "FRAME_IN,FRAME_OUT");
+        expectedOptions.put(ENABLED_CLUSTER_EVENT_CODES, "all");
+        expectedOptions.put(DISABLED_CLUSTER_EVENT_CODES, "CANVASS_POSITION,STATE_CHANGE");
+
+        final EnumMap<ConfigOption, String> configOptions = parseAgentArgs(
+            "||1600|abc|LOG_FILENAME=log.out|" +
+            "ENABLED_CLUSTER_EVENT_CODES=all|" +
+            "READER_CLASSNAME=my reader|" +
+            "DISABLED_DRIVER_EVENT_CODES=FRAME_IN,FRAME_OUT|" +
+            "ENABLED_DRIVER_EVENT_CODES=all|" +
+            "DISABLED_CLUSTER_EVENT_CODES=CANVASS_POSITION,STATE_CHANGE");
+
+        assertEquals(expectedOptions, configOptions);
+    }
+
+    @Test
+    void shouldParseAgentArgsThatEndWithExtraSeparators()
+    {
+        final EnumMap<ConfigOption, String> expectedOptions = new EnumMap<>(ConfigOption.class);
+        expectedOptions.put(ENABLED_ARCHIVE_EVENT_CODES, "REPLICATION_SESSION_STATE_CHANGE,CMD_IN_START_RECORDING");
+
+        final EnumMap<ConfigOption, String> configOptions =
+            parseAgentArgs("ENABLED_ARCHIVE_EVENT_CODES=REPLICATION_SESSION_STATE_CHANGE,CMD_IN_START_RECORDING||||");
+
+        assertEquals(expectedOptions, configOptions);
+    }
+
+    @Test
+    void shouldThrowAnIllegalArgumentExceptionUponUnknownConfigOptionNameInTheAgentArgs()
+    {
+        final IllegalArgumentException exception =
+            assertThrows(IllegalArgumentException.class, () -> parseAgentArgs("x=5"));
+        assertEquals("No enum constant io.aeron.agent.ConfigOption.x", exception.getMessage());
+    }
+}

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -15,7 +15,7 @@
  */
 package io.aeron.agent;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -30,17 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class EventConfigurationTest
 {
-    @AfterEach
-    void after()
-    {
-        System.clearProperty(ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME);
-        System.clearProperty(DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME);
-        System.clearProperty(ENABLED_CLUSTER_EVENT_CODES_PROP_NAME);
-        System.clearProperty(DISABLED_CLUSTER_EVENT_CODES_PROP_NAME);
-        System.clearProperty(ENABLED_EVENT_CODES_PROP_NAME);
-        System.clearProperty(DISABLED_EVENT_CODES_PROP_NAME);
-    }
-
     @Test
     public void nullValueMeansNoEventsEnabled()
     {
@@ -115,9 +104,13 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificDriverEvents()
     {
-        System.setProperty(ENABLED_EVENT_CODES_PROP_NAME, "all");
-        System.setProperty(DISABLED_EVENT_CODES_PROP_NAME, "FRAME_IN,FRAME_OUT");
-        EventConfiguration.init();
+        EventConfiguration.init(
+            "all",
+            "FRAME_IN,FRAME_OUT",
+            null,
+            null,
+            null,
+            null);
         assertEquals(DriverEventCode.values().length - 2, DRIVER_EVENT_CODES.size());
         assertFalse(DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_IN));
         assertFalse(DRIVER_EVENT_CODES.contains(DriverEventCode.FRAME_OUT));
@@ -126,11 +119,13 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificArchiverEvents()
     {
-        System.setProperty(ENABLED_ARCHIVE_EVENT_CODES_PROP_NAME, "all");
-        System.setProperty(
-            DISABLED_ARCHIVE_EVENT_CODES_PROP_NAME,
-            ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS.name() + "," + ArchiveEventCode.CMD_IN_CONNECT);
-        EventConfiguration.init();
+        EventConfiguration.init(
+            null,
+            null,
+            "all",
+            ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS.name() + "," + ArchiveEventCode.CMD_IN_CONNECT,
+            null,
+            null);
         assertEquals(ArchiveEventCode.values().length - 2, ARCHIVE_EVENT_CODES.size());
         assertFalse(ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CMD_IN_ATTACH_SEGMENTS));
         assertFalse(ARCHIVE_EVENT_CODES.contains(ArchiveEventCode.CMD_IN_CONNECT));
@@ -139,11 +134,13 @@ public class EventConfigurationTest
     @Test
     void shouldDisableSpecificClusterEvents()
     {
-        System.setProperty(ENABLED_CLUSTER_EVENT_CODES_PROP_NAME, "all");
-        System.setProperty(
-            DISABLED_CLUSTER_EVENT_CODES_PROP_NAME,
+        EventConfiguration.init(
+            null,
+            null,
+            null,
+            null,
+            "all",
             ClusterEventCode.ROLE_CHANGE.name() + "," + ClusterEventCode.ELECTION_STATE_CHANGE);
-        EventConfiguration.init();
         assertEquals(ClusterEventCode.values().length - 2, CLUSTER_EVENT_CODES.size());
         assertFalse(CLUSTER_EVENT_CODES.contains(ClusterEventCode.ROLE_CHANGE));
         assertFalse(CLUSTER_EVENT_CODES.contains(ClusterEventCode.ELECTION_STATE_CHANGE));

--- a/aeron-samples/scripts/dynamic-logging
+++ b/aeron-samples/scripts/dynamic-logging
@@ -17,7 +17,7 @@
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 2 ]; then
   echo "Usage: <PID> <command> [config files...]"
   echo "  <PID> - Java process ID to attach logging agent to."
   echo "  <command> - either 'start' to start logging or 'stop' to stop it."
@@ -31,6 +31,4 @@ source "${DIR}/java-common"
 
 AGENT_JAR="${DIR}/../../aeron-agent/build/libs/aeron-agent-${VERSION}.jar"
 
-exec "${DIR}/run-java" io.aeron.agent.DynamicLoggingAgent \
- "${AGENT_JAR}" \
- "$@"
+exec "${DIR}/run-java" io.aeron.agent.DynamicLoggingAgent "${AGENT_JAR}" "$@"

--- a/aeron-samples/scripts/dynamic-logging
+++ b/aeron-samples/scripts/dynamic-logging
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+##
+## Copyright 2014-2021 Real Logic Limited.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: <PID> <command> [config files...]"
+  echo "  <PID> - Java process ID to attach logging agent to."
+  echo "  <command> - either 'start' to start logging or 'stop' to stop it."
+  echo "  [config files...] - an optional list of property files to configure logging options."
+  echo "Alternatively logging options can be specified via the 'JVM_OPTS' env variable, e.g.:"
+  echo "JVM_OPTS=\"-Daeron.event.log=admin -Daeron.event.archive.log=all\" ./dynamic-logging 1111 start"
+  exit 1
+fi
+
+source "${DIR}/java-common"
+
+AGENT_JAR="${DIR}/../../aeron-agent/build/libs/aeron-agent-${VERSION}.jar"
+
+exec "${DIR}/run-java" io.aeron.agent.DynamicLoggingAgent \
+ "${AGENT_JAR}" \
+ "$@"

--- a/aeron-samples/scripts/dynamic-logging.cmd
+++ b/aeron-samples/scripts/dynamic-logging.cmd
@@ -1,0 +1,37 @@
+::
+:: Copyright 2014-2021 Real Logic Limited.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+:: https://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+
+@echo off
+set "DIR=%~dp0"
+
+set numArgs=0
+for %%x in (%*) do set /A numArgs+=1
+
+if %numArgs% LSS 2 (
+  echo "Usage: <PID> <command> [config files...]"
+  echo "  <PID> - Java process ID to attach logging agent to."
+  echo "  <command> - either 'start' to start logging or 'stop' to stop it."
+  echo "  [config files...] - an optional list of property files to configure logging options."
+  echo "Alternatively logging options can be specified via the 'JVM_OPTS' env variable, e.g.:"
+  echo "set \"JVM_OPTS=-Daeron.event.log=admin -Daeron.event.archive.log=all\" && dynamic-logging 1111 start"
+  exit /b 1
+)
+
+call "%DIR%\java-common"
+
+set "AGENT_JAR=%DIR%\..\..\aeron-agent\build\libs\aeron-agent-%VERSION%.jar"
+
+call "%DIR%\run-java" io.aeron.agent.DynamicLoggingAgent %AGENT_JAR% %*

--- a/build.gradle
+++ b/build.gradle
@@ -663,8 +663,8 @@ project(':aeron-agent') {
     dependencies {
         implementation aeronClusterProject
         implementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+        implementation "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
         testImplementation project(':aeron-test-support')
-        testImplementation "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
     }
 
     shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -838,9 +838,10 @@ project(':aeron-all') {
     def aeronArchiveProject = project(':aeron-archive')
     def aeronClusterProject = project(':aeron-cluster')
     def aeronSamplesProject = project(':aeron-samples')
+    def aeronAgentProject = project(':aeron-agent')
 
     dependencies {
-        implementation aeronClusterProject
+        implementation aeronAgentProject
         implementation aeronSamplesProject
         implementation "org.hdrhistogram:HdrHistogram:${hdrHistogramVersion}"
     }
@@ -865,7 +866,8 @@ project(':aeron-all') {
             aeronArchiveProject.sourceSets.generated.allSource,
             aeronClusterProject.sourceSets.main.allSource,
             aeronClusterProject.sourceSets.generated.allSource,
-            aeronSamplesProject.sourceSets.main.allSource)
+            aeronSamplesProject.sourceSets.main.allSource,
+            aeronAgentProject.sourceSets.main.allSource)
     }
 
     javadoc {
@@ -876,6 +878,7 @@ project(':aeron-all') {
         source += aeronClusterProject.sourceSets.main.allJava
         source += aeronClusterProject.sourceSets.generated.allJava
         source += aeronSamplesProject.sourceSets.main.allJava
+        source += aeronAgentProject.sourceSets.main.allJava
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
This PR adds scripts that allow enabling and disabling Agent-based logging of Aeron components.

The general form of the command is:
```bash
dynamic-logging <pid> <command> [config files...]
```
where `<pid>` is the JVM process ID and `<command>` is either `start` or `stop`. One can also pass an optional list of config property files or use `JVM_OPTS` env var instead.

Here is an example of enabling logging for the admin events of media driver process `1111` on Linux:
```bash
JVM_OPTS="-Daeron.event.log=admin" ./dynamic-logging 1111 start
```
And on Windows:
```batch
set "JVM_OPTS=-Daeron.event.log=admin" && dynamic-logging 1111 start
```
By default the log will be written to the `stdout` of the target process. Logging to a file can be specified via the `aeron.event.log.filename` property.
