### PR TITLE
Add public TimerServiceSupplier classes

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -3121,8 +3121,7 @@ public final class ConsensusModule implements AutoCloseable
                 final Class<?> klass = Class.forName(supplierName);
                 if (WheelTimerService.class.equals(klass))
                 {
-                    return (timerHandler) -> new WheelTimerService(
-                        timerHandler,
+                    return new WheelTimerServiceSupplier(
                         clusterClock.timeUnit(),
                         0,
                         findNextPositivePowerOfTwo(
@@ -3132,7 +3131,7 @@ public final class ConsensusModule implements AutoCloseable
                 else
                 {
                     final Constructor<?> constructor = klass.getDeclaredConstructor(TimerService.TimerHandler.class);
-                    return (timerHandler) ->
+                    return (clusterClock, timerHandler) ->
                     {
                         try
                         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -161,7 +161,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         this.controlToggle = ctx.controlToggleCounter();
         this.logPublisher = ctx.logPublisher();
         this.idleStrategy = ctx.idleStrategy();
-        this.timerService = ctx.timerServiceSupplier().newInstance(this);
+        this.timerService = ctx.timerServiceSupplier().newInstance(ctx.clusterClock().timeUnit(), this);
         this.activeMembers = ClusterMember.parse(ctx.clusterMembers());
         this.sessionProxy = new ClusterSessionProxy(egressPublisher);
         this.memberId = ctx.clusterMemberId();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/PriorityHeapTimerService.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/PriorityHeapTimerService.java
@@ -34,7 +34,7 @@ import java.util.function.Consumer;
  * <p>
  * <b>Note:</b> Not thread safe.
  */
-public final class PriorityHeapTimerService implements TimerService
+final class PriorityHeapTimerService implements TimerService
 {
     private static final TimerEntry[] EMPTY_TIMERS = new TimerEntry[0];
     private static final int MIN_CAPACITY = 8;
@@ -52,7 +52,7 @@ public final class PriorityHeapTimerService implements TimerService
      *
      * @param timerHandler to callback when a timer expires.
      */
-    public PriorityHeapTimerService(final TimerHandler timerHandler)
+    PriorityHeapTimerService(final TimerHandler timerHandler)
     {
         this.timerHandler = Objects.requireNonNull(timerHandler, "TimerHandler");
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/PriorityHeapTimerServiceSupplier.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/PriorityHeapTimerServiceSupplier.java
@@ -18,18 +18,15 @@ package io.aeron.cluster;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Supplier of {@link TimerService} implementations to be used by the {@link ConsensusModule}.
+ * Supplies instances of the {@link PriorityHeapTimerService}
  */
-@FunctionalInterface
-public interface TimerServiceSupplier
+public class PriorityHeapTimerServiceSupplier implements TimerServiceSupplier
 {
     /**
-     * New instance of the {@link TimerService}.
-     *
-     *
-     * @param timeUnit      units to be used by the underlying timer service.
-     * @param timerHandler  that must be invoked for each expired timer.
-     * @return              timer service instance ready for immediate usage.
+     * {@inheritDoc}
      */
-    TimerService newInstance(TimeUnit timeUnit, TimerService.TimerHandler timerHandler);
+    public TimerService newInstance(final TimeUnit timeUnit, final TimerService.TimerHandler timerHandler)
+    {
+        return new PriorityHeapTimerService(timerHandler);
+    }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/WheelTimerServiceSupplier.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/WheelTimerServiceSupplier.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.agrona.BitUtil.findNextPositivePowerOfTwo;
+
+/**
+ * Supplies an instance of a {@link WheelTimerService} based on the configuration given to the constructor
+ */
+public class WheelTimerServiceSupplier implements TimerServiceSupplier
+{
+    private final TimeUnit timeUnit;
+    private final long startTime;
+    private final long tickResolution;
+    private final int ticksPerWheel;
+
+    /**
+     * Construct the supplier with the necessary parameters to configure the timer wheel.
+     *
+     * @param timeUnit       for the values used to express the time.  This time unit is used to denote the supplied
+     *                       time values.  When the instance is constructed it will use this to convert the supplied
+     *                       <code>startTime</code> and <code>tickResolution</code> into the time unit that is being
+     *                       used by the cluster clock.
+     * @param startTime      for the wheel (in given {@link TimeUnit}).
+     * @param tickResolution for the wheel, i.e. how many {@link TimeUnit}s per tick.
+     * @param ticksPerWheel  or spokes, for the wheel (must be power of 2).
+     */
+    public WheelTimerServiceSupplier(
+        final TimeUnit timeUnit,
+        final long startTime,
+        final long tickResolution,
+        final int ticksPerWheel)
+    {
+        this.timeUnit = timeUnit;
+        this.startTime = startTime;
+        this.tickResolution = tickResolution;
+        this.ticksPerWheel = ticksPerWheel;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public TimerService newInstance(final TimeUnit clusterTimeUnit, final TimerService.TimerHandler timerHandler)
+    {
+        final long startTimeInClusterTimeUnits = clusterTimeUnit.convert(startTime, this.timeUnit);
+        final long resolutionInClusterTimeUnits = clusterTimeUnit.convert(tickResolution, this.timeUnit);
+
+        return new WheelTimerService(
+            timerHandler,
+            clusterTimeUnit,
+            startTimeInClusterTimeUnits,
+            findNextPositivePowerOfTwo(resolutionInClusterTimeUnits),
+            ticksPerWheel);
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -65,7 +65,7 @@ public class ConsensusModuleAgentTest
         .clusterNodeRoleCounter(mock(Counter.class))
         .timedOutClientCounter(mockTimedOutClientCounter)
         .idleStrategySupplier(NoOpIdleStrategy::new)
-        .timerServiceSupplier(timerHandler -> mock(TimerService.class))
+        .timerServiceSupplier((clusterClock, timerHandler) -> mock(TimerService.class))
         .aeron(mockAeron)
         .clusterMemberId(0)
         .authenticatorSupplier(new DefaultAuthenticatorSupplier())

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -86,7 +86,7 @@ class ConsensusModuleContextTest
             assertNotNull(supplier);
 
             final TimerService.TimerHandler timerHandler = mock(TimerService.TimerHandler.class);
-            final TimerService timerService = supplier.newInstance(timerHandler);
+            final TimerService timerService = supplier.newInstance(context.clusterClock().timeUnit(), timerHandler);
 
             assertNotNull(timerService);
             assertEquals(supplierName, timerService.getClass().getName());
@@ -122,7 +122,7 @@ class ConsensusModuleContextTest
         assertNotNull(supplier);
 
         final TimerService.TimerHandler timerHandler = mock(TimerService.TimerHandler.class);
-        final TimerService timerService = supplier.newInstance(timerHandler);
+        final TimerService timerService = supplier.newInstance(context.clusterClock().timeUnit(), timerHandler);
 
         assertNotNull(timerService);
         assertEquals(WheelTimerService.class, timerService.getClass());
@@ -131,7 +131,7 @@ class ConsensusModuleContextTest
     @Test
     void explicitTimerServiceSupplier()
     {
-        final TimerServiceSupplier supplier = timerHandler -> null;
+        final TimerServiceSupplier supplier = (clusterClock, timerHandler) -> null;
 
         context.timerServiceSupplier(supplier);
         assertSame(supplier, context.timerServiceSupplier());

--- a/aeron-cluster/src/test/java/io/aeron/cluster/PriorityHeapTimerServiceClusterTimeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/PriorityHeapTimerServiceClusterTimeTest.java
@@ -19,6 +19,6 @@ class PriorityHeapTimerServiceClusterTimeTest extends ClusterTimerTest
 {
     TimerServiceSupplier timerServiceSupplier()
     {
-        return PriorityHeapTimerService::new;
+        return (clusterClock, timerHandler) -> new PriorityHeapTimerService(timerHandler);
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/WheelTimerServiceClusterTimeTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/WheelTimerServiceClusterTimeTest.java
@@ -21,6 +21,6 @@ class WheelTimerServiceClusterTimeTest extends ClusterTimerTest
 {
     TimerServiceSupplier timerServiceSupplier()
     {
-        return timerHandler -> new WheelTimerService(timerHandler, TimeUnit.MILLISECONDS, 0, 8, 128);
+        return (clusterClock, timerHandler) -> new WheelTimerService(timerHandler, TimeUnit.MILLISECONDS, 0, 8, 128);
     }
 }


### PR DESCRIPTION
 To keep the actual timer services package protected.  Have the WheelTimerServiceSupplier convert from the supplied units to cluster clock units when constructing the timer wheel.