### PR TITLE
Name resolver address change event log

### DIFF
--- a/aeron-client/src/main/java/io/aeron/CommonContext.java
+++ b/aeron-client/src/main/java/io/aeron/CommonContext.java
@@ -355,6 +355,11 @@ public class CommonContext implements Cloneable
     public static final String RESERVED_OFFSET = "reserved";
 
     /**
+     * Name of the file used to store events such as warnings.
+     */
+    public static final String EVENT_LOG_FILE = "event.dat";
+
+    /**
      * Using an integer because there is no support for boolean. 1 is concluded, 0 is not concluded.
      */
     private static final AtomicIntegerFieldUpdater<CommonContext> IS_CONCLUDED_UPDATER = newUpdater(
@@ -530,6 +535,17 @@ public class CommonContext implements Cloneable
     public static File newCncFile(final String aeronDirectoryName)
     {
         return new File(aeronDirectoryName, CncFileDescriptor.CNC_FILE);
+    }
+
+    /**
+     * Create a new event log file in the administration directory.
+     *
+     * @return The newly created File.
+     * @param aeronDirectoryName name of the aeronDirectory that containing the event log file.
+     */
+    public static File newEventLogFile(final String aeronDirectoryName)
+    {
+        return new File(aeronDirectoryName, CommonContext.EVENT_LOG_FILE);
     }
 
     /**
@@ -854,6 +870,24 @@ public class CommonContext implements Cloneable
 
         return printErrorLog(errorLogBuffer(cncByteBuffer), out);
     }
+
+    /**
+     * Read the error log to a given {@link PrintStream}
+     *
+     * @param out            to write the error log contents to.
+     * @param eventLogBuffer containing the event log.
+     * @return the number of observations from the error log.
+     */
+    public int saveEventLog(final PrintStream out, final AtomicBuffer eventLogBuffer)
+    {
+        if (null == eventLogBuffer)
+        {
+            return 0;
+        }
+
+        return printErrorLog(eventLogBuffer, out);
+    }
+
 
     /**
      * Release resources used by the CommonContext.

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -187,6 +187,16 @@ public final class Configuration
     public static final int ERROR_BUFFER_LENGTH_DEFAULT = 1024 * 1024;
 
     /**
+     * Property name for length of the memory mapped buffer for the distinct event log.
+     */
+    public static final String EVENT_BUFFER_LENGTH_PROP_NAME = "aeron.event.buffer.length";
+
+    /**
+     * Default buffer length for the event buffer for the media driver.
+     */
+    public static final int EVENT_BUFFER_LENGTH_DEFAULT = 1024 * 1024;
+
+    /**
      * Property name for length of the memory mapped buffer for the {@link io.aeron.driver.reports.LossReport}.
      */
     public static final String LOSS_REPORT_BUFFER_LENGTH_PROP_NAME = "aeron.loss.report.buffer.length";
@@ -877,6 +887,16 @@ public final class Configuration
      * @return length of the memory mapped buffer for the distinct error log.
      */
     public static int errorBufferLength()
+    {
+        return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
+    }
+
+    /**
+     * Length of the memory mapped buffer for the distinct error log.
+     *
+     * @return length of the memory mapped buffer for the distinct error log.
+     */
+    public static int eventBufferLength()
     {
         return getSizeAsInt(ERROR_BUFFER_LENGTH_PROP_NAME, ERROR_BUFFER_LENGTH_DEFAULT);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -117,7 +117,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         selfResolutionDeadlineMs = 0;
         neighborResolutionDeadlineMs = nowMs + neighborResolutionIntervalMs;
 
-        cache = new DriverNameResolverCache(TIMEOUT_MS);
+        cache = new DriverNameResolverCache(TIMEOUT_MS, ctx.eventLog());
 
         final UdpChannel placeholderChannel = UdpChannel.parse("aeron:udp?endpoint=localhost:8050");
         transport = new UdpNameResolutionTransport(placeholderChannel, localSocketAddress, unsafeBuffer, ctx);

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolverCache.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolverCache.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.driver;
 
+import io.aeron.exceptions.AeronEvent;
 import io.aeron.protocol.ResolutionEntryFlyweight;
 import org.agrona.collections.ArrayListUtil;
 import org.agrona.concurrent.errors.DistinctErrorLog;
@@ -88,7 +89,7 @@ final class DriverNameResolverCache implements AutoCloseable
                 entry.address = Arrays.copyOf(address, addressLength);
                 entry.port = port;
 
-                eventLog.record(new RuntimeException(
+                eventLog.record(new AeronEvent(
                     "Address changed for name: " + new String(name, 0, nameLength, StandardCharsets.US_ASCII)));
             }
         }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3628,14 +3628,14 @@ public final class MediaDriver implements AutoCloseable
             }
         }
 
-        public MappedByteBuffer mapExistingEventLogBuffer()
+        private MappedByteBuffer mapExistingEventLogBuffer()
         {
             final File file = new File(aeronDirectory(), EVENT_LOG_FILE);
             try
             {
                 return IoUtil.mapExistingFile(file, "Event Log Buffer");
             }
-            catch (Exception e)
+            catch (final Exception ex)
             {
                 return null;
             }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -397,7 +397,7 @@ public final class MediaDriver implements AutoCloseable
                 IoUtil.removeTrailingSlashes(builder);
 
                 final SimpleDateFormat dateFormat = new SimpleDateFormat("-yyyy-MM-dd-HH-mm-ss-SSSZ");
-                builder.append(dateFormat.format(new Date())).append("-" + name + ".log");
+                builder.append(dateFormat.format(new Date())).append("-").append(name).append(".log");
                 final String errorLogFilename = builder.toString();
 
                 System.err.println("WARNING: Existing " + name + "s saved to: " + errorLogFilename);

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -390,7 +390,7 @@ public final class MediaDriver implements AutoCloseable
         try
         {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            final int observations = ctx.saveEventLog(new PrintStream(baos, false, US_ASCII), existingLogBuffer);
+            final int observations = ctx.saveEventLog(new PrintStream(baos, false, "ASCII"), existingLogBuffer);
             if (observations > 0)
             {
                 final StringBuilder builder = new StringBuilder(ctx.aeronDirectoryName());

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
@@ -75,6 +75,8 @@ public class ErrorAndEventLoggingTest
     @ExtendWith(HideOutputCallback.class)
     void shouldBackupEventAndErrorLogFiles() throws IOException
     {
+        TestMediaDriver.notSupportedOnCMediaDriver("Not yet implemented");
+
         final String aeronDirectoryName = CommonContext.generateRandomDirName();
 
         context = new MediaDriver.Context()

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
@@ -17,6 +17,7 @@ package io.aeron;
 
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.status.SystemCounterDescriptor;
+import io.aeron.test.HideOutputCallback;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
@@ -25,12 +26,12 @@ import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -49,9 +50,6 @@ public class ErrorAndEventLoggingTest
     private MediaDriver.Context context;
     private Aeron aeron;
     private TestMediaDriver driver;
-    private PrintStream out;
-    private PrintStream err;
-
 
     private void launch()
     {
@@ -59,21 +57,9 @@ public class ErrorAndEventLoggingTest
         aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
     }
 
-    @BeforeEach
-    public void before()
-    {
-        out = System.out;
-        err = System.err;
-        System.setOut(new PrintStream(OutputStream.nullOutputStream()));
-        System.setErr(new PrintStream(OutputStream.nullOutputStream()));
-    }
-
     @AfterEach
     public void after()
     {
-        System.setOut(out);
-        System.setOut(err);
-
         deleteBackupFiles("-event.log", "-error.log");
 
         CloseHelper.closeAll(closeables);
@@ -86,6 +72,7 @@ public class ErrorAndEventLoggingTest
 
     @Test
     @InterruptAfter(5)
+    @ExtendWith(HideOutputCallback.class)
     void shouldBackupEventAndErrorLogFiles() throws IOException
     {
         final String aeronDirectoryName = CommonContext.generateRandomDirName();

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
@@ -1,0 +1,176 @@
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.status.SystemCounterDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ErrorAndEventLoggingTest
+{
+    @RegisterExtension
+    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+
+    private final ArrayList<AutoCloseable> closeables = new ArrayList<>();
+
+    private MediaDriver.Context context;
+    private Aeron aeron;
+    private TestMediaDriver driver;
+
+    private void launch()
+    {
+        driver = TestMediaDriver.launch(context, watcher);
+        aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+    }
+
+    @AfterEach
+    public void after()
+    {
+        deleteBackupFiles("-event.log", "-error.log");
+
+        CloseHelper.closeAll(closeables);
+        CloseHelper.closeAll(aeron, driver);
+        if (null != driver)
+        {
+            driver.context().deleteDirectory();
+        }
+    }
+
+    @Test
+    @InterruptAfter(5)
+    void shouldValidateSenderMtuAgainstUriReceiverWindow() throws IOException
+    {
+        final String aeronDirectoryName = CommonContext.generateRandomDirName();
+
+        context = new MediaDriver.Context()
+            .aeronDirectoryName(aeronDirectoryName)
+            .errorHandler(null)
+            .resolverName("A")
+            .resolverInterface("0.0.0.0:8050")
+            .resolverBootstrapNeighbor("localhost:8051")
+            .dirDeleteOnStart(false);
+
+        launch();
+
+        final long initialErrorCount = aeron.countersReader().getCounterValue(SystemCounterDescriptor.ERRORS.id());
+
+        addPublication("aeron:udp?endpoint=localhost:9999|mtu=1408", 1000);
+        addSubscription("aeron:udp?endpoint=localhost:9999|rcv-wnd=1376", 1000);
+
+        Tests.awaitCounterDelta(aeron.countersReader(), SystemCounterDescriptor.ERRORS.id(), initialErrorCount, 1);
+
+        final Matcher<String> exceptionMessageMatcher = allOf(
+            containsString("mtuLength="),
+            containsString("> initialWindowLength="));
+
+        SystemTests.waitForErrorToOccur(driver.aeronDirectoryName(), exceptionMessageMatcher, Tests.SLEEP_1_MS);
+
+        try (
+            final MediaDriver otherDriver1 = MediaDriver.launchEmbedded(
+                new MediaDriver.Context()
+                    .resolverName("B")
+                    .resolverInterface("0.0.0.0:8051")
+                    .resolverBootstrapNeighbor("localhost:8050")
+                    .dirDeleteOnShutdown(true));
+            final MediaDriver otherDriver2 = MediaDriver.launchEmbedded(
+                new MediaDriver.Context()
+                    .resolverName("B")
+                    .resolverInterface("0.0.0.0:8052")
+                    .resolverBootstrapNeighbor("localhost:8050")
+                    .dirDeleteOnShutdown(true)))
+        {
+            SystemTests.waitForEventToOccur(
+                driver.aeronDirectoryName(),
+                containsString("Name changed for address"),
+                Tests.SLEEP_1_MS);
+        }
+
+        CloseHelper.closeAll(closeables);
+        closeables.clear();
+        CloseHelper.closeAll(aeron, driver);
+        aeron = null;
+        driver = null;
+
+        context = new MediaDriver.Context()
+            .aeronDirectoryName(aeronDirectoryName)
+            .errorHandler(null)
+            .dirDeleteOnStart(false);
+
+        launch();
+
+        final File backupErrorLogFile = findBackupErrorLogFile(aeronDirectoryName);
+
+        assertNotNull(backupErrorLogFile);
+        assertTrue(backupErrorLogFile.exists());
+        assertTrue(0 < backupErrorLogFile.length());
+
+        final File backupEventLogFile = findBackupEventLogFile(aeronDirectoryName);
+
+        assertNotNull(backupEventLogFile);
+        assertTrue(backupEventLogFile.exists());
+        assertTrue(0 < backupEventLogFile.length());
+    }
+
+    private Publication addPublication(final String channel, final int streamId)
+    {
+        final Publication pub = aeron.addPublication(channel, streamId);
+        closeables.add(pub);
+        return pub;
+    }
+
+    private Subscription addSubscription(final String channel, final int streamId)
+    {
+        final Subscription sub = aeron.addSubscription(channel, streamId);
+        closeables.add(sub);
+        return sub;
+    }
+
+    private File findBackupErrorLogFile(final String aeronDirectoryName)
+    {
+        return findBackupFile(aeronDirectoryName, "-error.log");
+    }
+
+    private File findBackupEventLogFile(final String aeronDirectoryName)
+    {
+        return findBackupFile(aeronDirectoryName, "-event.log");
+    }
+
+    private File findBackupFile(final String aeronDirectoryName, final String suffix)
+    {
+        final File aeronDirectory = new File(aeronDirectoryName);
+        final File[] aeronErrorBackupFiles = aeronDirectory.getParentFile().listFiles(
+            (dir, name) -> name.startsWith(aeronDirectory.getName()) && name.endsWith(suffix));
+
+        return null != aeronErrorBackupFiles && 1 == aeronErrorBackupFiles.length ? aeronErrorBackupFiles[0] : null;
+    }
+
+    private void deleteBackupFiles(final String... suffixes)
+    {
+        for (String suffix : suffixes)
+        {
+            final File backupErrorLogFile = findBackupFile(aeron.context().aeronDirectoryName(), suffix);
+            if (null != backupErrorLogFile)
+            {
+                //noinspection ResultOfMethodCallIgnored
+                backupErrorLogFile.delete();
+            }
+        }
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorAndEventLoggingTest.java
@@ -60,12 +60,11 @@ public class ErrorAndEventLoggingTest
     @AfterEach
     public void after()
     {
-        deleteBackupFiles("-event.log", "-error.log");
-
         CloseHelper.closeAll(closeables);
         CloseHelper.closeAll(aeron, driver);
         if (null != driver)
         {
+            deleteBackupFiles("-event.log", "-error.log");
             driver.context().deleteDirectory();
         }
     }

--- a/aeron-system-tests/src/test/java/io/aeron/SystemTests.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SystemTests.java
@@ -83,7 +83,7 @@ class SystemTests
 
         assertTrue(cncFile.exists());
 
-        MappedByteBuffer cncByteBuffer = IoUtil.mapExistingFile(cncFile, "cncFile");
+        final MappedByteBuffer cncByteBuffer = IoUtil.mapExistingFile(cncFile, "cncFile");
 
         try
         {
@@ -104,7 +104,7 @@ class SystemTests
 
         assertTrue(cncFile.exists());
 
-        MappedByteBuffer eventLogByteBuffer = IoUtil.mapExistingFile(cncFile, "event log file");
+        final MappedByteBuffer eventLogByteBuffer = IoUtil.mapExistingFile(cncFile, "event log file");
 
         try
         {

--- a/aeron-system-tests/src/test/java/io/aeron/driver/DriverNameResolverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/DriverNameResolverTest.java
@@ -29,6 +29,7 @@ import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.SleepingMillisIdleStrategy;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -131,6 +132,38 @@ public class DriverNameResolverTest
         awaitCounterValue("A", aNeighborsCounterId, 2);
         awaitCounterValue("B", bNeighborsCounterId, 2);
         awaitCounterValue("C", cNeighborsCounterId, 2);
+    }
+
+    @Test
+    @Disabled
+    @InterruptAfter(2000000)
+    public void shouldSeeNeighborsWhichHaveTheSameName()
+    {
+        addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
+            .aeronDirectoryName(baseDir + "-B1")
+            .resolverName("B")
+            .resolverInterface("0.0.0.0:8051")
+            .resolverBootstrapNeighbor("localhost:8050"), testWatcher));
+
+        addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
+            .aeronDirectoryName(baseDir + "-B2")
+            .resolverName("B")
+            .resolverInterface("0.0.0.0:8052")
+            .resolverBootstrapNeighbor("localhost:8050"), testWatcher));
+
+        addDriver(TestMediaDriver.launch(setDefaults(new MediaDriver.Context())
+            .aeronDirectoryName(baseDir + "-A")
+            .resolverName("A")
+            .resolverInterface("0.0.0.0:8050"), testWatcher));
+
+        startClients();
+
+        final int aNeighborsCounterId = awaitNeighborsCounterId("A");
+        final int bNeighborsCounterId = awaitNeighborsCounterId("B");
+        final int cNeighborsCounterId = awaitNeighborsCounterId("B");
+
+        awaitCounterValue("A", aNeighborsCounterId, 2);
+        awaitCounterValue("B", bNeighborsCounterId, 2);
     }
 
     @SlowTest

--- a/aeron-test-support/src/main/java/io/aeron/test/HideOutputCallback.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/HideOutputCallback.java
@@ -19,13 +19,9 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 
 public class HideOutputCallback implements BeforeEachCallback, AfterEachCallback
 {

--- a/aeron-test-support/src/main/java/io/aeron/test/HideOutputCallback.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/HideOutputCallback.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+public class HideOutputCallback implements BeforeEachCallback, AfterEachCallback
+{
+    private static final OutputStream NULL_OUTPUT = new OutputStream()
+    {
+        public void write(final int b) throws IOException
+        {
+            // No-op
+        }
+    };
+
+    private PrintStream out;
+    private PrintStream err;
+
+    public void beforeEach(final ExtensionContext context)
+    {
+        out = System.out;
+        err = System.err;
+
+        System.setOut(new PrintStream(NULL_OUTPUT));
+        System.setErr(new PrintStream(NULL_OUTPUT));
+    }
+
+    public void afterEach(final ExtensionContext context)
+    {
+        System.setOut(out);
+        System.setErr(err);
+    }
+}


### PR DESCRIPTION
- Adds an additional DistinctErrorLog for events that don't qualify as errors (works in a similar way to the error log).
- Logs an event when the address for a given name entry changes.
- Changes logic for DriverNameCache so that will update when the name is different.