### PR TITLE
[Java] Fix snapshot offset error in cluster samples

### DIFF
--- a/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredService.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/cluster/tutorial/BasicAuctionClusteredService.java
@@ -111,11 +111,11 @@ public class BasicAuctionClusteredService implements ClusteredService
     // tag::takeSnapshot[]
     public void onTakeSnapshot(final ExclusivePublication snapshotPublication)
     {
-        snapshotBuffer.putLong(CUSTOMER_ID_OFFSET, auction.getCurrentWinningCustomerId());    // <1>
-        snapshotBuffer.putLong(PRICE_OFFSET, auction.getBestPrice());
+        snapshotBuffer.putLong(SNAPSHOT_CUSTOMER_ID_OFFSET, auction.getCurrentWinningCustomerId());  // <1>
+        snapshotBuffer.putLong(SNAPSHOT_PRICE_OFFSET, auction.getBestPrice());
 
         idleStrategy.reset();
-        while (snapshotPublication.offer(snapshotBuffer, 0, SNAPSHOT_MESSAGE_LENGTH) < 0)     // <2>
+        while (snapshotPublication.offer(snapshotBuffer, 0, SNAPSHOT_MESSAGE_LENGTH) < 0)            // <2>
         {
             idleStrategy.idle();
         }


### PR DESCRIPTION
Following the cluster tutorial, after taking snapshot and a restart, restored auction state is always `Auction{bestPrice=10, currentWinningCustomerId=0}`
```
[381630.026182312] CLUSTER: ELECTION_STATE_CHANGE [34/34]: memberId=1 CANVASS -> FOLLOWER_REPLAY
attemptBid(this=Auction{bestPrice=10, currentWinningCustomerId=0}, price=9385,customerId=10)
```
`onTaskSnapshot` uses wrong index starting from 8(`CUSTOMER_ID_OFFSET`), while `loadSnapshot` read from 0(`SNAPSHOT_CUSTOMER_ID_OFFSET`).