### PR TITLE
Missing aeron-all directory after fresh checkout

### DIFF
--- a/aeron-all/README.md
+++ b/aeron-all/README.md
@@ -1,0 +1,4 @@
+Aeron All
+===
+
+This subproject contains all-in-one build of Aeron. 


### PR DESCRIPTION
Attempt to build `aeron-all` from fresh git clone, using `./gradlew :aeron-all:build` produces the following error:
```
Could not set process working directory to '$CLONE_DIR/aeron-all': could not setcwd() (errno 2: No such file or directory)
```

The `aeron-all` directory is missing. I've added simple `README.md` file (instead of `.gitkeep` as [suggested here](https://stackoverflow.com/questions/7229885/what-are-the-differences-between-gitignore-and-gitkeep#comment15172056_7229996)) to create the directory upon fresh clone.

