### PR TITLE
Refactored test using RepeatedTest annotation

### DIFF
--- a/aeron-driver/src/test/java/io/aeron/driver/OptimalMulticastDelayGeneratorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/OptimalMulticastDelayGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package io.aeron.driver;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 
 import java.util.concurrent.TimeUnit;
 
@@ -30,13 +30,10 @@ public class OptimalMulticastDelayGeneratorTest
     private final OptimalMulticastDelayGenerator generator = new OptimalMulticastDelayGenerator(
         MAX_BACKOFF, GROUP_SIZE);
 
-    @Test
+    @RepeatedTest(100_000)
     public void shouldNotExceedTmaxBackoff()
     {
-        for (int i = 0; i < 100_000; i++)
-        {
-            final double delay = generator.generateNewOptimalDelay();
-            assertThat(delay, lessThanOrEqualTo((double)MAX_BACKOFF));
-        }
+        final double delay = generator.generateNewOptimalDelay();
+        assertThat(delay, lessThanOrEqualTo((double)MAX_BACKOFF));
     }
 }


### PR DESCRIPTION
Problem:
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution, and this behavior is kept for a repetition structure.

Solution:
The RepeatedTest annotation make it possible to repeat a test multiple times, reporting the result of each execution individually. This way, we were able to make 1 original test containing a repetition structure into many individual and independently executed tests.