### PR TITLE
Fix NPE in cluster client after multiple redirects.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -1705,19 +1705,17 @@ public final class AeronCluster implements AutoCloseable
             {
                 ingressPublication = leader.publication;
                 leader.publication = null;
-                CloseHelper.closeAll(memberByIdMap.values());
-                memberByIdMap = parseIngressEndpoints(egressPoller.detail());
             }
-            else
-            {
-                CloseHelper.closeAll(memberByIdMap.values());
-                memberByIdMap = parseIngressEndpoints(egressPoller.detail());
 
+            CloseHelper.closeAll(memberByIdMap.values());
+            memberByIdMap = parseIngressEndpoints(egressPoller.detail());
+
+            if (ingressPublication == null)
+            {
                 final MemberIngress member = memberByIdMap.get(leaderMemberId);
                 final ChannelUri channelUri = ChannelUri.parse(ctx.ingressChannel());
                 channelUri.put(CommonContext.ENDPOINT_PARAM_NAME, member.endpoint);
-                member.publication = addIngressPublication(ctx, channelUri.toString(), ctx.ingressStreamId());
-                ingressPublication = member.publication;
+                ingressPublication = addIngressPublication(ctx, channelUri.toString(), ctx.ingressStreamId());
             }
 
             step(1);


### PR DESCRIPTION
Observed this exception during failover testing:

```
java.lang.NullPointerException
	at io.aeron.cluster.client.AeronCluster$AsyncConnect.awaitPublicationConnected(AeronCluster.java:1600)
	at io.aeron.cluster.client.AeronCluster$AsyncConnect.poll(AeronCluster.java:1529)
        ....
```

I believe thing can occur in the following scenario:
Step 1 => Step 2 => Step 3 => Redirect (member X) => Step 1 => Step 2 => Step 3 => Redirect (member Y) => Step 1 (Exception!)

This will occur due to the publication for member Y being closed at the point the client is redirected to member X.