### PR TITLE
Store errors in distinct log for cluster tests

### DIFF
--- a/.github/workflows/ci-low-cadence.yml
+++ b/.github/workflows/ci-low-cadence.yml
@@ -20,11 +20,6 @@ jobs:
         java: [ '8', '11', '16', '17-ea' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     steps:
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -39,6 +34,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -84,11 +84,6 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -103,6 +98,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -135,11 +135,6 @@ jobs:
       CC: cl
       CXX: cl
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -154,6 +149,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -185,11 +185,6 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -204,6 +199,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -240,11 +240,6 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -259,6 +254,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion

--- a/.github/workflows/ci-low-cadence.yml
+++ b/.github/workflows/ci-low-cadence.yml
@@ -20,6 +20,11 @@ jobs:
         java: [ '8', '11', '16', '17-ea' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     steps:
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -34,11 +39,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -84,6 +84,11 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -98,11 +103,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -135,6 +135,11 @@ jobs:
       CC: cl
       CXX: cl
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -149,11 +154,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -185,6 +185,11 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -199,11 +204,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -240,6 +240,11 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -254,11 +259,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         java: [ '8', '11', '16', '17-ea' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     steps:
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -40,11 +45,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -86,6 +86,11 @@ jobs:
         java: [ '8' ]
         os: [ 'ubuntu-20.04' ]
     steps:
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -100,11 +105,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -148,6 +148,11 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -162,11 +167,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -204,6 +204,11 @@ jobs:
       matrix:
         version: [ '7' ]
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -244,6 +249,11 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -258,11 +268,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -304,6 +309,11 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -318,11 +328,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -364,6 +369,11 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -378,11 +388,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -420,6 +425,11 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -434,11 +444,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -471,6 +476,11 @@ jobs:
       CC: cl
       CXX: cl
     steps:
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -485,11 +495,6 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
         java: [ '8', '11', '16', '17-ea' ]
         os: [ 'ubuntu-20.04', 'windows-latest' ]
     steps:
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -45,6 +40,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -86,11 +86,6 @@ jobs:
         java: [ '8' ]
         os: [ 'ubuntu-20.04' ]
     steps:
-      - name: Setup java
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.java }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -105,6 +100,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -148,11 +148,6 @@ jobs:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -167,6 +162,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -204,11 +204,6 @@ jobs:
       matrix:
         version: [ '7' ]
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -249,11 +244,6 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -268,6 +258,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -309,11 +304,6 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -328,6 +318,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -369,11 +364,6 @@ jobs:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -388,6 +378,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -425,11 +420,6 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -444,6 +434,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion
@@ -476,11 +471,6 @@ jobs:
       CC: cl
       CXX: cl
     steps:
-      - name: Setup java 8 to run the Gradle script
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'zulu'
-          java-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Cache Gradle dependencies
@@ -495,6 +485,11 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup java 8 to run the Gradle script
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 8
       - name: Setup BUILD_JAVA_HOME & BUILD_JAVA_VERSION
         run: |
           java -Xinternalversion

--- a/aeron-agent/src/test/java/io/aeron/agent/AgentTests.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/AgentTests.java
@@ -15,13 +15,15 @@
  */
 package io.aeron.agent;
 
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
@@ -38,6 +40,7 @@ import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.concurrent.ringbuffer.RecordDescriptor.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 final class AgentTests
 {
     static void startLogging(final EnumMap<ConfigOption, String> configOptions)
@@ -164,7 +167,7 @@ final class AgentTests
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void shouldStartAndStopLoggingAgent()
     {
         final int instanceCount = TestLoggingAgent.INSTANCE_COUNT.get();

--- a/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ArchiveLoggingAgentTest.java
@@ -21,6 +21,8 @@ import io.aeron.archive.ArchivingMediaDriver;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.IoUtil;
 import org.agrona.MutableDirectBuffer;
@@ -28,7 +30,7 @@ import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.MessageHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -41,6 +43,7 @@ import static io.aeron.agent.EventConfiguration.EVENT_READER_FRAME_LIMIT;
 import static io.aeron.agent.EventConfiguration.EVENT_RING_BUFFER;
 import static java.util.Collections.synchronizedSet;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveLoggingAgentTest
 {
     private static final Set<ArchiveEventCode> WAIT_LIST = synchronizedSet(EnumSet.noneOf(ArchiveEventCode.class));
@@ -59,14 +62,14 @@ public class ArchiveLoggingAgentTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logAll()
     {
         testArchiveLogging("all", EnumSet.of(CMD_OUT_RESPONSE, CMD_IN_AUTH_CONNECT, CMD_IN_KEEP_ALIVE));
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logControlSessionDemuxerOnFragment()
     {
         testArchiveLogging(CMD_IN_KEEP_ALIVE.name() + "," + CMD_IN_AUTH_CONNECT.id(),
@@ -74,7 +77,7 @@ public class ArchiveLoggingAgentTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logControlResponseProxySendResponseHook()
     {
         testArchiveLogging(CMD_OUT_RESPONSE.name(), EnumSet.of(CMD_OUT_RESPONSE));

--- a/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/ClusterLoggingAgentTest.java
@@ -26,6 +26,8 @@ import io.aeron.cluster.service.ClusteredService;
 import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver.Context;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import org.agrona.CloseHelper;
@@ -35,7 +37,7 @@ import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.MessageHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.EnumMap;
@@ -51,6 +53,7 @@ import static java.util.Collections.synchronizedSet;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterLoggingAgentTest
 {
     private static final Set<ClusterEventCode> WAIT_LIST = synchronizedSet(EnumSet.noneOf(ClusterEventCode.class));
@@ -72,28 +75,28 @@ public class ClusterLoggingAgentTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void logAll()
     {
         testClusterEventsLogging("all", EnumSet.of(ROLE_CHANGE, STATE_CHANGE, ELECTION_STATE_CHANGE));
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void logRoleChange()
     {
         testClusterEventsLogging(ROLE_CHANGE.name(), EnumSet.of(ROLE_CHANGE));
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void logStateChange()
     {
         testClusterEventsLogging(STATE_CHANGE.name(), EnumSet.of(STATE_CHANGE));
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void logElectionStateChange()
     {
         testClusterEventsLogging(ELECTION_STATE_CHANGE.name(), EnumSet.of(ELECTION_STATE_CHANGE));

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverLoggingAgentTest.java
@@ -20,6 +20,8 @@ import io.aeron.Publication;
 import io.aeron.Subscription;
 import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.MutableInteger;
@@ -28,7 +30,7 @@ import org.agrona.concurrent.MessageHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -46,6 +48,7 @@ import static java.util.Collections.synchronizedSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.INCLUDE;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class DriverLoggingAgentTest
 {
     private static final String NETWORK_CHANNEL =
@@ -61,7 +64,7 @@ public class DriverLoggingAgentTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logAllNetworkChannel()
     {
         testLogMediaDriverEvents(NETWORK_CHANNEL, "all", EnumSet.of(
@@ -89,7 +92,7 @@ public class DriverLoggingAgentTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logAllIpcChannel()
     {
         testLogMediaDriverEvents(IPC_CHANNEL, "all", EnumSet.of(
@@ -120,7 +123,7 @@ public class DriverLoggingAgentTest
         "CMD_IN_ADD_SUBSCRIPTION",
         "CMD_OUT_AVAILABLE_IMAGE"
     })
-    @Timeout(10)
+    @InterruptAfter(10)
     public void logIndividualEvents(final DriverEventCode eventCode)
     {
         try

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -30,6 +30,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
@@ -37,7 +39,7 @@ import org.agrona.concurrent.SystemEpochClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -63,7 +65,7 @@ import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Timeout(10)
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveTest
 {
     @Test
@@ -254,7 +256,7 @@ public class ArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldListRegisteredRecordingSubscriptions()
     {
         final int expectedStreamId = 7;
@@ -313,7 +315,7 @@ public class ArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldErrorOnLowSpace() throws IOException
     {
         final int streamId = 7;

--- a/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
+++ b/aeron-client/src/test/java/io/aeron/ClientConductorTest.java
@@ -22,13 +22,15 @@ import io.aeron.exceptions.RegistrationException;
 import io.aeron.exceptions.TimeoutException;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import org.agrona.ErrorHandler;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.broadcast.CopyBroadcastReceiver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -46,6 +48,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClientConductorTest
 {
     private static final int TERM_BUFFER_LENGTH = TERM_MIN_LENGTH;
@@ -219,7 +222,7 @@ public class ClientConductorTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     public void addPublicationShouldTimeoutWithoutReadyMessage()
     {
         assertThrows(DriverTimeoutException.class, () -> conductor.addPublication(CHANNEL, STREAM_ID_1));
@@ -396,7 +399,7 @@ public class ClientConductorTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     public void addSubscriptionShouldTimeoutWithoutOperationSuccessful()
     {
         assertThrows(DriverTimeoutException.class, () -> conductor.addSubscription(CHANNEL, STREAM_ID_1));

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3052,12 +3052,13 @@ final class ConsensusModuleAgent implements Agent
 
                 if (null != election)
                 {
-                    election.handleError(
-                        clusterClock.timeNanos(), new ClusterEvent("log recording ended unexpectedly"));
+                    election.handleError(clusterClock.timeNanos(), new ClusterEvent(
+                        "log recording ended unexpectedly (null != election)"));
                 }
                 else if (NULL_POSITION == terminationPosition)
                 {
-                    ctx.countedErrorHandler().onError(new ClusterEvent("log recording ended unexpectedly"));
+                    ctx.countedErrorHandler().onError(new ClusterEvent(
+                        "log recording ended unexpectedly (NULL_POSITION == terminationPosition"));
                     isElectionRequired = true;
                 }
             }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/AuthenticationTest.java
@@ -25,6 +25,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.Header;
 import io.aeron.security.*;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
@@ -35,7 +37,7 @@ import org.agrona.collections.MutableLong;
 import org.agrona.collections.MutableReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class AuthenticationTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -78,7 +81,7 @@ public class AuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldAuthenticateOnConnectRequestWithEmptyCredentials()
     {
         final AtomicLong serviceMsgCounter = new AtomicLong(0L);
@@ -140,7 +143,7 @@ public class AuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldAuthenticateOnConnectRequestWithCredentials()
     {
         final AtomicLong serviceMsgCounter = new AtomicLong(0L);
@@ -202,7 +205,7 @@ public class AuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldAuthenticateOnChallengeResponse()
     {
         final AtomicLong serviceMsgCounter = new AtomicLong(0L);
@@ -272,7 +275,7 @@ public class AuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRejectOnConnectRequest()
     {
         final AtomicLong serviceMsgCounter = new AtomicLong(0L);
@@ -338,7 +341,7 @@ public class AuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRejectOnChallengeResponse()
     {
         final AtomicLong serviceMsgCounter = new AtomicLong(0L);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
@@ -15,7 +15,9 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.ExclusivePublication;
+import io.aeron.Image;
+import io.aeron.Publication;
 import io.aeron.archive.Archive;
 import io.aeron.archive.ArchiveThreadingMode;
 import io.aeron.cluster.client.AeronCluster;
@@ -27,6 +29,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
@@ -38,7 +42,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -50,8 +54,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterNodeRestartTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -90,7 +96,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceWithReplay()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -114,7 +120,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceWithReplayAndContinue()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -140,7 +146,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceFromEmptySnapshot()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -167,7 +173,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceFromSnapshot()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -200,7 +206,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceFromSnapshotWithFurtherLog()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -236,7 +242,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTakeMultipleSnapshots()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -261,7 +267,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceWithTimerFromSnapshotWithFurtherLog()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -298,7 +304,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTriggerRescheduledTimerAfterReplay()
     {
         final AtomicLong triggeredTimersCount = new AtomicLong();
@@ -322,7 +328,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldRestartServiceTwiceWithInvalidSnapshotAndFurtherLog()
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);
@@ -376,7 +382,7 @@ public class ClusterNodeRestartTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldRestartServiceAfterShutdownWithInvalidatedSnapshot() throws InterruptedException
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeTest.java
@@ -26,6 +26,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.BufferClaim;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
@@ -36,11 +38,12 @@ import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterNodeTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -89,7 +92,7 @@ public class ClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldConnectAndSendKeepAlive()
     {
         container = launchEchoService();
@@ -101,7 +104,7 @@ public class ClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldEchoMessageViaServiceUsingDirectOffer()
     {
         final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
@@ -127,7 +130,7 @@ public class ClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldEchoMessageViaServiceUsingTryClaim()
     {
         final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
@@ -171,7 +174,7 @@ public class ClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldScheduleEventInService()
     {
         final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
@@ -198,7 +201,7 @@ public class ClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendResponseAfterServiceMessage()
     {
         final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterTimerTest.java
@@ -27,6 +27,8 @@ import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
@@ -37,16 +39,15 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterTimerTest
 {
     private static final long CATALOG_CAPACITY = 128 * 1024;
@@ -80,7 +81,7 @@ public class ClusterTimerTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRestartServiceWithTimerFromSnapshotWithFurtherLog()
     {
         final AtomicLong triggeredTimersCounter = new AtomicLong();
@@ -121,7 +122,7 @@ public class ClusterTimerTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTriggerRescheduledTimerAfterReplay()
     {
         final AtomicLong triggeredTimersCounter = new AtomicLong();
@@ -153,7 +154,7 @@ public class ClusterTimerTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void shouldRescheduleTimerWhenSchedulingWithExistingCorrelationId()
     {
         final AtomicLong timerCounter1 = new AtomicLong();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NameResolutionClusterNodeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NameResolutionClusterNodeTest.java
@@ -26,6 +26,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.driver.exceptions.InvalidChannelException;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
@@ -35,7 +37,7 @@ import org.agrona.ErrorHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(InterruptingTestCallback.class)
 class NameResolutionClusterNodeTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -95,7 +98,7 @@ class NameResolutionClusterNodeTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void shouldConnectAndSendKeepAliveWithBadName()
     {
         container = launchEchoService();

--- a/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/StartFromTruncatedRecordingLogTest.java
@@ -15,12 +15,16 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.CommonContext;
+import io.aeron.Counter;
+import io.aeron.Publication;
 import io.aeron.archive.Archive;
 import io.aeron.archive.ArchiveMarkFile;
 import io.aeron.archive.ArchiveThreadingMode;
 import io.aeron.archive.client.AeronArchive;
-import io.aeron.cluster.client.*;
+import io.aeron.cluster.client.AeronCluster;
+import io.aeron.cluster.client.ClusterException;
+import io.aeron.cluster.client.EgressListener;
 import io.aeron.cluster.codecs.EventCode;
 import io.aeron.cluster.service.ClientSession;
 import io.aeron.cluster.service.Cluster;
@@ -30,6 +34,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.TimeoutException;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.ClusterTests;
@@ -43,7 +49,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,6 +68,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SlowTest
+@ExtendWith(InterruptingTestCallback.class)
 public class StartFromTruncatedRecordingLogTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -181,7 +188,7 @@ public class StartFromTruncatedRecordingLogTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBeAbleToStartClusterFromTruncatedRecordingLog() throws IOException
     {
         try

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -28,6 +28,8 @@ import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.protocol.SetupFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.*;
@@ -37,7 +39,7 @@ import org.agrona.concurrent.status.Position;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -52,6 +54,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ReceiverTest
 {
     private static final int TERM_BUFFER_LENGTH = TERM_MIN_LENGTH;
@@ -186,7 +189,7 @@ public class ReceiverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldCreateRcvTermAndSendSmOnSetup() throws IOException
     {
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);

--- a/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SelectorAndTransportTest.java
@@ -21,6 +21,8 @@ import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.protocol.StatusMessageFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import org.agrona.BitUtil;
 import org.agrona.ErrorHandler;
 import org.agrona.collections.MutableInteger;
@@ -30,7 +32,7 @@ import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -44,6 +46,7 @@ import java.nio.channels.DatagramChannel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class SelectorAndTransportTest
 {
     private static final int RCV_PORT = 40123;
@@ -122,7 +125,7 @@ public class SelectorAndTransportTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHandleBasicSetupAndTearDown()
     {
         receiveChannelEndpoint = new ReceiveChannelEndpoint(
@@ -175,7 +178,7 @@ public class SelectorAndTransportTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendEmptyDataFrameUnicastFromSourceToReceiver()
     {
         final MutableInteger dataHeadersReceived = new MutableInteger(0);
@@ -226,7 +229,7 @@ public class SelectorAndTransportTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendMultipleDataFramesPerDatagramUnicastFromSourceToReceiver()
     {
         final MutableInteger dataHeadersReceived = new MutableInteger(0);
@@ -290,7 +293,7 @@ public class SelectorAndTransportTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHandleSmFrameFromReceiverToSender()
     {
         final MutableInteger controlMessagesReceived = new MutableInteger(0);

--- a/aeron-driver/src/test/java/io/aeron/driver/TerminateDriverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TerminateDriverTest.java
@@ -16,9 +16,11 @@
 package io.aeron.driver;
 
 import io.aeron.CommonContext;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -26,12 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class TerminateDriverTest
 {
     private final TerminationValidator mockTerminationValidator = mock(TerminationValidator.class);
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldCallTerminationHookUponValidRequest()
     {
         final AtomicBoolean hasTerminated = new AtomicBoolean(false);
@@ -57,7 +60,7 @@ public class TerminateDriverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldNotCallTerminationHookUponInvalidRequest()
     {
         final AtomicBoolean hasTerminated = new AtomicBoolean(false);

--- a/aeron-samples/src/main/java/io/aeron/samples/ErrorStat.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/ErrorStat.java
@@ -17,13 +17,16 @@ package io.aeron.samples;
 
 import io.aeron.CncFileDescriptor;
 import io.aeron.CommonContext;
+import org.agrona.IoUtil;
 import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.errors.ErrorLogReader;
 
 import java.io.File;
 import java.nio.MappedByteBuffer;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.function.Function;
 
 /**
  * Application to print out errors recorded in the command-and-control (cnc) file is maintained by media driver in
@@ -34,6 +37,18 @@ public class ErrorStat
 {
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
 
+    private static final String ERROR_FILE_NAME_PROP = "aeron.samples.error.file.name";
+    private static final String ERROR_FILE_NAME;
+
+    private static final String ERROR_FILE_OFFSET_PROP = "aeron.samples.error.file.offset";
+    private static final int ERROR_FILE_OFFSET;
+
+    static
+    {
+        ERROR_FILE_NAME = System.getProperty(ERROR_FILE_NAME_PROP);
+        ERROR_FILE_OFFSET = Integer.parseInt(System.getProperty(ERROR_FILE_OFFSET_PROP, "0"));
+    }
+
     /**
      * Main method for launching the process.
      *
@@ -41,15 +56,35 @@ public class ErrorStat
      */
     public static void main(final String[] args)
     {
-        final File cncFile = CommonContext.newDefaultCncFile();
-        System.out.println("Command `n Control file " + cncFile);
+        final MappedByteBuffer errorMmap;
+        final Function<MappedByteBuffer, AtomicBuffer> mmapToErrorBuffer;
 
-        final MappedByteBuffer cncByteBuffer = SamplesUtil.mapExistingFileReadOnly(cncFile);
+        if (null != ERROR_FILE_NAME)
+        {
+            final File errorFile = new File(ERROR_FILE_NAME);
+            System.out.println("Error file " + errorFile);
+            errorMmap = SamplesUtil.mapExistingFileReadOnly(errorFile);
+            mmapToErrorBuffer = mmap -> new UnsafeBuffer(
+                mmap, ERROR_FILE_OFFSET, errorMmap.capacity() - ERROR_FILE_OFFSET);
+        }
+        else
+        {
+            final File cncFile = CommonContext.newDefaultCncFile();
+            System.out.println("Command `n Control file " + cncFile);
+            errorMmap = SamplesUtil.mapExistingFileReadOnly(cncFile);
+            mmapToErrorBuffer = CommonContext::errorLogBuffer;
+        }
 
-        final AtomicBuffer buffer = CommonContext.errorLogBuffer(cncByteBuffer);
-        final int distinctErrorCount = ErrorLogReader.read(buffer, ErrorStat::accept);
-
-        System.out.format("%n%d distinct errors observed.%n", distinctErrorCount);
+        try
+        {
+            final AtomicBuffer buffer = mmapToErrorBuffer.apply(errorMmap);
+            final int distinctErrorCount = ErrorLogReader.read(buffer, ErrorStat::accept);
+            System.out.format("%n%d distinct errors observed.%n", distinctErrorCount);
+        }
+        finally
+        {
+            IoUtil.unmap(errorMmap);
+        }
     }
 
     private static void accept(

--- a/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/BufferClaimMessageTest.java
@@ -20,15 +20,17 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.BufferClaim;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableBoolean;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,6 +41,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class BufferClaimMessageTest
 {
     private static List<String> channels()
@@ -70,7 +73,7 @@ public class BufferClaimMessageTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessageWithInterleavedAbort(final String channel)
     {
         final MutableInteger fragmentCount = new MutableInteger();
@@ -113,7 +116,7 @@ public class BufferClaimMessageTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTransferReservedValue(final String channel)
     {
         final BufferClaim bufferClaim = new BufferClaim();

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelEndpointStatusTest.java
@@ -18,13 +18,17 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.driver.exceptions.InvalidChannelException;
-import io.aeron.exceptions.*;
+import io.aeron.exceptions.AeronException;
+import io.aeron.exceptions.ChannelEndpointException;
+import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.status.ChannelEndpointStatus;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.IoUtil;
@@ -33,7 +37,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 
@@ -43,9 +47,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ChannelEndpointStatusTest
 {
     private static final String URI = "aeron:udp?endpoint=localhost:23456";
@@ -140,14 +146,14 @@ public class ChannelEndpointStatusTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldErrorBadUri()
     {
         assertThrows(RegistrationException.class, () -> clientA.addSubscription("bad uri", STREAM_ID));
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBeAbleToQueryChannelStatusForSubscription()
     {
         final Subscription subscription = clientA.addSubscription(URI, STREAM_ID);
@@ -162,7 +168,7 @@ public class ChannelEndpointStatusTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBeAbleToQueryChannelStatusForPublication()
     {
         final Publication publication = clientA.addPublication(URI, STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTests.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTests.java
@@ -20,6 +20,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FrameDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -28,7 +30,7 @@ import org.agrona.CloseHelper;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -46,6 +48,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ChannelValidationTests
 {
     @RegisterExtension
@@ -362,7 +365,7 @@ public class ChannelValidationTests
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldValidateSenderMtuAgainstUriReceiverWindow() throws IOException
     {
         context.errorHandler(null);

--- a/aeron-system-tests/src/test/java/io/aeron/ClientErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ClientErrorHandlerTest.java
@@ -32,19 +32,22 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.FragmentHandler;
-import io.aeron.test.*;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.Tests.awaitConnected;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ClientErrorHandlerTest
 {
     private static final int STREAM_ID = 1001;
@@ -54,7 +57,7 @@ public class ClientErrorHandlerTest
     public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHaveCorrectTermBufferLength()
     {
         final MediaDriver.Context ctx = new MediaDriver.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ControlledMessageTest.java
@@ -20,19 +20,22 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ControlledMessageTest
 {
     private static final String CHANNEL = CommonContext.IPC_CHANNEL;
@@ -59,7 +62,7 @@ public class ControlledMessageTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessage()
     {
         try (Subscription subscription = aeron.addSubscription(CHANNEL, STREAM_ID);

--- a/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/CounterTest.java
@@ -18,20 +18,25 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.status.ReadableCounter;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.*;
 
-@Timeout(10)
+@ExtendWith(InterruptingTestCallback.class)
 public class CounterTest
 {
     private static final int COUNTER_TYPE_ID = 1101;
@@ -72,6 +77,7 @@ public class CounterTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldBeAbleToAddCounter()
     {
         final AvailableCounterHandler availableCounterHandlerClientA = mock(AvailableCounterHandler.class);
@@ -100,6 +106,7 @@ public class CounterTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldBeAbleToAddReadableCounterWithinHandler()
     {
         clientB.addAvailableCounterHandler(this::createReadableCounter);
@@ -124,6 +131,7 @@ public class CounterTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldCloseReadableCounterOnUnavailableCounter()
     {
         clientB.addAvailableCounterHandler(this::createReadableCounter);

--- a/aeron-system-tests/src/test/java/io/aeron/DriverNameResolverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/DriverNameResolverTest.java
@@ -18,6 +18,8 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
@@ -28,7 +30,7 @@ import org.agrona.concurrent.SleepingMillisIdleStrategy;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Map;
@@ -40,6 +42,7 @@ import static org.agrona.concurrent.status.CountersReader.*;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class DriverNameResolverTest
 {
     private static final SleepingMillisIdleStrategy SLEEP_50_MS = new SleepingMillisIdleStrategy(50);
@@ -75,7 +78,7 @@ public class DriverNameResolverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSeeNeighbor()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
@@ -98,7 +101,7 @@ public class DriverNameResolverTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSeeNeighborsViaGossip()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
@@ -131,7 +134,7 @@ public class DriverNameResolverTest
 
     @SlowTest
     @Test
-    @Timeout(15)
+    @InterruptAfter(15)
     public void shouldSeeNeighborsViaGossipAsLateJoiningDriver()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
@@ -176,7 +179,7 @@ public class DriverNameResolverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldResolveDriverNameAndAllowConnection()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
@@ -213,7 +216,7 @@ public class DriverNameResolverTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldTimeoutAllNeighborsAndCacheEntries()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
@@ -246,7 +249,7 @@ public class DriverNameResolverTest
 
     @SlowTest
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldTimeoutNeighborsAndCacheEntriesThatAreSeenViaGossip()
     {
         addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())

--- a/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ExclusivePublicationTest.java
@@ -19,6 +19,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.RawBlockHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -28,7 +30,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,6 +49,7 @@ import static java.util.Arrays.asList;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ExclusivePublicationTest
 {
     private static List<String> channels()
@@ -84,7 +87,7 @@ public class ExclusivePublicationTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPublishFromIndependentExclusivePublications(final String channel)
     {
         try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
@@ -132,7 +135,7 @@ public class ExclusivePublicationTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPublishFromConcurrentExclusivePublications(final String channel)
     {
         try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
@@ -202,7 +205,7 @@ public class ExclusivePublicationTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldOfferTwoBuffersFromIndependentExclusivePublications(final String channel)
     {
         try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
@@ -272,7 +275,7 @@ public class ExclusivePublicationTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldOfferTwoBuffersFromConcurrentExclusivePublications(final String channel)
     {
         try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
@@ -366,7 +369,7 @@ public class ExclusivePublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void offerBlockThrowsIllegalArgumentExceptionIfLengthExceedsAvailableSpaceWithinTheTerm()
     {
         final String channel = "aeron:ipc?term-length=64k";
@@ -389,7 +392,7 @@ public class ExclusivePublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void offerBlockReturnsClosedWhenPublicationIsClosed()
     {
         final String channel = "aeron:ipc?term-length=64k";
@@ -404,7 +407,7 @@ public class ExclusivePublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void offerBlockThrowsIllegalArgumentExceptionUponInvalidFirstFrame()
     {
         final String channel = "aeron:ipc?term-length=64k";
@@ -439,7 +442,7 @@ public class ExclusivePublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void offerBlockAcceptsUpToAnEntireTermOfData()
     {
         final String channel = "aeron:ipc?term-length=64k";
@@ -487,7 +490,7 @@ public class ExclusivePublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void offerBlockReturnsBackPressuredStatus()
     {
         final String channel = "aeron:ipc?term-length=64k";

--- a/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
@@ -20,14 +20,16 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +42,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class FragmentedMessageTest
 {
     private static List<String> channels()
@@ -76,7 +79,7 @@ public class FragmentedMessageTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessage(final String channel)
     {
         final FragmentAssembler assembler = new FragmentAssembler(mockFragmentHandler);

--- a/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/GapFillLossTest.java
@@ -23,13 +23,15 @@ import io.aeron.driver.ext.LossGenerator;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.ByteBuffer;
@@ -39,6 +41,7 @@ import static io.aeron.SystemTests.verifyLossOccurredForStream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThan;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class GapFillLossTest
 {
     private static final String CHANNEL = "aeron:udp?endpoint=localhost:24325";
@@ -56,7 +59,7 @@ public class GapFillLossTest
     final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldGapFillWhenLossOccurs() throws Exception
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocateDirect(MSG_LENGTH));

--- a/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ImageAvailabilityTest.java
@@ -17,12 +17,14 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ImageAvailabilityTest
 {
     private static List<String> channels()
@@ -68,7 +71,7 @@ public class ImageAvailabilityTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldCallImageHandlers(final String channel)
     {
         final AtomicInteger unavailableImageCount = new AtomicInteger();
@@ -120,7 +123,7 @@ public class ImageAvailabilityTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldCallImageHandlersWithPublisherOnDifferentClient(final String channel)
     {
         final AtomicInteger unavailableImageCount = new AtomicInteger();

--- a/aeron-system-tests/src/test/java/io/aeron/LifecycleTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/LifecycleTest.java
@@ -16,22 +16,25 @@
 package io.aeron;
 
 import io.aeron.driver.MediaDriver;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.mockito.Mockito.*;
 
-@Timeout(10)
+@ExtendWith(InterruptingTestCallback.class)
 public class LifecycleTest
 {
     @RegisterExtension
     public final MediaDriverTestWatcher testWatcher = new MediaDriverTestWatcher();
 
     @Test
+    @InterruptAfter(10)
     public void shouldStartAndStopInstantly()
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()
@@ -53,6 +56,7 @@ public class LifecycleTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldNotifyOfClientTimestampCounter()
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/MaxFlowControlStrategySystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxFlowControlStrategySystemTest.java
@@ -22,9 +22,11 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -33,7 +35,7 @@ import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -41,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MaxFlowControlStrategySystemTest
 {
     private static final String MULTICAST_URI = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost";
@@ -110,7 +113,7 @@ public class MaxFlowControlStrategySystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdown()
     {
         launch();
@@ -126,7 +129,7 @@ public class MaxFlowControlStrategySystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTimeoutImageWhenBehindForTooLongWithMaxMulticastFlowControlStrategy()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;

--- a/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MaxPositionPublicationTest.java
@@ -18,6 +18,8 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -25,7 +27,7 @@ import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.ByteBuffer;
@@ -33,6 +35,7 @@ import java.nio.ByteBuffer;
 import static io.aeron.Publication.MAX_POSITION_EXCEEDED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MaxPositionPublicationTest
 {
     private static final int STREAM_ID = 1007;
@@ -59,7 +62,7 @@ public class MaxPositionPublicationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPublishFromExclusivePublication()
     {
         final int initialTermId = -777;

--- a/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MemoryOrderingTest.java
@@ -19,9 +19,11 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.IdleStrategy;
@@ -29,13 +31,14 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MemoryOrderingTest
 {
     private static final String CHANNEL = "aeron:udp?endpoint=localhost:24325";
@@ -69,7 +72,7 @@ public class MemoryOrderingTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesInOrderWithFirstLongWordIntact() throws Exception
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));
@@ -120,7 +123,7 @@ public class MemoryOrderingTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesInOrderWithFirstLongWordIntactFromExclusivePublication() throws Exception
     {
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(ByteBuffer.allocate(MESSAGE_LENGTH));

--- a/aeron-system-tests/src/test/java/io/aeron/MinFlowControlSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MinFlowControlSystemTest.java
@@ -24,10 +24,12 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -36,7 +38,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -50,6 +52,7 @@ import static io.aeron.FlowControlTests.awaitConnectionAndStatusMessages;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MinFlowControlSystemTest
 {
     private static final String MULTICAST_URI = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost";
@@ -128,7 +131,7 @@ public class MinFlowControlSystemTest
 
     @ParameterizedTest
     @MethodSource("strategyConfigurations")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSlowToMinMulticastFlowControlStrategy(
         final FlowControlSupplier flowControlSupplier, final String publisherUriParams)
     {
@@ -197,7 +200,7 @@ public class MinFlowControlSystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRemoveDeadTaggedReceiverWithMinMulticastFlowControlStrategy()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -250,7 +253,7 @@ public class MinFlowControlSystemTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     void shouldPreventConnectionUntilGroupMinSizeIsMet()
     {
         final Integer groupSize = 3;
@@ -336,7 +339,7 @@ public class MinFlowControlSystemTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     void shouldPreventConnectionUntilAtLeastOneSubscriberConnectedWithRequiredGroupSizeZero()
     {
         final Integer groupSize = 0;
@@ -374,7 +377,7 @@ public class MinFlowControlSystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHandleSenderLimitCorrectlyWithMinGroupSize()
     {
         final String publisherUri = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost|fc=tagged,g:123/1";

--- a/aeron-system-tests/src/test/java/io/aeron/MinPositionSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MinPositionSubscriptionTest.java
@@ -18,17 +18,22 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.CommonContext.SPY_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MinPositionSubscriptionTest
 {
     private static final int STREAM_ID = 1001;
@@ -53,7 +58,7 @@ public class MinPositionSubscriptionTest
         driver.context().deleteDirectory();
     }
 
-    @Timeout(10)
+    @InterruptAfter(10)
     @Test
     public void shouldJoinAtSamePositionIpc()
     {
@@ -61,7 +66,7 @@ public class MinPositionSubscriptionTest
         shouldJoinAtSamePosition(channel, channel);
     }
 
-    @Timeout(10)
+    @InterruptAfter(10)
     @Test
     public void shouldJoinAtSamePositionUdp()
     {
@@ -69,7 +74,7 @@ public class MinPositionSubscriptionTest
         shouldJoinAtSamePosition(channel, channel);
     }
 
-    @Timeout(10)
+    @InterruptAfter(10)
     @Test
     public void shouldJoinAtSamePositionUdpSpy()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -23,16 +23,21 @@ import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.CountingFragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
-import org.agrona.*;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
+import org.agrona.IoUtil;
 import org.agrona.collections.MutableInteger;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -46,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiDestinationCastTest
 {
     private static final String PUB_MDC_DYNAMIC_URI = "aeron:udp?control=localhost:24325";
@@ -118,7 +124,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdownWithDynamic()
     {
         launch(Tests::onError);
@@ -135,7 +141,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdownWithManual()
     {
         launch(Tests::onError);
@@ -162,7 +168,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSendToTwoPortsWithDynamic()
     {
         final int numMessagesToSend = MESSAGES_PER_TERM * 3;
@@ -197,7 +203,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSendToTwoPortsWithDynamicSingleDriver()
     {
         final int numMessagesToSend = MESSAGES_PER_TERM * 3;
@@ -232,7 +238,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendToTwoPortsWithManualSingleDriver()
     {
         final int numMessagesToSend = MESSAGES_PER_TERM * 3;
@@ -267,7 +273,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void addDestinationWithSpySubscriptionsShouldFailWithRegistrationException()
     {
         final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
@@ -282,7 +288,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldManuallyRemovePortDuringActiveStream() throws InterruptedException
     {
         final int numMessagesToSend = MESSAGES_PER_TERM * 3;
@@ -338,7 +344,7 @@ public class MultiDestinationCastTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldManuallyAddPortDuringActiveStream() throws InterruptedException
     {
         final int numMessagesToSend = MESSAGES_PER_TERM * 3;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationSubscriptionTest.java
@@ -22,18 +22,23 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import org.agrona.*;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
+import org.agrona.IoUtil;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -44,6 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiDestinationSubscriptionTest
 {
     private static final String UNICAST_ENDPOINT_A = "localhost:24325";
@@ -120,7 +126,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void subscriptionCloseShouldAlsoCloseMediaDriverPorts()
     {
         launch(Tests::onError);
@@ -142,7 +148,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     @EnabledOnOs(OS.LINUX)
     public void destinationShouldInheritSocketBufferLengthsFromSubscription()
     {
@@ -158,7 +164,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void addDestinationWithSpySubscriptionsShouldFailWithRegistrationException()
     {
         final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
@@ -173,7 +179,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdownWithUnicast()
     {
         launch(Tests::onError);
@@ -187,7 +193,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdownWithMulticast()
     {
         launch(Tests::onError);
@@ -203,7 +209,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSpinUpAndShutdownWithDynamicMdc()
     {
         launch(Tests::onError);
@@ -217,7 +223,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendToSingleDestinationSubscriptionWithUnicast()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -245,7 +251,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     @SlowTest
     public void shouldAllowMultipleMdsSubscriptions()
     {
@@ -296,7 +302,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldFindMdsSubscriptionWithTags()
     {
         launch(Tests::onError);
@@ -329,7 +335,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     @SlowTest
     public void shouldAllowMultipleMdsSubscriptionsWithTags()
     {
@@ -390,7 +396,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendToSingleDestinationMultipleSubscriptionsWithUnicast()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -432,7 +438,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendToSingleDestinationSubscriptionWithMulticast()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -460,7 +466,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSendToSingleDestinationSubscriptionWithDynamicMdc()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -488,7 +494,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSendToMultipleDestinationSubscriptionWithSameStream()
     {
         final int numMessagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -563,7 +569,7 @@ public class MultiDestinationSubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldMergeStreamsFromMultiplePublicationsWithSameParams()
     {
         final int numMessagesToSend = 30;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDriverTest.java
@@ -20,6 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.IoUtil;
@@ -28,7 +30,7 @@ import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
@@ -36,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiDriverTest
 {
     private static final String MULTICAST_URI = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost";
@@ -97,7 +100,7 @@ public class MultiDriverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdown()
     {
         launch();
@@ -113,7 +116,7 @@ public class MultiDriverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldJoinExistingStreamWithLockStepSendingReceiving() throws InterruptedException
     {
         final int numMessagesToSendPreJoin = NUM_MESSAGES_PER_TERM / 2;
@@ -184,7 +187,7 @@ public class MultiDriverTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldJoinExistingIdleStreamWithLockStepSendingReceiving() throws InterruptedException
     {
         final int numMessagesToSendPreJoin = 0;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
@@ -19,18 +19,21 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiSubscriberTest
 {
     private static final String CHANNEL_1 = "aeron:udp?endpoint=localhost:24325|fruit=banana";
@@ -52,7 +55,7 @@ public class MultiSubscriberTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessageOnSeparateSubscriptions()
     {
         final FragmentHandler mockFragmentHandlerOne = mock(FragmentHandler.class);

--- a/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
@@ -21,9 +21,7 @@ import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
-import io.aeron.test.NetworkTestingUtil;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
+import io.aeron.test.*;
 import io.aeron.test.driver.DistinctErrorLogTestWatcher;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.RedirectingNameResolver;
@@ -35,7 +33,10 @@ import org.agrona.concurrent.SleepingMillisIdleStrategy;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.hamcrest.Matcher;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
@@ -89,6 +90,9 @@ public class NameReResolutionTest
     @RegisterExtension
     public final DistinctErrorLogTestWatcher logWatcher = new DistinctErrorLogTestWatcher();
 
+    @RegisterExtension
+    public final InterruptingTestCallback testCallback = new InterruptingTestCallback();
+
     private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
     private final FragmentHandler handler = mock(FragmentHandler.class);
     private CountersReader countersReader;
@@ -124,7 +128,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReResolveEndpointOnNotConnected()
     {
         final long initialResolutionChanges = countersReader.getCounterValue(RESOLUTION_CHANGES.id());
@@ -186,7 +190,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReResolveMdcManualEndpointOnNotConnected()
     {
         final long initialResolutionChanges = countersReader.getCounterValue(RESOLUTION_CHANGES.id());
@@ -249,7 +253,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldHandleMdcManualEndpointInitiallyUnresolved()
     {
         final long initialResolutionChanges = countersReader.getCounterValue(RESOLUTION_CHANGES.id());
@@ -295,7 +299,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReResolveMdcDynamicControlOnNotConnected()
     {
         final long initialResolutionChanges = countersReader.getCounterValue(RESOLUTION_CHANGES.id());
@@ -356,7 +360,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReResolveMdcDynamicControlOnManualDestinationSubscriptionOnNotConnected()
     {
         final long initialResolutionChanges = countersReader.getCounterValue(RESOLUTION_CHANGES.id());
@@ -419,7 +423,7 @@ public class NameReResolutionTest
 
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReportErrorOnReResolveFailure() throws IOException
     {
         buffer.putInt(0, 1);

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -23,16 +23,18 @@ import io.aeron.driver.ext.LossGenerator;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.RawBlockHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,9 +46,9 @@ import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static io.aeron.SystemTests.verifyLossOccurredForStream;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
-import static io.aeron.SystemTests.verifyLossOccurredForStream;
 import static java.util.Arrays.asList;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class PubAndSubTest
 {
     private static final String IPC_URI = "aeron:ipc";
@@ -111,7 +114,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessageViaPollFile(final String channel)
     {
         launch(channel);
@@ -147,7 +150,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldContinueAfterBufferRollover(final String channel)
     {
         final int termBufferLength = 64 * 1024;
@@ -178,7 +181,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldContinueAfterRolloverWithMinimalPaddingHeader(final String channel)
     {
         final int termBufferLength = 64 * 1024;
@@ -260,7 +263,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReceivePublishedMessageOneForOneWithDataLoss(final String channel) throws IOException
     {
         assumeFalse(IPC_URI.equals(channel));
@@ -303,7 +306,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessageBatchedWithDataLoss(final String channel) throws IOException
     {
         assumeFalse(IPC_URI.equals(channel));
@@ -351,7 +354,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldContinueAfterBufferRolloverBatched(final String channel)
     {
         final int termBufferLength = 64 * 1024;
@@ -408,7 +411,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldContinueAfterBufferRolloverWithPadding(final String channel)
     {
         /*
@@ -444,7 +447,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldContinueAfterBufferRolloverWithPaddingBatched(final String channel)
     {
         /*
@@ -485,7 +488,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveOnlyAfterSendingUpToFlowControlLimit(final String channel)
     {
         /*
@@ -550,7 +553,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessageOneForOneWithReSubscription(final String channel)
     {
         final int termBufferLength = 64 * 1024;
@@ -597,7 +600,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldFragmentExactMessageLengthsCorrectly(final String channel)
     {
         final int termBufferLength = 64 * 1024;
@@ -645,7 +648,7 @@ public class PubAndSubTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldNoticeDroppedSubscriber(final String channel)
     {
         launch(channel);

--- a/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublicationUnblockTest.java
@@ -20,14 +20,16 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.BufferClaim;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -38,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class PublicationUnblockTest
 {
     private static List<String> channels()
@@ -74,7 +77,7 @@ public class PublicationUnblockTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldUnblockNonCommittedMessage(final String channel)
     {
         final MutableInteger fragmentCount = new MutableInteger();

--- a/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PublishFromArbitraryPositionTest.java
@@ -20,6 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -28,7 +30,7 @@ import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
@@ -39,6 +41,7 @@ import java.util.Random;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class PublishFromArbitraryPositionTest
 {
     private static final int STREAM_ID = 1007;
@@ -76,7 +79,7 @@ public class PublishFromArbitraryPositionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPublishFromArbitraryJoinPosition() throws InterruptedException
     {
         final Random rnd = new Random();

--- a/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
@@ -18,6 +18,8 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -26,7 +28,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ResolvedEndpointSystemTest
 {
     private static final int STREAM_ID = 2002;
@@ -75,7 +78,7 @@ public class ResolvedEndpointSystemTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldSubscribeWithSystemAssignedPort()
     {
         final String uri = "aeron:udp?endpoint=localhost:0";
@@ -106,7 +109,7 @@ public class ResolvedEndpointSystemTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldSubscribeToSystemAssignedPorts()
     {
         final long tag1 = client.nextCorrelationId();
@@ -168,7 +171,7 @@ public class ResolvedEndpointSystemTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldSubscribeToSystemAssignedPortsUsingIPv6()
     {
         assumeFalse("true".equals(System.getProperty("java.net.preferIPv4Stack")));
@@ -217,7 +220,7 @@ public class ResolvedEndpointSystemTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldBindMultipleSystemAssignedEndpointsForMultiDestinationSubscription()
     {
         final String systemAssignedPortUri1 = "aeron:udp?endpoint=127.0.0.1:0";
@@ -260,7 +263,7 @@ public class ResolvedEndpointSystemTest
     }
 
     @Test
-    @Timeout(5)
+    @InterruptAfter(5)
     void shouldAllowSystemAssignedPortOnDynamicMultiDestinationPublication()
     {
         final String mdcUri = "aeron:udp?control=localhost:0";

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificPublicationTest.java
@@ -20,6 +20,8 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
@@ -30,7 +32,7 @@ import org.agrona.ErrorHandler;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,6 +43,7 @@ import static io.aeron.CommonContext.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 class SessionSpecificPublicationTest
 {
     private static final String ENDPOINT = "localhost:24325";
@@ -162,7 +165,7 @@ class SessionSpecificPublicationTest
 
     @ParameterizedTest
     @MethodSource("data")
-    @Timeout(20)
+    @InterruptAfter(20)
     @SlowTest
     void shouldNotAddPublicationWithSameSessionUntilLingerCompletes(final ChannelUriStringBuilder builder)
     {

--- a/aeron-system-tests/src/test/java/io/aeron/SessionSpecificSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SessionSpecificSubscriptionTest.java
@@ -20,11 +20,13 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class SessionSpecificSubscriptionTest
 {
     private static final String ENDPOINT = "localhost:24325";
@@ -77,7 +80,7 @@ public class SessionSpecificSubscriptionTest
         driver.context().deleteDirectory();
     }
 
-    @Timeout(10)
+    @InterruptAfter(10)
     @ParameterizedTest
     @MethodSource("data")
     public void shouldSubscribeToSpecificSessionIdsAndWildcard(final ChannelUriStringBuilder channelBuilder)

--- a/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySimulatedConnectionTest.java
@@ -20,14 +20,16 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class SpySimulatedConnectionTest
 {
     private static List<String> channels()
@@ -95,7 +98,7 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldNotSimulateConnectionWhenNotConfigured(final String channel)
     {
         launch();
@@ -110,7 +113,7 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSimulateConnectionWhenOnChannel(final String channel)
     {
         launch();
@@ -124,7 +127,7 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSimulateConnectionWithNoNetworkSubscriptions(final String channel)
     {
         final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -172,7 +175,7 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSimulateConnectionWithSlowNetworkSubscription(final String channel)
     {
         final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;
@@ -220,7 +223,7 @@ public class SpySimulatedConnectionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSimulateConnectionWithLeavingNetworkSubscription(final String channel)
     {
         final int messagesToSend = NUM_MESSAGES_PER_TERM * 3;

--- a/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpySubscriptionTest.java
@@ -19,6 +19,8 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
@@ -27,7 +29,7 @@ import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,6 +41,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class SpySubscriptionTest
 {
     private static List<String> channels()
@@ -79,7 +82,7 @@ public class SpySubscriptionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessage(final String channel)
     {
         try (Subscription subscription = aeron.addSubscription(channel, STREAM_ID);
@@ -119,7 +122,7 @@ public class SpySubscriptionTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldConnectToRecreatedChannelByTag()
     {
         final long tag1 = aeron.nextCorrelationId();

--- a/aeron-system-tests/src/test/java/io/aeron/StopStartSecondSubscriberTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/StopStartSecondSubscriberTest.java
@@ -17,14 +17,22 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
-import org.agrona.*;
+import org.agrona.BitUtil;
+import org.agrona.CloseHelper;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
@@ -33,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test that a second subscriber can be stopped and started again while data is being published.
  */
+@ExtendWith(InterruptingTestCallback.class)
 public class StopStartSecondSubscriberTest
 {
     private static final String CHANNEL1 = "aeron:udp?endpoint=localhost:24325";
@@ -98,14 +107,14 @@ public class StopStartSecondSubscriberTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSpinUpAndShutdown()
     {
         launch(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceivePublishedMessage()
     {
         launch(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);
@@ -142,28 +151,28 @@ public class StopStartSecondSubscriberTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesAfterStopStartOnSameChannelSameStream()
     {
         shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL1, STREAM_ID1);
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesAfterStopStartOnSameChannelDifferentStreams()
     {
         shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL1, STREAM_ID2);
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesAfterStopStartOnDifferentChannelsSameStream()
     {
         shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID1);
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReceiveMessagesAfterStopStartOnDifferentChannelsDifferentStreams()
     {
         shouldReceiveMessagesAfterStopStart(CHANNEL1, STREAM_ID1, CHANNEL2, STREAM_ID2);

--- a/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TaggedFlowControlSystemTest.java
@@ -21,16 +21,18 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.*;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,6 +48,7 @@ import static io.aeron.FlowControlTests.awaitConnectionAndStatusMessages;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class TaggedFlowControlSystemTest
 {
     private static final String MULTICAST_URI = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost";
@@ -151,7 +154,7 @@ public class TaggedFlowControlSystemTest
 
     @ParameterizedTest
     @MethodSource("strategyConfigurations")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldSlowToTaggedWithMulticastFlowControlStrategy(
         final FlowControlSupplier flowControlSupplier,
         final Long groupTag,
@@ -236,7 +239,7 @@ public class TaggedFlowControlSystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRemoveDeadReceiver()
     {
         final State state = new State();
@@ -311,7 +314,7 @@ public class TaggedFlowControlSystemTest
     @SuppressWarnings("methodlength")
     @SlowTest
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     void shouldPreventConnectionUntilRequiredGroupSizeMatchTagIsMet()
     {
         final Long groupTag = 2701L;
@@ -431,7 +434,7 @@ public class TaggedFlowControlSystemTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     void shouldPreventConnectionUntilAtLeastOneSubscriberConnectedWithRequiredGroupSizeZero()
     {
         final Long groupTag = 2701L;
@@ -478,7 +481,7 @@ public class TaggedFlowControlSystemTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHandleSenderLimitCorrectlyWithMinGroupSize()
     {
         final String publisherUri = "aeron:udp?endpoint=224.20.30.39:24326|interface=localhost|fc=tagged,g:123/1";

--- a/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TwoBufferOfferMessageTest.java
@@ -18,19 +18,22 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class TwoBufferOfferMessageTest
 {
     private static final String CHANNEL = "aeron:ipc?term-length=64k";
@@ -57,7 +60,7 @@ public class TwoBufferOfferMessageTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTransferUnfragmentedTwoPartMessage()
     {
         final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[256]);
@@ -93,7 +96,7 @@ public class TwoBufferOfferMessageTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldTransferFragmentedTwoPartMessage()
     {
         final UnsafeBuffer expectedBuffer = new UnsafeBuffer(new byte[32 + driver.context().mtuLength()]);

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -19,13 +19,15 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -40,6 +42,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class UntetheredSubscriptionTest
 {
     private static List<String> channels()
@@ -79,7 +82,7 @@ public class UntetheredSubscriptionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBecomeUnavailableWhenNotKeepingUp(final String channel)
     {
         final FragmentHandler fragmentHandler = (buffer, offset, length, header) -> {};
@@ -135,7 +138,7 @@ public class UntetheredSubscriptionTest
 
     @ParameterizedTest
     @MethodSource("channels")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRejoinAfterResting(final String channel)
     {
         final AtomicInteger unavailableImageCount = new AtomicInteger();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
@@ -24,16 +24,18 @@ import io.aeron.security.Authenticator;
 import io.aeron.security.AuthenticatorSupplier;
 import io.aeron.security.CredentialsSupplier;
 import io.aeron.security.SessionProxy;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveAuthenticationTest
 {
     private static final int RECORDED_STREAM_ID = 1033;
@@ -81,7 +84,7 @@ public class ArchiveAuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBeAbleToRecordWithDefaultCredentialsAndAuthenticator()
     {
         launchArchivingMediaDriver(null);
@@ -91,7 +94,7 @@ public class ArchiveAuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBeAbleToRecordWithAuthenticateOnConnectRequestWithCredentials()
     {
         final MutableLong authenticatorSessionId = new MutableLong(-1L);
@@ -144,7 +147,7 @@ public class ArchiveAuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldBeAbleToRecordWithAuthenticateOnChallengeResponse()
     {
         final MutableLong authenticatorSessionId = new MutableLong(-1L);
@@ -205,7 +208,7 @@ public class ArchiveAuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldNotBeAbleToConnectWithRejectOnConnectRequest()
     {
         final MutableLong authenticatorSessionId = new MutableLong(-1L);
@@ -265,7 +268,7 @@ public class ArchiveAuthenticationTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldNotBeAbleToConnectWithRejectOnChallengeResponse()
     {
         final MutableLong authenticatorSessionId = new MutableLong(-1L);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
@@ -21,9 +21,11 @@ import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.codecs.SourceLocation;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -31,7 +33,7 @@ import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
 
@@ -40,6 +42,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveDeleteAndRestartTest
 {
     private static final int SYNC_LEVEL = 0;
@@ -108,7 +111,7 @@ public class ArchiveDeleteAndRestartTest
         }
     }
 
-    @Timeout(10)
+    @InterruptAfter(10)
     @Test
     public void recordAndReplayExclusivePublication()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -26,15 +26,17 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.*;
 import org.agrona.collections.MutableBoolean;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,6 +55,7 @@ import static org.agrona.BufferUtil.allocateDirectAligned;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ArchiveTest
 {
     private static Stream<Arguments> threadingModes()
@@ -200,7 +203,7 @@ public class ArchiveTest
 
     @ParameterizedTest
     @MethodSource("threadingModes")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void recordAndReplayExclusivePublication(
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {
@@ -238,7 +241,7 @@ public class ArchiveTest
 
     @ParameterizedTest
     @MethodSource("threadingModes")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void replayExclusivePublicationWhileRecording(
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {
@@ -280,7 +283,7 @@ public class ArchiveTest
 
     @ParameterizedTest
     @MethodSource("threadingModes")
-    @Timeout(10)
+    @InterruptAfter(10)
     public void recordAndReplayConcurrentPublication(
         final ThreadingMode threadingMode, final ArchiveThreadingMode archiveThreadingMode)
     {

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -21,16 +21,18 @@ import io.aeron.archive.client.ArchiveException;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -43,6 +45,7 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class BasicArchiveTest
 {
     private static final int RECORDED_STREAM_ID = 33;
@@ -114,7 +117,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRecordThenReplayThenTruncate()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -193,7 +196,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void jumboRecordingDescriptorEndToEndTest()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -259,7 +262,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void purgeRecording()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -339,7 +342,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void purgeRecordingFailsIfRecordingIsActive()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -399,7 +402,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void purgeRecordingFailsIfThereAreActiveReplays()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -463,7 +466,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldRecordReplayAndCancelReplayEarly()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -504,7 +507,7 @@ public class BasicArchiveTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldReplayRecordingFromLateJoinPosition()
     {
         final String messagePrefix = "Message-Prefix-";

--- a/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/CatalogWithJumboRecordingsAndGapsTest.java
@@ -20,16 +20,18 @@ import io.aeron.CommonContext;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.CachedEpochClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -50,6 +52,7 @@ import static org.agrona.BitUtil.next;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+@ExtendWith(InterruptingTestCallback.class)
 class CatalogWithJumboRecordingsAndGapsTest
 {
     private static final int MTU_LENGTH = PAGE_SIZE * 4;
@@ -154,7 +157,7 @@ class CatalogWithJumboRecordingsAndGapsTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     void listRecording()
     {
         final int count = aeronArchive.listRecording(recordingIds[3],
@@ -184,7 +187,7 @@ class CatalogWithJumboRecordingsAndGapsTest
     }
 
     @ParameterizedTest
-    @Timeout(10)
+    @InterruptAfter(10)
     @MethodSource("listRecordingsArguments")
     void listRecordings(final long fromRecordingId, final int recordCount, final int expectedRecordCount)
     {
@@ -215,7 +218,7 @@ class CatalogWithJumboRecordingsAndGapsTest
     }
 
     @ParameterizedTest
-    @Timeout(10)
+    @InterruptAfter(10)
     @MethodSource("listRecordingsForUriArguments")
     void listRecordingsForUri(
         final long fromRecordingId,

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
@@ -25,9 +25,11 @@ import io.aeron.driver.Configuration;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.SystemUtil;
@@ -36,7 +38,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -52,6 +54,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ExtendRecordingTest
 {
     private static final String MY_ALIAS = "my-log";
@@ -140,7 +143,7 @@ public class ExtendRecordingTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldExtendRecordingAndReplay()
     {
         final long controlSessionId = aeronArchive.controlSessionId();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
@@ -18,15 +18,19 @@ package io.aeron.archive;
 import io.aeron.Aeron;
 import io.aeron.ChannelUriStringBuilder;
 import io.aeron.Publication;
-import io.aeron.archive.client.*;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.RecordingSignalAdapter;
+import io.aeron.archive.client.RecordingSignalConsumer;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableReference;
@@ -34,7 +38,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -43,6 +47,7 @@ import static io.aeron.archive.ArchiveSystemTests.*;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ManageRecordingHistoryTest
 {
     private static final int TERM_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
@@ -104,7 +109,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPurgeForStreamJoinedAtTheBeginning()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -132,7 +137,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPurgeForLateJoinedStream()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -164,7 +169,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldDetachThenAttachFullSegments()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -194,7 +199,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldDetachThenAttachWhenStartNotSegmentAligned()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -228,7 +233,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldMigrateSegmentsForStreamJoinedAtTheBeginning()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -276,7 +281,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldMigrateSegmentsForStreamNotSegmentAligned()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -327,7 +332,7 @@ public class ManageRecordingHistoryTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldPurgeRecording()
     {
         final String messagePrefix = "Message-Prefix-";

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -24,16 +24,22 @@ import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.test.DataCollector;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.LangUtil;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.status.CountersReader;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -45,6 +51,7 @@ import static io.aeron.archive.ArchiveSystemTests.*;
 import static io.aeron.archive.codecs.SourceLocation.REMOTE;
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ReplayMergeTest
 {
     private static final String MESSAGE_PREFIX = "Message-Prefix-";
@@ -175,7 +182,7 @@ public class ReplayMergeTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldMergeFromReplayToLive(final TestInfo testInfo)
     {
         try (Publication publication = aeron.addPublication(publicationChannel, STREAM_ID))

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -22,9 +22,11 @@ import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
-import io.aeron.test.Tests;
 import org.agrona.CloseHelper;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableLong;
@@ -35,7 +37,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
@@ -52,7 +54,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@Timeout(10)
+@ExtendWith(InterruptingTestCallback.class)
 public class ReplicateRecordingTest
 {
     private static final int SRC_CONTROL_STREAM_ID = AeronArchive.Configuration.CONTROL_STREAM_ID_DEFAULT;
@@ -199,6 +201,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldThrowExceptionWhenSrcRecordingIdUnknown()
     {
         final long unknownId = 7L;
@@ -221,6 +224,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateStoppedRecording()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -260,6 +264,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateStoppedRecordingsConcurrently()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -315,6 +320,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateLiveWithoutMergingRecording()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -358,6 +364,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateLiveRecordingAndStopAtSpecifiedPosition()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -413,6 +420,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateMoreThanOnce()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -466,6 +474,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateLiveRecordingAndMerge()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -510,6 +519,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateLiveRecordingAndMergeBeforeDataFlows()
     {
         final String messagePrefix = "Message-Prefix-";
@@ -549,6 +559,7 @@ public class ReplicateRecordingTest
     }
 
     @Test
+    @InterruptAfter(10)
     public void shouldReplicateLiveRecordingAndMergeWhileFollowingWithTaggedSubscription()
     {
         final String messagePrefix = "Message-Prefix-";

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
@@ -17,17 +17,20 @@ package io.aeron.cluster;
 
 import io.aeron.cluster.service.Cluster;
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class AppointedLeaderTest
 {
     @RegisterExtension
@@ -43,7 +46,7 @@ public class AppointedLeaderTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldConnectAndSendKeepAlive()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start();
@@ -58,7 +61,7 @@ public class AppointedLeaderTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldEchoMessagesViaService()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).withAppointedLeader(LEADER_ID).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/AppointedLeaderTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +39,7 @@ public class AppointedLeaderTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -168,7 +168,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @Timeout(60)
     public void shouldBackupClusterAfterCleanShutdown()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -18,12 +18,10 @@ package io.aeron.cluster;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.SlowTest;
-import io.aeron.test.TimeoutTestWatcher;
 import io.aeron.test.cluster.TestBackupNode;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -38,16 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ClusterBackupTest
 {
     @RegisterExtension
-    final TimeoutTestWatcher timeoutTestWatcher = new TimeoutTestWatcher();
-
-    @RegisterExtension
     final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
-
-    @BeforeEach
-    void setUp()
-    {
-        timeoutTestWatcher.monitorTestThread(Thread.currentThread());
-    }
 
     @AfterEach
     void tearDown()

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -174,33 +174,46 @@ public class ClusterBackupTest
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
         clusterTestWatcher.cluster(cluster);
 
+        System.out.println("cluster.awaitLeader()");
         final TestNode leader = cluster.awaitLeader();
 
         final int messageCount = 10;
+        System.out.println("cluster.awaitLeader()");
         cluster.connectClient();
+        System.out.println("cluster.sendMessages(messageCount)");
         cluster.sendMessages(messageCount);
+        System.out.println("cluster.awaitResponseMessageCount(messageCount)");
         cluster.awaitResponseMessageCount(messageCount);
+        System.out.println("cluster.awaitServicesMessageCount(messageCount)");
         cluster.awaitServicesMessageCount(messageCount);
 
         cluster.node(0).isTerminationExpected(true);
         cluster.node(1).isTerminationExpected(true);
         cluster.node(2).isTerminationExpected(true);
 
+        System.out.println("cluster.shutdownCluster(leader)");
         cluster.shutdownCluster(leader);
+        System.out.println("cluster.awaitNodeTerminations()");
         cluster.awaitNodeTerminations();
 
         assertTrue(cluster.node(0).service().wasSnapshotTaken());
         assertTrue(cluster.node(1).service().wasSnapshotTaken());
         assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
+        System.out.println("cluster.stopAllNodes()");
         cluster.stopAllNodes();
+        System.out.println("cluster.restartAllNodes(false)");
         cluster.restartAllNodes(false);
+        System.out.println("cluster.awaitLeader() #2");
         final TestNode newLeader = cluster.awaitLeader();
         final long logPosition = newLeader.service().cluster().logPosition();
 
+        System.out.println("cluster.startClusterBackupNode(true)");
         cluster.startClusterBackupNode(true);
 
+        System.out.println("cluster.awaitBackupState(ClusterBackup.State.BACKING_UP)");
         cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        System.out.println("cluster.awaitBackupLiveLogPosition(logPosition)");
         cluster.awaitBackupLiveLogPosition(logPosition);
     }
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -21,6 +21,7 @@ import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestBackupNode;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
+import org.agrona.concurrent.SystemNanoClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -174,47 +175,53 @@ public class ClusterBackupTest
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
         clusterTestWatcher.cluster(cluster);
 
-        System.out.println("cluster.awaitLeader()");
+        log("cluster.awaitLeader()");
         final TestNode leader = cluster.awaitLeader();
 
         final int messageCount = 10;
-        System.out.println("cluster.awaitLeader()");
+        log("cluster.awaitLeader()");
         cluster.connectClient();
-        System.out.println("cluster.sendMessages(messageCount)");
+        log("cluster.sendMessages(messageCount)");
         cluster.sendMessages(messageCount);
-        System.out.println("cluster.awaitResponseMessageCount(messageCount)");
+        log("cluster.awaitResponseMessageCount(messageCount)");
         cluster.awaitResponseMessageCount(messageCount);
-        System.out.println("cluster.awaitServicesMessageCount(messageCount)");
+        log("cluster.awaitServicesMessageCount(messageCount)");
         cluster.awaitServicesMessageCount(messageCount);
 
         cluster.node(0).isTerminationExpected(true);
         cluster.node(1).isTerminationExpected(true);
         cluster.node(2).isTerminationExpected(true);
 
-        System.out.println("cluster.shutdownCluster(leader)");
+        log("cluster.shutdownCluster(leader)");
         cluster.shutdownCluster(leader);
-        System.out.println("cluster.awaitNodeTerminations()");
+        log("cluster.awaitNodeTerminations()");
         cluster.awaitNodeTerminations();
 
         assertTrue(cluster.node(0).service().wasSnapshotTaken());
         assertTrue(cluster.node(1).service().wasSnapshotTaken());
         assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
-        System.out.println("cluster.stopAllNodes()");
+        log("cluster.stopAllNodes()");
         cluster.stopAllNodes();
-        System.out.println("cluster.restartAllNodes(false)");
+        log("cluster.restartAllNodes(false)");
         cluster.restartAllNodes(false);
-        System.out.println("cluster.awaitLeader() #2");
+        log("cluster.awaitLeader() #2");
         final TestNode newLeader = cluster.awaitLeader();
         final long logPosition = newLeader.service().cluster().logPosition();
 
-        System.out.println("cluster.startClusterBackupNode(true)");
+        log("cluster.startClusterBackupNode(true)");
         cluster.startClusterBackupNode(true);
 
-        System.out.println("cluster.awaitBackupState(ClusterBackup.State.BACKING_UP)");
+        log("cluster.awaitBackupState(ClusterBackup.State.BACKING_UP)");
         cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-        System.out.println("cluster.awaitBackupLiveLogPosition(logPosition)");
+        log("cluster.awaitBackupLiveLogPosition(logPosition)");
         cluster.awaitBackupLiveLogPosition(logPosition);
+    }
+
+    private void log(String msg)
+    {
+        final long l = SystemNanoClock.INSTANCE.nanoTime();
+        System.out.printf("[%d.%d] %s%n", l / 1_000_000_000, l % 1_000_000_000, msg);
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -17,13 +17,15 @@ package io.aeron.cluster;
 
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestBackupNode;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.cluster.TestCluster.aCluster;
@@ -32,6 +34,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterBackupTest
 {
     @RegisterExtension
@@ -45,7 +48,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterNoSnapshotsAndEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -66,7 +69,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -96,7 +99,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterNoSnapshotsAndThenSendMessages()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -126,7 +129,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterWithSnapshot()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -159,7 +162,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterAfterCleanShutdown()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -196,7 +199,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterWithSnapshotAndNonEmptyLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -236,7 +239,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterWithSnapshotThenSend()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -276,7 +279,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBeAbleToGetTimeOfNextBackupQuery()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -292,7 +295,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithReQuery()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -330,7 +333,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogAfterFailure()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -362,7 +365,7 @@ public class ClusterBackupTest
     }
 
     @Test
-    @Timeout(60)
+    @InterruptAfter(60)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithFailure()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -16,16 +16,19 @@
 package io.aeron.cluster;
 
 import io.aeron.cluster.client.AeronCluster;
+import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.SlowTest;
 import io.aeron.test.TimeoutTestWatcher;
 import io.aeron.test.cluster.TestBackupNode;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -37,370 +40,380 @@ public class ClusterBackupTest
     @RegisterExtension
     final TimeoutTestWatcher timeoutTestWatcher = new TimeoutTestWatcher();
 
+    @RegisterExtension
+    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+
     @BeforeEach
     void setUp()
     {
         timeoutTestWatcher.monitorTestThread(Thread.currentThread());
     }
 
+    @AfterEach
+    void tearDown()
+    {
+        assertEquals(
+            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+    }
+
     @Test
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndEmptyLog()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            cluster.awaitLeader();
-            cluster.startClusterBackupNode(true);
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(cluster.findLeader().service().cluster().logPosition());
-            cluster.stopAllNodes();
+        cluster.awaitLeader();
+        cluster.startClusterBackupNode(true);
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(cluster.findLeader().service().cluster().logPosition());
+        cluster.stopAllNodes();
 
-            assertEquals(0, node.service().messageCount());
-            assertFalse(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(0, node.service().messageCount());
+        assertFalse(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLog()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            final long logPosition = leader.service().cluster().logPosition();
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.startClusterBackupNode(true);
+        final long logPosition = leader.service().cluster().logPosition();
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        cluster.startClusterBackupNode(true);
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount, node.service().messageCount());
-            assertFalse(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount, node.service().messageCount());
+        assertFalse(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndThenSendMessages()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
-            cluster.startClusterBackupNode(true);
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        final TestNode leader = cluster.awaitLeader();
+        cluster.startClusterBackupNode(true);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
 
-            final long logPosition = leader.service().cluster().logPosition();
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        final long logPosition = leader.service().cluster().logPosition();
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount, node.service().messageCount());
-            assertFalse(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount, node.service().messageCount());
+        assertFalse(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterWithSnapshot()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            final long logPosition = leader.service().cluster().logPosition();
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            cluster.startClusterBackupNode(true);
+        final long logPosition = leader.service().cluster().logPosition();
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        cluster.startClusterBackupNode(true);
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount, node.service().messageCount());
-            assertTrue(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount, node.service().messageCount());
+        assertTrue(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterAfterCleanShutdown()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.node(0).isTerminationExpected(true);
-            cluster.node(1).isTerminationExpected(true);
-            cluster.node(2).isTerminationExpected(true);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.shutdownCluster(leader);
-            cluster.awaitNodeTerminations();
+        cluster.node(0).isTerminationExpected(true);
+        cluster.node(1).isTerminationExpected(true);
+        cluster.node(2).isTerminationExpected(true);
 
-            assertTrue(cluster.node(0).service().wasSnapshotTaken());
-            assertTrue(cluster.node(1).service().wasSnapshotTaken());
-            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+        cluster.shutdownCluster(leader);
+        cluster.awaitNodeTerminations();
 
-            cluster.stopAllNodes();
-            cluster.restartAllNodes(false);
-            final TestNode newLeader = cluster.awaitLeader();
-            final long logPosition = newLeader.service().cluster().logPosition();
+        assertTrue(cluster.node(0).service().wasSnapshotTaken());
+        assertTrue(cluster.node(1).service().wasSnapshotTaken());
+        assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
-            cluster.startClusterBackupNode(true);
+        cluster.stopAllNodes();
+        cluster.restartAllNodes(false);
+        final TestNode newLeader = cluster.awaitLeader();
+        final long logPosition = newLeader.service().cluster().logPosition();
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-        }
+        cluster.startClusterBackupNode(true);
+
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterWithSnapshotAndNonEmptyLog()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int preSnapshotMessageCount = 10;
-            final int postSnapshotMessageCount = 7;
-            final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
-            cluster.connectClient();
-            cluster.sendMessages(preSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(preSnapshotMessageCount);
-            cluster.awaitServicesMessageCount(preSnapshotMessageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final int preSnapshotMessageCount = 10;
+        final int postSnapshotMessageCount = 7;
+        final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
+        cluster.connectClient();
+        cluster.sendMessages(preSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(preSnapshotMessageCount);
+        cluster.awaitServicesMessageCount(preSnapshotMessageCount);
 
-            cluster.sendMessages(postSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(totalMessageCount);
-            cluster.awaitServiceMessageCount(leader, totalMessageCount);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            final long logPosition = leader.service().cluster().logPosition();
+        cluster.sendMessages(postSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(totalMessageCount);
+        cluster.awaitServiceMessageCount(leader, totalMessageCount);
 
-            cluster.startClusterBackupNode(true);
+        final long logPosition = leader.service().cluster().logPosition();
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        cluster.startClusterBackupNode(true);
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
-            cluster.awaitServiceMessageCount(node, totalMessageCount);
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(totalMessageCount, node.service().messageCount());
-            assertTrue(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+        cluster.awaitServiceMessageCount(node, totalMessageCount);
+
+        assertEquals(totalMessageCount, node.service().messageCount());
+        assertTrue(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterWithSnapshotThenSend()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int preSnapshotMessageCount = 10;
-            final int postSnapshotMessageCount = 7;
-            final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
-            cluster.connectClient();
-            cluster.sendMessages(preSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(preSnapshotMessageCount);
-            cluster.awaitServicesMessageCount(preSnapshotMessageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final int preSnapshotMessageCount = 10;
+        final int postSnapshotMessageCount = 7;
+        final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
+        cluster.connectClient();
+        cluster.sendMessages(preSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(preSnapshotMessageCount);
+        cluster.awaitServicesMessageCount(preSnapshotMessageCount);
 
-            cluster.startClusterBackupNode(true);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            cluster.sendMessages(postSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(totalMessageCount);
-            cluster.awaitServiceMessageCount(leader, totalMessageCount);
+        cluster.startClusterBackupNode(true);
 
-            final long logPosition = leader.service().cluster().logPosition();
+        cluster.sendMessages(postSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(totalMessageCount);
+        cluster.awaitServiceMessageCount(leader, totalMessageCount);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        final long logPosition = leader.service().cluster().logPosition();
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
-            cluster.awaitServiceMessageCount(node, totalMessageCount);
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(totalMessageCount, node.service().messageCount());
-            assertTrue(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+        cluster.awaitServiceMessageCount(node, totalMessageCount);
+
+        assertEquals(totalMessageCount, node.service().messageCount());
+        assertTrue(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
     public void shouldBeAbleToGetTimeOfNextBackupQuery()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            cluster.awaitLeader();
-            final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitLeader();
+        final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
 
-            final long nowMs = backupNode.epochClock().time();
-            assertThat(backupNode.nextBackupQueryDeadlineMs(), greaterThan(nowMs));
-        }
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+
+        final long nowMs = backupNode.epochClock().time();
+        assertThat(backupNode.nextBackupQueryDeadlineMs(), greaterThan(nowMs));
     }
 
     @Test
     @Timeout(30)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithReQuery()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            final long logPosition = leader.service().cluster().logPosition();
-            final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
+        final long logPosition = leader.service().cluster().logPosition();
+        final TestBackupNode backupNode = cluster.startClusterBackupNode(true);
 
-            assertTrue(backupNode.nextBackupQueryDeadlineMs(0));
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
 
-            cluster.sendMessages(5);
-            cluster.awaitResponseMessageCount(messageCount + 5);
-            cluster.awaitServiceMessageCount(leader, messageCount + 5);
+        assertTrue(backupNode.nextBackupQueryDeadlineMs(0));
 
-            final long nextLogPosition = leader.service().cluster().logPosition();
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(nextLogPosition);
-            cluster.stopAllNodes();
+        cluster.sendMessages(5);
+        cluster.awaitResponseMessageCount(messageCount + 5);
+        cluster.awaitServiceMessageCount(leader, messageCount + 5);
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        final long nextLogPosition = leader.service().cluster().logPosition();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(nextLogPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount + 5, node.service().messageCount());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount + 5, node.service().messageCount());
     }
 
     @Test
     @Timeout(40)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogAfterFailure()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leaderOne = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leaderOne = cluster.awaitLeader();
 
-            cluster.stopNode(leaderOne);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            final TestNode leaderTwo = cluster.awaitLeader();
-            final long logPosition = leaderTwo.service().cluster().logPosition();
+        cluster.stopNode(leaderOne);
 
-            cluster.startClusterBackupNode(true);
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopAllNodes();
+        final TestNode leaderTwo = cluster.awaitLeader();
+        final long logPosition = leaderTwo.service().cluster().logPosition();
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.startClusterBackupNode(true);
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount, node.service().messageCount());
-            assertFalse(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount, node.service().messageCount());
+        assertFalse(node.service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(60)
     public void shouldBackupClusterNoSnapshotsAndNonEmptyLogWithFailure()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
-        {
-            final TestNode leaderOne = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            final AeronCluster aeronCluster = cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        final TestNode leaderOne = cluster.awaitLeader();
 
-            final long logPosition = leaderOne.service().cluster().logPosition();
+        final int messageCount = 10;
+        final AeronCluster aeronCluster = cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.startClusterBackupNode(true);
+        final long logPosition = leaderOne.service().cluster().logPosition();
 
-            aeronCluster.sendKeepAlive();
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            aeronCluster.sendKeepAlive();
-            cluster.awaitBackupLiveLogPosition(logPosition);
-            cluster.stopNode(leaderOne);
+        cluster.startClusterBackupNode(true);
 
-            final TestNode leaderTwo = cluster.awaitLeader();
-            cluster.awaitNewLeadershipEvent(1);
+        aeronCluster.sendKeepAlive();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        aeronCluster.sendKeepAlive();
+        cluster.awaitBackupLiveLogPosition(logPosition);
+        cluster.stopNode(leaderOne);
 
-            cluster.sendMessages(5);
-            cluster.awaitResponseMessageCount(messageCount + 5);
+        final TestNode leaderTwo = cluster.awaitLeader();
+        cluster.awaitNewLeadershipEvent(1);
 
-            final long nextLogPosition = leaderTwo.service().cluster().logPosition();
+        cluster.sendMessages(5);
+        cluster.awaitResponseMessageCount(messageCount + 5);
 
-            cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
-            cluster.awaitBackupLiveLogPosition(nextLogPosition);
-            cluster.stopAllNodes();
+        final long nextLogPosition = leaderTwo.service().cluster().logPosition();
 
-            final TestNode node = cluster.startStaticNodeFromBackup();
-            cluster.awaitLeader();
+        cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        cluster.awaitBackupLiveLogPosition(nextLogPosition);
+        cluster.stopAllNodes();
 
-            assertEquals(messageCount + 5, node.service().messageCount());
-            assertFalse(node.service().wasSnapshotLoaded());
-        }
+        final TestNode node = cluster.startStaticNodeFromBackup();
+        cluster.awaitLeader();
+
+        assertEquals(messageCount + 5, node.service().messageCount());
+        assertFalse(node.service().wasSnapshotLoaded());
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -42,7 +41,7 @@ public class ClusterBackupTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -52,14 +52,22 @@ public class ClusterBackupTest
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
         clusterTestWatcher.cluster(cluster);
 
+        System.out.println("cluster.awaitLeader() #1");
         cluster.awaitLeader();
+        System.out.println("cluster.startClusterBackupNode(true) #1");
         cluster.startClusterBackupNode(true);
 
+        System.out.println("cluster.awaitBackupState(ClusterBackup.State.BACKING_UP)");
         cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
+        System.out.println(
+            "cluster.awaitBackupLiveLogPosition(cluster.findLeader().service().cluster().logPosition())");
         cluster.awaitBackupLiveLogPosition(cluster.findLeader().service().cluster().logPosition());
+        System.out.println("cluster.stopAllNodes()");
         cluster.stopAllNodes();
 
+        System.out.println("cluster.startStaticNodeFromBackup() #2");
         final TestNode node = cluster.startStaticNodeFromBackup();
+        System.out.println("cluster.awaitLeader() #2");
         cluster.awaitLeader();
 
         assertEquals(0, node.service().messageCount());

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -23,16 +23,20 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.samples.cluster.EchoServiceNode;
 import io.aeron.samples.cluster.tutorial.BasicAuctionClusterClient;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.TopologyTest;
 import io.aeron.test.launcher.FileResolveUtil;
 import io.aeron.test.launcher.RemoteLaunchClient;
-import org.agrona.*;
+import org.agrona.AsciiEncoding;
+import org.agrona.IoUtil;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.MutableReference;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -63,6 +67,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TopologyTest
+@ExtendWith(InterruptingTestCallback.class)
 public class ClusterNetworkTopologyTest
 {
     private static final int REMOTE_LAUNCH_PORT = 11112;
@@ -131,7 +136,7 @@ public class ClusterNetworkTopologyTest
 
     @ParameterizedTest
     @MethodSource("provideTopologyConfigurations")
-    @Timeout(60)
+    @InterruptAfter(60)
     void shouldGetEchoFromCluster(
         final List<String> hostnames,
         final List<String> internalHostnames,
@@ -159,7 +164,7 @@ public class ClusterNetworkTopologyTest
 
     @ParameterizedTest
     @MethodSource("singleTopologyConfigurations")
-    @Timeout(60)
+    @InterruptAfter(60)
     void shouldLogReplicate(
         final List<String> hostnames,
         final List<String> internalHostnames,

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -18,15 +18,12 @@ package io.aeron.cluster;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.log.EventLogExtension;
-import io.aeron.test.ClusterTestWatcher;
-import io.aeron.test.SlowTest;
-import io.aeron.test.Tests;
+import io.aeron.test.*;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -42,7 +39,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
-@ExtendWith(EventLogExtension.class)
+@ExtendWith({EventLogExtension.class, InterruptingTestCallback.class})
 public class ClusterTest
 {
     @RegisterExtension
@@ -57,7 +54,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldStopFollowerAndRestartFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -76,7 +73,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldNotifyClientOfNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -92,7 +89,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -112,7 +109,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldShutdownClusterAndRestartWithSnapshots()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -140,7 +137,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldAbortClusterAndRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -170,7 +167,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldAbortClusterOnTerminationTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -202,7 +199,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldEchoMessages()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -219,7 +216,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldHandleLeaderFailOverWhenNameIsNotResolvable()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -245,7 +242,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldHandleClusterStartWhenANameIsNotResolvable()
     {
         final int initiallyUnresolvableNodeId = 1;
@@ -269,7 +266,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(10)
+    @InterruptAfter(10)
     public void shouldHandleClusterStartWhereMostNamesBecomeResolvableDuringElection()
     {
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(0).withInvalidNameResolution(2).start();
@@ -292,7 +289,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldEchoMessagesThenContinueOnNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -326,7 +323,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldStopLeaderAndRestartAsFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -344,7 +341,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -367,7 +364,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(60)
+    @InterruptAfter(60)
     public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -395,7 +392,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldAcceptMessagesAfterSingleNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -420,7 +417,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldReplaySnapshotTakenWhileDown()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -453,7 +450,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(50)
+    @InterruptAfter(50)
     public void shouldTolerateMultipleLeaderFailures()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -480,7 +477,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(90)
+    @InterruptAfter(90)
     public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -514,7 +511,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldAcceptMessagesAfterTwoNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -548,7 +545,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(60)
+    @InterruptAfter(60)
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -602,7 +599,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -645,7 +642,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldCallOnRoleChangeOnBecomingLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -673,7 +670,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -702,7 +699,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldTerminateLeaderWhenServiceStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -723,7 +720,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldEnterElectionWhenRecordingStopsOnLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -749,7 +746,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRecoverFollowerWhenRecordingStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -779,7 +776,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldCloseClientOnTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -805,7 +802,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverWhileMessagesContinue() throws InterruptedException
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -848,7 +845,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldCatchupFromEmptyLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -871,7 +868,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -917,7 +914,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldCatchUpTwoFreshNodesAfterRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -953,7 +950,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1021,7 +1018,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1051,7 +1048,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverWhenLeaderHasAppendedMoreThanFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1081,7 +1078,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverWhenFollowerIsMultipleTermsBehind()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1119,7 +1116,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverWhenFollowerArrivesPartWayThroughTerm()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1146,7 +1143,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     public void shouldRecoverWhenFollowerArrivePartWayThroughTermAfterMissingElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1186,7 +1183,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @InterruptAfter(40)
     void shouldRecoverWhenLastSnapshotIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1229,7 +1226,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     void shouldRecoverWhenLastSnapshotForShutdownIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(1).start();
@@ -1261,7 +1258,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(60)
+    @InterruptAfter(60)
     void shouldHandleMultipleElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1299,7 +1296,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(50)
+    @InterruptAfter(50)
     void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1349,7 +1346,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(50)
+    @InterruptAfter(50)
     void shouldRecoverWhenLastTwosSnapshotsAreInvalidAfterElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -1411,14 +1408,14 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldCatchUpAfterFollowerMissesOneMessage()
     {
         shouldCatchUpAfterFollowerMissesMessage(NO_OP_MSG);
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldCatchUpAfterFollowerMissesTimerRegistration()
     {
         shouldCatchUpAfterFollowerMissesMessage(REGISTER_TIMER_MSG);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.cluster.service.Cluster.Role.LEADER;
@@ -806,7 +805,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(40)
     public void shouldRecoverWhileMessagesContinue() throws InterruptedException
     {
         cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -834,6 +834,8 @@ public class ClusterTest
         }
 
         cluster.awaitResponseMessageCount(messageCounter.get());
+        cluster.awaitServiceMessageCount(followerB, messageCounter.get());
+
         cluster.client().close();
         cluster.awaitActiveSessionCount(0);
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -18,19 +18,20 @@ package io.aeron.cluster;
 import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.log.EventLogExtension;
+import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.SlowTest;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.agrona.CloseHelper;
 import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.cluster.service.Cluster.Role.LEADER;
@@ -38,1621 +39,1415 @@ import static io.aeron.test.cluster.ClusterTests.*;
 import static io.aeron.test.cluster.TestCluster.*;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.function.Predicate.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
 @ExtendWith(EventLogExtension.class)
 public class ClusterTest
 {
+    @RegisterExtension
+    public final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+
+    private Predicate<String> errorLogFilter = TEST_CLUSTER_DEFAULT_LOG_FILTER;
+
     private TestCluster cluster = null;
 
     @AfterEach
-    void after()
+    void tearDown()
     {
-        CloseHelper.close(cluster);
+        assertEquals(0, clusterTestWatcher.errorCount(errorLogFilter), "Errors observed in cluster test");
     }
 
     @Test
     @Timeout(30)
-    public void shouldStopFollowerAndRestartFollower(final TestInfo testInfo)
+    public void shouldStopFollowerAndRestartFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            TestNode follower = cluster.followers().get(0);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(follower);
-            cluster.stopNode(follower);
+        cluster.awaitLeader();
+        TestNode follower = cluster.followers().get(0);
 
-            follower = cluster.startStaticNode(follower.index(), false);
+        awaitElectionClosed(follower);
+        cluster.stopNode(follower);
 
-            awaitElectionClosed(follower);
-            assertEquals(FOLLOWER, follower.role());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        follower = cluster.startStaticNode(follower.index(), false);
+
+        awaitElectionClosed(follower);
+        assertEquals(FOLLOWER, follower.role());
     }
 
     @Test
     @Timeout(40)
-    public void shouldNotifyClientOfNewLeader(final TestInfo testInfo)
+    public void shouldNotifyClientOfNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.connectClient();
-            cluster.awaitActiveSessionCount(cluster.followers().get(0), 1);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.stopNode(leader);
-            cluster.awaitNewLeadershipEvent(1);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.connectClient();
+        cluster.awaitActiveSessionCount(cluster.followers().get(0), 1);
+
+        cluster.stopNode(leader);
+        cluster.awaitNewLeadershipEvent(1);
     }
 
     @Test
     @Timeout(30)
-    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot(final TestInfo testInfo)
+    public void shouldStopLeaderAndFollowersThenRestartAllWithSnapshot()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.stopAllNodes();
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-            assertEquals(2, cluster.followers().size());
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            cluster.awaitSnapshotsLoaded();
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopAllNodes();
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+        assertEquals(2, cluster.followers().size());
+
+        cluster.awaitSnapshotsLoaded();
     }
 
     @Test
     @Timeout(30)
-    public void shouldShutdownClusterAndRestartWithSnapshots(final TestInfo testInfo)
+    public void shouldShutdownClusterAndRestartWithSnapshots()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.node(0).isTerminationExpected(true);
-            cluster.node(1).isTerminationExpected(true);
-            cluster.node(2).isTerminationExpected(true);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.shutdownCluster(leader);
-            cluster.awaitNodeTerminations();
+        cluster.node(0).isTerminationExpected(true);
+        cluster.node(1).isTerminationExpected(true);
+        cluster.node(2).isTerminationExpected(true);
 
-            assertTrue(cluster.node(0).service().wasSnapshotTaken());
-            assertTrue(cluster.node(1).service().wasSnapshotTaken());
-            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+        cluster.shutdownCluster(leader);
+        cluster.awaitNodeTerminations();
 
-            cluster.stopAllNodes();
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-            assertEquals(2, cluster.followers().size());
+        assertTrue(cluster.node(0).service().wasSnapshotTaken());
+        assertTrue(cluster.node(1).service().wasSnapshotTaken());
+        assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
-            cluster.awaitSnapshotsLoaded();
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopAllNodes();
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+        assertEquals(2, cluster.followers().size());
+
+        cluster.awaitSnapshotsLoaded();
     }
 
     @Test
     @Timeout(30)
-    public void shouldAbortClusterAndRestart(final TestInfo testInfo)
+    public void shouldAbortClusterAndRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.node(0).isTerminationExpected(true);
-            cluster.node(1).isTerminationExpected(true);
-            cluster.node(2).isTerminationExpected(true);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.abortCluster(leader);
-            cluster.awaitNodeTerminations();
+        cluster.node(0).isTerminationExpected(true);
+        cluster.node(1).isTerminationExpected(true);
+        cluster.node(2).isTerminationExpected(true);
 
-            assertFalse(cluster.node(0).service().wasSnapshotTaken());
-            assertFalse(cluster.node(1).service().wasSnapshotTaken());
-            assertFalse(cluster.node(2).service().wasSnapshotTaken());
+        cluster.abortCluster(leader);
+        cluster.awaitNodeTerminations();
 
-            cluster.stopAllNodes();
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-            assertEquals(2, cluster.followers().size());
+        assertFalse(cluster.node(0).service().wasSnapshotTaken());
+        assertFalse(cluster.node(1).service().wasSnapshotTaken());
+        assertFalse(cluster.node(2).service().wasSnapshotTaken());
 
-            assertFalse(cluster.node(0).service().wasSnapshotLoaded());
-            assertFalse(cluster.node(1).service().wasSnapshotLoaded());
-            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopAllNodes();
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+        assertEquals(2, cluster.followers().size());
+
+        assertFalse(cluster.node(0).service().wasSnapshotLoaded());
+        assertFalse(cluster.node(1).service().wasSnapshotLoaded());
+        assertFalse(cluster.node(2).service().wasSnapshotLoaded());
     }
 
     @Test
     @Timeout(30)
-    public void shouldAbortClusterOnTerminationTimeout(final TestInfo testInfo)
+    public void shouldAbortClusterOnTerminationTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
+        clusterTestWatcher.cluster(cluster);
 
-            assertEquals(2, followers.size());
-            final TestNode followerA = followers.get(0);
-            final TestNode followerB = followers.get(1);
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
 
-            leader.isTerminationExpected(true);
-            followerA.isTerminationExpected(true);
+        assertEquals(2, followers.size());
+        final TestNode followerA = followers.get(0);
+        final TestNode followerB = followers.get(1);
 
-            cluster.stopNode(followerB);
+        leader.isTerminationExpected(true);
+        followerA.isTerminationExpected(true);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        cluster.stopNode(followerB);
 
-            cluster.abortCluster(leader);
-            cluster.awaitNodeTermination(leader);
-            cluster.awaitNodeTermination(followerA);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            cluster.stopNode(leader);
-            cluster.stopNode(followerA);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.abortCluster(leader);
+        cluster.awaitNodeTermination(leader);
+        cluster.awaitNodeTermination(followerA);
+
+        cluster.stopNode(leader);
+        cluster.stopNode(followerA);
     }
 
     @Test
     @Timeout(40)
-    public void shouldEchoMessages(final TestInfo testInfo)
+    public void shouldEchoMessages()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            cluster.connectClient();
+        clusterTestWatcher.cluster(cluster);
 
-            final int expectedCount = 10;
+        cluster.awaitLeader();
+        cluster.connectClient();
 
-            cluster.sendMessages(expectedCount);
-            cluster.awaitResponseMessageCount(expectedCount);
-            cluster.awaitServicesMessageCount(expectedCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final int expectedCount = 10;
+
+        cluster.sendMessages(expectedCount);
+        cluster.awaitResponseMessageCount(expectedCount);
+        cluster.awaitServicesMessageCount(expectedCount);
     }
 
     @Test
     @Timeout(40)
-    public void shouldHandleLeaderFailOverWhenNameIsNotResolvable(final TestInfo testInfo)
+    public void shouldHandleLeaderFailOverWhenNameIsNotResolvable()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
-            cluster.connectClient();
+        clusterTestWatcher.cluster(cluster);
+        errorLogFilter = errorLogFilter.and(not(UNKNOWN_HOST_FILTER));
 
-            final int expectedCount = 10;
+        final TestNode originalLeader = cluster.awaitLeader();
+        cluster.connectClient();
 
-            cluster.sendMessages(expectedCount);
-            cluster.awaitResponseMessageCount(expectedCount);
-            cluster.awaitServicesMessageCount(expectedCount);
+        final int expectedCount = 10;
 
-            cluster.disableNameResolution(originalLeader.hostname());
-            originalLeader.close();
+        cluster.sendMessages(expectedCount);
+        cluster.awaitResponseMessageCount(expectedCount);
+        cluster.awaitServicesMessageCount(expectedCount);
 
-            cluster.awaitLeader();
+        cluster.disableNameResolution(originalLeader.hostname());
+        originalLeader.close();
 
-            cluster.sendMessages(expectedCount);
-            cluster.awaitResponseMessageCount(2 * expectedCount);
-            cluster.awaitServicesMessageCount(2 * expectedCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitLeader();
+
+        cluster.sendMessages(expectedCount);
+        cluster.awaitResponseMessageCount(2 * expectedCount);
+        cluster.awaitServicesMessageCount(2 * expectedCount);
     }
 
     @Test
     @Timeout(20)
-    public void shouldHandleClusterStartWhenANameIsNotResolvable(final TestInfo testInfo)
+    public void shouldHandleClusterStartWhenANameIsNotResolvable()
     {
         final int initiallyUnresolvableNodeId = 1;
 
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(initiallyUnresolvableNodeId).start();
-        try
-        {
-            cluster.awaitLeader();
-            cluster.connectClient();
+        clusterTestWatcher.cluster(cluster);
+        errorLogFilter = not(UNKNOWN_HOST_FILTER);
 
-            final int expectedCount = 10;
+        cluster.awaitLeader();
+        cluster.connectClient();
 
-            cluster.sendMessages(expectedCount);
-            cluster.awaitResponseMessageCount(expectedCount);
-            cluster.awaitServicesMessageCount(expectedCount);
+        final int expectedCount = 10;
 
-            cluster.restoreNameResolution(initiallyUnresolvableNodeId);
-            assertNotNull(cluster.startStaticNode(initiallyUnresolvableNodeId, true));
+        cluster.sendMessages(expectedCount);
+        cluster.awaitResponseMessageCount(expectedCount);
+        cluster.awaitServicesMessageCount(expectedCount);
 
-            cluster.awaitServiceMessageCount(cluster.node(initiallyUnresolvableNodeId), expectedCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.restoreNameResolution(initiallyUnresolvableNodeId);
+        assertNotNull(cluster.startStaticNode(initiallyUnresolvableNodeId, true));
+
+        cluster.awaitServiceMessageCount(cluster.node(initiallyUnresolvableNodeId), expectedCount);
     }
 
     @Test
     @Timeout(10)
-    public void shouldHandleClusterStartWhereMostNamesBecomeResolvableDuringElection(final TestInfo testInfo)
+    public void shouldHandleClusterStartWhereMostNamesBecomeResolvableDuringElection()
     {
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(0).withInvalidNameResolution(2).start();
-        try
-        {
-            awaitElectionState(cluster.node(1), ElectionState.CANVASS);
+        clusterTestWatcher.cluster(cluster);
+        errorLogFilter = errorLogFilter.and(not(UNKNOWN_HOST_FILTER));
 
-            cluster.restoreNameResolution(0);
-            cluster.restoreNameResolution(2);
-            assertNotNull(cluster.startStaticNode(0, true));
-            assertNotNull(cluster.startStaticNode(2, true));
+        awaitElectionState(cluster.node(1), ElectionState.CANVASS);
 
-            cluster.awaitLeader();
-            cluster.connectClient();
+        cluster.restoreNameResolution(0);
+        cluster.restoreNameResolution(2);
+        assertNotNull(cluster.startStaticNode(0, true));
+        assertNotNull(cluster.startStaticNode(2, true));
 
-            final int expectedCount = 10;
-            cluster.sendMessages(expectedCount);
-            cluster.awaitResponseMessageCount(expectedCount);
-            cluster.awaitServicesMessageCount(expectedCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitLeader();
+        cluster.connectClient();
+
+        final int expectedCount = 10;
+        cluster.sendMessages(expectedCount);
+        cluster.awaitResponseMessageCount(expectedCount);
+        cluster.awaitServicesMessageCount(expectedCount);
     }
 
     @Test
     @Timeout(40)
-    public void shouldEchoMessagesThenContinueOnNewLeader(final TestInfo testInfo)
+    public void shouldEchoMessagesThenContinueOnNewLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
-            cluster.connectClient();
+        clusterTestWatcher.cluster(cluster);
 
-            final int preFailureMessageCount = 10;
-            final int postFailureMessageCount = 7;
+        final TestNode originalLeader = cluster.awaitLeader();
+        cluster.connectClient();
 
-            cluster.sendMessages(preFailureMessageCount);
-            cluster.awaitResponseMessageCount(preFailureMessageCount);
-            cluster.awaitServicesMessageCount(preFailureMessageCount);
+        final int preFailureMessageCount = 10;
+        final int postFailureMessageCount = 7;
 
-            assertEquals(originalLeader.index(), cluster.client().leaderMemberId());
+        cluster.sendMessages(preFailureMessageCount);
+        cluster.awaitResponseMessageCount(preFailureMessageCount);
+        cluster.awaitServicesMessageCount(preFailureMessageCount);
 
-            cluster.stopNode(originalLeader);
+        assertEquals(originalLeader.index(), cluster.client().leaderMemberId());
 
-            final TestNode newLeader = cluster.awaitLeader(originalLeader.index());
-            cluster.awaitNewLeadershipEvent(1);
-            assertEquals(newLeader.index(), cluster.client().leaderMemberId());
+        cluster.stopNode(originalLeader);
 
-            cluster.sendMessages(postFailureMessageCount);
-            cluster.awaitResponseMessageCount(preFailureMessageCount + postFailureMessageCount);
+        final TestNode newLeader = cluster.awaitLeader(originalLeader.index());
+        cluster.awaitNewLeadershipEvent(1);
+        assertEquals(newLeader.index(), cluster.client().leaderMemberId());
 
-            final TestNode follower = cluster.followers().get(0);
+        cluster.sendMessages(postFailureMessageCount);
+        cluster.awaitResponseMessageCount(preFailureMessageCount + postFailureMessageCount);
 
-            cluster.awaitServiceMessageCount(newLeader, preFailureMessageCount + postFailureMessageCount);
-            cluster.awaitServiceMessageCount(follower, preFailureMessageCount + postFailureMessageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode follower = cluster.followers().get(0);
+
+        cluster.awaitServiceMessageCount(newLeader, preFailureMessageCount + postFailureMessageCount);
+        cluster.awaitServiceMessageCount(follower, preFailureMessageCount + postFailureMessageCount);
     }
 
     @Test
     @Timeout(40)
-    public void shouldStopLeaderAndRestartAsFollower(final TestInfo testInfo)
+    public void shouldStopLeaderAndRestartAsFollower()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.stopNode(originalLeader);
-            cluster.awaitLeader(originalLeader.index());
+        final TestNode originalLeader = cluster.awaitLeader();
 
-            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+        cluster.stopNode(originalLeader);
+        cluster.awaitLeader(originalLeader.index());
 
-            awaitElectionClosed(follower);
-            assertEquals(FOLLOWER, follower.role());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+
+        awaitElectionClosed(follower);
+        assertEquals(FOLLOWER, follower.role());
     }
 
     @Test
     @Timeout(40)
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter(final TestInfo testInfo)
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfter()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.stopNode(originalLeader);
-            cluster.awaitLeader(originalLeader.index());
+        final TestNode originalLeader = cluster.awaitLeader();
 
-            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+        cluster.stopNode(originalLeader);
+        cluster.awaitLeader(originalLeader.index());
 
-            awaitElectionClosed(follower);
-            assertEquals(FOLLOWER, follower.role());
+        final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        awaitElectionClosed(follower);
+        assertEquals(FOLLOWER, follower.role());
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
     }
 
     @Test
     @Timeout(60)
-    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader(final TestInfo testInfo)
+    public void shouldStopLeaderAndRestartAsFollowerWithSendingAfterThenStopLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.stopNode(originalLeader);
-            cluster.awaitLeader(originalLeader.index());
+        final TestNode originalLeader = cluster.awaitLeader();
 
-            final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
-            awaitElectionClosed(follower);
+        cluster.stopNode(originalLeader);
+        cluster.awaitLeader(originalLeader.index());
 
-            assertEquals(FOLLOWER, follower.role());
+        final TestNode follower = cluster.startStaticNode(originalLeader.index(), false);
+        awaitElectionClosed(follower);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        assertEquals(FOLLOWER, follower.role());
 
-            final TestNode leader = cluster.awaitLeader();
-            cluster.stopNode(leader);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            cluster.awaitLeader(leader.index());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode leader = cluster.awaitLeader();
+        cluster.stopNode(leader);
+
+        cluster.awaitLeader(leader.index());
     }
 
     @Test
     @Timeout(40)
-    public void shouldAcceptMessagesAfterSingleNodeCleanRestart(final TestInfo testInfo)
+    public void shouldAcceptMessagesAfterSingleNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            TestNode follower = cluster.followers().get(0);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(follower);
-            cluster.stopNode(follower);
+        cluster.awaitLeader();
+        TestNode follower = cluster.followers().get(0);
 
-            follower = cluster.startStaticNode(follower.index(), true);
+        awaitElectionClosed(follower);
+        cluster.stopNode(follower);
 
-            awaitElectionClosed(cluster.node(follower.index()));
-            assertEquals(FOLLOWER, follower.role());
+        follower = cluster.startStaticNode(follower.index(), true);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(follower, messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        awaitElectionClosed(cluster.node(follower.index()));
+        assertEquals(FOLLOWER, follower.role());
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(follower, messageCount);
     }
 
     @Test
     @Timeout(40)
-    public void shouldReplaySnapshotTakenWhileDown(final TestInfo testInfo)
+    public void shouldReplaySnapshotTakenWhileDown()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerA = followers.get(0);
-            TestNode followerB = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(followerB);
-            cluster.stopNode(followerB);
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerA = followers.get(0);
+        TestNode followerB = followers.get(1);
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(leader, 1);
-            cluster.awaitSnapshotCount(followerA, 1);
+        awaitElectionClosed(followerB);
+        cluster.stopNode(followerB);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(leader, 1);
+        cluster.awaitSnapshotCount(followerA, 1);
 
-            followerB = cluster.startStaticNode(followerB.index(), false);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            cluster.awaitSnapshotCount(followerB, 1);
-            assertEquals(FOLLOWER, followerB.role());
+        followerB = cluster.startStaticNode(followerB.index(), false);
 
-            cluster.awaitServiceMessageCount(followerB, messageCount);
-            assertEquals(0L, followerB.errors());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitSnapshotCount(followerB, 1);
+        assertEquals(FOLLOWER, followerB.role());
+
+        cluster.awaitServiceMessageCount(followerB, messageCount);
+        assertEquals(0L, followerB.errors());
     }
 
     @Test
     @Timeout(50)
-    public void shouldTolerateMultipleLeaderFailures(final TestInfo testInfo)
+    public void shouldTolerateMultipleLeaderFailures()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode firstLeader = cluster.awaitLeader();
-            cluster.stopNode(firstLeader);
+        clusterTestWatcher.cluster(cluster);
 
-            final TestNode secondLeader = cluster.awaitLeader();
+        final TestNode firstLeader = cluster.awaitLeader();
+        cluster.stopNode(firstLeader);
 
-            final long commitPos = secondLeader.commitPosition();
-            final TestNode newFollower = cluster.startStaticNode(firstLeader.index(), false);
+        final TestNode secondLeader = cluster.awaitLeader();
 
-            cluster.awaitCommitPosition(newFollower, commitPos);
-            awaitElectionClosed(newFollower);
+        final long commitPos = secondLeader.commitPosition();
+        final TestNode newFollower = cluster.startStaticNode(firstLeader.index(), false);
 
-            cluster.stopNode(secondLeader);
-            cluster.awaitLeader();
+        cluster.awaitCommitPosition(newFollower, commitPos);
+        awaitElectionClosed(newFollower);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopNode(secondLeader);
+        cluster.awaitLeader();
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
     }
 
     @Test
     @Timeout(90)
-    public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime(final TestInfo testInfo)
+    public void shouldRecoverAfterTwoLeadersNodesFailAndComeBackUpAtSameTime()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode firstLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 1_000_000; // Add enough messages so replay takes some time
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.closeClient();
+        final TestNode firstLeader = cluster.awaitLeader();
 
-            cluster.awaitActiveSessionCount(firstLeader, 0);
-            cluster.awaitActiveSessionCount(cluster.followers().get(0), 0);
-            cluster.awaitActiveSessionCount(cluster.followers().get(1), 0);
+        final int messageCount = 1_000_000; // Add enough messages so replay takes some time
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.closeClient();
 
-            cluster.stopNode(firstLeader);
+        cluster.awaitActiveSessionCount(firstLeader, 0);
+        cluster.awaitActiveSessionCount(cluster.followers().get(0), 0);
+        cluster.awaitActiveSessionCount(cluster.followers().get(1), 0);
 
-            final TestNode secondLeader = cluster.awaitLeader();
-            cluster.stopNode(secondLeader);
+        cluster.stopNode(firstLeader);
 
-            cluster.startStaticNode(firstLeader.index(), false);
-            cluster.startStaticNode(secondLeader.index(), false);
-            cluster.awaitLeader();
+        final TestNode secondLeader = cluster.awaitLeader();
+        cluster.stopNode(secondLeader);
 
-            cluster.connectClient();
-            cluster.sendMessages(10);
-            cluster.awaitResponseMessageCount(messageCount + 10);
-            cluster.awaitServicesMessageCount(messageCount + 10);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.startStaticNode(firstLeader.index(), false);
+        cluster.startStaticNode(secondLeader.index(), false);
+        cluster.awaitLeader();
+
+        cluster.connectClient();
+        cluster.sendMessages(10);
+        cluster.awaitResponseMessageCount(messageCount + 10);
+        cluster.awaitServicesMessageCount(messageCount + 10);
     }
 
     @Test
     @Timeout(30)
-    public void shouldAcceptMessagesAfterTwoNodeCleanRestart(final TestInfo testInfo)
+    public void shouldAcceptMessagesAfterTwoNodeCleanRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            TestNode followerA = followers.get(0), followerB = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(followerA);
-            awaitElectionClosed(followerB);
+        cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        TestNode followerA = followers.get(0), followerB = followers.get(1);
 
-            cluster.stopNode(followerA);
-            cluster.stopNode(followerB);
+        awaitElectionClosed(followerA);
+        awaitElectionClosed(followerB);
 
-            followerA = cluster.startStaticNode(followerA.index(), true);
-            followerB = cluster.startStaticNode(followerB.index(), true);
+        cluster.stopNode(followerA);
+        cluster.stopNode(followerB);
 
-            awaitElectionClosed(followerA);
-            awaitElectionClosed(followerB);
+        followerA = cluster.startStaticNode(followerA.index(), true);
+        followerB = cluster.startStaticNode(followerB.index(), true);
 
-            assertEquals(FOLLOWER, followerA.role());
-            assertEquals(FOLLOWER, followerB.role());
+        awaitElectionClosed(followerA);
+        awaitElectionClosed(followerB);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(followerA, messageCount);
-            cluster.awaitServiceMessageCount(followerB, messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        assertEquals(FOLLOWER, followerA.role());
+        assertEquals(FOLLOWER, followerB.role());
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(followerA, messageCount);
+        cluster.awaitServiceMessageCount(followerB, messageCount);
     }
 
     @Test
     @Timeout(60)
-    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos(
-        final TestInfo testInfo)
+    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosExceedsPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        TestNode followerA = followers.get(0), followerB = followers.get(1);
+
+        cluster.connectClient();
+
+        cluster.stopNode(followerA);
+        cluster.stopNode(followerB);
+
+        cluster.sendUnexpectedMessages(10);
+
+        final long commitPosition = leader.commitPosition();
+        while (leader.appendPosition() <= commitPosition)
         {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            TestNode followerA = followers.get(0), followerB = followers.get(1);
-
-            cluster.connectClient();
-
-            cluster.stopNode(followerA);
-            cluster.stopNode(followerB);
-
-            cluster.sendUnexpectedMessages(10);
-
-            final long commitPosition = leader.commitPosition();
-            while (leader.appendPosition() <= commitPosition)
-            {
-                Tests.yield();
-            }
-
-            final long targetPosition = leader.appendPosition();
-            cluster.stopNode(leader);
-            cluster.closeClient();
-
-            followerA = cluster.startStaticNode(followerA.index(), false);
-            followerB = cluster.startStaticNode(followerB.index(), false);
-
-            cluster.awaitLeader();
-
-            awaitElectionClosed(followerA);
-            awaitElectionClosed(followerB);
-
-            cluster.connectClient();
-
-            final int messageLength = 128;
-            int messageCount = 0;
-            while (followerA.commitPosition() < targetPosition)
-            {
-                cluster.pollUntilMessageSent(messageLength);
-                messageCount++;
-            }
-
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(followerA, messageCount);
-            cluster.awaitServiceMessageCount(followerB, messageCount);
-
-            final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
-            cluster.awaitServiceMessageCount(oldLeader, messageCount);
+            Tests.yield();
         }
-        catch (final Throwable ex)
+
+        final long targetPosition = leader.appendPosition();
+        cluster.stopNode(leader);
+        cluster.closeClient();
+
+        followerA = cluster.startStaticNode(followerA.index(), false);
+        followerB = cluster.startStaticNode(followerB.index(), false);
+
+        cluster.awaitLeader();
+
+        awaitElectionClosed(followerA);
+        awaitElectionClosed(followerB);
+
+        cluster.connectClient();
+
+        final int messageLength = 128;
+        int messageCount = 0;
+        while (followerA.commitPosition() < targetPosition)
         {
-            cluster.dumpData(testInfo, ex);
+            cluster.pollUntilMessageSent(messageLength);
+            messageCount++;
         }
+
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(followerA, messageCount);
+        cluster.awaitServiceMessageCount(followerB, messageCount);
+
+        final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
+        cluster.awaitServiceMessageCount(oldLeader, messageCount);
     }
 
     @Test
     @Timeout(30)
-    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos(
-        final TestInfo testInfo)
+    public void shouldRecoverWithUncommittedMessagesAfterRestartWhenNewCommitPosIsLessThanPreviousAppendedPos()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerA = followers.get(0);
+        final TestNode followerB = followers.get(1);
+
+        cluster.connectClient();
+
+        cluster.stopNode(followerA);
+        cluster.stopNode(followerB);
+
+        final int messageCount = 10;
+        cluster.sendUnexpectedMessages(messageCount);
+
+        final long commitPosition = leader.commitPosition();
+        while (leader.appendPosition() <= commitPosition)
         {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerA = followers.get(0);
-            final TestNode followerB = followers.get(1);
-
-            cluster.connectClient();
-
-            cluster.stopNode(followerA);
-            cluster.stopNode(followerB);
-
-            final int messageCount = 10;
-            cluster.sendUnexpectedMessages(messageCount);
-
-            final long commitPosition = leader.commitPosition();
-            while (leader.appendPosition() <= commitPosition)
-            {
-                Tests.yield();
-            }
-
-            cluster.stopNode(leader);
-            cluster.closeClient();
-
-            cluster.startStaticNode(followerA.index(), false);
-            cluster.startStaticNode(followerB.index(), false);
-            cluster.awaitLeader();
-
-            final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
-            awaitElectionClosed(oldLeader);
-
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+            Tests.yield();
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+
+        cluster.stopNode(leader);
+        cluster.closeClient();
+
+        cluster.startStaticNode(followerA.index(), false);
+        cluster.startStaticNode(followerB.index(), false);
+        cluster.awaitLeader();
+
+        final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
+        awaitElectionClosed(oldLeader);
+
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
     }
 
     @Test
     @Timeout(40)
-    public void shouldCallOnRoleChangeOnBecomingLeader(final TestInfo testInfo)
+    public void shouldCallOnRoleChangeOnBecomingLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leaderOne = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerA = followers.get(0);
-            final TestNode followerB = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(followerA);
-            awaitElectionClosed(followerB);
+        final TestNode leaderOne = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerA = followers.get(0);
+        final TestNode followerB = followers.get(1);
 
-            assertEquals(LEADER, leaderOne.service().roleChangedTo());
-            assertNull(followerA.service().roleChangedTo());
-            assertNull(followerB.service().roleChangedTo());
+        awaitElectionClosed(followerA);
+        awaitElectionClosed(followerB);
 
-            cluster.stopNode(leaderOne);
+        assertEquals(LEADER, leaderOne.service().roleChangedTo());
+        assertNull(followerA.service().roleChangedTo());
+        assertNull(followerB.service().roleChangedTo());
 
-            final TestNode leaderTwo = cluster.awaitLeader(leaderOne.index());
-            final TestNode follower = cluster.followers().get(0);
+        cluster.stopNode(leaderOne);
 
-            assertEquals(LEADER, leaderTwo.service().roleChangedTo());
-            assertNull(follower.service().roleChangedTo());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode leaderTwo = cluster.awaitLeader(leaderOne.index());
+        final TestNode follower = cluster.followers().get(0);
+
+        assertEquals(LEADER, leaderTwo.service().roleChangedTo());
+        assertNull(follower.service().roleChangedTo());
     }
 
     @Test
     @Timeout(40)
-    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers(final TestInfo testInfo)
+    public void shouldLoseLeadershipWhenNoActiveQuorumOfFollowers()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final TestNode.TestService service = leader.service();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerA = followers.get(0);
+        final TestNode followerB = followers.get(1);
+
+        assertEquals(LEADER, leader.role());
+        assertEquals(LEADER, service.roleChangedTo());
+
+        awaitElectionClosed(followerA);
+        awaitElectionClosed(followerB);
+
+        cluster.stopNode(followerA);
+        cluster.stopNode(followerB);
+
+        while (service.roleChangedTo() != FOLLOWER)
         {
-            final TestNode leader = cluster.awaitLeader();
-            final TestNode.TestService service = leader.service();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerA = followers.get(0);
-            final TestNode followerB = followers.get(1);
-
-            assertEquals(LEADER, leader.role());
-            assertEquals(LEADER, service.roleChangedTo());
-
-            awaitElectionClosed(followerA);
-            awaitElectionClosed(followerB);
-
-            cluster.stopNode(followerA);
-            cluster.stopNode(followerB);
-
-            while (service.roleChangedTo() != FOLLOWER)
-            {
-                Tests.sleep(100);
-            }
-            assertEquals(FOLLOWER, leader.role());
+            Tests.sleep(100);
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        assertEquals(FOLLOWER, leader.role());
     }
 
     @Test
     @Timeout(30)
-    public void shouldTerminateLeaderWhenServiceStops(final TestInfo testInfo)
+    public void shouldTerminateLeaderWhenServiceStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        cluster.connectClient();
+
+        leader.isTerminationExpected(true);
+        leader.container().close();
+
+        while (!leader.hasMemberTerminated())
         {
-            final TestNode leader = cluster.awaitLeader();
-            cluster.connectClient();
-
-            leader.isTerminationExpected(true);
-            leader.container().close();
-
-            while (!leader.hasMemberTerminated())
-            {
-                Tests.sleep(1);
-            }
-
-            cluster.awaitNewLeadershipEvent(1);
+            Tests.sleep(1);
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+
+        cluster.awaitNewLeadershipEvent(1);
     }
 
     @Test
     @Timeout(30)
-    public void shouldEnterElectionWhenRecordingStopsOnLeader(final TestInfo testInfo)
+    public void shouldEnterElectionWhenRecordingStopsOnLeader()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        cluster.connectClient();
+
+        final AeronArchive.Context archiveCtx = new AeronArchive.Context()
+            .controlRequestChannel(leader.archive().context().localControlChannel())
+            .controlResponseChannel(leader.archive().context().localControlChannel())
+            .controlRequestStreamId(leader.archive().context().localControlStreamId())
+            .aeronDirectoryName(leader.mediaDriver().aeronDirectoryName());
+
+        try (AeronArchive archive = AeronArchive.connect(archiveCtx))
         {
-            final TestNode leader = cluster.awaitLeader();
-            cluster.connectClient();
-
-            final AeronArchive.Context archiveCtx = new AeronArchive.Context()
-                .controlRequestChannel(leader.archive().context().localControlChannel())
-                .controlResponseChannel(leader.archive().context().localControlChannel())
-                .controlRequestStreamId(leader.archive().context().localControlStreamId())
-                .aeronDirectoryName(leader.mediaDriver().aeronDirectoryName());
-
-            try (AeronArchive archive = AeronArchive.connect(archiveCtx))
-            {
-                final int firstRecordingIdIsTheClusterLog = 0;
-                assertTrue(archive.tryStopRecordingByIdentity(firstRecordingIdIsTheClusterLog));
-            }
-
-            cluster.awaitNewLeadershipEvent(1);
-            cluster.followers(2);
+            final int firstRecordingIdIsTheClusterLog = 0;
+            assertTrue(archive.tryStopRecordingByIdentity(firstRecordingIdIsTheClusterLog));
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+
+        cluster.awaitNewLeadershipEvent(1);
+        cluster.followers(2);
     }
 
     @Test
     @Timeout(30)
-    public void shouldRecoverFollowerWhenRecordingStops(final TestInfo testInfo)
+    public void shouldRecoverFollowerWhenRecordingStops()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        cluster.awaitLeader();
+
+        final TestNode follower = cluster.followers().get(0);
+        final AeronArchive.Context archiveCtx = new AeronArchive.Context()
+            .controlRequestChannel(follower.archive().context().localControlChannel())
+            .controlResponseChannel(follower.archive().context().localControlChannel())
+            .controlRequestStreamId(follower.archive().context().localControlStreamId())
+            .aeronDirectoryName(follower.mediaDriver().aeronDirectoryName());
+
+        try (AeronArchive archive = AeronArchive.connect(archiveCtx))
         {
-            cluster.awaitLeader();
-
-            final TestNode follower = cluster.followers().get(0);
-            final AeronArchive.Context archiveCtx = new AeronArchive.Context()
-                .controlRequestChannel(follower.archive().context().localControlChannel())
-                .controlResponseChannel(follower.archive().context().localControlChannel())
-                .controlRequestStreamId(follower.archive().context().localControlStreamId())
-                .aeronDirectoryName(follower.mediaDriver().aeronDirectoryName());
-
-            try (AeronArchive archive = AeronArchive.connect(archiveCtx))
-            {
-                final int firstRecordingIdIsTheClusterLog = 0;
-                assertTrue(archive.tryStopRecordingByIdentity(firstRecordingIdIsTheClusterLog));
-            }
-
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-
-            cluster.awaitServiceMessageCount(follower, messageCount);
+            final int firstRecordingIdIsTheClusterLog = 0;
+            assertTrue(archive.tryStopRecordingByIdentity(firstRecordingIdIsTheClusterLog));
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.awaitServiceMessageCount(follower, messageCount);
     }
 
     @Test
     @Timeout(20)
-    public void shouldCloseClientOnTimeout(final TestInfo testInfo)
+    public void shouldCloseClientOnTimeout()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+
+        final AeronCluster client = cluster.connectClient();
+        final ConsensusModule.Context context = leader.consensusModule().context();
+        assertEquals(0, context.timedOutClientCounter().get());
+        assertFalse(client.isClosed());
+
+        Tests.sleep(NANOSECONDS.toMillis(context.sessionTimeoutNs()));
+
+        cluster.shouldErrorOnClientClose(false);
+        while (!client.isClosed())
         {
-            final TestNode leader = cluster.awaitLeader();
-
-            final AeronCluster client = cluster.connectClient();
-            final ConsensusModule.Context context = leader.consensusModule().context();
-            assertEquals(0, context.timedOutClientCounter().get());
-            assertFalse(client.isClosed());
-
-            Tests.sleep(NANOSECONDS.toMillis(context.sessionTimeoutNs()));
-
-            cluster.shouldErrorOnClientClose(false);
-            while (!client.isClosed())
-            {
-                Tests.sleep(1);
-                client.pollEgress();
-            }
-
-            assertEquals(1, context.timedOutClientCounter().get());
+            Tests.sleep(1);
+            client.pollEgress();
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+
+        assertEquals(1, context.timedOutClientCounter().get());
     }
 
     @Test
     @Timeout(40)
-    public void shouldRecoverWhileMessagesContinue(final TestInfo testInfo)
+    public void shouldRecoverWhileMessagesContinue() throws InterruptedException
     {
         cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
+
+        final MutableInteger messageCounter = new MutableInteger();
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerA = followers.get(0);
+        TestNode followerB = followers.get(1);
+
+        cluster.connectClient();
+        final long backoffIntervalNs = MICROSECONDS.toNanos(500);
+        final Thread messageThread = startPublisherThread(cluster, messageCounter, backoffIntervalNs);
+
         try
         {
-            final MutableInteger messageCounter = new MutableInteger();
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerA = followers.get(0);
-            TestNode followerB = followers.get(1);
+            cluster.stopNode(followerB);
+            Tests.sleep(2_000); // keep ingress going so the cluster advances.
 
-            cluster.connectClient();
-            final long backoffIntervalNs = MICROSECONDS.toNanos(500);
-            final Thread messageThread = startPublisherThread(cluster, messageCounter, backoffIntervalNs);
-
-            try
-            {
-                cluster.stopNode(followerB);
-                Tests.sleep(2_000); // keep ingress going so the cluster advances.
-
-                followerB = cluster.startStaticNode(followerB.index(), false);
-                Tests.sleep(2_000); // keep ingress going a while after catchup.
-                awaitElectionClosed(followerB);
-            }
-            finally
-            {
-                messageThread.interrupt();
-                messageThread.join();
-            }
-
-            cluster.awaitResponseMessageCount(messageCounter.get());
-            cluster.client().close();
-            cluster.awaitActiveSessionCount(0);
-
-            assertEquals(0L, leader.errors());
-            assertEquals(0L, followerA.errors());
-            assertEquals(0L, followerB.errors());
+            followerB = cluster.startStaticNode(followerB.index(), false);
+            Tests.sleep(2_000); // keep ingress going a while after catchup.
+            awaitElectionClosed(followerB);
         }
-        catch (final Throwable ex)
+        finally
         {
-            cluster.dumpData(testInfo, ex);
+            messageThread.interrupt();
+            messageThread.join();
         }
+
+        cluster.awaitResponseMessageCount(messageCounter.get());
+        cluster.client().close();
+        cluster.awaitActiveSessionCount(0);
+
+        assertEquals(0L, leader.errors());
+
+        assertEquals(0L, followerA.errors());
+
+        assertEquals(0L, followerB.errors());
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchupFromEmptyLog(final TestInfo testInfo)
+    public void shouldCatchupFromEmptyLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            TestNode follower = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(follower);
-            cluster.stopNode(follower);
+        cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        TestNode follower = followers.get(1);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        awaitElectionClosed(follower);
+        cluster.stopNode(follower);
 
-            follower = cluster.startStaticNode(follower.index(), true);
-            cluster.awaitServiceMessageCount(follower, messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        follower = cluster.startStaticNode(follower.index(), true);
+        cluster.awaitServiceMessageCount(follower, messageCount);
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart(final TestInfo testInfo)
+    public void shouldCatchupFromEmptyLogThenSnapshotAfterShutdownAndFollowerCleanStart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers(2);
-            final TestNode followerA = followers.get(0);
-            final TestNode followerB = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers(2);
+        final TestNode followerA = followers.get(0);
+        final TestNode followerB = followers.get(1);
 
-            leader.isTerminationExpected(true);
-            followerA.isTerminationExpected(true);
-            followerB.isTerminationExpected(true);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            cluster.shutdownCluster(leader);
-            cluster.awaitNodeTerminations();
+        leader.isTerminationExpected(true);
+        followerA.isTerminationExpected(true);
+        followerB.isTerminationExpected(true);
 
-            assertTrue(cluster.node(0).service().wasSnapshotTaken());
-            assertTrue(cluster.node(1).service().wasSnapshotTaken());
-            assertTrue(cluster.node(2).service().wasSnapshotTaken());
+        cluster.shutdownCluster(leader);
+        cluster.awaitNodeTerminations();
 
-            cluster.stopAllNodes();
+        assertTrue(cluster.node(0).service().wasSnapshotTaken());
+        assertTrue(cluster.node(1).service().wasSnapshotTaken());
+        assertTrue(cluster.node(2).service().wasSnapshotTaken());
 
-            cluster.startStaticNode(0, false);
-            cluster.startStaticNode(1, false);
-            cluster.startStaticNode(2, true);
+        cluster.stopAllNodes();
 
-            final TestNode newLeader = cluster.awaitLeader();
-            assertNotEquals(2, newLeader.index());
+        cluster.startStaticNode(0, false);
+        cluster.startStaticNode(1, false);
+        cluster.startStaticNode(2, true);
 
-            assertTrue(cluster.node(0).service().wasSnapshotLoaded());
-            assertTrue(cluster.node(1).service().wasSnapshotLoaded());
-            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+        final TestNode newLeader = cluster.awaitLeader();
+        assertNotEquals(2, newLeader.index());
 
-            cluster.awaitServiceMessageCount(cluster.node(2), messageCount);
-            cluster.awaitSnapshotCount(cluster.node(2), 1);
-            assertTrue(cluster.node(2).service().wasSnapshotTaken());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        assertTrue(cluster.node(0).service().wasSnapshotLoaded());
+        assertTrue(cluster.node(1).service().wasSnapshotLoaded());
+        assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+
+        cluster.awaitServiceMessageCount(cluster.node(2), messageCount);
+        cluster.awaitSnapshotCount(cluster.node(2), 1);
+        assertTrue(cluster.node(2).service().wasSnapshotTaken());
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpTwoFreshNodesAfterRestart(final TestInfo testInfo)
+    public void shouldCatchUpTwoFreshNodesAfterRestart()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+
+        final int messageCount = 50_000;
+        cluster.connectClient();
+        cluster.msgBuffer().putStringWithoutLengthAscii(0, NO_OP_MSG);
+        for (int i = 0; i < messageCount; i++)
         {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-
-            final int messageCount = 50_000;
-            cluster.connectClient();
-            cluster.msgBuffer().putStringWithoutLengthAscii(0, NO_OP_MSG);
-            for (int i = 0; i < messageCount; i++)
-            {
-                cluster.pollUntilMessageSent(NO_OP_MSG.length());
-            }
-            cluster.awaitResponseMessageCount(messageCount);
-
-            cluster.terminationsExpected(true);
-            cluster.abortCluster(leader);
-            cluster.awaitNodeTerminations();
-            cluster.stopAllNodes();
-
-            final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
-            final TestNode oldFollower1 = cluster.startStaticNode(followers.get(0).index(), true);
-            final TestNode oldFollower2 = cluster.startStaticNode(followers.get(1).index(), true);
-
-            cluster.awaitLeader();
-            cluster.awaitServicesMessageCount(messageCount);
-
-            assertEquals(0L, oldLeader.errors());
-            assertEquals(0L, oldFollower1.errors());
-            assertEquals(0L, oldFollower2.errors());
+            cluster.pollUntilMessageSent(NO_OP_MSG.length());
         }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.terminationsExpected(true);
+        cluster.abortCluster(leader);
+        cluster.awaitNodeTerminations();
+        cluster.stopAllNodes();
+
+        final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
+        final TestNode oldFollower1 = cluster.startStaticNode(followers.get(0).index(), true);
+        final TestNode oldFollower2 = cluster.startStaticNode(followers.get(1).index(), true);
+
+        cluster.awaitLeader();
+        cluster.awaitServicesMessageCount(messageCount);
+
+        assertEquals(0L, oldLeader.errors());
+        assertEquals(0L, oldFollower1.errors());
+        assertEquals(0L, oldFollower2.errors());
     }
 
     @Test
     @Timeout(30)
-    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog(final TestInfo testInfo)
+    public void shouldReplayMultipleSnapshotsWithEmptyFollowerLog()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+
+        int messageCount = 2;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
+
+        cluster.takeSnapshot(leader);
+        final int memberCount = 3;
+        for (int memberId = 0; memberId < memberCount; memberId++)
         {
-            final TestNode leader = cluster.awaitLeader();
+            final TestNode node = cluster.node(memberId);
+            cluster.awaitSnapshotCount(node, 1);
+            assertTrue(node.service().wasSnapshotTaken());
+            node.service().resetSnapshotTaken();
+        }
 
-            int messageCount = 2;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        cluster.sendMessages(1);
+        messageCount++;
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            cluster.takeSnapshot(leader);
-            final int memberCount = 3;
-            for (int memberId = 0; memberId < memberCount; memberId++)
-            {
-                final TestNode node = cluster.node(memberId);
-                cluster.awaitSnapshotCount(node, 1);
-                assertTrue(node.service().wasSnapshotTaken());
-                node.service().resetSnapshotTaken();
-            }
+        cluster.terminationsExpected(true);
 
+        cluster.awaitNeutralControlToggle(leader);
+        cluster.shutdownCluster(leader);
+        cluster.awaitNodeTerminations();
+
+        assertTrue(cluster.node(0).service().wasSnapshotTaken());
+        assertTrue(cluster.node(1).service().wasSnapshotTaken());
+        assertTrue(cluster.node(2).service().wasSnapshotTaken());
+
+        cluster.stopAllNodes();
+
+        cluster.startStaticNode(0, false);
+        cluster.startStaticNode(1, false);
+        cluster.startStaticNode(2, true);
+
+        final TestNode newLeader = cluster.awaitLeader();
+        assertNotEquals(2, newLeader.index());
+
+        assertTrue(cluster.node(0).service().wasSnapshotLoaded());
+        assertTrue(cluster.node(1).service().wasSnapshotLoaded());
+        assertFalse(cluster.node(2).service().wasSnapshotLoaded());
+
+        assertEquals(messageCount, cluster.node(0).service().messageCount());
+        assertEquals(messageCount, cluster.node(1).service().messageCount());
+
+        // Needs a little time to replay the transactions...
+        Tests.await(() -> cluster.node(2).service().messageCount() >= 3);
+        assertEquals(messageCount, cluster.node(2).service().messageCount());
+
+        final int messageCountAfterStart = 4;
+        cluster.reconnectClient();
+        cluster.sendMessages(messageCountAfterStart);
+        messageCount += messageCountAfterStart;
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne()
+    {
+        cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerOne = followers.get(0);
+        final TestNode followerTwo = followers.get(1);
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.stopNode(followerOne);
+        cluster.stopNode(followerTwo);
+
+        while (leader.role() == LEADER)
+        {
             cluster.sendMessages(1);
-            messageCount++;
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
-
-            cluster.terminationsExpected(true);
-
-            cluster.awaitNeutralControlToggle(leader);
-            cluster.shutdownCluster(leader);
-            cluster.awaitNodeTerminations();
-
-            assertTrue(cluster.node(0).service().wasSnapshotTaken());
-            assertTrue(cluster.node(1).service().wasSnapshotTaken());
-            assertTrue(cluster.node(2).service().wasSnapshotTaken());
-
-            cluster.stopAllNodes();
-
-            cluster.startStaticNode(0, false);
-            cluster.startStaticNode(1, false);
-            cluster.startStaticNode(2, true);
-
-            final TestNode newLeader = cluster.awaitLeader();
-            assertNotEquals(2, newLeader.index());
-
-            assertTrue(cluster.node(0).service().wasSnapshotLoaded());
-            assertTrue(cluster.node(1).service().wasSnapshotLoaded());
-            assertFalse(cluster.node(2).service().wasSnapshotLoaded());
-
-            assertEquals(messageCount, cluster.node(0).service().messageCount());
-            assertEquals(messageCount, cluster.node(1).service().messageCount());
-
-            // Needs a little time to replay the transactions...
-            Tests.await(() -> cluster.node(2).service().messageCount() >= 3);
-            assertEquals(messageCount, cluster.node(2).service().messageCount());
-
-            final int messageCountAfterStart = 4;
-            cluster.reconnectClient();
-            cluster.sendMessages(messageCountAfterStart);
-            messageCount += messageCountAfterStart;
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+            Tests.sleep(500);
         }
-        catch (final Throwable ex)
+
+        cluster.startStaticNode(followerTwo.index(), true);
+        cluster.awaitLeader();
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldRecoverWhenLeaderHasAppendedMoreThanFollower()
+    {
+        cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerOne = followers.get(0);
+        final TestNode followerTwo = followers.get(1);
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.stopNode(followerOne);
+
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 2);
+
+        cluster.stopNode(followerTwo);
+        cluster.stopNode(leader);
+
+        cluster.startStaticNode(leader.index(), false);
+        cluster.startStaticNode(followerOne.index(), false);
+        cluster.awaitLeader();
+    }
+
+    @Test
+    @Timeout(40)
+    public void shouldRecoverWhenFollowerIsMultipleTermsBehind()
+    {
+        cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode originalLeader = cluster.awaitLeader();
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.stopNode(originalLeader);
+        final TestNode newLeader = cluster.awaitLeader();
+        cluster.reconnectClient();
+
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 2);
+
+        cluster.stopNode(newLeader);
+        cluster.startStaticNode(newLeader.index(), false);
+        cluster.awaitLeader();
+        cluster.reconnectClient();
+
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 3);
+
+        cluster.startStaticNode(originalLeader.index(), false);
+        final TestNode lateJoiningNode = cluster.node(originalLeader.index());
+
+        while (lateJoiningNode.service().messageCount() < messageCount * 3)
         {
-            cluster.dumpData(testInfo, ex);
+            Tests.yieldingIdle("Waiting for late joining follower to catch up");
         }
     }
 
     @Test
     @Timeout(40)
-    public void shouldRecoverQuicklyAfterKillingFollowersThenRestartingOne(final TestInfo testInfo)
+    public void shouldRecoverWhenFollowerArrivesPartWayThroughTerm()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerOne = followers.get(0);
-            final TestNode followerTwo = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitLeader();
+        final TestNode followerOne = cluster.followers().get(0);
 
-            cluster.stopNode(followerOne);
-            cluster.stopNode(followerTwo);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            while (leader.role() == LEADER)
-            {
-                cluster.sendMessages(1);
-                Tests.sleep(500);
-            }
+        cluster.stopNode(followerOne);
 
-            cluster.startStaticNode(followerTwo.index(), true);
-            cluster.awaitLeader();
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 2);
+
+        cluster.startStaticNode(followerOne.index(), false);
+
+        // Needs a little time to replay the transactions...
+        Tests.await(() -> cluster.node(followerOne.index()).service().messageCount() >= messageCount * 2);
+        assertEquals(messageCount * 2, cluster.node(followerOne.index()).service().messageCount());
     }
 
     @Test
     @Timeout(40)
-    public void shouldRecoverWhenLeaderHasAppendedMoreThanFollower(final TestInfo testInfo)
+    public void shouldRecoverWhenFollowerArrivePartWayThroughTermAfterMissingElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerOne = followers.get(0);
-            final TestNode followerTwo = followers.get(1);
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
+        final List<TestNode> followers = cluster.followers();
+        final TestNode followerOne = followers.get(0);
+        final TestNode followerTwo = followers.get(1);
 
-            cluster.stopNode(followerOne);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 2);
+        cluster.stopNode(followerOne);
 
-            cluster.stopNode(followerTwo);
-            cluster.stopNode(leader);
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 2);
 
-            cluster.startStaticNode(leader.index(), false);
-            cluster.startStaticNode(followerOne.index(), false);
-            cluster.awaitLeader();
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopNode(followerTwo);
+        cluster.stopNode(leader);
+
+        cluster.startStaticNode(leader.index(), false);
+        cluster.startStaticNode(followerTwo.index(), false);
+        cluster.awaitLeader();
+        cluster.reconnectClient();
+
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount * 3);
+
+        cluster.startStaticNode(followerOne.index(), false);
+
+        // Needs a little time to replay the transactions...
+        Tests.await(() -> cluster.node(followerOne.index()).service().messageCount() >= messageCount * 3);
+        assertEquals(messageCount * 3, cluster.node(followerOne.index()).service().messageCount());
     }
 
     @Test
     @Timeout(40)
-    public void shouldRecoverWhenFollowerIsMultipleTermsBehind(final TestInfo testInfo)
+    void shouldRecoverWhenLastSnapshotIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode originalLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        final TestNode leader0 = cluster.awaitLeader();
 
-            cluster.stopNode(originalLeader);
-            final TestNode newLeader = cluster.awaitLeader();
-            cluster.reconnectClient();
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
 
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 2);
+        cluster.takeSnapshot(leader0);
+        cluster.awaitSnapshotCount(1);
 
-            cluster.stopNode(newLeader);
-            cluster.startStaticNode(newLeader.index(), false);
-            cluster.awaitLeader();
-            cluster.reconnectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitServicesMessageCount(numMessages * 2);
 
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 3);
+        cluster.takeSnapshot(leader0);
+        cluster.awaitSnapshotCount(2);
 
-            cluster.startStaticNode(originalLeader.index(), false);
-            final TestNode lateJoiningNode = cluster.node(originalLeader.index());
+        cluster.stopNode(leader0);
+        cluster.awaitLeader(leader0.index());
+        cluster.awaitNewLeadershipEvent(1);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader0.index(), false);
 
-            while (lateJoiningNode.service().messageCount() < messageCount * 3)
-            {
-                Tests.yieldingIdle("Waiting for late joining follower to catch up");
-            }
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
-    }
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 3);
+        cluster.awaitServicesMessageCount(numMessages * 3);
 
-    @Test
-    @Timeout(40)
-    public void shouldRecoverWhenFollowerArrivesPartWayThroughTerm(final TestInfo testInfo)
-    {
-        cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            final TestNode followerOne = cluster.followers().get(0);
+        cluster.terminationsExpected(true);
+        cluster.stopAllNodes();
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        cluster.invalidateLatestSnapshot();
 
-            cluster.stopNode(followerOne);
-
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 2);
-
-            cluster.startStaticNode(followerOne.index(), false);
-
-            // Needs a little time to replay the transactions...
-            Tests.await(() -> cluster.node(followerOne.index()).service().messageCount() >= messageCount * 2);
-            assertEquals(messageCount * 2, cluster.node(followerOne.index()).service().messageCount());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
-    }
-
-    @Test
-    @Timeout(40)
-    public void shouldRecoverWhenFollowerArrivePartWayThroughTermAfterMissingElection(final TestInfo testInfo)
-    {
-        cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final List<TestNode> followers = cluster.followers();
-            final TestNode followerOne = followers.get(0);
-            final TestNode followerTwo = followers.get(1);
-
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-
-            cluster.stopNode(followerOne);
-
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 2);
-
-            cluster.stopNode(followerTwo);
-            cluster.stopNode(leader);
-
-            cluster.startStaticNode(leader.index(), false);
-            cluster.startStaticNode(followerTwo.index(), false);
-            cluster.awaitLeader();
-            cluster.reconnectClient();
-
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount * 3);
-
-            cluster.startStaticNode(followerOne.index(), false);
-
-            // Needs a little time to replay the transactions...
-            Tests.await(() -> cluster.node(followerOne.index()).service().messageCount() >= messageCount * 3);
-            assertEquals(messageCount * 3, cluster.node(followerOne.index()).service().messageCount());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
-    }
-
-    @Test
-    @Timeout(40)
-    void shouldRecoverWhenLastSnapshotIsMarkedInvalid(final TestInfo testInfo)
-    {
-        cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader0 = cluster.awaitLeader();
-
-            final int numMessages = 3;
-            cluster.connectClient();
-            cluster.sendMessages(numMessages);
-            cluster.awaitServicesMessageCount(numMessages);
-
-            cluster.takeSnapshot(leader0);
-            cluster.awaitSnapshotCount(1);
-
-            cluster.sendMessages(numMessages);
-            cluster.awaitServicesMessageCount(numMessages * 2);
-
-            cluster.takeSnapshot(leader0);
-            cluster.awaitSnapshotCount(2);
-
-            cluster.stopNode(leader0);
-            cluster.awaitLeader(leader0.index());
-            cluster.awaitNewLeadershipEvent(1);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader0.index(), false);
-
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 3);
-            cluster.awaitServicesMessageCount(numMessages * 3);
-
-            cluster.terminationsExpected(true);
-            cluster.stopAllNodes();
-
-            cluster.invalidateLatestSnapshot();
-
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-            cluster.awaitServicesMessageCount(numMessages * 3);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+        cluster.awaitServicesMessageCount(numMessages * 3);
     }
 
     @Test
     @Timeout(30)
-    void shouldRecoverWhenLastSnapshotForShutdownIsMarkedInvalid(final TestInfo testInfo)
+    void shouldRecoverWhenLastSnapshotForShutdownIsMarkedInvalid()
     {
         cluster = aCluster().withStaticNodes(1).start();
-        try
-        {
-            TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int numMessages = 3;
-            cluster.connectClient();
-            cluster.sendMessages(numMessages);
-            cluster.awaitServicesMessageCount(numMessages);
+        TestNode leader = cluster.awaitLeader();
 
-            cluster.stopNode(leader);
-            cluster.startStaticNode(leader.index(), false);
-            leader = cluster.awaitLeader();
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
 
-            cluster.terminationsExpected(true);
-            cluster.shutdownCluster(leader);
-            cluster.awaitNodeTerminations();
-            assertTrue(leader.service().wasSnapshotTaken());
-            cluster.stopNode(leader);
+        cluster.stopNode(leader);
+        cluster.startStaticNode(leader.index(), false);
+        leader = cluster.awaitLeader();
 
-            cluster.invalidateLatestSnapshot();
+        cluster.terminationsExpected(true);
+        cluster.shutdownCluster(leader);
+        cluster.awaitNodeTerminations();
+        assertTrue(leader.service().wasSnapshotTaken());
+        cluster.stopNode(leader);
 
-            cluster.restartAllNodes(false);
-            leader = cluster.awaitLeader();
-            cluster.awaitServicesMessageCount(numMessages);
-            assertTrue(leader.service().wasSnapshotTaken());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.invalidateLatestSnapshot();
+
+        cluster.restartAllNodes(false);
+        leader = cluster.awaitLeader();
+        cluster.awaitServicesMessageCount(numMessages);
+        assertTrue(leader.service().wasSnapshotTaken());
     }
 
     @Test
     @Timeout(60)
-    void shouldHandleMultipleElections(final TestInfo testInfo)
+    void shouldHandleMultipleElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader0 = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int numMessages = 3;
-            cluster.connectClient();
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages);
-            cluster.awaitServicesMessageCount(numMessages);
+        final TestNode leader0 = cluster.awaitLeader();
 
-            cluster.stopNode(leader0);
-            final TestNode leader1 = cluster.awaitLeader(leader0.index());
-            cluster.awaitNewLeadershipEvent(1);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader0.index(), false);
-            awaitElectionClosed(cluster.node(leader0.index()));
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
 
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 2);
-            cluster.awaitServicesMessageCount(numMessages * 2);
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader(leader0.index());
+        cluster.awaitNewLeadershipEvent(1);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader0.index(), false);
+        awaitElectionClosed(cluster.node(leader0.index()));
 
-            cluster.stopNode(leader1);
-            cluster.awaitLeader(leader1.index());
-            cluster.awaitNewLeadershipEvent(2);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader1.index(), false);
-            awaitElectionClosed(cluster.node(leader1.index()));
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 2);
+        cluster.awaitServicesMessageCount(numMessages * 2);
 
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 3);
-            cluster.awaitServicesMessageCount(numMessages * 3);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopNode(leader1);
+        cluster.awaitLeader(leader1.index());
+        cluster.awaitNewLeadershipEvent(2);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader1.index(), false);
+        awaitElectionClosed(cluster.node(leader1.index()));
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 3);
+        cluster.awaitServicesMessageCount(numMessages * 3);
     }
 
     @Test
     @Timeout(50)
-    void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections(final TestInfo testInfo)
+    void shouldRecoverWhenLastSnapshotIsInvalidBetweenTwoElections()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader0 = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int numMessages = 3;
-            cluster.connectClient();
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages);
-            cluster.awaitServicesMessageCount(numMessages);
+        final TestNode leader0 = cluster.awaitLeader();
 
-            cluster.stopNode(leader0);
-            final TestNode leader1 = cluster.awaitLeader(leader0.index());
-            cluster.awaitNewLeadershipEvent(1);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader0.index(), false);
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
 
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 2);
-            cluster.awaitServicesMessageCount(numMessages * 2);
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader(leader0.index());
+        cluster.awaitNewLeadershipEvent(1);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader0.index(), false);
 
-            cluster.takeSnapshot(leader1);
-            cluster.awaitSnapshotCount(1);
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 2);
+        cluster.awaitServicesMessageCount(numMessages * 2);
 
-            cluster.stopNode(leader1);
-            cluster.awaitLeader(leader1.index());
-            cluster.awaitNewLeadershipEvent(2);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader1.index(), false);
+        cluster.takeSnapshot(leader1);
+        cluster.awaitSnapshotCount(1);
 
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 3);
-            cluster.awaitServicesMessageCount(numMessages * 3);
+        cluster.stopNode(leader1);
+        cluster.awaitLeader(leader1.index());
+        cluster.awaitNewLeadershipEvent(2);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader1.index(), false);
 
-            // No snapshot for Term 2
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 3);
+        cluster.awaitServicesMessageCount(numMessages * 3);
 
-            cluster.terminationsExpected(true);
-            cluster.stopAllNodes();
+        // No snapshot for Term 2
 
-            cluster.invalidateLatestSnapshot();
+        cluster.terminationsExpected(true);
+        cluster.stopAllNodes();
 
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-            cluster.awaitServicesMessageCount(numMessages * 3);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.invalidateLatestSnapshot();
+
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+        cluster.awaitServicesMessageCount(numMessages * 3);
     }
 
     @Test
     @Timeout(50)
-    void shouldRecoverWhenLastTwosSnapshotsAreInvalidAfterElection(final TestInfo testInfo)
+    void shouldRecoverWhenLastTwosSnapshotsAreInvalidAfterElection()
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode leader0 = cluster.awaitLeader();
+
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
+
+        cluster.takeSnapshot(leader0);
+        cluster.awaitSnapshotCount(1);
+
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader(leader0.index());
+        cluster.awaitNewLeadershipEvent(1);
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader0.index(), false);
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 2);
+        cluster.awaitServicesMessageCount(numMessages * 2);
+
+        cluster.takeSnapshot(leader1);
+        for (int i = 0; i < 3; i++)
         {
-            final TestNode leader0 = cluster.awaitLeader();
-
-            final int numMessages = 3;
-            cluster.connectClient();
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages);
-            cluster.awaitServicesMessageCount(numMessages);
-
-            cluster.takeSnapshot(leader0);
-            cluster.awaitSnapshotCount(1);
-
-            cluster.stopNode(leader0);
-            final TestNode leader1 = cluster.awaitLeader(leader0.index());
-            cluster.awaitNewLeadershipEvent(1);
-            assertTrue(cluster.client().sendKeepAlive());
-            cluster.startStaticNode(leader0.index(), false);
-
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 2);
-            cluster.awaitServicesMessageCount(numMessages * 2);
-
-            cluster.takeSnapshot(leader1);
-            for (int i = 0; i < 3; i++)
-            {
-                cluster.awaitSnapshotCount(cluster.node(i), leader0.index() == i ? 1 : 2);
-            }
-
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 3);
-            cluster.awaitServicesMessageCount(numMessages * 3);
-
-            cluster.takeSnapshot(leader1);
-            for (int i = 0; i < 3; i++)
-            {
-                cluster.awaitSnapshotCount(cluster.node(i), leader0.index() == i ? 2 : 3);
-            }
-
-            cluster.sendMessages(numMessages);
-            cluster.awaitResponseMessageCount(numMessages * 4);
-            cluster.awaitServicesMessageCount(numMessages * 4);
-
-            cluster.terminationsExpected(true);
-            cluster.stopAllNodes();
-
-            cluster.invalidateLatestSnapshot();
-            cluster.invalidateLatestSnapshot();
-
-            cluster.restartAllNodes(false);
-            cluster.awaitLeader();
-
-            cluster.awaitSnapshotCount(2);
-
-            cluster.awaitServicesMessageCount(numMessages * 4);
+            cluster.awaitSnapshotCount(cluster.node(i), leader0.index() == i ? 1 : 2);
         }
-        catch (final Throwable ex)
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 3);
+        cluster.awaitServicesMessageCount(numMessages * 3);
+
+        cluster.takeSnapshot(leader1);
+        for (int i = 0; i < 3; i++)
         {
-            cluster.dumpData(testInfo, ex);
+            cluster.awaitSnapshotCount(cluster.node(i), leader0.index() == i ? 2 : 3);
         }
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 4);
+        cluster.awaitServicesMessageCount(numMessages * 4);
+
+        cluster.terminationsExpected(true);
+        cluster.stopAllNodes();
+
+        cluster.invalidateLatestSnapshot();
+        cluster.invalidateLatestSnapshot();
+
+        cluster.restartAllNodes(false);
+        cluster.awaitLeader();
+
+        cluster.awaitSnapshotCount(2);
+
+        cluster.awaitServicesMessageCount(numMessages * 4);
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpAfterFollowerMissesOneMessage(final TestInfo testInfo)
+    public void shouldCatchUpAfterFollowerMissesOneMessage()
     {
-        shouldCatchUpAfterFollowerMissesMessage(NO_OP_MSG, testInfo);
+        shouldCatchUpAfterFollowerMissesMessage(NO_OP_MSG);
     }
 
     @Test
     @Timeout(30)
-    public void shouldCatchUpAfterFollowerMissesTimerRegistration(final TestInfo testInfo)
+    public void shouldCatchUpAfterFollowerMissesTimerRegistration()
     {
-        shouldCatchUpAfterFollowerMissesMessage(REGISTER_TIMER_MSG, testInfo);
+        shouldCatchUpAfterFollowerMissesMessage(REGISTER_TIMER_MSG);
     }
 
-    private void shouldCatchUpAfterFollowerMissesMessage(final String message, final TestInfo testInfo)
+    private void shouldCatchUpAfterFollowerMissesMessage(final String message)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            cluster.awaitLeader();
-            TestNode follower = cluster.followers().get(0);
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.stopNode(follower);
+        cluster.awaitLeader();
+        TestNode follower = cluster.followers().get(0);
 
-            cluster.connectClient();
-            cluster.msgBuffer().putStringWithoutLengthAscii(0, message);
-            cluster.pollUntilMessageSent(message.length());
-            cluster.awaitResponseMessageCount(1);
+        cluster.stopNode(follower);
 
-            follower = cluster.startStaticNode(follower.index(), false);
+        cluster.connectClient();
+        cluster.msgBuffer().putStringWithoutLengthAscii(0, message);
+        cluster.pollUntilMessageSent(message.length());
+        cluster.awaitResponseMessageCount(1);
 
-            awaitElectionClosed(follower);
-            assertEquals(FOLLOWER, follower.role());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        follower = cluster.startStaticNode(follower.index(), false);
+
+        awaitElectionClosed(follower);
+        assertEquals(FOLLOWER, follower.role());
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -39,7 +39,6 @@ import static io.aeron.test.cluster.ClusterTests.*;
 import static io.aeron.test.cluster.TestCluster.*;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.function.Predicate.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -227,7 +226,7 @@ public class ClusterTest
     {
         cluster = aCluster().withStaticNodes(3).start();
         clusterTestWatcher.cluster(cluster);
-        errorLogFilter = errorLogFilter.and(not(UNKNOWN_HOST_FILTER));
+        errorLogFilter = errorLogFilter.and(UNKNOWN_HOST_FILTER.negate());
 
         final TestNode originalLeader = cluster.awaitLeader();
         cluster.connectClient();
@@ -256,7 +255,7 @@ public class ClusterTest
 
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(initiallyUnresolvableNodeId).start();
         clusterTestWatcher.cluster(cluster);
-        errorLogFilter = not(UNKNOWN_HOST_FILTER);
+        errorLogFilter = errorLogFilter.and(UNKNOWN_HOST_FILTER.negate());
 
         cluster.awaitLeader();
         cluster.connectClient();
@@ -279,7 +278,7 @@ public class ClusterTest
     {
         cluster = aCluster().withStaticNodes(3).withInvalidNameResolution(0).withInvalidNameResolution(2).start();
         clusterTestWatcher.cluster(cluster);
-        errorLogFilter = errorLogFilter.and(not(UNKNOWN_HOST_FILTER));
+        errorLogFilter = errorLogFilter.and(UNKNOWN_HOST_FILTER.negate());
 
         awaitElectionState(cluster.node(1), ElectionState.CANVASS);
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.cluster.service.Cluster.Role.LEADER;
@@ -805,7 +806,7 @@ public class ClusterTest
     }
 
     @Test
-    @Timeout(40)
+    @Timeout(10)
     public void shouldRecoverWhileMessagesContinue() throws InterruptedException
     {
         cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +47,7 @@ class ClusterToolTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterToolTest.java
@@ -16,12 +16,14 @@
 package io.aeron.cluster;
 
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -38,6 +40,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
+@ExtendWith(InterruptingTestCallback.class)
 class ClusterToolTest
 {
     @RegisterExtension
@@ -51,7 +54,7 @@ class ClusterToolTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     void shouldHandleSnapshotOnLeaderOnly()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -85,7 +88,7 @@ class ClusterToolTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     void shouldNotSnapshotWhenSuspendedOnly()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
@@ -115,7 +118,7 @@ class ClusterToolTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     void shouldSuspendAndResume()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -16,13 +16,15 @@
 package io.aeron.cluster;
 
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
@@ -30,6 +32,7 @@ import static io.aeron.test.cluster.TestCluster.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
+@ExtendWith(InterruptingTestCallback.class)
 public class DynamicMembershipTest
 {
     private TestCluster cluster = null;
@@ -45,7 +48,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldQueryClusterMembers(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -60,7 +63,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshots(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -79,7 +82,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -100,7 +103,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithCatchup(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -120,7 +123,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeWithEmptySnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -140,7 +143,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -166,7 +169,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -200,7 +203,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRemoveFollower(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -220,7 +223,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRemoveLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
@@ -242,7 +245,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRemoveLeaderAfterDynamicNodeJoined(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -268,7 +271,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldRemoveLeaderAfterDynamicNodeJoinedThenRestartCluster(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
@@ -309,7 +312,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldJoinDynamicNodeToSingleStaticLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(1).withDynamicNodes(1).start();
@@ -323,7 +326,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsAndRestartDynamicNode(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -15,17 +15,20 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.cluster.service.ClusterTerminationException;
+import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
-import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.test.cluster.TestCluster.*;
+import static java.util.function.Predicate.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -33,10 +36,16 @@ public class DynamicMembershipTest
 {
     private TestCluster cluster = null;
 
+    @RegisterExtension
+    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+
     @AfterEach
-    void after()
+    void tearDown()
     {
-        CloseHelper.close(cluster);
+        assertEquals(
+            0,
+            clusterTestWatcher.errorCount(not(s -> s.startsWith(ClusterTerminationException.class.getName()))),
+            "Errors observed in cluster test");
     }
 
     @Test
@@ -44,19 +53,14 @@ public class DynamicMembershipTest
     public void shouldQueryClusterMembers(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final ClusterMembership clusterMembership = leader.clusterMembership();
+        clusterTestWatcher.cluster(cluster);
 
-            assertEquals(leader.index(), clusterMembership.leaderMemberId);
-            assertEquals("", clusterMembership.passiveMembersStr);
-            assertEquals(cluster.staticClusterMembers(), clusterMembership.activeMembersStr);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode leader = cluster.awaitLeader();
+        final ClusterMembership clusterMembership = leader.clusterMembership();
+
+        assertEquals(leader.index(), clusterMembership.leaderMemberId);
+        assertEquals("", clusterMembership.passiveMembersStr);
+        assertEquals(cluster.staticClusterMembers(), clusterMembership.activeMembersStr);
     }
 
     @Test
@@ -64,23 +68,18 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshots(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode leader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            final ClusterMembership clusterMembership = awaitMembershipSize(leader, 4);
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
 
-            assertEquals(leader.index(), clusterMembership.leaderMemberId);
-            assertEquals("", clusterMembership.passiveMembersStr);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final ClusterMembership clusterMembership = awaitMembershipSize(leader, 4);
+
+        assertEquals(leader.index(), clusterMembership.leaderMemberId);
+        assertEquals("", clusterMembership.passiveMembersStr);
     }
 
     @Test
@@ -88,25 +87,20 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode leader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(leader, messageCount);
-            cluster.awaitServiceMessageCount(dynamicMember, messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(leader, messageCount);
+        cluster.awaitServiceMessageCount(dynamicMember, messageCount);
     }
 
     @Test
@@ -114,24 +108,19 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithCatchup(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(leader, messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(leader, messageCount);
 
-            cluster.awaitServiceMessageCount(dynamicMember, messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+
+        cluster.awaitServiceMessageCount(dynamicMember, messageCount);
     }
 
     @Test
@@ -139,24 +128,19 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithEmptySnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final TestNode leader = cluster.awaitLeader();
 
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            cluster.awaitSnapshotLoadedForService(dynamicMember);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMember);
     }
 
     @Test
@@ -164,30 +148,25 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshot(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
 
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
 
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            cluster.awaitSnapshotLoadedForService(dynamicMember);
-            assertEquals(messageCount, dynamicMember.service().messageCount());
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMember);
+        assertEquals(messageCount, dynamicMember.service().messageCount());
     }
 
     @Test
@@ -195,38 +174,33 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotThenSend(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            final int preSnapshotMessageCount = 10;
-            final int postSnapshotMessageCount = 7;
-            final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
-            cluster.connectClient();
-            cluster.sendMessages(preSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(preSnapshotMessageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.takeSnapshot(leader);
-            cluster.awaitSnapshotCount(1);
-            assertTrue(cluster.client().sendKeepAlive());
+        final int preSnapshotMessageCount = 10;
+        final int postSnapshotMessageCount = 7;
+        final int totalMessageCount = preSnapshotMessageCount + postSnapshotMessageCount;
+        cluster.connectClient();
+        cluster.sendMessages(preSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(preSnapshotMessageCount);
 
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
+        assertTrue(cluster.client().sendKeepAlive());
 
-            assertTrue(cluster.client().sendKeepAlive());
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            cluster.awaitSnapshotLoadedForService(dynamicMember);
-            assertEquals(preSnapshotMessageCount, dynamicMember.service().messageCount());
+        assertTrue(cluster.client().sendKeepAlive());
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
 
-            cluster.sendMessages(postSnapshotMessageCount);
-            cluster.awaitResponseMessageCount(totalMessageCount);
-            cluster.awaitServiceMessageCount(dynamicMember, totalMessageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitSnapshotLoadedForService(dynamicMember);
+        assertEquals(preSnapshotMessageCount, dynamicMember.service().messageCount());
+
+        cluster.sendMessages(postSnapshotMessageCount);
+        cluster.awaitResponseMessageCount(totalMessageCount);
+        cluster.awaitServiceMessageCount(dynamicMember, totalMessageCount);
     }
 
     @Test
@@ -234,24 +208,19 @@ public class DynamicMembershipTest
     public void shouldRemoveFollower(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final TestNode follower = cluster.followers().get(0);
+        clusterTestWatcher.cluster(cluster);
 
-            follower.isTerminationExpected(true);
-            leader.removeMember(follower.index(), false);
+        final TestNode leader = cluster.awaitLeader();
+        final TestNode follower = cluster.followers().get(0);
 
-            cluster.awaitNodeTermination(follower);
-            cluster.stopNode(follower);
+        follower.isTerminationExpected(true);
+        leader.removeMember(follower.index(), false);
 
-            final ClusterMembership clusterMembership = awaitMembershipSize(leader, 2);
-            assertEquals(leader.index(), clusterMembership.leaderMemberId);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitNodeTermination(follower);
+        cluster.stopNode(follower);
+
+        final ClusterMembership clusterMembership = awaitMembershipSize(leader, 2);
+        assertEquals(leader.index(), clusterMembership.leaderMemberId);
     }
 
     @Test
@@ -259,26 +228,21 @@ public class DynamicMembershipTest
     public void shouldRemoveLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).start();
-        try
-        {
-            final TestNode initialLeader = cluster.awaitLeader();
+        clusterTestWatcher.cluster(cluster);
 
-            initialLeader.isTerminationExpected(true);
-            initialLeader.removeMember(initialLeader.index(), false);
+        final TestNode initialLeader = cluster.awaitLeader();
 
-            cluster.awaitNodeTermination(initialLeader);
-            cluster.stopNode(initialLeader);
+        initialLeader.isTerminationExpected(true);
+        initialLeader.removeMember(initialLeader.index(), false);
 
-            final TestNode newLeader = cluster.awaitLeader(initialLeader.index());
-            final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 2);
+        cluster.awaitNodeTermination(initialLeader);
+        cluster.stopNode(initialLeader);
 
-            assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
-            assertNotEquals(initialLeader.index(), clusterMembership.leaderMemberId);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode newLeader = cluster.awaitLeader(initialLeader.index());
+        final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 2);
+
+        assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
+        assertNotEquals(initialLeader.index(), clusterMembership.leaderMemberId);
     }
 
     @Test
@@ -286,30 +250,25 @@ public class DynamicMembershipTest
     public void shouldRemoveLeaderAfterDynamicNodeJoined(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode initialLeader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(dynamicMember);
-            awaitMembershipSize(initialLeader, 4);
+        final TestNode initialLeader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            initialLeader.isTerminationExpected(true);
-            initialLeader.removeMember(initialLeader.index(), false);
+        awaitElectionClosed(dynamicMember);
+        awaitMembershipSize(initialLeader, 4);
 
-            cluster.awaitNodeTermination(initialLeader);
-            cluster.stopNode(initialLeader);
+        initialLeader.isTerminationExpected(true);
+        initialLeader.removeMember(initialLeader.index(), false);
 
-            final TestNode newLeader = cluster.awaitLeader(initialLeader.index());
-            final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 3);
+        cluster.awaitNodeTermination(initialLeader);
+        cluster.stopNode(initialLeader);
 
-            assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
-            assertNotEquals(initialLeader.index(), clusterMembership.leaderMemberId);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode newLeader = cluster.awaitLeader(initialLeader.index());
+        final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 3);
+
+        assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
+        assertNotEquals(initialLeader.index(), clusterMembership.leaderMemberId);
     }
 
     @Test
@@ -317,45 +276,40 @@ public class DynamicMembershipTest
     public void shouldRemoveLeaderAfterDynamicNodeJoinedThenRestartCluster(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
+        clusterTestWatcher.cluster(cluster);
+
+        final TestNode initialLeader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+
+        awaitElectionClosed(dynamicMember);
+        awaitMembershipSize(initialLeader, 4);
+
+        final int initialLeaderIndex = initialLeader.index();
+        initialLeader.isTerminationExpected(true);
+        initialLeader.removeMember(initialLeaderIndex, false);
+
+        cluster.awaitNodeTermination(initialLeader);
+        cluster.stopNode(initialLeader);
+
+        final TestNode newLeader = cluster.awaitLeader(initialLeaderIndex);
+        final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 3);
+
+        assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
+        assertNotEquals(initialLeaderIndex, clusterMembership.leaderMemberId);
+
+        cluster.stopAllNodes();
+
+        for (int i = 0; i < 3; i++)
         {
-            final TestNode initialLeader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
-
-            awaitElectionClosed(dynamicMember);
-            awaitMembershipSize(initialLeader, 4);
-
-            final int initialLeaderIndex = initialLeader.index();
-            initialLeader.isTerminationExpected(true);
-            initialLeader.removeMember(initialLeaderIndex, false);
-
-            cluster.awaitNodeTermination(initialLeader);
-            cluster.stopNode(initialLeader);
-
-            final TestNode newLeader = cluster.awaitLeader(initialLeaderIndex);
-            final ClusterMembership clusterMembership = awaitMembershipSize(newLeader, 3);
-
-            assertEquals(newLeader.index(), clusterMembership.leaderMemberId);
-            assertNotEquals(initialLeaderIndex, clusterMembership.leaderMemberId);
-
-            cluster.stopAllNodes();
-
-            for (int i = 0; i < 3; i++)
+            if (initialLeaderIndex != i)
             {
-                if (initialLeaderIndex != i)
-                {
-                    cluster.startStaticNode(i, false);
-                }
+                cluster.startStaticNode(i, false);
             }
+        }
 
-            cluster.awaitLeader();
-            assertEquals(1, cluster.followers().size());
-            awaitElectionClosed(cluster.followers().get(0));
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.awaitLeader();
+        assertEquals(1, cluster.followers().size());
+        awaitElectionClosed(cluster.followers().get(0));
     }
 
     @Test
@@ -363,18 +317,13 @@ public class DynamicMembershipTest
     public void shouldJoinDynamicNodeToSingleStaticLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(1).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode initialLeader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(1, true);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(dynamicMember);
-            awaitMembershipSize(initialLeader, 2);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        final TestNode initialLeader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(1, true);
+
+        awaitElectionClosed(dynamicMember);
+        awaitMembershipSize(initialLeader, 2);
     }
 
     @Test
@@ -382,34 +331,29 @@ public class DynamicMembershipTest
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsAndRestartDynamicNode(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
-        try
-        {
-            final TestNode leader = cluster.awaitLeader();
-            final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        clusterTestWatcher.cluster(cluster);
 
-            awaitElectionClosed(dynamicMember);
-            assertEquals(FOLLOWER, dynamicMember.role());
+        final TestNode leader = cluster.awaitLeader();
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
 
-            final ClusterMembership clusterMembership = awaitMembershipSize(leader, 4);
+        awaitElectionClosed(dynamicMember);
+        assertEquals(FOLLOWER, dynamicMember.role());
 
-            assertEquals(leader.index(), clusterMembership.leaderMemberId);
-            assertEquals("", clusterMembership.passiveMembersStr);
+        final ClusterMembership clusterMembership = awaitMembershipSize(leader, 4);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+        assertEquals(leader.index(), clusterMembership.leaderMemberId);
+        assertEquals("", clusterMembership.passiveMembersStr);
 
-            cluster.stopNode(dynamicMember);
-            final TestNode staticMember = cluster.startStaticNodeFromDynamicNode(3);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
 
-            awaitElectionClosed(staticMember);
-            cluster.awaitServiceMessageCount(cluster.node(3), messageCount);
-        }
-        catch (final Throwable ex)
-        {
-            cluster.dumpData(testInfo, ex);
-        }
+        cluster.stopNode(dynamicMember);
+        final TestNode staticMember = cluster.startStaticNodeFromDynamicNode(3);
+
+        awaitElectionClosed(staticMember);
+        cluster.awaitServiceMessageCount(cluster.node(3), messageCount);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -41,7 +41,7 @@ public class DynamicMembershipTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.cluster.service.ClusterTerminationException;
 import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.SlowTest;
 import io.aeron.test.cluster.TestCluster;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.test.cluster.TestCluster.*;
-import static java.util.function.Predicate.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -43,9 +41,7 @@ public class DynamicMembershipTest
     void tearDown()
     {
         assertEquals(
-            0,
-            clusterTestWatcher.errorCount(not(s -> s.startsWith(ClusterTerminationException.class.getName()))),
-            "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiClusteredServicesTest.java
@@ -22,6 +22,8 @@ import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
@@ -30,12 +32,13 @@ import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiClusteredServicesTest
 {
     final AtomicLong serviceAMessageCount = new AtomicLong(0);
@@ -70,7 +73,7 @@ public class MultiClusteredServicesTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSupportMultipleServicesPerNode()
     {
         final List<TestCluster.NodeContext> nodeContexts = new ArrayList<>();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
@@ -26,6 +26,8 @@ import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.Header;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.StubClusteredService;
 import io.aeron.test.cluster.TestCluster;
@@ -36,17 +38,18 @@ import org.agrona.ExpandableArrayBuffer;
 import org.agrona.SystemUtil;
 import org.agrona.collections.MutableReference;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiModuleSharedDriverTest
 {
     @SuppressWarnings("methodlength")
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSupportTwoSingleNodeClusters()
     {
         final MediaDriver.Context driverCtx = new MediaDriver.Context()
@@ -151,7 +154,7 @@ public class MultiModuleSharedDriverTest
     }
 
     @Test
-    @Timeout(30)
+    @InterruptAfter(30)
     public void shouldSupportTwoMultiNodeClusters()
     {
         try (MultiClusterNode node0 = new MultiClusterNode(0);

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -40,7 +39,7 @@ public class MultiNodeTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiNodeTest.java
@@ -18,11 +18,13 @@ package io.aeron.cluster;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -30,6 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class MultiNodeTest
 {
     @RegisterExtension
@@ -43,7 +46,7 @@ public class MultiNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldElectAppointedLeaderWithThreeNodesWithNoReplayNoSnapshot()
     {
         final int appointedLeaderIndex = 1;
@@ -60,7 +63,7 @@ public class MultiNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReplayWithAppointedLeaderWithThreeNodesWithNoSnapshot()
     {
         final int appointedLeaderIndex = 1;
@@ -87,7 +90,7 @@ public class MultiNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldCatchUpWithAppointedLeaderWithThreeNodesWithNoSnapshot()
     {
         final int appointedLeaderIndex = 1;
@@ -123,7 +126,7 @@ public class MultiNodeTest
 
     @ParameterizedTest
     @ValueSource(strings = { "9020", "0" })
-    @Timeout(20)
+    @InterruptAfter(20)
     void shouldConnectClientUsingResolvedResponsePort(final String responsePort)
     {
         final AeronCluster.Context clientCtx = new AeronCluster.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,7 +35,7 @@ public class ServiceIpcIngressTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -16,16 +16,19 @@
 package io.aeron.cluster;
 
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.TestCluster;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class ServiceIpcIngressTest
 {
     @RegisterExtension
@@ -39,7 +42,7 @@ public class ServiceIpcIngressTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldEchoIpcMessages()
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ServiceIpcIngressTest.java
@@ -15,33 +15,48 @@
  */
 package io.aeron.cluster;
 
+import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.TestCluster;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ServiceIpcIngressTest
 {
+    @RegisterExtension
+    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+
+    @AfterEach
+    void tearDown()
+    {
+        assertEquals(
+            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+    }
+
     @Test
     @Timeout(20)
     public void shouldEchoIpcMessages()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(3).start())
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        clusterTestWatcher.cluster(cluster);
+
+        cluster.awaitLeader();
+        cluster.connectClient();
+
+        final int messageCount = 10;
+        for (int i = 0; i < messageCount; i++)
         {
-            cluster.awaitLeader();
-            cluster.connectClient();
-
-            final int messageCount = 10;
-            for (int i = 0; i < messageCount; i++)
-            {
-                cluster.msgBuffer().putStringWithoutLengthAscii(0, ClusterTests.ECHO_IPC_INGRESS_MSG);
-                cluster.pollUntilMessageSent(ClusterTests.ECHO_IPC_INGRESS_MSG.length());
-            }
-
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServicesMessageCount(messageCount);
+            cluster.msgBuffer().putStringWithoutLengthAscii(0, ClusterTests.ECHO_IPC_INGRESS_MSG);
+            cluster.pollUntilMessageSent(ClusterTests.ECHO_IPC_INGRESS_MSG.length());
         }
+
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -17,16 +17,19 @@ package io.aeron.cluster;
 
 import io.aeron.cluster.service.Cluster;
 import io.aeron.test.ClusterTestWatcher;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(InterruptingTestCallback.class)
 public class SingleNodeTest
 {
     @RegisterExtension
@@ -40,7 +43,7 @@ public class SingleNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldStartCluster()
     {
         final TestCluster cluster = aCluster().withStaticNodes(1).start();
@@ -53,7 +56,7 @@ public class SingleNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldSendMessagesToCluster()
     {
         final TestCluster cluster = aCluster().withStaticNodes(1).start();
@@ -71,7 +74,7 @@ public class SingleNodeTest
     }
 
     @Test
-    @Timeout(20)
+    @InterruptAfter(20)
     public void shouldReplayLog()
     {
         final TestCluster cluster = aCluster().withStaticNodes(1).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -37,7 +36,7 @@ public class SingleNodeTest
     void tearDown()
     {
         assertEquals(
-            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+            0, clusterTestWatcher.errorCount(), "Errors observed in cluster test");
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/SingleNodeTest.java
@@ -16,66 +16,80 @@
 package io.aeron.cluster;
 
 import io.aeron.cluster.service.Cluster;
+import io.aeron.test.ClusterTestWatcher;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.cluster.TestNode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static io.aeron.test.cluster.TestCluster.TEST_CLUSTER_DEFAULT_LOG_FILTER;
 import static io.aeron.test.cluster.TestCluster.aCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SingleNodeTest
 {
+    @RegisterExtension
+    final ClusterTestWatcher clusterTestWatcher = new ClusterTestWatcher();
+
+    @AfterEach
+    void tearDown()
+    {
+        assertEquals(
+            0, clusterTestWatcher.errorCount(TEST_CLUSTER_DEFAULT_LOG_FILTER), "Errors observed in cluster test");
+    }
+
     @Test
     @Timeout(20)
     public void shouldStartCluster()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(1).start();
+        clusterTestWatcher.cluster(cluster);
 
-            assertEquals(0, leader.index());
-            assertEquals(Cluster.Role.LEADER, leader.role());
-        }
+        final TestNode leader = cluster.awaitLeader();
+
+        assertEquals(0, leader.index());
+        assertEquals(Cluster.Role.LEADER, leader.role());
     }
 
     @Test
     @Timeout(20)
     public void shouldSendMessagesToCluster()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(1).start();
+        clusterTestWatcher.cluster(cluster);
 
-            assertEquals(0, leader.index());
-            assertEquals(Cluster.Role.LEADER, leader.role());
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.connectClient();
-            cluster.sendMessages(10);
-            cluster.awaitResponseMessageCount(10);
-            cluster.awaitServiceMessageCount(leader, 10);
-        }
+        assertEquals(0, leader.index());
+        assertEquals(Cluster.Role.LEADER, leader.role());
+
+        cluster.connectClient();
+        cluster.sendMessages(10);
+        cluster.awaitResponseMessageCount(10);
+        cluster.awaitServiceMessageCount(leader, 10);
     }
 
     @Test
     @Timeout(20)
     public void shouldReplayLog()
     {
-        try (TestCluster cluster = aCluster().withStaticNodes(1).start())
-        {
-            final TestNode leader = cluster.awaitLeader();
+        final TestCluster cluster = aCluster().withStaticNodes(1).start();
+        clusterTestWatcher.cluster(cluster);
 
-            final int messageCount = 10;
-            cluster.connectClient();
-            cluster.sendMessages(messageCount);
-            cluster.awaitResponseMessageCount(messageCount);
-            cluster.awaitServiceMessageCount(leader, messageCount);
+        final TestNode leader = cluster.awaitLeader();
 
-            cluster.stopNode(leader);
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServiceMessageCount(leader, messageCount);
 
-            cluster.startStaticNode(0, false);
-            final TestNode newLeader = cluster.awaitLeader();
-            cluster.awaitServiceMessageCount(newLeader, messageCount);
-        }
+        cluster.stopNode(leader);
+
+        cluster.startStaticNode(0, false);
+        final TestNode newLeader = cluster.awaitLeader();
+        cluster.awaitServiceMessageCount(newLeader, messageCount);
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import io.aeron.CommonContext;
+import io.aeron.samples.SamplesUtil;
+import io.aeron.test.cluster.TestCluster;
+import org.agrona.CloseHelper;
+import org.agrona.IoUtil;
+import org.agrona.collections.MutableInteger;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.errors.ErrorLogReader;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.io.File;
+import java.nio.MappedByteBuffer;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class ClusterTestWatcher implements TestWatcher
+{
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ");
+    private volatile TestCluster testCluster = null;
+
+    public void cluster(final TestCluster testCluster)
+    {
+        this.testCluster = testCluster;
+    }
+
+    public void testFailed(final ExtensionContext context, final Throwable cause)
+    {
+        if (null != testCluster)
+        {
+            printErrors(testCluster.dataCollector().cncFiles(), testCluster.dataCollector().errorLogFiles());
+
+            final String testClass = context.getTestClass().orElseThrow(IllegalStateException::new).getName();
+            final String testMethod = context.getTestMethod().orElseThrow(IllegalStateException::new).getName();
+
+            testCluster.dataCollector().dumpData(testClass, testMethod);
+        }
+
+        CloseHelper.close(testCluster);
+    }
+
+    public int errorCount(final Predicate<String> filter)
+    {
+        if (null != testCluster)
+        {
+            return countErrors(
+                testCluster.dataCollector().cncFiles(),
+                testCluster.dataCollector().errorLogFiles(),
+                filter);
+        }
+        return 0;
+    }
+
+    public int errorCount()
+    {
+        return errorCount(s -> true);
+    }
+
+    private void printErrors(final List<Path> cncPaths, final List<Path> clusterErrorPaths)
+    {
+        printErrors(cncPaths, "Command `n Control", CommonContext::errorLogBuffer);
+        printErrors(clusterErrorPaths, "Cluster Errors", UnsafeBuffer::new);
+    }
+
+    private void printErrors(
+        final List<Path> cncPaths,
+        final String fileDescription,
+        final Function<MappedByteBuffer, AtomicBuffer> toErrorBuffer)
+    {
+        for (final Path cncPath : cncPaths)
+        {
+            final File cncFile = cncPath.toFile();
+            final MappedByteBuffer cncByteBuffer = SamplesUtil.mapExistingFileReadOnly(cncFile);
+            final AtomicBuffer buffer = toErrorBuffer.apply(cncByteBuffer);
+
+            System.out.printf("%n%n%s file %s%n", fileDescription, cncFile);
+            final int distinctErrorCount = ErrorLogReader.read(buffer, ClusterTestWatcher::printObservationCallback);
+            System.out.format("%d distinct errors observed.%n", distinctErrorCount);
+        }
+    }
+
+    private int countErrors(
+        final List<Path> paths,
+        final Predicate<String> filter,
+        final Function<MappedByteBuffer, AtomicBuffer> toErrorBuffer)
+    {
+        final MutableInteger errorCount = new MutableInteger(0);
+
+        for (final Path path : paths)
+        {
+            final File cncFile = path.toFile();
+            final MappedByteBuffer cncMmap = SamplesUtil.mapExistingFileReadOnly(cncFile);
+            try
+            {
+                final AtomicBuffer buffer = toErrorBuffer.apply(cncMmap);
+                ErrorLogReader.read(
+                    buffer,
+                    (observationCount, firstObservationTimestamp, lastObservationTimestamp, encodedException) ->
+                    {
+                        if (filter.test(encodedException))
+                        {
+                            errorCount.set(errorCount.get() + observationCount);
+                        }
+                    });
+            }
+            finally
+            {
+                IoUtil.unmap(cncMmap);
+            }
+        }
+
+        return errorCount.get();
+    }
+
+    private int countErrors(
+        final List<Path> cncPaths,
+        final List<Path> clusterErrorPaths,
+        final Predicate<String> filter)
+    {
+        return countErrors(cncPaths, filter, CommonContext::errorLogBuffer) +
+            countErrors(clusterErrorPaths, filter, UnsafeBuffer::new);
+    }
+
+    private static void printObservationCallback(
+        final int observationCount,
+        final long firstObservationTimestamp,
+        final long lastObservationTimestamp,
+        final String encodedException)
+    {
+        System.out.format(
+            "***%n%d observations from %s to %s for:%n %s%n",
+            observationCount,
+            DATE_FORMAT.format(new Date(firstObservationTimestamp)),
+            DATE_FORMAT.format(new Date(lastObservationTimestamp)),
+            encodedException);
+    }
+
+    public void testDisabled(final ExtensionContext context, final Optional<String> reason)
+    {
+        CloseHelper.close(testCluster);
+    }
+
+    public void testSuccessful(final ExtensionContext context)
+    {
+        CloseHelper.close(testCluster);
+    }
+
+    public void testAborted(final ExtensionContext context, final Throwable cause)
+    {
+        CloseHelper.close(testCluster);
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
@@ -99,7 +99,8 @@ public class ClusterTestWatcher implements TestWatcher
                 final AtomicBuffer buffer = toErrorBuffer.apply(mmap);
 
                 System.out.printf("%n%n%s file %s%n", fileDescription, cncFile);
-                final int distinctErrorCount = ErrorLogReader.read(buffer, ClusterTestWatcher::printObservationCallback);
+                final int distinctErrorCount = ErrorLogReader.read(
+                    buffer, ClusterTestWatcher::printObservationCallback);
                 System.out.format("%d distinct errors observed.%n", distinctErrorCount);
             }
             finally

--- a/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/DataCollector.java
@@ -15,6 +15,8 @@
  */
 package io.aeron.test;
 
+import io.aeron.CncFileDescriptor;
+import io.aeron.test.cluster.TestNode;
 import org.agrona.LangUtil;
 import org.agrona.SystemUtil;
 import org.junit.jupiter.api.TestInfo;
@@ -91,6 +93,24 @@ public final class DataCollector
     }
 
     /**
+     * Copy data from all of the added locations to the directory {@code $rootDir/$testClass_$testMethod}, where:
+     * <ul>
+     *     <li>{@code $rootDir} is the root directory specified when {@link #DataCollector} was created.</li>
+     *     <li>{@code $testClass} is the fully qualified class name of the test class.</li>
+     *     <li>{@code $testMethod} is the test method name.</li>
+     * </ul>
+     *
+     * @param testClass name of the test class from JUnit.
+     * @param testMethod name of the test method from JUnit.
+     * @return {@code null} if no data was copied or an actual destination directory used.
+     * @see #dumpData(String)
+     */
+    public Path dumpData(final String testClass, final String testMethod)
+    {
+        return copyData(testClass + SEPARATOR + testMethod);
+    }
+
+    /**
      * Copy data from all of the added locations to the directory {@code $rootDir/$destinationDir}, where:
      * <ul>
      *     <li>{@code $rootDir} is the root directory specified when {@link #DataCollector} was created.</li>
@@ -116,6 +136,22 @@ public final class DataCollector
         }
 
         return copyData(destinationDir);
+    }
+
+    public List<Path> cncFiles()
+    {
+        return this.locations.stream()
+            .map(p -> p.resolve(CncFileDescriptor.CNC_FILE))
+            .filter(Files::exists)
+            .collect(toList());
+    }
+
+    public List<Path> errorLogFiles()
+    {
+        return this.locations.stream()
+            .map(p -> p.resolve(TestNode.CLUSTER_ERROR_FILE))
+            .filter(Files::exists)
+            .collect(toList());
     }
 
     public String toString()
@@ -313,4 +349,5 @@ public final class DataCollector
             Files.createDirectories(dst.getParent());
         }
     }
+
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/InterruptAfter.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/InterruptAfter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InterruptAfter
+{
+    long value();
+
+    TimeUnit unit() default TimeUnit.SECONDS;
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/InterruptingTestCallback.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/InterruptingTestCallback.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+public class InterruptingTestCallback implements BeforeEachCallback, AfterEachCallback
+{
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledFuture<?> timer = null;
+
+    public void afterEach(final ExtensionContext context) throws Exception
+    {
+        if (null != timer)
+        {
+            timer.cancel(false);
+        }
+    }
+
+    public void beforeEach(final ExtensionContext context) throws Exception
+    {
+        timer = null;
+        final InterruptAfter annotation = context.getRequiredTestMethod().getAnnotation(InterruptAfter.class);
+        if (null != annotation)
+        {
+            final Thread testThread = Thread.currentThread();
+            timer = scheduler.schedule(testThread::interrupt, annotation.value(), annotation.unit());
+        }
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/SpecificTest.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/SpecificTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("specific")
+public @interface SpecificTest
+{
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -22,14 +22,16 @@ import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.exceptions.TimeoutException;
 import org.agrona.LangUtil;
-import org.agrona.SystemUtil;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.SleepingMillisIdleStrategy;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 
-import javax.management.*;
+import javax.management.Attribute;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicLong;
@@ -172,9 +174,6 @@ public class Tests
         }
 
         appendStackTrace(sb).append('\n');
-
-        System.out.println(sb);
-        System.out.println(SystemUtil.threadDump());
     }
 
     /**

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -39,7 +39,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 
 /**
@@ -98,8 +97,7 @@ public class Tests
     {
         if (Thread.currentThread().isInterrupted())
         {
-            unexpectedInterruptStackTrace(null);
-            fail("unexpected interrupt");
+            throw new TimeoutException("unexpected interrupt");
         }
     }
 
@@ -115,9 +113,7 @@ public class Tests
     {
         if (Thread.currentThread().isInterrupted())
         {
-            final String message = messageSupplier.get();
-            unexpectedInterruptStackTrace(message);
-            fail("unexpected interrupt - " + message);
+            throw new TimeoutException(messageSupplier.get());
         }
     }
 
@@ -135,9 +131,7 @@ public class Tests
     {
         if (Thread.currentThread().isInterrupted())
         {
-            final String message = String.format(format, args);
-            unexpectedInterruptStackTrace(message);
-            fail("unexpected interrupt - " + message);
+            throw new TimeoutException(String.format(format, args));
         }
     }
 
@@ -153,8 +147,7 @@ public class Tests
     {
         if (Thread.currentThread().isInterrupted())
         {
-            unexpectedInterruptStackTrace(message);
-            fail("unexpected interrupt - " + message);
+            throw new TimeoutException(message);
         }
     }
 
@@ -219,8 +212,7 @@ public class Tests
         }
         catch (final InterruptedException ex)
         {
-            unexpectedInterruptStackTrace(null);
-            LangUtil.rethrowUnchecked(ex);
+            throw new TimeoutException(ex, AeronException.Category.ERROR);
         }
     }
 
@@ -238,8 +230,7 @@ public class Tests
         }
         catch (final InterruptedException ex)
         {
-            unexpectedInterruptStackTrace(messageSupplier.get());
-            LangUtil.rethrowUnchecked(ex);
+            throw new TimeoutException(messageSupplier.get());
         }
     }
 
@@ -258,8 +249,7 @@ public class Tests
         }
         catch (final InterruptedException ex)
         {
-            unexpectedInterruptStackTrace(String.format(format, params));
-            LangUtil.rethrowUnchecked(ex);
+            throw new TimeoutException(String.format(format, params));
         }
     }
 
@@ -433,8 +423,7 @@ public class Tests
             Thread.yield();
             if (Thread.currentThread().isInterrupted())
             {
-                unexpectedInterruptStackTrace("awaiting=" + value + " counter=" + counterValue);
-                fail("unexpected interrupt");
+                throw new TimeoutException("awaiting=" + value + " counter=" + counterValue);
             }
         }
     }
@@ -453,8 +442,7 @@ public class Tests
             Thread.yield();
             if (Thread.currentThread().isInterrupted())
             {
-                unexpectedInterruptStackTrace("awaiting=" + value + " counter=" + counterValue);
-                fail("unexpected interrupt");
+                throw new TimeoutException("awaiting=" + value + " counter=" + counterValue);
             }
 
             if (counter.isClosed())

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -338,7 +338,6 @@ public class TestCluster implements AutoCloseable
             .aeronDirectoryName(aeronDirName)
             .threadingMode(ThreadingMode.SHARED)
             .termBufferSparseFile(true)
-            .errorHandler(errorHandler(index))
             .dirDeleteOnStart(true)
             .dirDeleteOnShutdown(false);
 
@@ -353,7 +352,6 @@ public class TestCluster implements AutoCloseable
             .deleteArchiveOnStart(cleanStart);
 
         context.consensusModuleContext
-            .errorHandler(errorHandler(index))
             .clusterMemberId(NULL_VALUE)
             .clusterMembers("")
             .clusterConsensusEndpoints(clusterConsensusEndpoints)
@@ -374,8 +372,7 @@ public class TestCluster implements AutoCloseable
                 .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
                 .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
             .clusterDir(new File(baseDirName, "service"))
-            .clusteredService(context.service)
-            .errorHandler(errorHandler(index));
+            .clusteredService(context.service);
 
         nodes[index] = new TestNode(context, dataCollector);
 
@@ -404,7 +401,6 @@ public class TestCluster implements AutoCloseable
             .aeronDirectoryName(aeronDirName)
             .threadingMode(ThreadingMode.SHARED)
             .termBufferSparseFile(true)
-            .errorHandler(errorHandler(index))
             .dirDeleteOnShutdown(false)
             .dirDeleteOnStart(true);
 
@@ -419,7 +415,6 @@ public class TestCluster implements AutoCloseable
             .deleteArchiveOnStart(false);
 
         context.consensusModuleContext
-            .errorHandler(errorHandler(index))
             .clusterMemberId(index)
             .clusterMembers(clusterMembers(0, staticMemberCount + 1))
             .startupCanvassTimeoutNs(STARTUP_CANVASS_TIMEOUT_NS)
@@ -440,8 +435,7 @@ public class TestCluster implements AutoCloseable
                 .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
                 .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
             .clusterDir(new File(baseDirName, "service"))
-            .clusteredService(context.service)
-            .errorHandler(errorHandler(index));
+            .clusteredService(context.service);
 
         nodes[index] = new TestNode(context, dataCollector);
 
@@ -524,7 +518,6 @@ public class TestCluster implements AutoCloseable
             .aeronDirectoryName(aeronDirName)
             .threadingMode(ThreadingMode.SHARED)
             .termBufferSparseFile(true)
-            .errorHandler(errorHandler(backupNodeIndex))
             .dirDeleteOnStart(true);
 
         context.archiveContext
@@ -537,7 +530,6 @@ public class TestCluster implements AutoCloseable
             .deleteArchiveOnStart(false);
 
         context.consensusModuleContext
-            .errorHandler(errorHandler(backupNodeIndex))
             .clusterMemberId(backupNodeIndex)
             .clusterMembers(singleNodeClusterMember(0, backupNodeIndex))
             .appointedLeaderId(backupNodeIndex)
@@ -557,8 +549,7 @@ public class TestCluster implements AutoCloseable
                 .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
                 .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
             .clusterDir(new File(baseDirName, "service"))
-            .clusteredService(context.service)
-            .errorHandler(errorHandler(backupNodeIndex));
+            .clusteredService(context.service);
 
         backupNode = null;
         nodes[backupNodeIndex] = new TestNode(context, dataCollector);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -730,13 +730,14 @@ public class TestCluster implements AutoCloseable
 
         while ((count = responseCount.get()) < messageCount)
         {
-            Thread.yield();
-            if (Thread.interrupted())
-            {
-                final String message = "count=" + count + " awaiting=" + messageCount;
-                Tests.unexpectedInterruptStackTrace(message);
-                fail(message);
-            }
+            Tests.sleep(1, "count=%d awaiting=%d", count, messageCount);
+//            Thread.yield();
+//            if (Thread.interrupted())
+//            {
+//                final String message = "count=" + count + " awaiting=" + messageCount;
+//                Tests.unexpectedInterruptStackTrace(message);
+//                throw new TimeoutException(message);
+//            }
 
             client.pollEgress();
 
@@ -1030,8 +1031,7 @@ public class TestCluster implements AutoCloseable
             if (Thread.interrupted())
             {
                 final String message = "count=" + count + " awaiting=" + messageCount + " node=" + node;
-                Tests.unexpectedInterruptStackTrace(message);
-                fail(message);
+                throw new TimeoutException(message);
             }
 
             if (service.hasReceivedUnexpectedMessage())

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -63,7 +63,6 @@ import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.cluster.ConsensusModule.Configuration.SNAPSHOT_CHANNEL_DEFAULT;
 import static io.aeron.test.cluster.ClusterTests.errorHandler;
-import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,7 +73,7 @@ public class TestCluster implements AutoCloseable
     public static final Predicate<String> CLUSTER_TERMINATION_FILTER =
         s -> s.contains(ClusterTerminationException.class.getName());
     public static final Predicate<String> TEST_CLUSTER_DEFAULT_LOG_FILTER =
-        not(WARNING_FILTER).and(not(CLUSTER_TERMINATION_FILTER));
+        WARNING_FILTER.negate().and(CLUSTER_TERMINATION_FILTER.negate());
 
     private static final int SEGMENT_FILE_LENGTH = 16 * 1024 * 1024;
     private static final long CATALOG_CAPACITY = 128 * 1024;

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -25,7 +25,6 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.client.EgressListener;
 import io.aeron.cluster.codecs.EventCode;
 import io.aeron.cluster.service.Cluster;
-import io.aeron.cluster.service.ClusterTerminationException;
 import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
@@ -47,14 +46,12 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.File;
-import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -68,13 +65,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCluster implements AutoCloseable
 {
-    public static final Predicate<String> UNKNOWN_HOST_FILTER = s -> s.contains(UnknownHostException.class.getName());
-    public static final Predicate<String> WARNING_FILTER = s -> s.contains("WARN");
-    public static final Predicate<String> CLUSTER_TERMINATION_FILTER =
-        s -> s.contains(ClusterTerminationException.class.getName());
-    public static final Predicate<String> TEST_CLUSTER_DEFAULT_LOG_FILTER =
-        WARNING_FILTER.negate().and(CLUSTER_TERMINATION_FILTER.negate());
-
     private static final int SEGMENT_FILE_LENGTH = 16 * 1024 * 1024;
     private static final long CATALOG_CAPACITY = 128 * 1024;
     private static final String LOG_CHANNEL = "aeron:udp?term-length=512k";

--- a/build.gradle
+++ b/build.gradle
@@ -821,6 +821,7 @@ project(':aeron-test-support') {
     dependencies {
         api project(':aeron-client')
         api project(':aeron-cluster')
+        api project(':aeron-samples')
         api "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
         implementation "org.mockito:mockito-core:${mockitoVersion}"
     }


### PR DESCRIPTION
- Remove the try/catch block to track errors in cluster tests, instead uses a test watcher.
- Store errors from media driver in cnc.dat and cluster errors in their own distinct error log (so that it can be picked up by the cluster data capture used for building artifacts in CI).
- Check error logs on success and fail if errors are present.
- Specify errors to include in validation check (allows exclusion for expected errors).
- Modify ErrorStat (Java & C) to print out errors from a raw distinct error log