### PR TITLE
[C] Enable C driver in slow tests.

### DIFF
--- a/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/ClusterTestWatcher.java
@@ -42,10 +42,13 @@ import java.util.function.Predicate;
 
 public class ClusterTestWatcher implements TestWatcher
 {
-    public static final Predicate<String> UNKNOWN_HOST_FILTER = (s) -> s.contains(UnknownHostException.class.getName());
+    private static final String CLUSTER_TERMINATION_EXCEPTION = ClusterTerminationException.class.getName();
+    private static final String UNKNOWN_HOST_EXCEPTION = UnknownHostException.class.getName();
+    public static final Predicate<String> UNKNOWN_HOST_FILTER =
+        (s) -> s.contains(UNKNOWN_HOST_EXCEPTION) || s.contains("unknown host");
     public static final Predicate<String> WARNING_FILTER = (s) -> s.contains("WARN");
     public static final Predicate<String> CLUSTER_TERMINATION_FILTER =
-        (s) -> s.contains(ClusterTerminationException.class.getName());
+        (s) -> s.contains(CLUSTER_TERMINATION_EXCEPTION);
     public static final Predicate<String> TEST_CLUSTER_DEFAULT_LOG_FILTER =
         WARNING_FILTER.negate().and(CLUSTER_TERMINATION_FILTER.negate());
 

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -109,6 +109,9 @@ public class TestNode implements AutoCloseable
             if (clusterErrorFile.exists())
             {
                 clusterErrorMmap = IoUtil.mapExistingFile(clusterErrorFile, "cluster error log file");
+                // Erase existing errors
+                final UnsafeBuffer unsafeBuffer = new UnsafeBuffer(clusterErrorMmap);
+                unsafeBuffer.setMemory(0, unsafeBuffer.capacity(), (byte)0);
             }
             else
             {

--- a/build.gradle
+++ b/build.gradle
@@ -805,7 +805,7 @@ project(':aeron-system-tests') {
         }
     }
 
-    test {
+    tasks.withType(Test) {
         systemProperty('java.net.preferIPv4Stack', 'true')
         systemProperty('aeron.test.system.aeronmd.path', System.getProperty('aeron.test.system.aeronmd.path'))
     }


### PR DESCRIPTION
This PR contains the following changes:
- Enables C driver in the slow tests.
- Fixes [java.lang.IndexOutOfBoundsException: index=120 length=1937075275 capacity=1048576](https://github.com/real-logic/aeron/runs/3389075776?check_suite_focus=true) issue that was caused by the reuse of existing `cluster.err` file.
- Updates `UNKNOWN_HOST_FILTER` to handle errors as they are logged by the C driver.