### PR TITLE
Use Aeron::nextCorrelationId in tests for tags.  Update ChannelUriStringBuilder to build from existing URIs.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -1444,7 +1444,7 @@ abstract class ArchiveConductor
 
     private static ChannelUriStringBuilder strippedChannelBuilder(final ChannelUri channelUri)
     {
-        final ChannelUriStringBuilder builder = new ChannelUriStringBuilder()
+        return new ChannelUriStringBuilder()
             .media(channelUri.media())
             .endpoint(channelUri)
             .networkInterface(channelUri)
@@ -1460,28 +1460,8 @@ abstract class ArchiveConductor
             .socketRcvbufLength(channelUri)
             .socketSndbufLength(channelUri)
             .receiverWindowLength(channelUri)
+            .sessionId(channelUri)
             .alias(channelUri);
-
-        final String sessionIdStr = channelUri.get(CommonContext.SESSION_ID_PARAM_NAME);
-        if (null != sessionIdStr)
-        {
-            if (ChannelUri.isTagged(sessionIdStr))
-            {
-                final long tag = ChannelUri.getTag(sessionIdStr);
-                if (tag < Integer.MIN_VALUE || tag > Integer.MAX_VALUE)
-                {
-                    throw new IllegalArgumentException("invalid session id tag value: " + tag);
-                }
-
-                builder.isSessionIdTagged(true).sessionId((int)tag);
-            }
-            else
-            {
-                builder.sessionId(Integer.valueOf(sessionIdStr));
-            }
-        }
-
-        return builder;
     }
 
     private static String makeKey(final int streamId, final ChannelUri channelUri)

--- a/aeron-client/src/main/java/io/aeron/ChannelUri.java
+++ b/aeron-client/src/main/java/io/aeron/ChannelUri.java
@@ -264,6 +264,9 @@ public final class ChannelUri
 
         final ChannelUri that = (ChannelUri)o;
 
+        final HashSet<String> missedkeys = new HashSet<>(params.keySet());
+        final boolean b = missedkeys.removeAll(that.params.keySet());
+
         return Objects.equals(prefix, that.prefix) &&
             Objects.equals(media, that.media) &&
             Objects.equals(params, that.params) &&
@@ -584,5 +587,39 @@ public final class ChannelUri
         }
 
         return count;
+    }
+
+    Map<String, String> diff(final ChannelUri that)
+    {
+        final HashMap<String, String> differingValues = new HashMap<>();
+
+        if (!Objects.equals(prefix, that.prefix))
+        {
+            differingValues.put("prefix", prefix + " != " + that.prefix);
+        }
+
+        if (!Objects.equals(media, that.media))
+        {
+            differingValues.put("media", media + " != " + that.media);
+        }
+
+        if (!Objects.equals(params, that.params))
+        {
+            params.forEach((key, value) ->
+            {
+                final String thatValue = that.params.get(key);
+                if (!Objects.equals(value, thatValue))
+                {
+                    differingValues.put(key, value + " != " + thatValue);
+                }
+            });
+        }
+
+        if (!Arrays.equals(tags, that.tags))
+        {
+            differingValues.put(TAGS_PARAM_NAME, Arrays.toString(tags) + " != " + Arrays.toString(that.tags));
+        }
+
+        return differingValues;
     }
 }

--- a/aeron-client/src/test/java/io/aeron/ChannelUriStringBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/ChannelUriStringBuilderTest.java
@@ -17,6 +17,8 @@ package io.aeron;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -126,5 +128,31 @@ public class ChannelUriStringBuilderTest
         assertEquals(
             "aeron:udp?endpoint=address:9999|rcv-wnd=8192",
             builder.build());
+    }
+
+    @Test
+    void shouldBuildChannelBuilderUsingExistingStringWithAllTheFields()
+    {
+        final String uri = "aeron-spy:aeron:udp?endpoint=127.0.0.1:0|interface=127.0.0.1|control=127.0.0.2:0|" +
+            "control-mode=manual|tags=2,4|alias=foo|cc=cubic|fc=min|reliable=false|ttl=16|mtu=8992|" +
+            "term-length=1048576|init-term-id=5|term-offset=64|term-id=4353|session-id=2314234|gtag=3|linger=0|" +
+            "sparse=true|eos=true|tether=false|group=false|ssc=true|so-sndbuf=8388608|so-rcvbuf=2097152|" +
+            "rcv-wnd=1048576";
+
+        final ChannelUri fromString = ChannelUri.parse(uri);
+        final ChannelUri fromBuilder = ChannelUri.parse(new ChannelUriStringBuilder(uri).build());
+
+        assertEquals(Collections.emptyMap(), fromString.diff(fromBuilder));
+    }
+
+    @Test
+    void shouldBuildChannelBuilderUsingExistingStringWithTaggedSessionIdAndIpc()
+    {
+        final String uri = "aeron:ipc?session-id=tag:123456";
+
+        final ChannelUri fromString = ChannelUri.parse(uri);
+        final ChannelUri fromBuilder = ChannelUri.parse(new ChannelUriStringBuilder(uri).build());
+
+        assertEquals(Collections.emptyMap(), fromString.diff(fromBuilder));
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -53,7 +53,7 @@ public class MultiDestinationCastTest
     private static final String SUB2_MDC_DYNAMIC_URI = "aeron:udp?control=localhost:24325|group=true";
     private static final String SUB3_MDC_DYNAMIC_URI = CommonContext.SPY_PREFIX + PUB_MDC_DYNAMIC_URI;
 
-    private static final String PUB_MDC_MANUAL_URI = "aeron:udp?control-mode=manual|tags=3,4";
+    private static final String PUB_MDC_MANUAL_URI = "aeron:udp?control-mode=manual";
     private static final String SUB1_MDC_MANUAL_URI = "aeron:udp?endpoint=localhost:24326|group=true";
     private static final String SUB2_MDC_MANUAL_URI = "aeron:udp?endpoint=localhost:24327|group=true";
     private static final String SUB3_MDC_MANUAL_URI = CommonContext.SPY_PREFIX + PUB_MDC_MANUAL_URI;
@@ -140,11 +140,16 @@ public class MultiDestinationCastTest
     {
         launch(Tests::onError);
 
+        final String taggedMdcUri = new ChannelUriStringBuilder(PUB_MDC_MANUAL_URI).tags(
+            clientA.nextCorrelationId(),
+            clientA.nextCorrelationId()).build();
+        final String spySubscriptionUri = new ChannelUriStringBuilder(taggedMdcUri).prefix("aeron-spy").build();
+
         subscriptionA = clientA.addSubscription(SUB1_MDC_MANUAL_URI, STREAM_ID);
         subscriptionB = clientB.addSubscription(SUB2_MDC_MANUAL_URI, STREAM_ID);
-        subscriptionC = clientA.addSubscription(SUB3_MDC_MANUAL_URI, STREAM_ID);
+        subscriptionC = clientA.addSubscription(spySubscriptionUri, STREAM_ID);
 
-        publication = clientA.addPublication(PUB_MDC_MANUAL_URI, STREAM_ID);
+        publication = clientA.addPublication(taggedMdcUri, STREAM_ID);
         publication.addDestination(SUB1_MDC_MANUAL_URI);
         final long correlationId = publication.asyncAddDestination(SUB2_MDC_MANUAL_URI);
 

--- a/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
@@ -109,9 +109,20 @@ public class ResolvedEndpointSystemTest
     @Timeout(5)
     void shouldSubscribeToSystemAssignedPorts()
     {
-        final String systemAssignedPortUri1 = "aeron:udp?endpoint=127.0.0.1:0|tags=1002";
-        final String systemAssignedPortUri2 = "aeron:udp?endpoint=127.0.0.1:0|tags=1003";
-        final String tagged1 = "aeron:udp?tags=1002";
+        final long tag1 = client.nextCorrelationId();
+        final long tag2 = client.nextCorrelationId();
+
+        final String systemAssignedPortUri1 = new ChannelUriStringBuilder()
+            .media("udp")
+            .endpoint("127.0.0.1:0")
+            .tags(tag1, null)
+            .build();
+        final String systemAssignedPortUri2 = new ChannelUriStringBuilder()
+            .media("udp")
+            .endpoint("127.0.0.1:0")
+            .tags(tag2, null)
+            .build();
+        final String tagged1 = new ChannelUriStringBuilder().media("udp").tags(tag1, null).build();
 
         try (Subscription sub1 = client.addSubscription(systemAssignedPortUri1, STREAM_ID);
             Subscription sub2 = client.addSubscription(systemAssignedPortUri2, STREAM_ID);
@@ -161,12 +172,18 @@ public class ResolvedEndpointSystemTest
     void shouldSubscribeToSystemAssignedPortsUsingIPv6()
     {
         assumeFalse("true".equals(System.getProperty("java.net.preferIPv4Stack")));
+        final long channelTag = client.nextCorrelationId();
 
-        final String systemAssignedPortUri = "aeron:udp?endpoint=[::1]:0|tags=1001";
-        final String tagged2 = "aeron:udp?tags=1001";
+        final String systemAssignedPortUri = new ChannelUriStringBuilder()
+            .media("udp")
+            .endpoint("[::1]:0")
+            .tags(channelTag, null)
+            .build();
+        final String taggedUri = new ChannelUriStringBuilder().media("udp").tags(channelTag, null).build();
+
 
         try (Subscription sub1 = client.addSubscription(systemAssignedPortUri, STREAM_ID);
-            Subscription sub2 = client.addSubscription(tagged2, STREAM_ID + 1))
+            Subscription sub2 = client.addSubscription(taggedUri, STREAM_ID + 1))
         {
             List<String> bindAddressAndPort1;
             while ((bindAddressAndPort1 = sub1.localSocketAddresses()).isEmpty())

--- a/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
@@ -122,19 +122,39 @@ public class SpySubscriptionTest
     @Timeout(10)
     public void shouldConnectToRecreatedChannelByTag()
     {
-        final String channelOne = "aeron:udp?tags=1|endpoint=localhost:24325";
+        final long tag1 = aeron.nextCorrelationId();
+        final String channelOne = new ChannelUriStringBuilder()
+            .media("udp")
+            .tags(tag1, null)
+            .endpoint("localhost:24325")
+            .build();
+        final ChannelUriStringBuilder spyChannelOneBuilder = new ChannelUriStringBuilder()
+            .prefix("aeron-spy")
+            .media("udp")
+            .tags(tag1, null);
+
         try (Publication publication = aeron.addExclusivePublication(channelOne, STREAM_ID);
             Subscription spy = aeron.addSubscription(
-                SPY_PREFIX + "aeron:udp?tags=1|session-id=" + publication.sessionId(), STREAM_ID))
+                spyChannelOneBuilder.sessionId(publication.sessionId()).build(), STREAM_ID))
         {
             Tests.await(spy::isConnected);
             assertNotNull(spy.imageBySessionId(publication.sessionId()));
         }
 
-        final String channelTwo = "aeron:udp?tags=2|endpoint=localhost:24325";
+        final long tag2 = aeron.nextCorrelationId();
+        final String channelTwo = new ChannelUriStringBuilder()
+            .media("udp")
+            .tags(tag2, null)
+            .endpoint("localhost:24325")
+            .build();
+        final ChannelUriStringBuilder spyChannelTwoBuilder = new ChannelUriStringBuilder()
+            .prefix("aeron-spy")
+            .media("udp")
+            .tags(tag2, null);
+
         try (Publication publication = aeron.addExclusivePublication(channelTwo, STREAM_ID);
             Subscription spy = aeron.addSubscription(
-                SPY_PREFIX + "aeron:udp?tags=2|session-id=" + publication.sessionId(), STREAM_ID))
+                spyChannelTwoBuilder.sessionId(publication.sessionId()).build(), STREAM_ID))
         {
             Tests.await(spy::isConnected);
             assertNotNull(spy.imageBySessionId(publication.sessionId()));

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -554,8 +554,8 @@ public class ReplicateRecordingTest
         final String messagePrefix = "Message-Prefix-";
         final int messageCount = 10;
         final long srcRecordingId;
-        final long channelTagId = 333;
-        final long subscriptionTagId = 777;
+        final long channelTagId = dstAeron.nextCorrelationId();
+        final long subscriptionTagId = dstAeron.nextCorrelationId();
         final String taggedChannel =
             "aeron:udp?control-mode=manual|rejoin=false|tags=" + channelTagId + "," + subscriptionTagId;
 


### PR DESCRIPTION
Support constructing a ChannelUriStringBuilder from an existing URI (String or ChannelUri).  Use Aeron::nextCorrelationId throughout tests to show most appropriate usage.  Encapsulate handling of tagged session ids in the ChannelUriStringBuilder.