### PR TITLE
[C/C++] Add sanitise build for MSVC and fix issues found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,12 @@ elseif (MSVC)
     if (CXX_WARNINGS_AS_ERRORS)
         add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)
     endif (CXX_WARNINGS_AS_ERRORS)
+
+    if (SANITISE_BUILD)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /Zi /D AERON_SANITIZE_ENABLED")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /Zi /D AERON_SANITIZE_ENABLED")
+    endif (SANITISE_BUILD)
+
 endif ()
 
 

--- a/aeron-client/src/main/c/aeron_socket.c
+++ b/aeron-client/src/main/c/aeron_socket.c
@@ -203,7 +203,7 @@ int getifaddrs(struct ifaddrs **ifap)
             ULONG prefixLength = unicast->OnLinkPrefixLength;
 
             /* map prefix to netmask */
-            ift->ifa_netmask = malloc(sizeof(struct sockaddr));
+            ift->ifa_netmask = malloc(unicast->Address.iSockaddrLength);
             ift->ifa_netmask->sa_family = unicast->Address.lpSockaddr->sa_family;
 
             switch (unicast->Address.lpSockaddr->sa_family)

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -452,6 +452,7 @@ bool aeron_driver_agent_logging_events_init(const char *event_log, const char *e
         if (NULL == event_log_disable_dup)
         {
             fprintf(stderr, "failed to copy logging disable events string\n");
+            aeron_free(event_log_dup);
             return false;
         }
 
@@ -461,6 +462,7 @@ bool aeron_driver_agent_logging_events_init(const char *event_log, const char *e
         if (num_events_disable < 0)
         {
             fprintf(stderr, "failed to parse logging events: '%s'\n", event_log_disable);
+            aeron_free(event_log_dup);
             aeron_free(event_log_disable_dup);
             return false;
         }

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_loss.c
@@ -95,8 +95,16 @@ void aeron_udp_channel_transport_loss_load_env()
     aeron_udp_channel_interceptor_loss_params_t *params;
     const char *args = AERON_CONFIG_GETENV_OR_DEFAULT(AERON_UDP_CHANNEL_TRANSPORT_BINDINGS_LOSS_ARGS_ENV_VAR, "");
     char *args_dup = strdup(args);
+    if (NULL == args_dup)
+    {
+        AERON_SET_ERR(errno, "%s", "Duplicating args string");
+        return;
+    }
 
-    aeron_alloc((void **)&params, sizeof(aeron_udp_channel_interceptor_loss_params_t));
+    if (aeron_alloc((void **)&params, sizeof(aeron_udp_channel_interceptor_loss_params_t)) < 0)
+    {
+        return;
+    }
 
     if (aeron_udp_channel_interceptor_loss_parse_params(args_dup, params) >= 0)
     {

--- a/cppbuild/cppbuild.cmd
+++ b/cppbuild/cppbuild.cmd
@@ -38,6 +38,9 @@ for %%o in (%*) do (
         set "BUILD_DIR=%DIR%\Debug"
         set "BUILD_CONFIG=Debug"
         echo "Enabling debug build"
+    ) else if "%%o"=="--sanitise-build" (
+        set "EXTRA_CMAKE_ARGS=!EXTRA_CMAKE_ARGS! -DSANITISE_BUILD=ON"
+        echo "Enabling sanitise build"
     ) else (
         echo "Unknown option %%o"
         echo "Use --help for help"


### PR DESCRIPTION
**Note:** I haven't added sanitise Windows build to CI, because it currently reports lots of _false positives_ in the form of `attempting free on address which was not malloc()-ed`.
For example:
```powershell
==8312==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x11d73a0a2200 in thread T0
    #0 0x7ff7b3c3fc5c in free D:\agent\_work\4\s\src\vctools\crt\asan\llvm\compiler-rt\lib\asan\asan_malloc_win.cpp:110
    #1 0x7ffab60649f3  (C:\Windows\SYSTEM32\ucrtbased.dll+0x1800749f3)
    #2 0x7ffab6064364  (C:\Windows\SYSTEM32\ucrtbased.dll+0x180074364)
    #3 0x7ffab6064499  (C:\Windows\SYSTEM32\ucrtbased.dll+0x180074499)
    #4 0x7ffab6064b00  (C:\Windows\SYSTEM32\ucrtbased.dll+0x180074b00)
    #5 0x7ffab7034aa8 in __scrt_dllmain_uninitialize_c d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\utility\utility.cpp:398
    #6 0x7ffab703506b in dllmain_crt_process_detach d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp:180
    #7 0x7ffab7034eb6 in dllmain_crt_dispatch d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp:220
    #8 0x7ffab70351bd in dllmain_dispatch d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp:293
    #9 0x7ffab70352c0 in _DllMainCRTStartup d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\dll_dllmain.cpp:334
    #10 0x7ffb179e9a1c  (C:\Windows\SYSTEM32\ntdll.dll+0x180019a1c)
    #11 0x7ffb17a2db90  (C:\Windows\SYSTEM32\ntdll.dll+0x18005db90)
    #12 0x7ffb17a2da2c  (C:\Windows\SYSTEM32\ntdll.dll+0x18005da2c)
    #13 0x7ffb1610e0aa  (C:\Windows\System32\KERNEL32.DLL+0x18001e0aa)
    #14 0x7ff7b3d6a869 in exit_or_terminate_process minkernel\crts\ucrt\src\appcrt\startup\exit.cpp:143
    #15 0x7ff7b3d6a825 in common_exit minkernel\crts\ucrt\src\appcrt\startup\exit.cpp:280
    #16 0x7ff7b3d6ab75 in exit minkernel\crts\ucrt\src\appcrt\startup\exit.cpp:293
    #17 0x7ff7b3d02fe6 in __scrt_common_main_seh d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:295
    #18 0x7ff7b3d02e8d in __scrt_common_main d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:330
    #19 0x7ff7b3d030ed in mainCRTStartup d:\agent\_work\4\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:16
    #20 0x7ffb16107033  (C:\Windows\System32\KERNEL32.DLL+0x180017033)
    #21 0x7ffb17a22650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)
```
See [sanitise.txt](https://github.com/real-logic/aeron/files/6901030/sanitise.txt) for the full list of remaining reported issues.
