### PR TITLE
Add nanoTime to AeronArchive.Context

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -794,6 +794,7 @@ public final class Archive implements AutoCloseable
         private Supplier<IdleStrategy> replayerIdleStrategySupplier;
         private Supplier<IdleStrategy> recorderIdleStrategySupplier;
         private EpochClock epochClock;
+        private NanoClock nanoClock;
         private AuthenticatorSupplier authenticatorSupplier;
         private Counter controlSessionsCounter;
 
@@ -891,6 +892,11 @@ public final class Archive implements AutoCloseable
             {
                 epochClock = SystemEpochClock.INSTANCE;
             }
+            
+            if (null == nanoClock)
+            {
+                nanoClock = SystemNanoClock.INSTANCE;
+            }
 
             if (null != aeron)
             {
@@ -922,6 +928,7 @@ public final class Archive implements AutoCloseable
                         .aeronDirectoryName(aeronDirectoryName)
                         .errorHandler(errorHandler)
                         .epochClock(epochClock)
+                        .nanoClock(nanoClock)
                         .driverAgentInvoker(mediaDriverAgentInvoker)
                         .useConductorAgentInvoker(true)
                         .subscriberErrorHandler(RethrowingErrorHandler.INSTANCE)
@@ -1612,6 +1619,28 @@ public final class Archive implements AutoCloseable
         public EpochClock epochClock()
         {
             return epochClock;
+        }
+        
+        /**
+         * Set the {@link NanoClock} to be used for tracking wall clock time.
+         *
+         * @param clock {@link NanoClock} to be used for tracking wall clock time.
+         * @return this for a fluent API.
+         */
+        public Context nanoClock(final NanoClock clock)
+        {
+            this.nanoClock = clock;
+            return this;
+        }
+
+        /**
+         * Get the {@link NanoClock} to used for tracking wall clock time.
+         *
+         * @return the {@link NanoClock} to used for tracking wall clock time.
+         */
+        public NanoClock nanoClock()
+        {
+            return nanoClock;
         }
 
         /**

--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -892,7 +892,7 @@ public final class Archive implements AutoCloseable
             {
                 epochClock = SystemEpochClock.INSTANCE;
             }
-            
+
             if (null == nanoClock)
             {
                 nanoClock = SystemNanoClock.INSTANCE;
@@ -1620,7 +1620,7 @@ public final class Archive implements AutoCloseable
         {
             return epochClock;
         }
-        
+
         /**
          * Set the {@link NanoClock} to be used for tracking wall clock time.
          *


### PR DESCRIPTION
I have found that when using a dedicated media driver for Aeron Archive, I have needed to supply a nanoClock in order to debug, as by default the SystemNanoClock.INSTANCE is used and I could not see a way to override that.