### PR TITLE
Always use error log

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -27,7 +27,6 @@ import io.aeron.security.AuthenticatorSupplier;
 import org.agrona.*;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.errors.DistinctErrorLog;
-import org.agrona.concurrent.errors.LoggingErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.StatusIndicator;
 
@@ -914,11 +913,9 @@ public final class Archive implements AutoCloseable
                 markFile = new ArchiveMarkFile(this);
             }
 
-            if (null == errorHandler)
-            {
-                errorHandler = new LoggingErrorHandler(new DistinctErrorLog(
-                    markFile.errorBuffer(), epochClock, US_ASCII));
-            }
+            errorHandler = CommonContext.setupErrorHandler(
+                errorHandler,
+                new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII));
 
             if (null == aeron)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -20,7 +20,9 @@ import io.aeron.archive.client.AeronArchive;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
-import io.aeron.cluster.service.*;
+import io.aeron.cluster.service.ClusterCounters;
+import io.aeron.cluster.service.ClusterMarkFile;
+import io.aeron.cluster.service.ClusteredServiceContainer;
 import io.aeron.exceptions.ConcurrentConcludeException;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
@@ -29,7 +31,6 @@ import org.agrona.IoUtil;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.errors.DistinctErrorLog;
-import org.agrona.concurrent.errors.LoggingErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.io.File;
@@ -532,10 +533,7 @@ public final class ClusterBackup implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII);
             }
 
-            if (null == errorHandler)
-            {
-                errorHandler = new LoggingErrorHandler(errorLog);
-            }
+            errorHandler = CommonContext.setupErrorHandler(errorHandler, errorLog);
 
             if (null == aeron)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -28,7 +28,6 @@ import io.aeron.security.AuthenticatorSupplier;
 import org.agrona.*;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.errors.DistinctErrorLog;
-import org.agrona.concurrent.errors.LoggingErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 
@@ -1205,10 +1204,7 @@ public final class ConsensusModule implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII);
             }
 
-            if (null == errorHandler)
-            {
-                errorHandler = new LoggingErrorHandler(errorLog);
-            }
+            errorHandler = CommonContext.setupErrorHandler(errorHandler, errorLog);
 
             if (null == recordingLog)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -114,7 +114,7 @@ public final class ClusterMarkFile implements AutoCloseable
             final UnsafeBuffer existingErrorBuffer = new UnsafeBuffer(
                 buffer, headerDecoder.headerLength(), headerDecoder.errorBufferLength());
 
-            saveExistingErrors(file, existingErrorBuffer, System.err);
+            saveExistingErrors(file, existingErrorBuffer, type, System.err);
             existingErrorBuffer.setMemory(0, headerDecoder.errorBufferLength(), (byte)0);
         }
         else
@@ -379,12 +379,16 @@ public final class ClusterMarkFile implements AutoCloseable
 
     /**
      * Save the existing errors from a {@link MarkFile} to a {@link PrintStream} for logging.
-     *
      * @param markFile    which contains the error buffer.
      * @param errorBuffer which wraps the error log.
+     * @param type        type of the mark file being checked.
      * @param logger      to which the existing errors will be printed.
      */
-    public static void saveExistingErrors(final File markFile, final AtomicBuffer errorBuffer, final PrintStream logger)
+    public static void saveExistingErrors(
+        final File markFile,
+        final AtomicBuffer errorBuffer,
+        final ClusterComponentType type,
+        final PrintStream logger)
     {
         try
         {
@@ -394,7 +398,7 @@ public final class ClusterMarkFile implements AutoCloseable
             {
                 final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSSZ");
                 final String errorLogFilename =
-                    markFile.getParent() + '-' + dateFormat.format(new Date()) + "-error.log";
+                    markFile.getParent() + '-' + type.name() + '-' + dateFormat.format(new Date()) + "-error.log";
 
                 if (null != logger)
                 {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -25,7 +25,6 @@ import io.aeron.exceptions.ConfigurationException;
 import org.agrona.*;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.errors.DistinctErrorLog;
-import org.agrona.concurrent.errors.LoggingErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.StatusIndicator;
 
@@ -670,10 +669,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
                 errorLog = new DistinctErrorLog(markFile.errorBuffer(), epochClock, US_ASCII);
             }
 
-            if (null == errorHandler)
-            {
-                errorHandler = new LoggingErrorHandler(errorLog);
-            }
+            errorHandler = CommonContext.setupErrorHandler(this.errorHandler, errorLog);
 
             if (null == delegatingErrorHandler)
             {

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterNodeRestartTest.java
@@ -29,9 +29,7 @@ import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.Tests;
+import io.aeron.test.*;
 import io.aeron.test.cluster.ClusterTests;
 import io.aeron.test.cluster.StubClusteredService;
 import org.agrona.CloseHelper;
@@ -59,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith(InterruptingTestCallback.class)
+@ExtendWith({InterruptingTestCallback.class, HideStdErrExtension.class})
 public class ClusterNodeRestartTest
 {
     private static final long CATALOG_CAPACITY = 1024 * 1024;
@@ -385,6 +383,7 @@ public class ClusterNodeRestartTest
 
     @Test
     @InterruptAfter(20)
+    @IgnoreStdErr
     public void shouldRestartServiceAfterShutdownWithInvalidatedSnapshot() throws InterruptedException
     {
         final AtomicLong serviceMsgCount = new AtomicLong(0);

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -32,7 +32,6 @@ import org.agrona.*;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.broadcast.BroadcastTransmitter;
 import org.agrona.concurrent.errors.DistinctErrorLog;
-import org.agrona.concurrent.errors.LoggingErrorHandler;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.agrona.concurrent.status.*;
@@ -3428,10 +3427,7 @@ public final class MediaDriver implements AutoCloseable
                     createErrorLogBuffer(cncByteBuffer, cncMetaDataBuffer), epochClock, US_ASCII);
             }
 
-            if (null == errorHandler)
-            {
-                errorHandler = new LoggingErrorHandler(errorLog);
-            }
+            errorHandler = CommonContext.setupErrorHandler(this.errorHandler, errorLog);
 
             receiverProxy = new ReceiverProxy(
                 threadingMode, receiverCommandQueue, systemCounters.get(RECEIVER_PROXY_FAILS));

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.status.SystemCounterDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.MediaDriverTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.agrona.collections.MutableReference;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(InterruptingTestCallback.class)
+public class ErrorHandlerTest
+{
+    @RegisterExtension
+    public final MediaDriverTestWatcher watcher = new MediaDriverTestWatcher();
+
+    private final MediaDriver.Context context = new MediaDriver.Context();
+    {
+        context
+            .errorHandler(ignore -> {})
+            .dirDeleteOnStart(true)
+            .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500))
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100));
+    }
+
+    private final ArrayList<AutoCloseable> closeables = new ArrayList<>();
+
+    private Aeron aeron;
+    private TestMediaDriver driver;
+
+    private void launch()
+    {
+        driver = TestMediaDriver.launch(context, watcher);
+        aeron = Aeron.connect();
+    }
+
+    @AfterEach
+    public void after()
+    {
+        CloseHelper.closeAll(closeables);
+        CloseHelper.closeAll(aeron, driver);
+        if (null != driver)
+        {
+            driver.context().deleteDirectory();
+        }
+    }
+
+    @Test
+    @InterruptAfter(5)
+    void shouldReportToErrorHandlerAndDistinctErrorLog() throws IOException
+    {
+        final MutableReference<Throwable> throwableRef = new MutableReference<>(null);
+        context.errorHandler(throwableRef::set);
+
+        launch();
+
+        final long initialErrorCount = aeron.countersReader().getCounterValue(SystemCounterDescriptor.ERRORS.id());
+
+        addPublication("aeron:udp?endpoint=localhost:9999|mtu=1408", 1000);
+        addSubscription("aeron:udp?endpoint=localhost:9999|rcv-wnd=1376", 1000);
+
+        Tests.awaitCounterDelta(aeron.countersReader(), SystemCounterDescriptor.ERRORS.id(), initialErrorCount, 1);
+
+        final Matcher<String> exceptionMessageMatcher = allOf(
+            containsString("mtuLength="),
+            containsString("> initialWindowLength="));
+
+        SystemTests.waitForErrorToOccur(driver.aeronDirectoryName(), exceptionMessageMatcher, Tests.SLEEP_1_MS);
+
+        assertNotNull(throwableRef.get());
+    }
+
+    private Publication addPublication(final String channel, final int streamId)
+    {
+        final Publication pub = aeron.addPublication(channel, streamId);
+        closeables.add(pub);
+        return pub;
+    }
+
+    private Subscription addSubscription(final String channel, final int streamId)
+    {
+        final Subscription sub = aeron.addSubscription(channel, streamId);
+        closeables.add(sub);
+        return sub;
+    }
+}

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
@@ -20,6 +20,7 @@ import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
+import io.aeron.test.driver.CTestMediaDriver;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
@@ -79,6 +80,8 @@ public class ErrorHandlerTest
     @InterruptAfter(5)
     void shouldReportToErrorHandlerAndDistinctErrorLog() throws IOException
     {
+        TestMediaDriver.notSupportedOnCMediaDriver("C driver doesn't support ErrorHandler callbacks");
+
         final MutableReference<Throwable> throwableRef = new MutableReference<>(null);
         context.errorHandler(throwableRef::set);
 

--- a/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ErrorHandlerTest.java
@@ -20,7 +20,6 @@ import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.Tests;
-import io.aeron.test.driver.CTestMediaDriver;
 import io.aeron.test.driver.MediaDriverTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;

--- a/aeron-test-support/src/main/java/io/aeron/test/HideStdErrExtension.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/HideStdErrExtension.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class HideStdErrExtension implements BeforeEachCallback, AfterEachCallback
+{
+    private final PrintStream nullPrintStream = new PrintStream(new NullOutputStream());
+    private PrintStream originalStream = null;
+
+    public void beforeEach(final ExtensionContext context) throws Exception
+    {
+        if (context.getTestMethod().isPresent() &&
+            null != context.getTestMethod().get().getAnnotation(IgnoreStdErr.class))
+        {
+            originalStream = System.err;
+            System.setErr(nullPrintStream);
+        }
+    }
+
+    public void afterEach(final ExtensionContext context) throws Exception
+    {
+        if (null != originalStream)
+        {
+            System.setErr(originalStream);
+            originalStream = null;
+        }
+    }
+
+
+    private static class NullOutputStream extends OutputStream
+    {
+        public void write(final int ignore) throws IOException
+        {
+        }
+    }
+}


### PR DESCRIPTION
- Setup errorHandlers so that errors are always sent to the configured distinct error log as well as the user specified error handler for Driver, Archive, ConsensusModule, ClusteredServiceContainer, and ClusterBackup.  
- Add stderr output suppression for specific tests.