### PR TITLE
Add logging for name resolutions.  

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/CommonEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/CommonEventDissector.java
@@ -84,9 +84,19 @@ final class CommonEventDissector
     static int dissectSocketAddress(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
         int relativeOffset = 0;
-
         final int port = buffer.getInt(offset + relativeOffset, LITTLE_ENDIAN);
         relativeOffset += SIZE_OF_INT;
+
+        relativeOffset += dissectInetAddress(buffer, offset + relativeOffset, builder);
+
+        builder.append(':').append(port);
+
+        return relativeOffset;
+    }
+
+    static int dissectInetAddress(final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int relativeOffset = 0;
 
         final int addressLength = buffer.getInt(offset + relativeOffset);
         relativeOffset += SIZE_OF_INT;
@@ -101,14 +111,13 @@ final class CommonEventDissector
                 .append('.')
                 .append(buffer.getByte(i + 2) & 0xFF)
                 .append('.')
-                .append(buffer.getByte(i + 3) & 0xFF)
-                .append(':')
-                .append(port);
+                .append(buffer.getByte(i + 3) & 0xFF);
         }
         else if (16 == addressLength)
         {
             final int i = offset + relativeOffset;
             builder
+                .append('[')
                 .append(toHexString(((buffer.getByte(i) << 8) & 0xFF00) | buffer.getByte(i + 1) & 0xFF))
                 .append(':')
                 .append(toHexString(((buffer.getByte(i + 2) << 8) & 0xFF00) | buffer.getByte(i + 3) & 0xFF))
@@ -124,12 +133,11 @@ final class CommonEventDissector
                 .append(toHexString(((buffer.getByte(i + 12) << 8) & 0xFF00) | buffer.getByte(i + 13) & 0xFF))
                 .append(':')
                 .append(toHexString(((buffer.getByte(i + 14) << 8) & 0xFF00) | buffer.getByte(i + 15) & 0xFF))
-                .append(':')
-                .append(port);
+                .append(']');
         }
         else
         {
-            builder.append("unknown-address:").append(port);
+            builder.append("unknown-address");
         }
 
         relativeOffset += addressLength;

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -80,7 +80,9 @@ public enum DriverEventCode implements EventCode
     NAME_RESOLUTION_NEIGHBOR_REMOVED(47, DriverEventDissector::dissectAddress),
 
     FLOW_CONTROL_RECEIVER_ADDED(48, DriverEventDissector::dissectFlowControlReceiver),
-    FLOW_CONTROL_RECEIVER_REMOVED(49, DriverEventDissector::dissectFlowControlReceiver);
+    FLOW_CONTROL_RECEIVER_REMOVED(49, DriverEventDissector::dissectFlowControlReceiver),
+
+    NAME_RESOLUTION_RESOLVE(50, DriverEventDissector::dissectResolve);
 
     static final int EVENT_CODE_TYPE = EventCodeType.DRIVER.getTypeCode();
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -20,8 +20,7 @@ import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.*;
 import org.agrona.MutableDirectBuffer;
 
-import static io.aeron.agent.CommonEventDissector.dissectLogHeader;
-import static io.aeron.agent.CommonEventDissector.dissectSocketAddress;
+import static io.aeron.agent.CommonEventDissector.*;
 import static io.aeron.agent.DriverEventCode.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.BitUtil.SIZE_OF_INT;
@@ -324,6 +323,24 @@ final class DriverEventDissector
 
         builder.append(" channel=");
         buffer.getStringAscii(absoluteOffset, builder);
+    }
+
+    static void dissectResolve(
+        final DriverEventCode code, final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, code, buffer, absoluteOffset, builder);
+
+        builder.append(": resolver=");
+        absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
+        absoluteOffset += SIZE_OF_INT; // String length
+
+        builder.append(" hostname=");
+        absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
+        absoluteOffset += SIZE_OF_INT; // String length
+
+        builder.append(" address=");
+        dissectInetAddress(buffer, absoluteOffset, builder);
     }
 
     static int frameType(final MutableDirectBuffer buffer, final int termOffset)

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -15,8 +15,10 @@
  */
 package io.aeron.agent;
 
+import io.aeron.driver.NameResolver;
 import net.bytebuddy.asm.Advice;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import static io.aeron.agent.DriverEventCode.*;
@@ -51,6 +53,21 @@ class DriverInterceptor
             static void neighborRemoved(final long nowMs, final InetSocketAddress address)
             {
                 LOGGER.logAddress(NAME_RESOLUTION_NEIGHBOR_REMOVED, address);
+            }
+        }
+
+        static class Resolve
+        {
+            @Advice.OnMethodExit
+            static void resolve(
+                final String name,
+                final String uriParamName,
+                final boolean isReResolution,
+                @Advice.Return final InetAddress address,
+                @Advice.This final NameResolver nameResolver)
+            {
+                LOGGER.logResolve(
+                    DriverEventCode.NAME_RESOLUTION_RESOLVE, nameResolver.getClass().getSimpleName(), name, address);
             }
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/EventLogAgent.java
@@ -339,6 +339,14 @@ public final class EventLogAgent
             DriverInterceptor.NameResolution.NeighborRemoved.class,
             "neighborRemoved");
 
+        tempBuilder = addEventInstrumentation(
+            tempBuilder,
+            DRIVER_EVENT_CODES,
+            DriverEventCode.NAME_RESOLUTION_RESOLVE,
+            "NameResolver",
+            DriverInterceptor.NameResolution.Resolve.class,
+            "resolve");
+
         return tempBuilder;
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/CommonEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/CommonEventDissectorTest.java
@@ -87,7 +87,7 @@ class CommonEventDissectorTest
         final int decodedLength = CommonEventDissector.dissectSocketAddress(buffer, offset, builder);
 
         assertEquals(24, decodedLength);
-        assertEquals("9c7c:12:7880:2c2c:ab0:5016:7a05:59d:7777", builder.toString());
+        assertEquals("[9c7c:12:7880:2c2c:ab0:5016:7a05:59d]:7777", builder.toString());
     }
 
     @Test


### PR DESCRIPTION
- Refactor out common code for handling addresses and socket addresses.  
- Test for dissecting IPv6 addresses.
- Use URL style formatting for IPv6 addresses (i.e. surround with `[]`).