### PR TITLE
C driver packet timestamps

### DIFF
--- a/aeron-client/src/main/c/uri/aeron_uri.h
+++ b/aeron-client/src/main/c/uri/aeron_uri.h
@@ -65,6 +65,8 @@ aeron_uri_params_t;
 #define AERON_URI_SOCKET_SNDBUF_KEY "so-sndbuf"
 #define AERON_URI_SOCKET_RCVBUF_KEY "so-rcvbuf"
 #define AERON_URI_RECEIVER_WINDOW_KEY "rcv-wnd"
+#define AERON_URI_PACKET_TIMESTAMP_OFFSET "packet-ts-offset"
+#define AERON_URI_PACKET_TIMESTAMP_OFFSET_RESERVED "reserved"
 #define AERON_URI_INVALID_TAG (-1)
 
 typedef struct aeron_udp_channel_params_stct

--- a/aeron-client/src/main/c/uri/aeron_uri.h
+++ b/aeron-client/src/main/c/uri/aeron_uri.h
@@ -65,7 +65,7 @@ aeron_uri_params_t;
 #define AERON_URI_SOCKET_SNDBUF_KEY "so-sndbuf"
 #define AERON_URI_SOCKET_RCVBUF_KEY "so-rcvbuf"
 #define AERON_URI_RECEIVER_WINDOW_KEY "rcv-wnd"
-#define AERON_URI_PACKET_TIMESTAMP_OFFSET "packet-ts-offset"
+#define AERON_URI_PACKET_TIMESTAMP_OFFSET "pkt-ts-offset"
 #define AERON_URI_PACKET_TIMESTAMP_OFFSET_RESERVED "reserved"
 #define AERON_URI_INVALID_TAG (-1)
 

--- a/aeron-client/src/test/c/aeron_client_conductor_test.cpp
+++ b/aeron-client/src/test/c/aeron_client_conductor_test.cpp
@@ -52,7 +52,7 @@ extern "C"
 
 #define TIME_ADVANCE_INTERVAL_NS (1000 * 1000LL)
 
-#define PUB_URI "aeron:udp?endpoint=localhost:24567"
+#define URI_RESERVED "aeron:udp?endpoint=localhost:24567"
 #define DEST_URI "aeron:udp?endpoint=localhost:24568"
 #define SUB_URI "aeron:udp?endpoint=localhost:24567"
 #define STREAM_ID (101)
@@ -393,7 +393,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationSuccessfully)
     aeron_async_add_publication_t *async = nullptr;
     aeron_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -415,7 +415,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationSuccessfullyMaxMessageSize)
     aeron_async_add_publication_t *async = nullptr;
     aeron_publication_t *publication = nullptr;
     const size_t uri_length = MAX_MESSAGE_SIZE - sizeof(aeron_publication_command_t);
-    char *uri = allocateStringWithPrefix(PUB_URI, "|alias=", 'X', uri_length);
+    char *uri = allocateStringWithPrefix(URI_RESERVED, "|alias=", 'X', uri_length);
 
     ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, uri, STREAM_ID), 0);
     doWork();
@@ -442,7 +442,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddPublicationFromDriverError)
     aeron_async_add_publication_t *async = nullptr;
     aeron_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -460,7 +460,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddPublicationFromDriverTimeout)
     aeron_async_add_publication_t *async = nullptr;
     aeron_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -477,7 +477,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationSuccessfully)
     aeron_async_add_exclusive_publication_t *async = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_exclusive_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -499,7 +499,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationSuccessfullyMaxMessageS
     aeron_async_add_exclusive_publication_t *async = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
     const size_t uri_length = MAX_MESSAGE_SIZE - sizeof(aeron_publication_command_t);
-    char *uri = allocateStringWithPrefix(PUB_URI, "|alias=", 'C', uri_length);
+    char *uri = allocateStringWithPrefix(URI_RESERVED, "|alias=", 'C', uri_length);
 
     ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, uri, STREAM_ID), 0);
     doWork();
@@ -526,7 +526,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddExclusivePublicationFromDriverError)
     aeron_async_add_exclusive_publication_t *async = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_exclusive_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -543,7 +543,7 @@ TEST_F(ClientConductorTest, shouldErrorOnAddExclusivePublicationFromDriverTimeou
     aeron_async_add_exclusive_publication_t *async = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     ASSERT_EQ(aeron_async_add_exclusive_publication_poll(&publication, async), 0) << aeron_errmsg();
@@ -735,7 +735,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationAndHandleOnNewPublication)
     aeron_publication_t *publication = nullptr;
     bool was_on_new_publication_called = false;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     m_on_new_publication = [&](aeron_async_add_publication_t *async,
@@ -744,7 +744,7 @@ TEST_F(ClientConductorTest, shouldAddPublicationAndHandleOnNewPublication)
         int32_t session_id,
         int64_t correlation_id)
     {
-        EXPECT_EQ(strcmp(channel, PUB_URI), 0);
+        EXPECT_EQ(strcmp(channel, URI_RESERVED), 0);
         EXPECT_EQ(stream_id, STREAM_ID);
         EXPECT_EQ(session_id, SESSION_ID);
         EXPECT_EQ(correlation_id, async->registration_id);
@@ -772,7 +772,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationAndHandleOnNewPublicati
     aeron_exclusive_publication_t *publication = nullptr;
     bool was_on_new_exclusive_publication_called = false;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     m_on_new_exclusive_publication = [&](aeron_async_add_exclusive_publication_t *async,
@@ -781,7 +781,7 @@ TEST_F(ClientConductorTest, shouldAddExclusivePublicationAndHandleOnNewPublicati
         int32_t session_id,
         int64_t correlation_id)
     {
-        EXPECT_EQ(strcmp(channel, PUB_URI), 0);
+        EXPECT_EQ(strcmp(channel, URI_RESERVED), 0);
         EXPECT_EQ(stream_id, STREAM_ID);
         EXPECT_EQ(session_id, SESSION_ID);
         EXPECT_EQ(correlation_id, async->registration_id);
@@ -846,7 +846,7 @@ TEST_F(ClientConductorTest, shouldHandlePublicationAddRemoveDestination)
     aeron_async_destination_t *async_remove_dest = nullptr;
     aeron_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async_pub, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async_pub, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     transmitOnPublicationReady(async_pub, m_logFileName, false);
@@ -884,7 +884,7 @@ TEST_F(ClientConductorTest, shouldHandlePublicationAddRemoveDestinationMaxMessag
     aeron_async_destination_t *async_remove_dest = nullptr;
     aeron_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async_pub, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_publication(&async_pub, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     transmitOnPublicationReady(async_pub, m_logFileName, false);
@@ -926,7 +926,7 @@ TEST_F(ClientConductorTest, shouldHandleExclusivePublicationAddDestination)
     aeron_async_destination_t *async_dest = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async_pub, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async_pub, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     transmitOnPublicationReady(async_pub, m_logFileName, false);
@@ -964,7 +964,7 @@ TEST_F(ClientConductorTest, shouldHandleExclusivePublicationAddDestinationMaxMes
     aeron_async_destination_t *async_dest = nullptr;
     aeron_exclusive_publication_t *publication = nullptr;
 
-    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async_pub, &m_conductor, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_client_conductor_async_add_exclusive_publication(&async_pub, &m_conductor, URI_RESERVED, STREAM_ID), 0);
     doWork();
 
     transmitOnPublicationReady(async_pub, m_logFileName, false);
@@ -1009,7 +1009,7 @@ TEST_F(ClientConductorTest, shouldHandleSubscriptionAddDestination)
 
     ASSERT_EQ(
         aeron_client_conductor_async_add_subscription(
-            &async_sub, &m_conductor, PUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr),
+            &async_sub, &m_conductor, URI_RESERVED, STREAM_ID, nullptr, nullptr, nullptr, nullptr),
         0);
     doWork();
 
@@ -1049,7 +1049,7 @@ TEST_F(ClientConductorTest, shouldHandleSubscriptionAddDestinationMaxMessageSize
 
     ASSERT_EQ(
         aeron_client_conductor_async_add_subscription(
-            &async_sub, &m_conductor, PUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr),
+            &async_sub, &m_conductor, URI_RESERVED, STREAM_ID, nullptr, nullptr, nullptr, nullptr),
         0);
     doWork();
 

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -3150,7 +3150,7 @@ int aeron_driver_conductor_on_add_network_subscription(
         return -1;
     }
 
-    // If we found an existing endpoint free the channel. Channel is no longer required beyond this point.
+    // If we found an existing endpoint, free the channel. Channel is no longer required beyond this point.
     if (endpoint->conductor_fields.udp_channel != udp_channel)
     {
         aeron_udp_channel_delete(udp_channel);

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -142,6 +142,16 @@ static bool aeron_driver_conductor_has_clashing_subscription(
                 AERON_SET_ERR(EINVAL, "option conflicts with existing subscription: rejoin=%s", value);
                 return true;
             }
+
+            if (params->packet_timestamp_offset != link->packet_timestamp_offset)
+            {
+                AERON_SET_ERR(
+                    EINVAL,
+                    "option conflicts with existing subscription: packet-ts-offset=%" PRId32 " %s",
+                    params->packet_timestamp_offset,
+                    aeron_driver_uri_get_offset_info(params->packet_timestamp_offset));
+                return true;
+            }
         }
     }
 
@@ -2983,6 +2993,7 @@ int aeron_driver_conductor_on_add_ipc_subscription(
     link->subscribable_list.length = 0;
     link->subscribable_list.capacity = 0;
     link->subscribable_list.array = NULL;
+    link->packet_timestamp_offset = AERON_NULL_VALUE;
 
     aeron_driver_conductor_on_subscription_ready(
         conductor, command->correlated.correlation_id, AERON_CHANNEL_STATUS_INDICATOR_NOT_ALLOCATED);
@@ -3080,6 +3091,7 @@ int aeron_driver_conductor_on_add_spy_subscription(
     link->subscribable_list.length = 0;
     link->subscribable_list.capacity = 0;
     link->subscribable_list.array = NULL;
+    link->packet_timestamp_offset = params.packet_timestamp_offset;
 
     aeron_driver_conductor_on_subscription_ready(
         conductor, command->correlated.correlation_id, AERON_CHANNEL_STATUS_INDICATOR_NOT_ALLOCATED);
@@ -3220,6 +3232,7 @@ int aeron_driver_conductor_on_add_network_subscription(
         link->subscribable_list.length = 0;
         link->subscribable_list.capacity = 0;
         link->subscribable_list.array = NULL;
+        link->packet_timestamp_offset = params.packet_timestamp_offset;
 
         aeron_driver_conductor_on_subscription_ready(
             conductor, correlation_id, endpoint->channel_status.counter_id);

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -147,7 +147,7 @@ static bool aeron_driver_conductor_has_clashing_subscription(
             {
                 AERON_SET_ERR(
                     EINVAL,
-                    "option conflicts with existing subscription: packet-ts-offset=%" PRId32 " %s",
+                    "option conflicts with existing subscription: pkt-ts-offset=%" PRId32 " %s",
                     params->packet_timestamp_offset,
                     aeron_driver_uri_get_offset_info(params->packet_timestamp_offset));
                 return true;

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -1784,7 +1784,8 @@ aeron_receive_channel_endpoint_t *aeron_driver_conductor_get_or_add_receive_chan
                 correlation_id,
                 status_indicator.counter_id,
                 socket_rcvbuf,
-                socket_sndbuf) < 0)
+                socket_sndbuf,
+                aeron_udp_channel_is_packet_timestamping(channel)) < 0)
             {
                 AERON_APPEND_ERR("correlation_id=%" PRId64, correlation_id);
                 return NULL;
@@ -3588,7 +3589,8 @@ int aeron_driver_conductor_on_add_receive_destination(
         command->registration_id,
         endpoint->channel_status.counter_id,
         endpoint->conductor_fields.socket_rcvbuf,
-        endpoint->conductor_fields.socket_sndbuf) < 0)
+        endpoint->conductor_fields.socket_sndbuf,
+        aeron_udp_channel_is_packet_timestamping(endpoint->conductor_fields.udp_channel)) < 0)
     {
         goto error_cleanup;
     }

--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -98,6 +98,7 @@ typedef struct aeron_subscription_link_stct
     int32_t channel_length;
     int64_t registration_id;
     int64_t client_id;
+    int32_t packet_timestamp_offset;
 
     aeron_receive_channel_endpoint_t *endpoint;
     aeron_udp_channel_t *spy_channel;

--- a/aeron-driver/src/main/c/aeron_driver_name_resolver.c
+++ b/aeron-driver/src/main/c/aeron_driver_name_resolver.c
@@ -119,7 +119,8 @@ void aeron_driver_name_resolver_receive(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 static int aeron_driver_name_resolver_from_sockaddr(
     struct sockaddr_storage *addr, aeron_name_resolver_cache_addr_t *cache_addr);
@@ -217,6 +218,7 @@ int aeron_driver_name_resolver_init(
         0,
         context->socket_rcvbuf,
         context->socket_sndbuf,
+        false,
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_CONDUCTOR) < 0)
     {
@@ -511,7 +513,8 @@ void aeron_driver_name_resolver_receive(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp)
 {
     aeron_driver_name_resolver_t *resolver = receiver_clientd;
     aeron_frame_header_t *frame_header = (aeron_frame_header_t *)buffer;

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -357,7 +357,8 @@ void aeron_receive_channel_endpoint_dispatch(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp)
 {
     aeron_driver_receiver_t *receiver = (aeron_driver_receiver_t *)receiver_clientd;
     aeron_frame_header_t *frame_header = (aeron_frame_header_t *)buffer;
@@ -376,7 +377,8 @@ void aeron_receive_channel_endpoint_dispatch(
         case AERON_HDR_TYPE_DATA:
             if (length >= sizeof(aeron_data_header_t))
             {
-                if (aeron_receive_channel_endpoint_on_data(endpoint, destination, buffer, length, addr) < 0)
+                if (aeron_receive_channel_endpoint_on_data(
+                    endpoint, destination, buffer, length, addr, packet_timestamp) < 0)
                 {
                     AERON_APPEND_ERR("%s", "receiver on_data");
                     aeron_driver_receiver_log_error(receiver);
@@ -423,17 +425,52 @@ void aeron_receive_channel_endpoint_dispatch(
     }
 }
 
+static void aeron_receive_channel_endpoint_set_packet_timestamp(
+    aeron_receive_channel_endpoint_t *endpoint,
+    struct timespec *packet_timestamp,
+    aeron_data_header_t *data_header,
+    uint8_t *body_buffer,
+    size_t body_length)
+{
+    if (NULL == packet_timestamp)
+    {
+        return;
+    }
+
+    int64_t timestamp_ns =
+        (INT64_C(1000) * 1000 * 1000 * packet_timestamp->tv_sec) + packet_timestamp->tv_nsec;
+
+    int32_t offset = endpoint->conductor_fields.udp_channel->packet_timestamp_offset;
+    if (AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET == offset)
+    {
+        data_header->reserved_value = timestamp_ns;
+    }
+    else if (0 <= offset && offset <= (int32_t)(body_length - sizeof(timestamp_ns)))
+    {
+        memcpy(body_buffer + (size_t)offset, &timestamp_ns, sizeof(timestamp_ns));
+    }
+}
+
 int aeron_receive_channel_endpoint_on_data(
     aeron_receive_channel_endpoint_t *endpoint,
     aeron_receive_destination_t *destination,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp)
 {
     aeron_data_header_t *data_header = (aeron_data_header_t *)buffer;
 
     aeron_receive_destination_update_last_activity_ns(
         destination, aeron_clock_cached_nano_time(endpoint->cached_clock));
+
+    aeron_receive_channel_endpoint_set_packet_timestamp(
+        endpoint,
+        packet_timestamp,
+        data_header,
+        buffer + sizeof(aeron_data_header_t),
+        length - sizeof(aeron_data_header_t)
+    );
 
     return aeron_data_packet_dispatcher_on_data(
         &endpoint->dispatcher, endpoint, destination, data_header, buffer, length, addr);

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -445,7 +445,9 @@ static void aeron_receive_channel_endpoint_set_packet_timestamp(
     {
         data_header->reserved_value = timestamp_ns;
     }
-    else if (0 <= offset && offset <= (int32_t)(body_length - sizeof(timestamp_ns)))
+    else if (0 <= offset &&
+        offset <= (int32_t)(body_length - sizeof(timestamp_ns)) &&
+        offset <= (int32_t)((data_header->frame_header.frame_length - sizeof(*data_header)) - sizeof(timestamp_ns)))
     {
         memcpy(body_buffer + (size_t)offset, &timestamp_ns, sizeof(timestamp_ns));
     }

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
@@ -135,14 +135,16 @@ void aeron_receive_channel_endpoint_dispatch(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 int aeron_receive_channel_endpoint_on_data(
     aeron_receive_channel_endpoint_t *endpoint,
     aeron_receive_destination_t *destination,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 int aeron_receive_channel_endpoint_on_setup(
     aeron_receive_channel_endpoint_t *endpoint,

--- a/aeron-driver/src/main/c/media/aeron_receive_destination.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_destination.c
@@ -27,7 +27,8 @@ int aeron_receive_destination_create(
     int64_t registration_id,
     int32_t channel_status_counter_id,
     size_t socket_rcvbuf,
-    size_t socket_sndbuf)
+    size_t socket_sndbuf,
+    bool is_packet_timestamping)
 {
     aeron_receive_destination_t *_destination = NULL;
 
@@ -50,7 +51,7 @@ int aeron_receive_destination_create(
         0 != channel->multicast_ttl ? channel->multicast_ttl : context->multicast_ttl,
         socket_rcvbuf,
         socket_sndbuf,
-        aeron_udp_channel_is_packet_timestamping(channel),
+        is_packet_timestamping,
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_RECEIVER) < 0)
     {

--- a/aeron-driver/src/main/c/media/aeron_receive_destination.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_destination.c
@@ -50,6 +50,7 @@ int aeron_receive_destination_create(
         0 != channel->multicast_ttl ? channel->multicast_ttl : context->multicast_ttl,
         socket_rcvbuf,
         socket_sndbuf,
+        aeron_udp_channel_is_packet_timestamping(channel),
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_RECEIVER) < 0)
     {

--- a/aeron-driver/src/main/c/media/aeron_receive_destination.h
+++ b/aeron-driver/src/main/c/media/aeron_receive_destination.h
@@ -50,7 +50,8 @@ int aeron_receive_destination_create(
     int64_t registration_id,
     int32_t channel_status_counter_id,
     size_t socket_rcvbuf,
-    size_t socket_sndbuf);
+    size_t socket_sndbuf,
+    bool is_packet_timestamping);
 
 void aeron_receive_destination_delete(
     aeron_receive_destination_t *destination, aeron_counters_manager_t *counters_manager);

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -94,6 +94,7 @@ int aeron_send_channel_endpoint_create(
         0 != channel->multicast_ttl ? channel->multicast_ttl : context->multicast_ttl,
         _endpoint->conductor_fields.socket_rcvbuf,
         _endpoint->conductor_fields.socket_sndbuf,
+        false,
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_SENDER) < 0)
     {
@@ -291,7 +292,8 @@ void aeron_send_channel_endpoint_dispatch(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp)
 {
     aeron_driver_sender_t *sender = (aeron_driver_sender_t *)sender_clientd;
     aeron_frame_header_t *frame_header = (aeron_frame_header_t *)buffer;

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
@@ -96,7 +96,8 @@ void aeron_send_channel_endpoint_dispatch(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 void aeron_send_channel_endpoint_on_nak(
     aeron_send_channel_endpoint_t *endpoint, uint8_t *buffer, size_t length, struct sockaddr_storage *addr);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -420,9 +420,7 @@ int aeron_udp_channel_parse(
         _channel->canonical_length = strlen(_channel->canonical_form);
     }
 
-    const char *offset_str = aeron_uri_find_param_value(
-        &_channel->uri.params.udp.additional_params, AERON_URI_PACKET_TIMESTAMP_OFFSET);
-    if (aeron_udp_channel_parse_packet_timestamp_offset(offset_str, &_channel->packet_timestamp_offset) < 0)
+    if (aeron_driver_uri_get_packet_timestamp_offset(&_channel->uri, &_channel->packet_timestamp_offset) < 0)
     {
         AERON_APPEND_ERR("%s", "");
         goto error_cleanup;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -161,40 +161,6 @@ int aeron_uri_udp_canonicalise(
     return snprintf(canonical_form, length, "UDP-%s-%s%s", local_data_str, remote_data_str, unique_suffix);
 }
 
-_Static_assert(
-    AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET != AERON_NULL_VALUE,
-    "AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET == AERON_NULL_VALUE");
-
-int aeron_udp_channel_parse_packet_timestamp_offset(const char *offset_str, int32_t *offset)
-{
-    *offset = AERON_NULL_VALUE;
-
-    if (NULL == offset_str)
-    {
-        return 0;
-    }
-
-    if (0 == strcmp(AERON_URI_PACKET_TIMESTAMP_OFFSET_RESERVED, offset_str))
-    {
-        *offset = AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET;
-        return 0;
-    }
-
-    char *end_ptr = NULL;
-    errno = 0;
-    long parse_offset = strtol(offset_str, &end_ptr, 0);
-    errno = 0 == errno && '\0' != *end_ptr ? EINVAL : 0;
-    if (0 != errno)
-    {
-        AERON_SET_ERR(errno, "Invalid %s: %s", AERON_URI_PACKET_TIMESTAMP_OFFSET, offset_str);
-        return -1;
-    }
-
-    *offset = (int32_t)parse_offset;
-
-    return 0;
-}
-
 int aeron_udp_channel_parse(
     size_t uri_length,
     const char *uri,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.h
@@ -22,6 +22,8 @@
 #include "util/aeron_netutil.h"
 #include "aeron_name_resolver.h"
 
+#define AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET (-8)
+
 typedef struct aeron_udp_channel_stct
 {
     char original_uri[AERON_MAX_PATH];
@@ -45,6 +47,7 @@ typedef struct aeron_udp_channel_stct
     size_t socket_sndbuf_length;
     size_t socket_rcvbuf_length;
     size_t receiver_window_length;
+    int32_t packet_timestamp_offset;
 }
 aeron_udp_channel_t;
 
@@ -81,6 +84,12 @@ inline size_t aeron_udp_channel_socket_so_sndbuf(aeron_udp_channel_t *channel, s
 inline size_t aeron_udp_channel_socket_so_rcvbuf(aeron_udp_channel_t *channel, size_t default_so_rcvbuf)
 {
     return 0 != channel->socket_rcvbuf_length ? channel->socket_rcvbuf_length : default_so_rcvbuf;
+}
+
+inline bool aeron_udp_channel_is_packet_timestamping(aeron_udp_channel_t *channel)
+{
+    return AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET == channel->packet_timestamp_offset ||
+        0 <= channel->packet_timestamp_offset;
 }
 
 #endif //AERON_UDP_CHANNEL_H

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -245,7 +245,7 @@ int aeron_udp_channel_transport_init(
 
     if (is_packet_timestamping)
     {
-        if (aeron_udp_channel_transport_setup_packet_timestamps(transport))
+        if (aeron_udp_channel_transport_setup_packet_timestamps(transport) < 0)
         {
             AERON_APPEND_ERR("%s", "");
             goto error;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -383,7 +383,8 @@ int aeron_udp_channel_transport_recvmmsg(
             transport->destination_clientd,
             msgvec[i].msg_hdr.msg_iov[0].iov_base,
             msgvec[i].msg_len,
-            msgvec[i].msg_hdr.msg_name);
+            msgvec[i].msg_hdr.msg_name,
+            NULL);
         *bytes_rcved += msgvec[i].msg_len;
         work_count++;
     }

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
@@ -29,6 +29,7 @@ typedef struct aeron_udp_channel_transport_stct
     void *bindings_clientd;
     void *destination_clientd;
     void *interceptor_clientds[AERON_UDP_CHANNEL_TRANSPORT_MAX_INTERCEPTORS];
+    bool is_packet_timestamping;
 }
 aeron_udp_channel_transport_t;
 
@@ -42,6 +43,7 @@ int aeron_udp_channel_transport_init(
     uint8_t ttl,
     size_t socket_rcvbuf,
     size_t socket_sndbuf,
+    bool is_packet_timestamping,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity);
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -417,7 +417,8 @@ extern void aeron_udp_channel_incoming_interceptor_recv_func(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 extern void aeron_udp_channel_incoming_interceptor_to_endpoint(
     void *interceptor_state,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -47,6 +47,7 @@ typedef int (*aeron_udp_channel_transport_init_func_t)(
     uint8_t ttl,
     size_t socket_rcvbuf,
     size_t socket_sndbuf,
+    bool is_packet_timestamping,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity);
 
@@ -60,7 +61,8 @@ typedef void (*aeron_udp_transport_recv_func_t)(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp);
 
 typedef int (*aeron_udp_channel_transport_recvmmsg_func_t)(
     aeron_udp_channel_transport_t *transport,
@@ -320,7 +322,8 @@ inline void aeron_udp_channel_incoming_interceptor_recv_func(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *packet_timestamp)
 {
     aeron_udp_channel_incoming_interceptor_t *interceptor = data_paths->incoming_interceptors;
 
@@ -356,7 +359,7 @@ inline void aeron_udp_channel_incoming_interceptor_to_endpoint(
 #pragma GCC diagnostic pop
 #endif
 
-    func(NULL, transport, receiver_clientd, endpoint_clientd, destination_clientd, buffer, length, addr);
+    func(NULL, transport, receiver_clientd, endpoint_clientd, destination_clientd, buffer, length, addr, NULL);
 }
 
 int aeron_udp_channel_data_paths_init(

--- a/aeron-driver/src/main/c/uri/aeron_driver_uri.h
+++ b/aeron-driver/src/main/c/uri/aeron_driver_uri.h
@@ -49,6 +49,7 @@ typedef struct aeron_driver_uri_subscription_params_stct
     bool has_session_id;
     int32_t session_id;
     size_t initial_window_length;
+    int32_t packet_timestamp_offset;
 }
 aeron_driver_uri_subscription_params_t;
 
@@ -75,6 +76,9 @@ int aeron_subscription_params_validate_initial_window_for_rcvbuf(
     aeron_driver_uri_subscription_params_t *params,
     size_t endpoint_socket_rcvbuf,
     size_t os_default_socket_rcvbuf);
+
+int aeron_driver_uri_get_packet_timestamp_offset(aeron_uri_t *uri, int32_t *offset);
+const char *aeron_driver_uri_get_offset_info(int32_t offset);
 
 
 #endif //AERON_AERON_DRIVER_URI_H

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -91,3 +91,4 @@ set_tests_properties(c_cnc_test PROPERTIES RUN_SERIAL TRUE)
 aeron_driver_test(congestion_control_test aeron_congestion_control_test.cpp)
 
 aeron_driver_test(network_publication_test aeron_network_publication_test.cpp)
+aeron_driver_test(packet_timestamps_test aeron_packet_timestamps_test.cpp)

--- a/aeron-driver/src/test/c/aeron_c_cnc_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_cnc_test.cpp
@@ -27,7 +27,7 @@ extern "C"
 #include "aeron_system_counters.h"
 }
 
-#define PUB_URI "aeron:udp?endpoint=127.0.0.1:24325"
+#define URI_RESERVED "aeron:udp?endpoint=127.0.0.1:24325"
 #define PUB_URI_2 "aeron:udp?endpoint=127.0.0.1:24326"
 #define STREAM_ID (117)
 
@@ -197,7 +197,7 @@ TEST_F(CncTest, shouldGetCountersAndDistinctErrorLogs)
 
     aeron_async_add_subscription_t *async;
     ASSERT_EQ(aeron_async_add_subscription(
-        &async, m_aeron, PUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0) << aeron_errmsg();
+        &async, m_aeron, URI_RESERVED, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0) << aeron_errmsg();
     ASSERT_EQ(nullptr, awaitSubscriptionOrError(async));
 
     filter = CounterIdFilter{ AERON_SYSTEM_COUNTER_ERRORS };

--- a/aeron-driver/src/test/c/aeron_c_local_addresses_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_local_addresses_test.cpp
@@ -37,7 +37,7 @@ extern "C"
 #endif
 #define PUB_URI_ENDPOINT "127.0.0.1"
 #define PUB_URI_CONTROL "127.0.0.1:24326"
-#define PUB_URI "aeron:udp?endpoint=" PUB_URI_ENDPOINT ":0|control=" PUB_URI_CONTROL
+#define URI_RESERVED "aeron:udp?endpoint=" PUB_URI_ENDPOINT ":0|control=" PUB_URI_CONTROL
 #define PUB_URI_IPV6 "aeron:udp?endpoint=[::1]:0"
 #define STREAM_ID (117)
 
@@ -84,7 +84,7 @@ TEST_F(CLocalAddressesTest, shouldGetAddressForPublication)
 
     ASSERT_TRUE(connect());
 
-    ASSERT_EQ(aeron_async_add_publication(&async, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_publication(&async, m_aeron, URI_RESERVED, STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitPublicationOrError(async))) << aeron_errmsg();
 
     ASSERT_EQ(1, aeron_publication_local_sockaddrs(publication, m_addrs, NUM_BUFFERS));
@@ -106,7 +106,7 @@ TEST_F(CLocalAddressesTest, shouldGetAddressForExclusivePublication)
 
     ASSERT_TRUE(connect());
 
-    ASSERT_EQ(aeron_async_add_exclusive_publication(&async, m_aeron, PUB_URI, STREAM_ID), 0);
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&async, m_aeron, URI_RESERVED, STREAM_ID), 0);
     ASSERT_TRUE((publication = awaitExclusivePublicationOrError(async))) << aeron_errmsg();
 
     ASSERT_EQ(1, aeron_exclusive_publication_local_sockaddrs(publication, m_addrs, NUM_BUFFERS));
@@ -130,7 +130,7 @@ TEST_F(CLocalAddressesTest, shouldGetAddressForSubscription)
     ASSERT_TRUE(connect());
 
     ASSERT_EQ(aeron_async_add_subscription(
-        &async, m_aeron, PUB_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+        &async, m_aeron, URI_RESERVED, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
     ASSERT_TRUE((subscription = awaitSubscriptionOrError(async))) << aeron_errmsg();
 
     ASSERT_EQ(1, aeron_subscription_local_sockaddrs(subscription, m_addrs, NUM_BUFFERS));

--- a/aeron-driver/src/test/c/aeron_driver_uri_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_uri_test.cpp
@@ -294,6 +294,32 @@ TEST_F(DriverUriTest, shouldParseSubscriptionSessionId)
     EXPECT_EQ(params.session_id, 1001);
 }
 
+TEST_F(DriverUriTest, shouldGetPacketTimestampOffset)
+{
+    aeron_driver_uri_subscription_params_t params = {};
+
+    EXPECT_EQ(AERON_URI_PARSE("aeron:udp?endpoint=224.10.9.8|session-id=1001|packet-ts-offset=reserved", &m_uri), 0);
+    EXPECT_EQ(aeron_driver_uri_subscription_params(&m_uri, &params, &m_conductor), 0);
+
+    int32_t offset = 0;
+    ASSERT_NE(-1, aeron_driver_uri_get_packet_timestamp_offset(&m_uri, &offset));
+    EXPECT_EQ(AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET, offset);
+    EXPECT_EQ(offset, params.packet_timestamp_offset);
+}
+
+TEST_F(DriverUriTest, shouldDefaultPacketTimestampOffsetToAeronNullValue)
+{
+    aeron_driver_uri_subscription_params_t params = {};
+
+    EXPECT_EQ(AERON_URI_PARSE("aeron:udp?endpoint=224.10.9.8|session-id=1001", &m_uri), 0);
+    EXPECT_EQ(aeron_driver_uri_subscription_params(&m_uri, &params, &m_conductor), 0);
+
+    int32_t offset = 0;
+    ASSERT_NE(-1, aeron_driver_uri_get_packet_timestamp_offset(&m_uri, &offset));
+    EXPECT_EQ(AERON_NULL_VALUE, offset);
+    EXPECT_EQ(offset, params.packet_timestamp_offset);
+}
+
 class UriResolverTest : public testing::Test
 {
 public:

--- a/aeron-driver/src/test/c/aeron_driver_uri_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_uri_test.cpp
@@ -298,7 +298,7 @@ TEST_F(DriverUriTest, shouldGetPacketTimestampOffset)
 {
     aeron_driver_uri_subscription_params_t params = {};
 
-    EXPECT_EQ(AERON_URI_PARSE("aeron:udp?endpoint=224.10.9.8|session-id=1001|packet-ts-offset=reserved", &m_uri), 0);
+    EXPECT_EQ(AERON_URI_PARSE("aeron:udp?endpoint=224.10.9.8|session-id=1001|pkt-ts-offset=reserved", &m_uri), 0);
     EXPECT_EQ(aeron_driver_uri_subscription_params(&m_uri, &params, &m_conductor), 0);
 
     int32_t offset = 0;

--- a/aeron-driver/src/test/c/aeron_errors_test.cpp
+++ b/aeron-driver/src/test/c/aeron_errors_test.cpp
@@ -30,7 +30,7 @@ extern "C"
 #include "util/aeron_error.h"
 }
 
-#define PUB_URI "aeron:udp?endpoint=localhost:24325"
+#define URI_RESERVED "aeron:udp?endpoint=localhost:24325"
 #define STREAM_ID (117)
 
 class ErrorCallbackValidation

--- a/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
+++ b/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
@@ -48,6 +48,10 @@ int64_t null_reserved_value(void *clientd, uint8_t *buffer, size_t frame_length)
 
 TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValue)
 {
+#if !defined(__linux__)
+    GTEST_SKIP();
+#endif
+
     aeron_async_add_publication_t *async_pub = nullptr;
     aeron_async_add_subscription_t *async_sub = nullptr;
     std::string uri = std::string(URI);
@@ -104,6 +108,10 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValue)
 
 TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesAtOffset)
 {
+#if !defined(__linux__)
+    GTEST_SKIP();
+#endif
+
     aeron_async_add_publication_t *async_pub = nullptr;
     aeron_async_add_subscription_t *async_sub = nullptr;
     std::stringstream uriStream;

--- a/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
+++ b/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
@@ -168,7 +168,7 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesAtOffset)
     EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
 }
 
-TEST_F(PacketTimestampsTest, shouldTimestampConfigurationShouldClashIfNotMatching)
+TEST_F(PacketTimestampsTest, shouldErrorIfTimestampConfigurationClashes)
 {
     aeron_async_add_subscription_t *async_sub = nullptr;
 
@@ -194,4 +194,211 @@ TEST_F(PacketTimestampsTest, shouldTimestampConfigurationShouldClashIfNotMatchin
     ASSERT_EQ(aeron_async_add_subscription(
         &async_sub, m_aeron, uriDifferentOffset_s, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
     ASSERT_FALSE(awaitSubscriptionOrError(async_sub));
+}
+
+TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValueWithMergedMds)
+{
+#if !defined(__linux__)
+    GTEST_SKIP();
+#endif
+
+    aeron_async_add_exclusive_publication_t *asyncPubA = nullptr;
+    aeron_async_add_exclusive_publication_t *asyncPubB = nullptr;
+    aeron_async_add_subscription_t *asyncSub = nullptr;
+    aeron_async_destination_t *asyncDestA = nullptr;
+    aeron_async_destination_t *asyncDestB = nullptr;
+    std::string destinationA = std::string("aeron:udp?endpoint=localhost:24325");
+    std::string destinationB = std::string("aeron:udp?endpoint=localhost:24326");
+    std::string mdsUri = std::string("aeron:udp?control-mode=manual|packet-ts-offset=reserved");
+
+    struct message_t message = {};
+    message.padding = AERON_NULL_VALUE;
+    message.timestamp_2 = AERON_NULL_VALUE;
+    strcpy(message.text, "hello");
+
+    ASSERT_TRUE(connect());
+
+    ASSERT_EQ(aeron_async_add_subscription(
+        &asyncSub, m_aeron, mdsUri.c_str(), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(asyncSub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+
+    ASSERT_EQ(0, aeron_subscription_async_add_destination(&asyncDestA, m_aeron, subscription, destinationA.c_str()));
+    ASSERT_TRUE(awaitDestinationOrError(asyncDestA));
+
+    ASSERT_EQ(0, aeron_subscription_async_add_destination(&asyncDestB, m_aeron, subscription, destinationB.c_str()));
+    ASSERT_TRUE(awaitDestinationOrError(asyncDestB));
+
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&asyncPubA, m_aeron, destinationA.c_str(), STREAM_ID), 0);
+    aeron_publication_t *publicationA = awaitPublicationOrError(asyncPubA);
+    ASSERT_TRUE(publicationA) << aeron_errmsg();
+
+    aeron_publication_constants_t pubAConstants;
+    aeron_publication_constants(publicationA, &pubAConstants);
+    int64_t pubAPosition = aeron_publication_position(publicationA);
+
+    int32_t termId = aeron_logbuffer_compute_term_id_from_position(
+        pubAPosition,
+        pubAConstants.position_bits_to_shift,
+        pubAConstants.initial_term_id);
+    int32_t termOffset = pubAPosition & (pubAConstants.term_buffer_length - 1);
+
+    std::stringstream publicationBStream;
+    publicationBStream << destinationB;
+    publicationBStream << "|session-id=" << pubAConstants.session_id;
+    publicationBStream << "|init-term-id=" << pubAConstants.initial_term_id;
+    publicationBStream << "|term-id=" << termId;
+    publicationBStream << "|term-offset=" << termOffset;
+    std::string destB = publicationBStream.str();
+
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&asyncPubB, m_aeron, destB.c_str(), STREAM_ID), 0);
+    aeron_publication_t *publicationB = awaitPublicationOrError(asyncPubB);
+    ASSERT_TRUE(publicationB) << aeron_errmsg();
+
+    awaitConnected(subscription);
+
+    int poll_result;
+    int called = 0;
+    poll_handler_t handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
+    {
+        aeron_header_values_t header_values;
+        aeron_header_values(header, &header_values);
+        message_t *incoming = (message_t*)buffer;
+        EXPECT_NE(AERON_NULL_VALUE, header_values.frame.reserved_value);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->padding);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->timestamp_2);
+        EXPECT_STREQ(incoming->text, message.text);
+        called++;
+    };
+
+    while (aeron_publication_offer(
+        publicationA, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_EQ(1, called);
+
+    while (aeron_publication_offer(
+        publicationB, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    // Check that publicationB's first message is merged (i.e. not visible to the subscription).
+    for (int i = 0; i < 500; i++)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        ASSERT_EQ(0, poll(subscription, handler, 1));
+    }
+
+    while (aeron_publication_offer(
+        publicationB, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_EQ(2, called);
+
+    EXPECT_EQ(aeron_publication_close(publicationA, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}
+
+TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValueWithNonMergedMds)
+{
+#if !defined(__linux__)
+    GTEST_SKIP();
+#endif
+
+    aeron_async_add_publication_t *asyncPubA = nullptr;
+    aeron_async_add_publication_t *asyncPubB = nullptr;
+    aeron_async_add_subscription_t *asyncSub = nullptr;
+    aeron_async_destination_t *asyncDestA = nullptr;
+    aeron_async_destination_t *asyncDestB = nullptr;
+    std::string destinationA = std::string("aeron:udp?endpoint=localhost:24325");
+    std::string destinationB = std::string("aeron:udp?endpoint=localhost:24326");
+    std::string mdsUri = std::string("aeron:udp?control-mode=manual|packet-ts-offset=reserved");
+
+    struct message_t message = {};
+    message.padding = AERON_NULL_VALUE;
+    message.timestamp_2 = AERON_NULL_VALUE;
+    strcpy(message.text, "hello");
+
+    ASSERT_TRUE(connect());
+
+    ASSERT_EQ(aeron_async_add_subscription(
+        &asyncSub, m_aeron, mdsUri.c_str(), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(asyncSub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+
+    ASSERT_EQ(0, aeron_subscription_async_add_destination(&asyncDestA, m_aeron, subscription, destinationA.c_str()));
+    ASSERT_TRUE(awaitDestinationOrError(asyncDestA));
+
+    ASSERT_EQ(0, aeron_subscription_async_add_destination(&asyncDestB, m_aeron, subscription, destinationB.c_str()));
+    ASSERT_TRUE(awaitDestinationOrError(asyncDestB));
+
+    ASSERT_EQ(aeron_async_add_publication(&asyncPubA, m_aeron, destinationA.c_str(), STREAM_ID), 0);
+    aeron_publication_t *publicationA = awaitPublicationOrError(asyncPubA);
+    ASSERT_TRUE(publicationA) << aeron_errmsg();
+
+    ASSERT_EQ(aeron_async_add_publication(&asyncPubB, m_aeron, destinationB.c_str(), STREAM_ID), 0);
+    aeron_publication_t *publicationB = awaitPublicationOrError(asyncPubB);
+    ASSERT_TRUE(publicationB) << aeron_errmsg();
+
+    awaitConnected(subscription);
+
+    while (aeron_publication_offer(
+        publicationA, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    while (aeron_publication_offer(
+        publicationB, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    int poll_result;
+    int called = 0;
+    poll_handler_t handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
+    {
+        aeron_header_values_t header_values;
+        aeron_header_values(header, &header_values);
+        message_t *incoming = (message_t*)buffer;
+        EXPECT_NE(AERON_NULL_VALUE, header_values.frame.reserved_value);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->padding);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->timestamp_2);
+        EXPECT_STREQ(incoming->text, message.text);
+        called++;
+    };
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_EQ(1, called);
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_EQ(2, called);
+
+    EXPECT_EQ(aeron_publication_close(publicationA, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
 }

--- a/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
+++ b/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <functional>
+
+#include <gtest/gtest.h>
+
+#include "aeron_test_base.h"
+
+extern "C"
+{
+#include "concurrent/aeron_atomic.h"
+#include "agent/aeron_driver_agent.h"
+#include "aeron_driver_context.h"
+}
+
+#define URI "aeron:udp?endpoint=localhost:24325"
+#define STREAM_ID (117)
+
+struct message_t
+{
+    int64_t padding;
+    int64_t timestamp_2;
+    char text[16];
+};
+
+class PacketTimestampsTest : public CSystemTestBase, public testing::Test
+{
+};
+
+int64_t null_reserved_value(void *clientd, uint8_t *buffer, size_t frame_length)
+{
+    return AERON_NULL_VALUE;
+}
+
+TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValue)
+{
+    aeron_async_add_publication_t *async_pub = nullptr;
+    aeron_async_add_subscription_t *async_sub = nullptr;
+    std::string uri = std::string(URI);
+    const char *uri_s = uri.append("|packet-ts-offset=reserved").c_str();
+
+    struct message_t message = {};
+    message.padding = AERON_NULL_VALUE;
+    message.timestamp_2 = AERON_NULL_VALUE;
+    strcpy(message.text, "hello");
+
+    ASSERT_TRUE(connect());
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, uri_s, STREAM_ID), 0);
+
+    aeron_publication_t *publication = awaitPublicationOrError(async_pub);
+    ASSERT_TRUE(publication) << aeron_errmsg();
+
+    ASSERT_EQ(aeron_async_add_subscription(
+        &async_sub, m_aeron, uri_s, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(async_sub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+    awaitConnected(subscription);
+
+    while (aeron_publication_offer(
+        publication, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    int poll_result;
+    bool called = false;
+    poll_handler_t handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
+    {
+        aeron_header_values_t header_values;
+        aeron_header_values(header, &header_values);
+        message_t *incoming = (message_t*)buffer;
+        EXPECT_NE(AERON_NULL_VALUE, header_values.frame.reserved_value);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->padding);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->timestamp_2);
+        EXPECT_STREQ(incoming->text, message.text);
+        called = true;
+    };
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_TRUE(called);
+
+    EXPECT_EQ(aeron_publication_close(publication, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}
+
+TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesAtOffset)
+{
+    aeron_async_add_publication_t *async_pub = nullptr;
+    aeron_async_add_subscription_t *async_sub = nullptr;
+    std::stringstream uriStream;
+    uriStream << URI << "|packet-ts-offset=" << offsetof(message_t, timestamp_2) << '\0';
+    std::string uri = uriStream.str();
+    const char *uri_s = uri.c_str();
+
+    struct message_t message = {};
+    message.padding = AERON_NULL_VALUE;
+    message.timestamp_2 = AERON_NULL_VALUE;
+    strcpy(message.text, "hello");
+
+    ASSERT_TRUE(connect());
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, uri_s, STREAM_ID), 0);
+
+    aeron_publication_t *publication = awaitPublicationOrError(async_pub);
+    ASSERT_TRUE(publication) << aeron_errmsg();
+
+    ASSERT_EQ(aeron_async_add_subscription(
+        &async_sub, m_aeron, uri_s, STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(async_sub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+    awaitConnected(subscription);
+
+    while (aeron_publication_offer(
+        publication, (const uint8_t *)&message, sizeof(message), null_reserved_value, nullptr) < 0)
+    {
+        std::this_thread::yield();
+    }
+
+    int poll_result;
+    bool called = false;
+    poll_handler_t handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
+    {
+        aeron_header_values_t header_values;
+        aeron_header_values(header, &header_values);
+        message_t *incoming = (message_t*)buffer;
+        EXPECT_EQ(AERON_NULL_VALUE, header_values.frame.reserved_value);
+        EXPECT_EQ(AERON_NULL_VALUE, incoming->padding);
+        EXPECT_NE(AERON_NULL_VALUE, incoming->timestamp_2);
+        EXPECT_STREQ(incoming->text, message.text);
+        called = true;
+    };
+
+    while ((poll_result = poll(subscription, handler, 1)) == 0)
+    {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(poll_result, 1) << aeron_errmsg();
+    EXPECT_TRUE(called);
+
+    EXPECT_EQ(aeron_publication_close(publication, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}
+

--- a/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
+++ b/aeron-driver/src/test/c/aeron_packet_timestamps_test.cpp
@@ -55,7 +55,7 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValue)
     aeron_async_add_publication_t *async_pub = nullptr;
     aeron_async_add_subscription_t *async_sub = nullptr;
     std::string uri = std::string(URI);
-    const char *uri_s = uri.append("|packet-ts-offset=reserved").c_str();
+    const char *uri_s = uri.append("|pkt-ts-offset=reserved").c_str();
 
     struct message_t message = {};
     message.padding = AERON_NULL_VALUE;
@@ -115,7 +115,7 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesAtOffset)
     aeron_async_add_publication_t *async_pub = nullptr;
     aeron_async_add_subscription_t *async_sub = nullptr;
     std::stringstream uriStream;
-    uriStream << URI << "|packet-ts-offset=" << offsetof(message_t, timestamp_2) << '\0';
+    uriStream << URI << "|pkt-ts-offset=" << offsetof(message_t, timestamp_2) << '\0';
     std::string uri = uriStream.str();
     const char *uri_s = uri.c_str();
 
@@ -173,12 +173,12 @@ TEST_F(PacketTimestampsTest, shouldErrorIfTimestampConfigurationClashes)
     aeron_async_add_subscription_t *async_sub = nullptr;
 
     std::string uriOriginal = std::string(URI);
-    const char *uriOriginal_s = uriOriginal.append("|packet-ts-offset=8").c_str();
+    const char *uriOriginal_s = uriOriginal.append("|pkt-ts-offset=8").c_str();
 
     const char *uriNotSpecified_s = URI;
 
     std::string uriDifferentOffset = std::string(URI);
-    const char *uriDifferentOffset_s = uriDifferentOffset.append("|packet-ts-offset=reserved").c_str();
+    const char *uriDifferentOffset_s = uriDifferentOffset.append("|pkt-ts-offset=reserved").c_str();
 
     ASSERT_TRUE(connect());
 
@@ -209,7 +209,7 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValueWithMerged
     aeron_async_destination_t *asyncDestB = nullptr;
     std::string destinationA = std::string("aeron:udp?endpoint=localhost:24325");
     std::string destinationB = std::string("aeron:udp?endpoint=localhost:24326");
-    std::string mdsUri = std::string("aeron:udp?control-mode=manual|packet-ts-offset=reserved");
+    std::string mdsUri = std::string("aeron:udp?control-mode=manual|pkt-ts-offset=reserved");
 
     struct message_t message = {};
     message.padding = AERON_NULL_VALUE;
@@ -328,7 +328,7 @@ TEST_F(PacketTimestampsTest, shouldPutTimestampInMessagesReservedValueWithNonMer
     aeron_async_destination_t *asyncDestB = nullptr;
     std::string destinationA = std::string("aeron:udp?endpoint=localhost:24325");
     std::string destinationB = std::string("aeron:udp?endpoint=localhost:24326");
-    std::string mdsUri = std::string("aeron:udp?control-mode=manual|packet-ts-offset=reserved");
+    std::string mdsUri = std::string("aeron:udp?control-mode=manual|pkt-ts-offset=reserved");
 
     struct message_t message = {};
     message.padding = AERON_NULL_VALUE;

--- a/aeron-driver/src/test/c/aeron_publication_image_test.cpp
+++ b/aeron-driver/src/test/c/aeron_publication_image_test.cpp
@@ -55,7 +55,7 @@ TEST_F(PublicationImageTest, shouldAddAndRemoveDestination)
     aeron_receive_destination_t *dest_1;
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
@@ -64,7 +64,7 @@ TEST_F(PublicationImageTest, shouldAddAndRemoveDestination)
     aeron_receive_destination_t *dest_2;
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));
@@ -124,13 +124,13 @@ TEST_F(PublicationImageTest, shouldSendControlMessagesToAllDestinations)
     aeron_udp_channel_parse(strlen(uri_2), uri_2, &m_resolver, &channel_2, false);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));
@@ -196,13 +196,13 @@ TEST_F(PublicationImageTest, shouldHandleEosAcrossDestinations)
     aeron_udp_channel_parse(strlen(uri_2), uri_2, &m_resolver, &channel_2, false);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));
@@ -258,13 +258,13 @@ TEST_F(PublicationImageTest, shouldNotSendControlMessagesToAllDestinationThatHav
     aeron_clock_update_cached_nano_time(m_context->receiver_cached_clock, t0_ns);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));
@@ -329,13 +329,13 @@ TEST_F(PublicationImageTest, shouldTrackActiveTransportAccountBasedOnFrames)
     aeron_clock_update_cached_nano_time(m_context->receiver_cached_clock, t0_ns);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0, false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));
@@ -398,13 +398,29 @@ TEST_F(PublicationImageTest, shouldTrackUnderRunningTransportsWithLastSmAndRecei
     aeron_clock_update_cached_nano_time(m_context->receiver_cached_clock, t0_ns);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_1, channel_1, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_1,
+        channel_1,
+        m_context,
+        &m_counters_manager,
+        registration_id,
+        endpoint->channel_status.counter_id,
+        0,
+        0,
+        false));
     ASSERT_EQ(1, aeron_receive_channel_endpoint_add_destination(endpoint, dest_1));
 
     aeron_publication_image_t *image = createImage(endpoint, dest_1, stream_id, session_id);
 
     ASSERT_LE(0, aeron_receive_destination_create(
-        &dest_2, channel_2, m_context, &m_counters_manager, registration_id, endpoint->channel_status.counter_id, 0, 0));
+        &dest_2,
+        channel_2,
+        m_context,
+        &m_counters_manager,
+        registration_id,
+        endpoint->channel_status.counter_id,
+        0,
+        0,
+        false));
     ASSERT_EQ(2, aeron_receive_channel_endpoint_add_destination(endpoint, dest_2));
 
     ASSERT_EQ(2, aeron_publication_image_add_destination(image, dest_2));

--- a/aeron-driver/src/test/c/aeron_receiver_test.h
+++ b/aeron-driver/src/test/c/aeron_receiver_test.h
@@ -137,7 +137,7 @@ protected:
         if (!channel->is_manual_control_mode)
         {
             if (0 != aeron_receive_destination_create(
-                &destination, channel, m_context, &m_counters_manager, 0, status_indicator.counter_id, 0, 0))
+                &destination, channel, m_context, &m_counters_manager, 0, status_indicator.counter_id, 0, 0, false))
             {
                 return nullptr;
             }

--- a/aeron-driver/src/test/c/aeron_test_base.h
+++ b/aeron-driver/src/test/c/aeron_test_base.h
@@ -130,6 +130,22 @@ public:
         return subscription;
     }
 
+    static bool awaitDestinationOrError(aeron_async_destination_t *async)
+    {
+        do
+        {
+            std::this_thread::yield();
+            switch (aeron_subscription_async_destination_poll(async))
+            {
+                case -1:
+                    return false;
+                case 1:
+                    return true;
+            }
+        }
+        while (true);
+    }
+
     static aeron_counter_t *awaitCounterOrError(aeron_async_add_counter_t *async)
     {
         aeron_counter_t *counter = nullptr;

--- a/aeron-driver/src/test/c/aeron_test_udp_bindings.h
+++ b/aeron-driver/src/test/c/aeron_test_udp_bindings.h
@@ -40,6 +40,7 @@ int aeron_test_udp_channel_transport_init(
     uint8_t ttl,
     size_t socket_rcvbuf,
     size_t socket_sndbuf,
+    bool is_packet_timestamping,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity)
 {


### PR DESCRIPTION
Add the ability to get RX packet timestamps added to incoming messages.  This is enabled using the URI parameter `pkt-ts-offset`.  If this is 0 or greater, the 64 bit timestamp will be written into that position within the body of the message.  The special value `reserved` can also be used, in that case it will be written into reserved value field with the data header.  The timestamp is a 64bit count of nanoseconds since epoch.

If an incoming packet contains multiple fragments, it will only write the timestamp to the first fragment in the batch (to avoid having to scan a batch for each header).

The implementation currently only works with the C driver in Linux.

The configuration is set on the receive channel endpoint.  The `pkt-ts-offset` is used in subscription matching so creating two subscriptions to the same endpoint with different values for that parameter will raise an error.

It will attempt to turn on hardware timestamps.  It is up to the system administrator to enable hardware timestamps for the appropriate driver on the specific system.  The `hwstamp_ctl` which is part of the ptplinux package is one option - however it requires admin privileges, so is not done through Aeron itself.  If the hardware timestamps are disabled or unavailable the kernel will inject a software timestamp.