### PR TITLE
Fix timestamp of publishNewLeadershipTerm

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -293,7 +293,7 @@ class Election
                     case LEADER_INIT:
                     case LEADER_READY:
                     case LEADER_REPLAY:
-                        publishNewLeadershipTerm(follower, logLeadershipTermId, ctx.clusterClock().timeNanos());
+                        publishNewLeadershipTerm(follower, logLeadershipTermId, ctx.clusterClock().time());
                         break;
                 }
             }


### PR DESCRIPTION
According to `https://github.com/real-logic/aeron/blob/master/aeron-cluster/src/main/java/io/aeron/cluster/Election.java#L1041`,  the unit of timestamp should  be the same as ClusterClock.