### PR TITLE
Allow name resolution failure on construction of consensus publications

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -284,7 +284,12 @@ final class ConsensusModuleAgent implements Agent
             }
 
             ClusterMember.addConsensusPublications(
-                activeMembers, thisMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                activeMembers,
+                thisMember,
+                ctx.consensusChannel(),
+                ctx.consensusStreamId(),
+                aeron,
+                ctx.countedErrorHandler());
 
             election = new Election(
                 true,
@@ -497,6 +502,12 @@ final class ConsensusModuleAgent implements Agent
             final ClusterMember follower = clusterMemberByIdMap.get(followerMemberId);
             if (null != follower && logLeadershipTermId <= this.leadershipTermId)
             {
+                if (null == follower.publication())
+                {
+                    ClusterMember.addConsensusPublication(
+                        follower, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
+                }
+
                 final RecordingLog.Entry currentTermEntry = recordingLog.getTermEntry(this.leadershipTermId);
                 final long termBaseLogPosition = currentTermEntry.termBaseLogPosition;
                 final long timestamp = ctx.clusterClock().timeNanos();
@@ -702,7 +713,7 @@ final class ConsensusModuleAgent implements Agent
                     clusterMemberByIdMap.put(newMember.id(), newMember);
 
                     ClusterMember.addConsensusPublication(
-                        newMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                        newMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
                     logPublisher.addDestination(ctx.isLogMdc(), newMember.logEndpoint());
                 }
             }
@@ -759,7 +770,7 @@ final class ConsensusModuleAgent implements Agent
                 if (null == member.publication())
                 {
                     ClusterMember.addConsensusPublication(
-                        member, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                        member, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
                     logPublisher.addDestination(ctx.isLogMdc(), member.logEndpoint());
                 }
 
@@ -1222,7 +1233,8 @@ final class ConsensusModuleAgent implements Agent
                         thisMember,
                         ctx.consensusChannel(),
                         ctx.consensusStreamId(),
-                        aeron);
+                        aeron,
+                        ctx.countedErrorHandler());
                 }
                 else
                 {
@@ -1312,7 +1324,12 @@ final class ConsensusModuleAgent implements Agent
                 thisMember = clusterMemberByIdMap.get(memberId);
 
                 ClusterMember.addConsensusPublications(
-                    activeMembers, thisMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                    activeMembers,
+                    thisMember,
+                    ctx.consensusChannel(),
+                    ctx.consensusStreamId(),
+                    aeron,
+                    ctx.countedErrorHandler());
             }
         }
     }
@@ -1616,7 +1633,12 @@ final class ConsensusModuleAgent implements Agent
             leaderMember = dynamicJoin.leader();
 
             ClusterMember.addConsensusPublications(
-                activeMembers, thisMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                activeMembers,
+                thisMember,
+                ctx.consensusChannel(),
+                ctx.consensusStreamId(),
+                aeron,
+                ctx.countedErrorHandler());
         }
 
         if (NULL_VALUE == memberId)
@@ -2906,7 +2928,7 @@ final class ConsensusModuleAgent implements Agent
             if (null == eventMember.publication())
             {
                 ClusterMember.addConsensusPublication(
-                    eventMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron);
+                    eventMember, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
             }
 
             activeMembers = ClusterMember.addMember(activeMembers, eventMember);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -493,6 +493,8 @@ final class ConsensusModuleAgent implements Agent
         final long leadershipTermId,
         final int followerMemberId)
     {
+        checkFollowerAndAddConsensusPublication(followerMemberId);
+
         if (null != election)
         {
             election.onCanvassPosition(logLeadershipTermId, logPosition, leadershipTermId, followerMemberId);
@@ -502,12 +504,6 @@ final class ConsensusModuleAgent implements Agent
             final ClusterMember follower = clusterMemberByIdMap.get(followerMemberId);
             if (null != follower && logLeadershipTermId <= this.leadershipTermId)
             {
-                if (null == follower.publication())
-                {
-                    ClusterMember.addConsensusPublication(
-                        follower, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
-                }
-
                 final RecordingLog.Entry currentTermEntry = recordingLog.getTermEntry(this.leadershipTermId);
                 final long termBaseLogPosition = currentTermEntry.termBaseLogPosition;
                 final long timestamp = ctx.clusterClock().timeNanos();
@@ -3186,6 +3182,16 @@ final class ConsensusModuleAgent implements Agent
         {
             ingressAdapter.connect(aeron.addSubscription(
                 ctx.ingressChannel(), ctx.ingressStreamId(), null, this::onUnavailableIngressImage));
+        }
+    }
+
+    private void checkFollowerAndAddConsensusPublication(final int followerMemberId)
+    {
+        final ClusterMember follower = clusterMemberByIdMap.get(followerMemberId);
+        if (null != follower && null == follower.publication())
+        {
+            ClusterMember.addConsensusPublication(
+                follower, ctx.consensusChannel(), ctx.consensusStreamId(), aeron, ctx.countedErrorHandler());
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
@@ -56,6 +56,11 @@ final class ConsensusPublisher
         final long leadershipTermId,
         final int followerMemberId)
     {
+        if (null == publication)
+        {
+            return;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + CanvassPositionEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -88,6 +93,11 @@ final class ConsensusPublisher
         final long candidateTermId,
         final int candidateMemberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + RequestVoteEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -124,6 +134,11 @@ final class ConsensusPublisher
         final int followerMemberId,
         final boolean vote)
     {
+        if (null == publication)
+        {
+            return;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + VoteEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -166,6 +181,11 @@ final class ConsensusPublisher
         final int logSessionId,
         final boolean isStartup)
     {
+        if (null == publication)
+        {
+            return;
+        }
+
         if (CommonContext.NULL_SESSION_ID == logSessionId)
         {
             throw new ClusterException("logSessionId was null, should always have a value");
@@ -210,6 +230,11 @@ final class ConsensusPublisher
         final long logPosition,
         final int followerMemberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + AppendPositionEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -242,6 +267,11 @@ final class ConsensusPublisher
         final long logPosition,
         final int leaderMemberId)
     {
+        if (null == publication)
+        {
+            return;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + CommitPositionEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -273,6 +303,11 @@ final class ConsensusPublisher
         final int followerMemberId,
         final String catchupEndpoint)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length =
             MessageHeaderEncoder.ENCODED_LENGTH +
             CatchupPositionEncoder.BLOCK_LENGTH +
@@ -306,6 +341,11 @@ final class ConsensusPublisher
 
     boolean stopCatchup(final ExclusivePublication publication, final long leadershipTermId, final int followerMemberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + StopCatchupEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -334,6 +374,11 @@ final class ConsensusPublisher
     boolean addPassiveMember(
         final ExclusivePublication publication, final long correlationId, final String memberEndpoints)
     {
+        if (null == publication)
+        {
+            return true;
+        }
+
         addPassiveMemberEncoder
             .wrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
             .correlationId(correlationId)
@@ -364,6 +409,11 @@ final class ConsensusPublisher
         final String activeMembers,
         final String passiveMembers)
     {
+        if (null == publication)
+        {
+            return true;
+        }
+
         clusterMembersChangeEncoder
             .wrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
             .correlationId(correlationId)
@@ -392,6 +442,11 @@ final class ConsensusPublisher
     boolean snapshotRecordingQuery(
         final ExclusivePublication publication, final long correlationId, final int requestMemberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + SnapshotRecordingQueryEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -423,6 +478,11 @@ final class ConsensusPublisher
         final RecordingLog.RecoveryPlan recoveryPlan,
         final String memberEndpoints)
     {
+        if (null == publication)
+        {
+            return;
+        }
+
         snapshotRecordingsEncoder.wrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
             .correlationId(correlationId);
 
@@ -461,6 +521,11 @@ final class ConsensusPublisher
 
     boolean joinCluster(final ExclusivePublication publication, final long leadershipTermId, final int memberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + JoinClusterEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -489,6 +554,11 @@ final class ConsensusPublisher
     boolean terminationPosition(
         final ExclusivePublication publication, final long leadershipTermId, final long logPosition)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + TerminationPositionEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -518,6 +588,11 @@ final class ConsensusPublisher
     boolean terminationAck(
         final ExclusivePublication publication, final long leadershipTermId, final long logPosition, final int memberId)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + TerminationAckEncoder.BLOCK_LENGTH;
 
         int attempts = SEND_ATTEMPTS;
@@ -553,6 +628,11 @@ final class ConsensusPublisher
         final String responseChannel,
         final byte[] encodedCredentials)
     {
+        if (null == publication)
+        {
+            return false;
+        }
+
         backupQueryEncoder
             .wrapAndApplyHeader(buffer, 0, messageHeaderEncoder)
             .correlationId(correlationId)

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
@@ -21,6 +21,7 @@ import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,7 +33,7 @@ public class AppointedLeaderTest
     @Timeout(20)
     public void shouldConnectAndSendKeepAlive()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(LEADER_ID))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start())
         {
             final TestNode leader = cluster.awaitLeader();
             assertEquals(LEADER_ID, leader.index());
@@ -47,7 +48,7 @@ public class AppointedLeaderTest
     @Timeout(20)
     public void shouldEchoMessagesViaService()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(LEADER_ID))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start())
         {
             final TestNode leader = cluster.awaitLeader();
             assertEquals(LEADER_ID, leader.index());

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,7 +47,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndEmptyLog()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             cluster.awaitLeader();
             cluster.startClusterBackupNode(true);
@@ -68,7 +68,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLog()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -98,7 +98,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndThenSendMessages()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
             cluster.startClusterBackupNode(true);
@@ -128,7 +128,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterWithSnapshot()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -161,7 +161,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterAfterCleanShutdown()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -198,7 +198,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterWithSnapshotAndNonEmptyLog()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -238,7 +238,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterWithSnapshotThenSend()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -278,7 +278,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBeAbleToGetTimeOfNextBackupQuery()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             cluster.awaitLeader();
             final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
@@ -294,7 +294,7 @@ public class ClusterBackupTest
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithReQuery()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -332,7 +332,7 @@ public class ClusterBackupTest
     @Timeout(40)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogAfterFailure()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leaderOne = cluster.awaitLeader();
 
@@ -364,7 +364,7 @@ public class ClusterBackupTest
     @Timeout(60)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithFailure()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leaderOne = cluster.awaitLeader();
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -24,12 +24,14 @@ import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.List;
 
-import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.cluster.service.Cluster.Role.LEADER;
 import static io.aeron.test.cluster.ClusterTests.*;
@@ -54,7 +56,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldStopFollowerAndRestartFollower(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -78,7 +80,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldNotifyClientOfNewLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -99,7 +101,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -124,7 +126,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldShutdownClusterAndRestartWithSnapshots(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -157,7 +159,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldAbortClusterAndRestart(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -192,7 +194,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldAbortClusterOnTerminationTimeout(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -229,7 +231,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldEchoMessages(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -251,7 +253,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldHandleLeaderFailOverWhenNameIsNotResolvable(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -339,7 +341,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldEchoMessagesThenContinueOnNewLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -378,7 +380,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldStopLeaderAndRestartAsFollower(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -401,7 +403,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -429,7 +431,7 @@ public class ClusterTest
     @Timeout(60)
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -462,7 +464,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldAcceptMessagesAfterSingleNodeCleanRestart(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -492,7 +494,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldReplaySnapshotTakenWhileDown(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -530,7 +532,7 @@ public class ClusterTest
     @Timeout(50)
     public void shouldTolerateMultipleLeaderFailures(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode firstLeader = cluster.awaitLeader();
@@ -562,7 +564,7 @@ public class ClusterTest
     @Timeout(90)
     public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode firstLeader = cluster.awaitLeader();
@@ -601,7 +603,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldAcceptMessagesAfterTwoNodeCleanRestart(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -641,7 +643,7 @@ public class ClusterTest
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos(
         final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -701,7 +703,7 @@ public class ClusterTest
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos(
         final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -749,7 +751,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldCallOnRoleChangeOnBecomingLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leaderOne = cluster.awaitLeader();
@@ -782,7 +784,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -816,7 +818,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldTerminateLeaderWhenServiceStops(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -842,7 +844,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldEnterElectionWhenRecordingStopsOnLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -873,7 +875,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldRecoverFollowerWhenRecordingStops(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -908,7 +910,7 @@ public class ClusterTest
     @Timeout(20)
     public void shouldCloseClientOnTimeout(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -939,7 +941,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverWhileMessagesContinue(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final MutableInteger messageCounter = new MutableInteger();
@@ -985,7 +987,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldCatchupFromEmptyLog(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -1013,7 +1015,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1064,7 +1066,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldCatchUpTwoFreshNodesAfterRestart(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1105,7 +1107,7 @@ public class ClusterTest
     @Timeout(30)
     public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1178,7 +1180,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1213,7 +1215,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverWhenLeaderHasAppendedMoreThanFollower(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1248,7 +1250,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverWhenFollowerIsMultipleTermsBehind(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode originalLeader = cluster.awaitLeader();
@@ -1291,7 +1293,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverWhenFollowerArrivesPartWayThroughTerm(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();
@@ -1323,7 +1325,7 @@ public class ClusterTest
     @Timeout(40)
     public void shouldRecoverWhenFollowerArrivePartWayThroughTermAfterMissingElection(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -1368,7 +1370,7 @@ public class ClusterTest
     @Timeout(40)
     void shouldRecoverWhenLastSnapshotIsMarkedInvalid(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader0 = cluster.awaitLeader();
@@ -1416,7 +1418,7 @@ public class ClusterTest
     @Timeout(30)
     void shouldRecoverWhenLastSnapshotForShutdownIsMarkedInvalid(final TestInfo testInfo)
     {
-        cluster = startSingleNodeStaticCluster();
+        cluster = aCluster().withStaticNodes(1).start();
         try
         {
             TestNode leader = cluster.awaitLeader();
@@ -1453,7 +1455,7 @@ public class ClusterTest
     @Timeout(60)
     void shouldHandleMultipleElections(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader0 = cluster.awaitLeader();
@@ -1496,7 +1498,7 @@ public class ClusterTest
     @Timeout(50)
     void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader0 = cluster.awaitLeader();
@@ -1551,7 +1553,7 @@ public class ClusterTest
     @Timeout(50)
     void shouldRecoverWhenLastTwosSnapshotsAreInvalidAfterElection(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader0 = cluster.awaitLeader();
@@ -1630,7 +1632,7 @@ public class ClusterTest
 
     private void shouldCatchUpAfterFollowerMissesMessage(final String message, final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             cluster.awaitLeader();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -28,7 +28,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -41,7 +41,7 @@ class ClusterToolTest
     @Timeout(30)
     void shouldHandleSnapshotOnLeaderOnly()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
             final long initialSnapshotCount = leader.consensusModule().context().snapshotCounter().get();
@@ -75,7 +75,7 @@ class ClusterToolTest
     @Timeout(30)
     void shouldNotSnapshotWhenSuspendedOnly()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
             final long initialSnapshotCount = leader.consensusModule().context().snapshotCounter().get();
@@ -105,7 +105,7 @@ class ClusterToolTest
     @Timeout(30)
     void shouldSuspendAndResume()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final TestNode leader = cluster.awaitLeader();
             final CapturingPrintStream capturingPrintStream = new CapturingPrintStream();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -24,12 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
-import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.test.cluster.TestCluster.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
 public class DynamicMembershipTest
@@ -46,7 +43,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldQueryClusterMembers(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -66,7 +63,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshots(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -90,7 +87,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsThenSend(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -116,7 +113,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithCatchup(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -141,7 +138,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeWithEmptySnapshot(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -166,7 +163,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshot(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -197,7 +194,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotThenSend(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -236,7 +233,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldRemoveFollower(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();
@@ -261,7 +258,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldRemoveLeader(final TestInfo testInfo)
     {
-        cluster = startThreeNodeStaticCluster(NULL_VALUE);
+        cluster = aCluster().withStaticNodes(3).start();
         try
         {
             final TestNode initialLeader = cluster.awaitLeader();
@@ -288,7 +285,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldRemoveLeaderAfterDynamicNodeJoined(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode initialLeader = cluster.awaitLeader();
@@ -319,7 +316,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldRemoveLeaderAfterDynamicNodeJoinedThenRestartCluster(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode initialLeader = cluster.awaitLeader();
@@ -365,7 +362,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldJoinDynamicNodeToSingleStaticLeader(final TestInfo testInfo)
     {
-        cluster = startCluster(1, 1);
+        cluster = aCluster().withStaticNodes(1).withDynamicNodes(1).start();
         try
         {
             final TestNode initialLeader = cluster.awaitLeader();
@@ -384,7 +381,7 @@ public class DynamicMembershipTest
     @Timeout(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsAndRestartDynamicNode(final TestInfo testInfo)
     {
-        cluster = startCluster(3, 1);
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         try
         {
             final TestNode leader = cluster.awaitLeader();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
@@ -105,7 +105,7 @@ public class MultiClusteredServicesTest
             .threadingMode(ThreadingMode.SHARED)
             .dirDeleteOnStart(true)
             .aeronDirectoryName(aeronDirName)
-            .nameResolver(new RedirectingNameResolver(TestCluster.NAME_NODE_MAPPINGS)));
+            .nameResolver(new RedirectingNameResolver(TestCluster.DEFAULT_NODE_MAPPINGS)));
 
         final AeronCluster client = AeronCluster.connect(new AeronCluster.Context()
             .aeronDirectoryName(aeronDirName)

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
@@ -52,7 +52,7 @@ public class MultiModuleSharedDriverTest
         final MediaDriver.Context driverCtx = new MediaDriver.Context()
             .threadingMode(ThreadingMode.SHARED)
             .errorHandler(Tests::onError)
-            .nameResolver(new RedirectingNameResolver(TestCluster.NAME_NODE_MAPPINGS))
+            .nameResolver(new RedirectingNameResolver(TestCluster.DEFAULT_NODE_MAPPINGS))
             .dirDeleteOnStart(true);
 
         final Archive.Context archiveCtx = new Archive.Context()
@@ -240,7 +240,7 @@ public class MultiModuleSharedDriverTest
                 .aeronDirectoryName(CommonContext.getAeronDirectoryName() + "-" + nodeId)
                 .threadingMode(ThreadingMode.SHARED)
                 .errorHandler(Tests::onError)
-                .nameResolver(new RedirectingNameResolver(TestCluster.NAME_NODE_MAPPINGS))
+                .nameResolver(new RedirectingNameResolver(TestCluster.DEFAULT_NODE_MAPPINGS))
                 .dirDeleteOnStart(true);
 
             final Archive.Context archiveCtx = new Archive.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MultiNodeTest
@@ -35,7 +35,7 @@ public class MultiNodeTest
     {
         final int appointedLeaderIndex = 1;
 
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(appointedLeaderIndex))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -52,7 +52,7 @@ public class MultiNodeTest
     {
         final int appointedLeaderIndex = 1;
 
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(appointedLeaderIndex))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -79,7 +79,7 @@ public class MultiNodeTest
     {
         final int appointedLeaderIndex = 1;
 
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(appointedLeaderIndex))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderIndex).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -117,7 +117,7 @@ public class MultiNodeTest
             .ingressChannel("aeron:udp?term-length=64k")
             .egressChannel("aeron:udp?term-length=64k|endpoint=localhost:" + responsePort);
 
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             final int numMessages = 10;
             cluster.connectClient(clientCtx);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -20,7 +20,7 @@ import io.aeron.test.cluster.TestCluster;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.test.cluster.TestCluster.aCluster;
 
 public class ServiceIpcIngressTest
 {
@@ -28,7 +28,7 @@ public class ServiceIpcIngressTest
     @Timeout(20)
     public void shouldEchoIpcMessages()
     {
-        try (TestCluster cluster = TestCluster.startThreeNodeStaticCluster(NULL_VALUE))
+        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
         {
             cluster.awaitLeader();
             cluster.connectClient();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -21,6 +21,7 @@ import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SingleNodeTest
@@ -29,7 +30,7 @@ public class SingleNodeTest
     @Timeout(20)
     public void shouldStartCluster()
     {
-        try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
+        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -42,7 +43,7 @@ public class SingleNodeTest
     @Timeout(20)
     public void shouldSendMessagesToCluster()
     {
-        try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
+        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
         {
             final TestNode leader = cluster.awaitLeader();
 
@@ -60,7 +61,7 @@ public class SingleNodeTest
     @Timeout(20)
     public void shouldReplayLog()
     {
-        try (TestCluster cluster = TestCluster.startSingleNodeStaticCluster())
+        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
         {
             final TestNode leader = cluster.awaitLeader();
 

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
@@ -19,7 +19,6 @@ import io.aeron.Publication;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.service.ClusterTerminationException;
 import io.aeron.exceptions.AeronException;
-import io.aeron.test.Tests;
 import org.agrona.ErrorHandler;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.LangUtil;

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
@@ -19,6 +19,7 @@ import io.aeron.Publication;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.service.ClusterTerminationException;
 import io.aeron.exceptions.AeronException;
+import io.aeron.test.Tests;
 import org.agrona.ErrorHandler;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.LangUtil;
@@ -27,6 +28,8 @@ import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.YieldingIdleStrategy;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,10 +73,9 @@ public class ClusterTests
         return
             (ex) ->
             {
-                if (ex instanceof AeronException && ((AeronException)ex).category() == AeronException.Category.WARN)
+                if (ex instanceof AeronException && ((AeronException)ex).category() == AeronException.Category.WARN ||
+                    shouldDownScaleToWarning(ex))
                 {
-                    //System.err.println("\n *** Warning in member " + memberId + " \n");
-                    //ex.printStackTrace();
                     addWarning(ex);
                     return;
                 }
@@ -85,10 +87,19 @@ public class ClusterTests
 
                 addError(ex);
 
-                System.err.println("\n*** Error in member " + memberId + " ***\n\n");
-                ex.printStackTrace();
+                printMessageAndStackTrace("\n*** Error in member " + memberId + " ***\n\n", ex);
+
                 printWarning();
             };
+    }
+
+    private static void printMessageAndStackTrace(final String message, final Throwable ex)
+    {
+        final StringWriter out = new StringWriter();
+        final PrintWriter writer = new PrintWriter(out);
+        writer.println(message);
+        ex.printStackTrace(writer);
+        System.err.println(out);
     }
 
     public static void addError(final Throwable ex)
@@ -122,17 +133,23 @@ public class ClusterTests
         final Throwable warning = WARNING.get();
         if (null != warning)
         {
-            System.err.println("\n*** Warning captured ***");
+            printMessageAndStackTrace("\n*** Warning captured ***", warning);
             warning.printStackTrace();
         }
     }
 
     public static void failOnClusterError()
     {
-        final Throwable error = ERROR.getAndSet(null);
-        final Throwable warning = WARNING.getAndSet(null);
+        Throwable error = ERROR.getAndSet(null);
+        Throwable warning = WARNING.getAndSet(null);
 
-        if (null != error && !(error instanceof UnknownHostException))
+        if (null != error && shouldDownScaleToWarning(error))
+        {
+            warning = error;
+            error = null;
+        }
+
+        if (null != error)
         {
             if (null != warning)
             {
@@ -148,6 +165,23 @@ public class ClusterTests
             System.err.println("\n*** Warning captured with interrupt ***");
             warning.printStackTrace();
         }
+    }
+
+    private static boolean shouldDownScaleToWarning(final Throwable error)
+    {
+        Throwable maybeWarning = error;
+        do
+        {
+            if (null == error || maybeWarning instanceof UnknownHostException)
+            {
+                return true;
+            }
+
+            maybeWarning = error.getCause();
+        }
+        while (null != maybeWarning);
+
+        return false;
     }
 
     public static Thread startPublisherThread(

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -47,7 +47,10 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -170,21 +173,6 @@ public class TestCluster implements AutoCloseable
         this.dynamicMemberCount = dynamicMemberCount;
         this.appointedLeaderId = appointedLeaderId;
         this.invalidInitialResolutions = invalidInitialResolutions;
-    }
-
-    public static TestCluster startThreeNodeStaticCluster(final int appointedLeaderId)
-    {
-        return aCluster().withStaticNodes(3).withAppointedLeader(appointedLeaderId).start();
-    }
-
-    public static TestCluster startSingleNodeStaticCluster()
-    {
-        return aCluster().withStaticNodes(1).start();
-    }
-
-    public static TestCluster startCluster(final int staticMemberCount, final int dynamicMemberCount)
-    {
-        return aCluster().withStaticNodes(staticMemberCount).withDynamicNodes(dynamicMemberCount).start();
     }
 
     public static void awaitElectionClosed(final TestNode follower)

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -189,7 +189,12 @@ public class TestCluster implements AutoCloseable
 
     public static void awaitElectionClosed(final TestNode follower)
     {
-        while (follower.electionState() != ElectionState.CLOSED)
+        awaitElectionState(follower, ElectionState.CLOSED);
+    }
+
+    public static void awaitElectionState(final TestNode node, final ElectionState electionState)
+    {
+        while (node.electionState() != electionState)
         {
             await(10);
         }

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -500,9 +500,9 @@ public class TestNode implements AutoCloseable
         final AtomicBoolean hasServiceTerminated = new AtomicBoolean();
         final TestService service;
 
-        Context(final TestService service)
+        Context(final TestService service, final String nodeMappings)
         {
-            mediaDriverContext.nameResolver(new RedirectingNameResolver(TestCluster.NAME_NODE_MAPPINGS));
+            mediaDriverContext.nameResolver(new RedirectingNameResolver(nodeMappings));
             this.service = service;
         }
     }


### PR DESCRIPTION
And re-resolve upon a CANVASS message from the member missing its publication.

Lots of tweaks to the cluster tests to allow name resolution failures and recovery.  Tests for starting a cluster with a missing member and one where the majority of nodes become available during an election.