### PR TITLE
[Java] Timely free direct ByteBuffers used by BufferBuilder/FragmentAssembler.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -178,6 +178,14 @@ public final class BufferBuilder
         return this;
     }
 
+    void free()
+    {
+        if (isDirect)
+        {
+            BufferUtil.free(buffer);
+        }
+    }
+
     private void ensureCapacity(final int additionalLength)
     {
         final long requiredCapacity = (long)limit + additionalLength;

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -178,6 +178,7 @@ public final class BufferBuilder
         return this;
     }
 
+    // intentionally left package-private
     void free()
     {
         if (isDirect)

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -71,7 +71,7 @@ public final class BufferBuilder
         {
             throw new IllegalArgumentException(
                 "initialCapacity outside range 0 - " + MAX_CAPACITY +
-                    ": initialCapacity=" + initialCapacity);
+                ": initialCapacity=" + initialCapacity);
         }
 
         this.isDirect = isDirect;
@@ -197,8 +197,8 @@ public final class BufferBuilder
             {
                 throw new IllegalStateException(
                     "insufficient capacity: maxCapacity=" + MAX_CAPACITY +
-                        " limit=" + limit +
-                        " additionalLength=" + additionalLength);
+                    " limit=" + limit +
+                    " additionalLength=" + additionalLength);
             }
 
             resize(findSuitableCapacity(capacity, requiredCapacity));

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -70,7 +70,7 @@ public final class BufferBuilder
         {
             throw new IllegalArgumentException(
                 "initialCapacity outside range 0 - " + MAX_CAPACITY +
-                ": initialCapacity=" + initialCapacity);
+                    ": initialCapacity=" + initialCapacity);
         }
 
         this.isDirect = isDirect;
@@ -150,7 +150,11 @@ public final class BufferBuilder
      */
     public BufferBuilder compact()
     {
-        resize(Math.max(INIT_MIN_CAPACITY, limit));
+        final int newCapacity = Math.max(INIT_MIN_CAPACITY, limit);
+        if (newCapacity != buffer.capacity())
+        {
+            resize(newCapacity);
+        }
 
         return this;
     }
@@ -184,8 +188,8 @@ public final class BufferBuilder
             {
                 throw new IllegalStateException(
                     "insufficient capacity: maxCapacity=" + MAX_CAPACITY +
-                    " limit=" + limit +
-                    " additionalLength=" + additionalLength);
+                        " limit=" + limit +
+                        " additionalLength=" + additionalLength);
             }
 
             resize(findSuitableCapacity(capacity, requiredCapacity));

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.aeron;
 
+import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -200,10 +201,12 @@ public final class BufferBuilder
     {
         if (isDirect)
         {
-            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(newCapacity);
-            byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-            buffer.getBytes(0, byteBuffer, 0, limit);
-            buffer.wrap(byteBuffer);
+            final ByteBuffer newByteBuffer = ByteBuffer.allocateDirect(newCapacity);
+            newByteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            buffer.getBytes(0, newByteBuffer, 0, limit);
+            final ByteBuffer originalByteBuffer = buffer.byteBuffer();
+            buffer.wrap(newByteBuffer);
+            BufferUtil.free(originalByteBuffer);
         }
         else
         {

--- a/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
@@ -169,7 +169,16 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
      */
     public boolean freeSessionBuffer(final int sessionId)
     {
-        return null != builderBySessionIdMap.remove(sessionId);
+        final BufferBuilder builder = builderBySessionIdMap.remove(sessionId);
+        if (null != builder)
+        {
+            if (isDirectByteBuffer)
+            {
+                builder.free();
+            }
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -177,6 +186,13 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
      */
     public void clear()
     {
+        if (isDirectByteBuffer)
+        {
+            for (final BufferBuilder builder : builderBySessionIdMap.values())
+            {
+                builder.free();
+            }
+        }
         builderBySessionIdMap.clear();
     }
 

--- a/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
@@ -157,7 +157,16 @@ public class FragmentAssembler implements FragmentHandler
      */
     public boolean freeSessionBuffer(final int sessionId)
     {
-        return null != builderBySessionIdMap.remove(sessionId);
+        final BufferBuilder builder = builderBySessionIdMap.remove(sessionId);
+        if (null != builder)
+        {
+            if (isDirectByteBuffer)
+            {
+                builder.free();
+            }
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -165,6 +174,13 @@ public class FragmentAssembler implements FragmentHandler
      */
     public void clear()
     {
+        if (isDirectByteBuffer)
+        {
+            for (final BufferBuilder builder : builderBySessionIdMap.values())
+            {
+                builder.free();
+            }
+        }
         builderBySessionIdMap.clear();
     }
 

--- a/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
@@ -20,6 +20,8 @@ import io.aeron.logbuffer.Header;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.Int2ObjectHashMap;
 
+import java.util.Collection;
+
 import static io.aeron.logbuffer.FrameDescriptor.*;
 
 /**
@@ -182,6 +184,11 @@ public class FragmentAssembler implements FragmentHandler
             }
         }
         builderBySessionIdMap.clear();
+    }
+
+    Collection<BufferBuilder> bufferBuilders()
+    {
+        return builderBySessionIdMap.values();
     }
 
     private BufferBuilder getBufferBuilder(final int sessionId)

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -289,4 +289,32 @@ class BufferBuilderTest
 
         BufferUtil.assertDirectByteBufferFreed(originalByteBuffer);
     }
+
+    @Test
+    void freeIsANoOpIfBufferIsNotDirect()
+    {
+        final BufferBuilder builder = new BufferBuilder(64);
+        final MutableDirectBuffer buffer = builder.buffer();
+        final byte[] byteArray = buffer.byteArray();
+
+        builder.free();
+
+        assertSame(buffer, builder.buffer());
+        assertSame(byteArray, buffer.byteArray());
+    }
+
+    @Test
+    void freeShouldFreeDirectByteBuffer()
+    {
+        final BufferBuilder builder = new BufferBuilder(64, true);
+        final MutableDirectBuffer buffer = builder.buffer();
+        final ByteBuffer byteBuffer = buffer.byteBuffer();
+        BufferUtil.assertDirectByteBufferAllocated(byteBuffer);
+
+        builder.free();
+
+        assertSame(buffer, builder.buffer());
+        assertSame(byteBuffer, buffer.byteBuffer());
+        BufferUtil.assertDirectByteBufferFreed(byteBuffer);
+    }
 }

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -268,4 +268,25 @@ class BufferBuilderTest
         assertSame(byteBuffer, buffer.byteBuffer());
         assertEquals(addressOffset, buffer.addressOffset());
     }
+
+    @Test
+    void resizeShouldFreePreviouslyUsedDirectByteBuffer()
+    {
+        final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[128]);
+        final BufferBuilder builder = new BufferBuilder(32, true);
+        final MutableDirectBuffer buffer = builder.buffer();
+        final ByteBuffer originalByteBuffer = buffer.byteBuffer();
+        final long originalAddressOffset = buffer.addressOffset();
+        assertNotEquals(0, originalAddressOffset);
+        BufferUtil.assertDirectByteBufferAllocated(originalByteBuffer);
+
+        assertSame(builder, builder.append(srcBuffer, 0, srcBuffer.capacity()));
+
+        assertEquals(INIT_MIN_CAPACITY, buffer.capacity());
+        assertNotSame(originalByteBuffer, buffer.byteBuffer());
+        assertNotEquals(originalAddressOffset, buffer.addressOffset());
+        BufferUtil.assertDirectByteBufferAllocated(buffer.byteBuffer());
+
+        BufferUtil.assertDirectByteBufferFreed(originalByteBuffer);
+    }
 }

--- a/aeron-client/src/test/java/io/aeron/BufferUtil.java
+++ b/aeron-client/src/test/java/io/aeron/BufferUtil.java
@@ -71,15 +71,10 @@ final class BufferUtil
     private static long getAddressFromCleaner(final ByteBuffer buffer)
     {
         assertTrue(buffer.isDirect());
-        final Class<? extends ByteBuffer> bufferClass = buffer.getClass();
-        assertEquals("java.nio.DirectByteBuffer", bufferClass.getName());
-
         final Object cleaner = UNSAFE.getObject(buffer, CLEANER_FIELD_OFFSET);
         assertNotNull(cleaner);
-
         final Object thunk = UNSAFE.getObject(cleaner, THUNK_FIELD_OFFSET);
         assertNotNull(thunk);
-
         return UNSAFE.getLong(thunk, ADDRESS_FIELD_OFFSET);
     }
 }

--- a/aeron-client/src/test/java/io/aeron/BufferUtil.java
+++ b/aeron-client/src/test/java/io/aeron/BufferUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import java.nio.ByteBuffer;
+
+import static org.agrona.UnsafeAccess.UNSAFE;
+import static org.junit.jupiter.api.Assertions.*;
+
+final class BufferUtil
+{
+    private static final long CLEANER_FIELD_OFFSET;
+    private static final long THUNK_FIELD_OFFSET;
+    private static final long ADDRESS_FIELD_OFFSET;
+
+    static
+    {
+        try
+        {
+            final Class<?> bufferClass = Class.forName("java.nio.DirectByteBuffer");
+            CLEANER_FIELD_OFFSET = UNSAFE.objectFieldOffset(bufferClass.getDeclaredField("cleaner"));
+
+            Class<?> cleanerClass = null;
+            try
+            {
+                cleanerClass = Class.forName("jdk.internal.ref.Cleaner");
+            }
+            catch (final ClassNotFoundException ex)
+            {
+                cleanerClass = Class.forName("sun.misc.Cleaner");
+            }
+
+            THUNK_FIELD_OFFSET = UNSAFE.objectFieldOffset(cleanerClass.getDeclaredField("thunk"));
+
+            final Class<?> thunkClass = Class.forName("java.nio.DirectByteBuffer$Deallocator");
+            ADDRESS_FIELD_OFFSET = UNSAFE.objectFieldOffset(thunkClass.getDeclaredField("address"));
+        }
+        catch (final ClassNotFoundException | NoSuchFieldException ex)
+        {
+            throw new Error("failed to initialize BufferUtil", ex);
+        }
+    }
+
+    private BufferUtil()
+    {
+    }
+
+    static void assertDirectByteBufferAllocated(final ByteBuffer buffer)
+    {
+        assertNotEquals(0, getAddressFromCleaner(buffer));
+    }
+
+    static void assertDirectByteBufferFreed(final ByteBuffer buffer)
+    {
+        assertEquals(0, getAddressFromCleaner(buffer));
+    }
+
+    private static long getAddressFromCleaner(final ByteBuffer buffer)
+    {
+        assertTrue(buffer.isDirect());
+        final Class<? extends ByteBuffer> bufferClass = buffer.getClass();
+        assertEquals("java.nio.DirectByteBuffer", bufferClass.getName());
+
+        final Object cleaner = UNSAFE.getObject(buffer, CLEANER_FIELD_OFFSET);
+        assertNotNull(cleaner);
+
+        final Object thunk = UNSAFE.getObject(cleaner, THUNK_FIELD_OFFSET);
+        assertNotNull(thunk);
+
+        return UNSAFE.getLong(thunk, ADDRESS_FIELD_OFFSET);
+    }
+}


### PR DESCRIPTION
This PR contains the following changes:
- `BufferBuilder.compact` - should resize only if capacity is not the same as the target capacity.
- Resizing internal buffer should free old direct ByteBuffer.
- `BufferBuilder.free` - adds an ability to free internal direct ByteBuffer.
- `FragmentAssembler/ControlledFragmentAssembler` - invoke `BufferBuilder.free` when direct buffers are used.