### PR TITLE
C driver preallocate bindings

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -2518,3 +2518,31 @@ int64_t aeron_driver_context_get_conductor_cycle_threshold_ns(aeron_driver_conte
     return NULL != context ?
         context->conductor_cycle_threshold_ns : AERON_DRIVER_CONDUCTOR_CYCLE_THRESHOLD_NS_DEFAULT;
 }
+
+int aeron_driver_context_bindings_clientd_find_first_free_index(aeron_driver_context_t *context)
+{
+    for (size_t i = 0; i < context->num_bindings_clientd_entries; i++)
+    {
+        if (NULL == context->bindings_clientd_entries[i].clientd)
+        {
+            return (int)i;
+        }
+    }
+
+    return -1;
+}
+
+int aeron_driver_context_bindings_clientd_find(aeron_driver_context_t *context, const char *name)
+{
+    for (size_t i = 0; i < context->num_bindings_clientd_entries; i++)
+    {
+        aeron_driver_context_bindings_clientd_entry_t *entry = &context->bindings_clientd_entries[i];
+
+        if (NULL != entry->name && 0 == strncmp(entry->name, name, strlen(name)))
+        {
+            return (int)i;
+        }
+    }
+
+    return -1;
+}

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -277,6 +277,8 @@ size_t aeron_cnc_length(aeron_driver_context_t *context);
 
 int aeron_driver_context_bindings_clientd_create_entries(aeron_driver_context_t *context);
 int aeron_driver_context_bindings_clientd_delete_entries(aeron_driver_context_t *context);
+int aeron_driver_context_bindings_clientd_find_first_free_index(aeron_driver_context_t *context);
+int aeron_driver_context_bindings_clientd_find(aeron_driver_context_t *context, const char *name);
 
 inline void aeron_cnc_version_signal_cnc_ready(aeron_cnc_metadata_t *metadata, int32_t cnc_version)
 {

--- a/aeron-driver/src/test/c/aeron_c_system_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_system_test.cpp
@@ -17,12 +17,14 @@
 #include <functional>
 
 #include <gtest/gtest.h>
+#include <aeron_driver_context.h>
 
 #include "aeron_test_base.h"
 
 extern "C"
 {
 #include "concurrent/aeron_atomic.h"
+#include "agent/aeron_driver_agent.h"
 }
 
 #define PUB_URI "aeron:udp?endpoint=localhost:24325"
@@ -49,6 +51,44 @@ TEST_P(CSystemTest, shouldSpinUpDriverAndConnectSuccessfully)
 
     aeron_close(aeron);
     aeron_context_close(context);
+}
+
+TEST_P(CSystemTest, shouldReallocateBindingsClientd)
+{
+    aeron_driver_context_t *context;
+    aeron_driver_t *driver;
+    const char *name0 = "name0";
+    int val0 = 10;
+    const char *name1 = "name1";
+    int val1 = 11;
+
+    aeron_env_set("AERON_UDP_CHANNEL_INCOMING_INTERCEPTORS", "loss");
+
+    ASSERT_EQ(aeron_driver_context_init(&context), 0);
+
+    aeron_driver_context_set_dir_delete_on_start(context, true);
+
+    ASSERT_EQ(2U, context->num_bindings_clientd_entries);
+
+    context->bindings_clientd_entries[0].name = name0;
+    context->bindings_clientd_entries[0].clientd = &val0;
+    context->bindings_clientd_entries[1].name = name1;
+    context->bindings_clientd_entries[1].clientd = &val1;
+
+    aeron_driver_agent_logging_events_init("FRAME_IN", "");
+    aeron_driver_agent_init_logging_events_interceptors(context);
+
+    ASSERT_EQ(0, aeron_driver_init(&driver, context)) << aeron_errmsg();
+
+    ASSERT_EQ(3U, context->num_bindings_clientd_entries);
+
+    ASSERT_STREQ(name0, context->bindings_clientd_entries[0].name);
+    ASSERT_EQ((void *)&val0, context->bindings_clientd_entries[0].clientd);
+    ASSERT_STREQ(name1, context->bindings_clientd_entries[1].name);
+    ASSERT_EQ((void *)&val1, context->bindings_clientd_entries[1].clientd);
+
+    aeron_driver_close(driver);
+    aeron_driver_context_close(context);
 }
 
 TEST_P(CSystemTest, shouldAddAndClosePublication)

--- a/aeron-driver/src/test/c/aeron_c_system_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_system_test.cpp
@@ -17,7 +17,6 @@
 #include <functional>
 
 #include <gtest/gtest.h>
-#include <aeron_driver_context.h>
 
 #include "aeron_test_base.h"
 
@@ -25,6 +24,7 @@ extern "C"
 {
 #include "concurrent/aeron_atomic.h"
 #include "agent/aeron_driver_agent.h"
+#include "aeron_driver_context.h"
 }
 
 #define PUB_URI "aeron:udp?endpoint=localhost:24325"
@@ -57,16 +57,20 @@ TEST_P(CSystemTest, shouldReallocateBindingsClientd)
 {
     aeron_driver_context_t *context;
     aeron_driver_t *driver;
+    char aeron_dir[AERON_MAX_PATH];
     const char *name0 = "name0";
     int val0 = 10;
     const char *name1 = "name1";
     int val1 = 11;
 
+    aeron_temp_filename(aeron_dir, AERON_MAX_PATH - 1);
+
     aeron_env_set("AERON_UDP_CHANNEL_INCOMING_INTERCEPTORS", "loss");
 
     ASSERT_EQ(aeron_driver_context_init(&context), 0);
 
-    aeron_driver_context_set_dir_delete_on_start(context, true);
+    aeron_driver_context_set_dir(context, aeron_dir);
+    aeron_driver_context_set_dir_delete_on_shutdown(context, true);
 
     ASSERT_EQ(2U, context->num_bindings_clientd_entries);
 


### PR DESCRIPTION
- Allow for bindings to be updated before calling `aeron_driver_init`.
- Add internal functions for find used and free slots in the bindings_clientd list.