### PR TITLE
[Java] Add simple system tests for packet timestamps validate C drive…

### DIFF
--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -326,6 +326,13 @@ public class CommonContext implements Cloneable
     public static final String RECEIVER_WINDOW_LENGTH_PARAM_NAME = "rcv-wnd";
 
     /**
+     * Parameter name of the offset for the packet timestamp to be inserted into the incoming message
+     * on a subscription.  The special value of 'reserved' can be used to insert into the reserved value
+     * field.
+     */
+    public static final String PACKET_TIMESTAMP_OFFSET = "pkt-ts-offset";
+
+    /**
      * Using an integer because there is no support for boolean. 1 is concluded, 0 is not concluded.
      */
     private static final AtomicIntegerFieldUpdater<CommonContext> IS_CONCLUDED_UPDATER = newUpdater(

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -757,6 +757,9 @@ public final class DriverConductor implements Agent
         final String channel, final int streamId, final long registrationId, final long clientId)
     {
         final UdpChannel udpChannel = UdpChannel.parse(channel, nameResolver);
+
+        validateTimestampConfiguration(udpChannel);
+
         final SubscriptionParams params = SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
 
         checkForClashingSubscription(params, udpChannel, streamId);
@@ -1929,6 +1932,15 @@ public final class DriverConductor implements Agent
 
             throw new InvalidChannelException(
                 paramName + "=" + newLength + " does not match existing value of " + existingValue + " uri=" + channel);
+        }
+    }
+
+    private static void validateTimestampConfiguration(UdpChannel udpChannel)
+    {
+        if (null != udpChannel.channelUri().get(PACKET_TIMESTAMP_OFFSET))
+        {
+            throw new InvalidChannelException(
+                "Packet timestamps '" + PACKET_TIMESTAMP_OFFSET + "' are not supported in the Java driver");
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1935,7 +1935,7 @@ public final class DriverConductor implements Agent
         }
     }
 
-    private static void validateTimestampConfiguration(UdpChannel udpChannel)
+    private static void validateTimestampConfiguration(final UdpChannel udpChannel)
     {
         if (null != udpChannel.channelUri().get(PACKET_TIMESTAMP_OFFSET))
         {

--- a/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
@@ -1,0 +1,71 @@
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.exceptions.RegistrationException;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class TimestampingSystemTest
+{
+    public static final long SENTINEL_VALUE = -1L;
+    public static final String CHANNEL_WITH_PACKET_TIMESTAMP = "aeron:udp?endpoint=localhost:0|pkt-ts-offset=reserved";
+
+    @RegisterExtension
+    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+
+    @Test
+    void shouldErrorOnPacketTimestampsInJavaDriver()
+    {
+        assumeTrue(TestMediaDriver.shouldRunJavaMediaDriver());
+
+        try (final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
+            final Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            assertThrows(
+                RegistrationException.class,
+                () -> aeron.addSubscription(CHANNEL_WITH_PACKET_TIMESTAMP, 1000));
+        }
+    }
+
+    @Test
+    void shouldSupportPacketTimestampsInJavaDriver()
+    {
+        assumeTrue(TestMediaDriver.shouldRunCMediaDriver());
+
+        final DirectBuffer buffer = new UnsafeBuffer(new byte[64]);
+
+        try (final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
+            final Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            final Subscription sub = aeron.addSubscription(CHANNEL_WITH_PACKET_TIMESTAMP, 1000);
+            final String uri = new ChannelUriStringBuilder()
+                .media("udp")
+                .endpoint(sub.resolvedEndpoint())
+                .build();
+
+            final Publication pub = aeron.addPublication(uri, 1000);
+
+            Tests.awaitConnected(pub);
+
+            while (0 < pub.offer(buffer, 0, buffer.capacity(), (termBuffer, termOffset, frameLength) -> SENTINEL_VALUE))
+            {
+                Tests.yieldingIdle("Failed to offer message");
+            }
+
+            while (1 < sub.poll(
+                (buffer1, offset, length, header) -> assertNotEquals(SENTINEL_VALUE, header.reservedValue()), 1))
+            {
+                Tests.yieldingIdle("Failed to receive message");
+            }
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
@@ -52,7 +52,7 @@ public class TimestampingSystemTest
     }
 
     @Test
-    void shouldSupportPacketTimestampsInJavaDriver()
+    void shouldSupportPacketTimestampsInCDriver()
     {
         assumeTrue(TestMediaDriver.shouldRunCMediaDriver());
 

--- a/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron;
 
 import io.aeron.driver.MediaDriver;
@@ -27,8 +42,8 @@ public class TimestampingSystemTest
     {
         assumeTrue(TestMediaDriver.shouldRunJavaMediaDriver());
 
-        try (final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
-            final Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        try (TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
         {
             assertThrows(
                 RegistrationException.class,
@@ -43,8 +58,8 @@ public class TimestampingSystemTest
 
         final DirectBuffer buffer = new UnsafeBuffer(new byte[64]);
 
-        try (final TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
-            final Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        try (TestMediaDriver driver = TestMediaDriver.launch(new MediaDriver.Context(), watcher);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
         {
             final Subscription sub = aeron.addSubscription(CHANNEL_WITH_PACKET_TIMESTAMP, 1000);
             final String uri = new ChannelUriStringBuilder()

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/TestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/TestMediaDriver.java
@@ -32,6 +32,11 @@ public interface TestMediaDriver extends AutoCloseable
         return !isEmpty(System.getProperty(AERONMD_PATH_PROP_NAME));
     }
 
+    static boolean shouldRunJavaMediaDriver()
+    {
+        return !shouldRunCMediaDriver();
+    }
+
     static void notSupportedOnCMediaDriver(final String reason)
     {
         assumeFalse(shouldRunCMediaDriver(), () -> "not support by C Media Driver: " + reason);


### PR DESCRIPTION
…r, verify error response for Java driver.  Add rejection logic for packet timestamps in Java driver.