### PR TITLE
Return -1 instead of throwing in findLastMatchingRecording

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -585,10 +585,9 @@ abstract class ArchiveConductor
         final byte[] channelFragment,
         final ControlSession controlSession)
     {
-        if (minRecordingId < 0 || minRecordingId >= catalog.nextRecordingId())
+        if (minRecordingId < 0)
         {
-            final String msg = "min recording id outside valid range [0, " +
-                max(0, catalog.nextRecordingId() - 1) + "]: " + minRecordingId;
+            final String msg = "minRecordingId=" + minRecordingId + " is < 0";
             controlSession.sendErrorResponse(correlationId, UNKNOWN_RECORDING, msg, controlResponseProxy);
         }
         else

--- a/aeron-samples/src/test/java/io/aeron/samples/archive/RecordingDescriptorCollectorTest.java
+++ b/aeron-samples/src/test/java/io/aeron/samples/archive/RecordingDescriptorCollectorTest.java
@@ -70,7 +70,6 @@ public class RecordingDescriptorCollectorTest
                     .max()
                     .getAsLong();
 
-                System.out.println("Paged from: " + fromRecordingId);
                 fromRecordingId = maxRecordingId + 1;
             }
         }


### PR DESCRIPTION
If the `minRecordingId` is larger than highest recordingId in the catalogue.  This gives more consistent behaviour and more closely matches the documented API.