### PR TITLE
[C++] Archive Client AsyncConnect::poll: Avoid proceeding to step 1 until m_subscription is non-null

### DIFF
--- a/aeron-archive/src/main/cpp/client/AeronArchive.cpp
+++ b/aeron-archive/src/main/cpp/client/AeronArchive.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<AeronArchive> AeronArchive::AsyncConnect::poll()
         m_step = 1;
     }
 
-    if (1 == m_step)
+    if (1 == m_step && m_subscription)
     {
         std::string controlResponseChannel = m_subscription->tryResolveChannelEndpointPort();
         if (controlResponseChannel.empty())

--- a/aeron-archive/src/main/cpp/client/AeronArchive.cpp
+++ b/aeron-archive/src/main/cpp/client/AeronArchive.cpp
@@ -41,8 +41,8 @@ std::shared_ptr<AeronArchive> AeronArchive::AsyncConnect::poll()
         throw TimeoutException(
             "Archive connect timeout: step=" + std::to_string(m_step) +
             (m_step < 2 ?
-                " publication.uri=" + m_publication->channel() :
-                " subscription.uri=" + m_subscription->channel()),
+                " publication.uri=" + (m_publication ? m_publication->channel() : "<undiscovered>") :
+                " subscription.uri=" + (m_subscription ? m_subscription->channel() : "<undiscovered>")),
             SOURCEINFO);
     }
 


### PR DESCRIPTION
findSubscription() may return a null pointer that is used unchecked in step 1.