### PR TITLE
[C/C++] Pass media timestamp through the C driver interceptor chain.

### DIFF
--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -728,7 +728,8 @@ void aeron_driver_agent_incoming_msg(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp)
 {
     struct msghdr message;
     struct iovec iov;
@@ -753,7 +754,8 @@ void aeron_driver_agent_incoming_msg(
         destination_clientd,
         buffer,
         length,
-        addr);
+        addr,
+        media_timestamp);
 }
 
 void aeron_untethered_subscription_state_change(

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -429,7 +429,8 @@ extern void aeron_udp_channel_incoming_interceptor_to_endpoint(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp);
 
 extern int aeron_udp_channel_interceptors_transport_notifications(
     aeron_udp_channel_data_paths_t *data_paths,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -178,7 +178,8 @@ typedef void (*aeron_udp_channel_interceptor_incoming_func_t)(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec* media_timestamp);
 
 typedef int (*aeron_udp_channel_interceptor_init_func_t)(
     void **interceptor_state,
@@ -336,7 +337,8 @@ inline void aeron_udp_channel_incoming_interceptor_recv_func(
         destination_clientd,
         buffer,
         length,
-        addr);
+        addr,
+        media_timestamp);
 }
 
 inline void aeron_udp_channel_incoming_interceptor_to_endpoint(
@@ -348,18 +350,28 @@ inline void aeron_udp_channel_incoming_interceptor_to_endpoint(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp)
 {
 #if defined(AERON_COMPILER_GCC)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif
-    aeron_udp_transport_recv_func_t func = (aeron_udp_transport_recv_func_t)interceptor_state;
+    aeron_udp_transport_recv_func_t recv_func = (aeron_udp_transport_recv_func_t)interceptor_state;
 #if defined(AERON_COMPILER_GCC)
 #pragma GCC diagnostic pop
 #endif
 
-    func(NULL, transport, receiver_clientd, endpoint_clientd, destination_clientd, buffer, length, addr, NULL);
+    recv_func(
+        NULL,
+        transport,
+        receiver_clientd,
+        endpoint_clientd,
+        destination_clientd,
+        buffer,
+        length,
+        addr,
+        media_timestamp);
 }
 
 int aeron_udp_channel_data_paths_init(

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
@@ -144,7 +144,8 @@ void aeron_udp_channel_interceptor_loss_incoming(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp)
 {
     if (!aeron_udp_channel_interceptor_loss_should_drop_frame(
         buffer, aeron_udp_channel_interceptor_loss_params->rate,
@@ -159,7 +160,8 @@ void aeron_udp_channel_interceptor_loss_incoming(
             destination_clientd,
             buffer,
             length,
-            addr);
+            addr,
+            media_timestamp);
     }
 }
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.h
@@ -39,7 +39,8 @@ void aeron_udp_channel_interceptor_loss_incoming(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr);
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp);
 
 int aeron_udp_channel_interceptor_loss_configure(const aeron_udp_channel_interceptor_loss_params_t *loss_params);
 

--- a/aeron-driver/src/test/c/aeron_timestamps_test.cpp
+++ b/aeron-driver/src/test/c/aeron_timestamps_test.cpp
@@ -39,6 +39,12 @@ struct message_t
 
 class TimestampsTest : public CSystemTestBase, public testing::Test
 {
+public:
+    TimestampsTest() : CSystemTestBase(std::vector<std::pair<std::string, std::string>>{
+            { "AERON_UDP_CHANNEL_INCOMING_INTERCEPTORS", "loss" },
+            { "AERON_UDP_CHANNEL_TRANSPORT_BINDINGS_LOSS_ARGS", "rate=0" }
+        })
+    {}
 };
 
 int64_t null_reserved_value(void *clientd, uint8_t *buffer, size_t frame_length)

--- a/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
+++ b/aeron-driver/src/test/c/media/aeron_udp_channel_transport_loss_test.cpp
@@ -55,7 +55,8 @@ void aeron_udp_channel_interceptor_loss_incoming_delegate(
     void *destination_clientd,
     uint8_t *buffer,
     size_t length,
-    struct sockaddr_storage *addr)
+    struct sockaddr_storage *addr,
+    struct timespec *media_timestamp)
 {
     auto *state = (delegate_recv_state_t *)interceptor_state;
 
@@ -88,9 +89,9 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardAllPacketsWithRateOfOne)
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 0);
 }
@@ -121,9 +122,9 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfOneWithD
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 2);
 }
@@ -153,9 +154,9 @@ TEST_F(UdpChannelTransportLossTest, shouldNotDiscardAllPacketsWithRateOfZero)
     aeron_udp_channel_interceptor_loss_configure(&params);
 
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_0, 1024, nullptr, NULL);
     aeron_udp_channel_interceptor_loss_incoming(
-        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr);
+        nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data_1, 1024, nullptr, NULL);
 
     EXPECT_EQ(delegate_recv_state.messages_received, 2);
 }
@@ -186,7 +187,7 @@ TEST_F(UdpChannelTransportLossTest, shouldDiscardRoughlyHalfTheMessages)
         frame_header->type = msg_type;
 
         aeron_udp_channel_interceptor_loss_incoming(
-            nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data + (i * 1024), 1024, nullptr);
+            nullptr, &delegate, nullptr, nullptr, nullptr, nullptr, data + (i * 1024), 1024, nullptr, NULL);
     }
 
     EXPECT_LT(delegate_recv_state.messages_received, static_cast<int>(vlen));


### PR DESCRIPTION
Configure timestamp tests to use loss interceptor with 0 loss to exercise/test that code path.