### PR TITLE
[Java] Implement missing Context.toString() and align implementations (issue #1236)

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -2469,7 +2469,7 @@ public final class Archive implements AutoCloseable
                 "\n    dataBuffer=" + dataBuffer +
                 "\n    replayBuffer=" + replayBuffer +
                 "\n    recordChecksumBuffer=" + recordChecksumBuffer +
-                '}';
+                "\n}";
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -3061,6 +3061,34 @@ public final class AeronArchive implements AutoCloseable
             }
         }
 
+        /**
+         * {@inheritDoc}
+         */
+        public String toString()
+        {
+            return "AeronArchive.Context" +
+                "\n{" +
+                "\n    isConcluded=" + (1 == isConcluded) +
+                "\n    ownsAeronClient=" + ownsAeronClient +
+                "\n    aeronDirectoryName='" + aeronDirectoryName + '\'' +
+                "\n    aeron=" + aeron +
+                "\n    messageTimeoutNs=" + messageTimeoutNs +
+                "\n    recordingEventsChannel='" + recordingEventsChannel + '\'' +
+                "\n    recordingEventsStreamId=" + recordingEventsStreamId +
+                "\n    controlRequestChannel='" + controlRequestChannel + '\'' +
+                "\n    controlRequestStreamId=" + controlRequestStreamId +
+                "\n    controlResponseChannel='" + controlResponseChannel + '\'' +
+                "\n    controlResponseStreamId=" + controlResponseStreamId +
+                "\n    controlTermBufferSparse=" + controlTermBufferSparse +
+                "\n    controlTermBufferLength=" + controlTermBufferLength +
+                "\n    controlMtuLength=" + controlMtuLength +
+                "\n    idleStrategy=" + idleStrategy +
+                "\n    lock=" + lock +
+                "\n    errorHandler=" + errorHandler +
+                "\n    credentialsSupplier=" + credentialsSupplier +
+                "\n}";
+        }
+
         private String applyDefaultParams(final String channel)
         {
             final ChannelUri channelUri = ChannelUri.parse(channel);

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1469,7 +1469,7 @@ public class Aeron implements AutoCloseable
                 "\n{" +
                 "\n    isConcluded=" + isConcluded() +
                 "\n    aeronDirectory=" + aeronDirectory() +
-                "\n    aeronDirectoryName=" + aeronDirectoryName() +
+                "\n    aeronDirectoryName='" + aeronDirectoryName() + '\'' +
                 "\n    cncFile=" + cncFile() +
                 "\n    countersMetaDataBuffer=" + countersMetaDataBuffer() +
                 "\n    countersValuesBuffer=" + countersValuesBuffer() +

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -1460,6 +1460,50 @@ public class Aeron implements AutoCloseable
             super.close();
         }
 
+        /**
+         * {@inheritDoc}
+         */
+        public String toString()
+        {
+            return "Aeron.Context" +
+                "\n{" +
+                "\n    isConcluded=" + isConcluded() +
+                "\n    aeronDirectory=" + aeronDirectory() +
+                "\n    aeronDirectoryName=" + aeronDirectoryName() +
+                "\n    cncFile=" + cncFile() +
+                "\n    countersMetaDataBuffer=" + countersMetaDataBuffer() +
+                "\n    countersValuesBuffer=" + countersValuesBuffer() +
+                "\n    driverTimeoutMs=" + driverTimeoutMs() +
+                "\n    clientId=" + clientId +
+                "\n    useConductorAgentInvoker=" + useConductorAgentInvoker +
+                "\n    preTouchMappedMemory=" + preTouchMappedMemory +
+                "\n    driverAgentInvoker=" + driverAgentInvoker +
+                "\n    clientLock=" + clientLock +
+                "\n    epochClock=" + epochClock +
+                "\n    nanoClock=" + nanoClock +
+                "\n    idleStrategy=" + idleStrategy +
+                "\n    awaitingIdleStrategy=" + awaitingIdleStrategy +
+                "\n    toClientBuffer=" + toClientBuffer +
+                "\n    toDriverBuffer=" + toDriverBuffer +
+                "\n    driverProxy=" + driverProxy +
+                "\n    cncByteBuffer=" + cncByteBuffer +
+                "\n    cncMetaDataBuffer=" + cncMetaDataBuffer +
+                "\n    logBuffersFactory=" + logBuffersFactory +
+                "\n    errorHandler=" + errorHandler +
+                "\n    subscriberErrorHandler=" + subscriberErrorHandler +
+                "\n    availableImageHandler=" + availableImageHandler +
+                "\n    unavailableImageHandler=" + unavailableImageHandler +
+                "\n    availableCounterHandler=" + availableCounterHandler +
+                "\n    unavailableCounterHandler=" + unavailableCounterHandler +
+                "\n    closeHandler=" + closeHandler +
+                "\n    keepAliveIntervalNs=" + keepAliveIntervalNs +
+                "\n    interServiceTimeoutNs=" + interServiceTimeoutNs +
+                "\n    resourceLingerDurationNs=" + resourceLingerDurationNs +
+                "\n    closeLingerDurationNs=" + closeLingerDurationNs +
+                "\n    threadFactory=" + threadFactory +
+                "\n}";
+        }
+
         private void connectToDriver()
         {
             final long deadlineMs = epochClock.time() + driverTimeoutMs();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackup.java
@@ -1603,7 +1603,7 @@ public final class ClusterBackup implements AutoCloseable
                 "\n    shutdownSignalBarrier=" + shutdownSignalBarrier +
                 "\n    terminationHook=" + terminationHook +
                 "\n    eventsListener=" + eventsListener +
-                '}';
+                "\n}";
         }
 
         private void concludeMarkFile()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -3211,7 +3211,7 @@ public final class ConsensusModule implements AutoCloseable
                 "\n    logPublisher=" + logPublisher +
                 "\n    egressPublisher=" + egressPublisher +
                 "\n    isLogMdc=" + isLogMdc +
-                '}';
+                "\n}";
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -1440,6 +1440,33 @@ public final class AeronCluster implements AutoCloseable
                 CloseHelper.close(aeron);
             }
         }
+
+        /**
+         * {@inheritDoc}
+         */
+        public String toString()
+        {
+            return "AeronCluster.Context" +
+                "\n{" +
+                "\n    isConcluded=" + (1 == isConcluded) +
+                "\n    ownsAeronClient=" + ownsAeronClient +
+                "\n    aeronDirectoryName='" + aeronDirectoryName + '\'' +
+                "\n    aeron=" + aeron +
+                "\n    messageTimeoutNs=" + messageTimeoutNs +
+                "\n    ingressEndpoints='" + ingressEndpoints + '\'' +
+                "\n    ingressChannel='" + ingressChannel + '\'' +
+                "\n    ingressStreamId=" + ingressStreamId +
+                "\n    egressChannel='" + egressChannel + '\'' +
+                "\n    egressStreamId=" + egressStreamId +
+                "\n    idleStrategy=" + idleStrategy +
+                "\n    credentialsSupplier=" + credentialsSupplier +
+                "\n    isIngressExclusive=" + isIngressExclusive +
+                "\n    errorHandler=" + errorHandler +
+                "\n    isDirectAssemblers=" + isDirectAssemblers +
+                "\n    egressListener=" + egressListener +
+                "\n    controlledEgressListener=" + controlledEgressListener +
+                "\n}";
+        }
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -1577,6 +1577,12 @@ public final class ClusteredServiceContainer implements AutoCloseable
             return "ClusteredServiceContainer.Context" +
                 "\n{" +
                 "\n    isConcluded=" + (1 == isConcluded) +
+                "\n    ownsAeronClient=" + ownsAeronClient +
+                "\n    aeronDirectoryName='" + aeronDirectoryName + '\'' +
+                "\n    aeron=" + aeron +
+                "\n    archiveContext=" + archiveContext +
+                "\n    clusterDirectoryName='" + clusterDirectoryName + '\'' +
+                "\n    clusterDir=" + clusterDir +
                 "\n    appVersion=" + appVersion +
                 "\n    clusterId=" + clusterId +
                 "\n    serviceId=" + serviceId +
@@ -1600,17 +1606,11 @@ public final class ClusteredServiceContainer implements AutoCloseable
                 "\n    delegatingErrorHandler=" + delegatingErrorHandler +
                 "\n    errorCounter=" + errorCounter +
                 "\n    countedErrorHandler=" + countedErrorHandler +
-                "\n    archiveContext=" + archiveContext +
-                "\n    clusterDirectoryName='" + clusterDirectoryName + '\'' +
-                "\n    clusterDir=" + clusterDir +
-                "\n    aeronDirectoryName='" + aeronDirectoryName + '\'' +
-                "\n    aeron=" + aeron +
-                "\n    ownsAeronClient=" + ownsAeronClient +
                 "\n    clusteredService=" + clusteredService +
                 "\n    shutdownSignalBarrier=" + shutdownSignalBarrier +
                 "\n    terminationHook=" + terminationHook +
                 "\n    markFile=" + markFile +
-                '}';
+                "\n}";
         }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3562,6 +3562,8 @@ public final class MediaDriver implements AutoCloseable
                 "\n    aeronDirectory=" + aeronDirectory() +
                 "\n    aeronDirectoryName=" + aeronDirectoryName() +
                 "\n    cncFile=" + cncFile() +
+                "\n    countersMetaDataBuffer=" + countersMetaDataBuffer() +
+                "\n    countersValuesBuffer=" + countersValuesBuffer() +
                 "\n    driverTimeoutMs=" + driverTimeoutMs() +
                 "\n    printConfigurationOnStart=" + printConfigurationOnStart +
                 "\n    useWindowsHighResTimer=" + useWindowsHighResTimer +

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3559,7 +3559,9 @@ public final class MediaDriver implements AutoCloseable
                 "\n    isConcluded=" + isConcluded() +
                 "\n    isClosed=" + isClosed +
                 "\n    cncVersion=" + SemanticVersion.toString(CNC_VERSION) +
+                "\n    aeronDirectory=" + aeronDirectory() +
                 "\n    aeronDirectoryName=" + aeronDirectoryName() +
+                "\n    cncFile=" + cncFile() +
                 "\n    driverTimeoutMs=" + driverTimeoutMs() +
                 "\n    printConfigurationOnStart=" + printConfigurationOnStart +
                 "\n    useWindowsHighResTimer=" + useWindowsHighResTimer +

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3560,7 +3560,7 @@ public final class MediaDriver implements AutoCloseable
                 "\n    isClosed=" + isClosed +
                 "\n    cncVersion=" + SemanticVersion.toString(CNC_VERSION) +
                 "\n    aeronDirectory=" + aeronDirectory() +
-                "\n    aeronDirectoryName=" + aeronDirectoryName() +
+                "\n    aeronDirectoryName='" + aeronDirectoryName() + '\'' +
                 "\n    cncFile=" + cncFile() +
                 "\n    countersMetaDataBuffer=" + countersMetaDataBuffer() +
                 "\n    countersValuesBuffer=" + countersValuesBuffer() +
@@ -3644,9 +3644,9 @@ public final class MediaDriver implements AutoCloseable
                 "\n    terminationValidator=" + terminationValidator +
                 "\n    terminationHook=" + terminationHook +
                 "\n    nameResolver=" + nameResolver +
-                "\n    resolverName=" + resolverName +
-                "\n    resolverInterface=" + resolverInterface +
-                "\n    resolverBootstrapNeighbor=" + resolverBootstrapNeighbor +
+                "\n    resolverName='" + resolverName + '\'' +
+                "\n    resolverInterface='" + resolverInterface + '\'' +
+                "\n    resolverBootstrapNeighbor='" + resolverBootstrapNeighbor + '\'' +
                 "\n    sendToStatusMessagePollRatio=" + sendToStatusMessagePollRatio +
                 "\n    unicastFeedbackDelayGenerator=" + unicastFeedbackDelayGenerator +
                 "\n    multicastFeedbackDelayGenerator=" + multicastFeedbackDelayGenerator +


### PR DESCRIPTION
This PR fixes #1236:
- Implements missing `toString` on `AeronCluster.Context`, `Aeron.Context`, `AeronArchive.Context`.
- Use single quotes when outputting String values.
- Always put closing curly brace on a new line.