### PR TITLE
Sample code interrupts.

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -630,7 +630,7 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
     fprintf(fpout, "\n    re_resolution_check_interval_ns=%" PRIu64, context->re_resolution_check_interval_ns);
 
     const aeron_udp_channel_transport_bindings_t *bindings = context->udp_channel_transport_bindings;
-    while (NULL != bindings)
+    if (NULL != bindings)
     {
         fprintf(
             fpout, "\n    udp_channel_transport_bindings.%s=%s,%p%s",
@@ -638,12 +638,10 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
             bindings->meta_info.name,
             bindings->meta_info.source_symbol,
             aeron_dlinfo(bindings->meta_info.source_symbol, buffer, sizeof(buffer)));
-
-        bindings = bindings->meta_info.next_binding;
     }
 
     const aeron_udp_channel_transport_bindings_t *conductor_bindings = context->conductor_udp_channel_transport_bindings;
-    while (NULL != conductor_bindings)
+    if (NULL != conductor_bindings)
     {
         fprintf(
             fpout, "\n    conductor_udp_channel_transport_bindings.%s=%s,%p%s",
@@ -651,8 +649,6 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
             conductor_bindings->meta_info.name,
             conductor_bindings->meta_info.source_symbol,
             aeron_dlinfo(conductor_bindings->meta_info.source_symbol, buffer, sizeof(buffer)));
-
-        conductor_bindings = conductor_bindings->meta_info.next_binding;
     }
 
     const aeron_udp_channel_interceptor_bindings_t *interceptor_bindings;

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.c
@@ -49,7 +49,6 @@ aeron_udp_channel_transport_bindings_t aeron_udp_channel_transport_bindings_defa
             "default",
             "media",
             NULL,
-            NULL
         }
     };
 
@@ -75,7 +74,6 @@ aeron_udp_channel_transport_bindings_t *aeron_udp_channel_transport_bindings_loa
                 EINVAL, "could not find UDP channel transport bindings %s: dlsym - %s", bindings_name, aeron_dlerror());
             return NULL;
         }
-        bindings->meta_info.next_binding = NULL; // Make sure it is not some random data.
         bindings->meta_info.source_symbol = bindings;
     }
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -129,7 +129,6 @@ struct aeron_udp_channel_transport_bindings_stct
     {
         const char *name;
         const char *type;
-        const aeron_udp_channel_transport_bindings_t *next_binding;
         const void *source_symbol;
     }
     meta_info;

--- a/aeron-samples/src/main/cpp/BasicPublisher.cpp
+++ b/aeron-samples/src/main/cpp/BasicPublisher.cpp
@@ -103,10 +103,7 @@ int main(int argc, char **argv)
             });
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         // add the publication to start the process
         std::int64_t id = aeron->addPublication(settings.channel, settings.streamId);
 

--- a/aeron-samples/src/main/cpp/BasicPublisher.cpp
+++ b/aeron-samples/src/main/cpp/BasicPublisher.cpp
@@ -83,8 +83,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optMessages, 1, 1, "number          Number of Messages."));
     cp.addOption(CommandOption(optLinger,   1, 1, "milliseconds    Linger timeout in milliseconds."));
 
-    signal(SIGINT, sigIntHandler);
-
     try
     {
         Settings settings = parseCmdLine(cp, argc, argv);
@@ -105,6 +103,9 @@ int main(int argc, char **argv)
             });
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         // add the publication to start the process
         std::int64_t id = aeron->addPublication(settings.channel, settings.streamId);

--- a/aeron-samples/src/main/cpp/BasicSubscriber.cpp
+++ b/aeron-samples/src/main/cpp/BasicSubscriber.cpp
@@ -87,8 +87,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optChannel,  1, 1, "channel     Channel."));
     cp.addOption(CommandOption(optStreamId, 1, 1, "streamId    Stream ID."));
 
-    signal(SIGINT, sigIntHandler);
-
     try
     {
         Settings settings = parseCmdLine(cp, argc, argv);
@@ -123,6 +121,9 @@ int main(int argc, char **argv)
             });
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         // add the subscription to start the process
         std::int64_t id = aeron->addSubscription(settings.channel, settings.streamId);

--- a/aeron-samples/src/main/cpp/BasicSubscriber.cpp
+++ b/aeron-samples/src/main/cpp/BasicSubscriber.cpp
@@ -121,10 +121,7 @@ int main(int argc, char **argv)
             });
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         // add the subscription to start the process
         std::int64_t id = aeron->addSubscription(settings.channel, settings.streamId);
 

--- a/aeron-samples/src/main/cpp/ExclusiveThroughput.cpp
+++ b/aeron-samples/src/main/cpp/ExclusiveThroughput.cpp
@@ -120,8 +120,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optLinger,   1, 1, "milliseconds    Linger timeout in milliseconds."));
     cp.addOption(CommandOption(optFrags,    1, 1, "limit           Fragment Count Limit."));
 
-    signal(SIGINT, sigIntHandler);
-
     std::shared_ptr<std::thread> rateReporterThread;
     std::shared_ptr<std::thread> pollThread;
 
@@ -170,6 +168,9 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         std::int64_t subscriptionId = aeron.addSubscription(settings.channel, settings.streamId);
         std::int64_t publicationId = aeron.addExclusivePublication(settings.channel, settings.streamId);

--- a/aeron-samples/src/main/cpp/ExclusiveThroughput.cpp
+++ b/aeron-samples/src/main/cpp/ExclusiveThroughput.cpp
@@ -168,10 +168,7 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         std::int64_t subscriptionId = aeron.addSubscription(settings.channel, settings.streamId);
         std::int64_t publicationId = aeron.addExclusivePublication(settings.channel, settings.streamId);
 

--- a/aeron-samples/src/main/cpp/Ping.cpp
+++ b/aeron-samples/src/main/cpp/Ping.cpp
@@ -198,10 +198,7 @@ int main(int argc, char **argv)
         context.preTouchMappedMemory(true);
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         subscriptionId = aeron.addSubscription(settings.pongChannel, settings.pongStreamId);
         publicationId = aeron.addExclusivePublication(settings.pingChannel, settings.pingStreamId);
 

--- a/aeron-samples/src/main/cpp/PingPong.cpp
+++ b/aeron-samples/src/main/cpp/PingPong.cpp
@@ -218,10 +218,7 @@ int main(int argc, char **argv)
         context.preTouchMappedMemory(true);
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         pongSubscriptionId = aeron->addSubscription(settings.pongChannel, settings.pongStreamId);
         pingPublicationId = aeron->addPublication(settings.pingChannel, settings.pingStreamId);
         pingSubscriptionId = aeron->addSubscription(settings.pingChannel, settings.pingStreamId);

--- a/aeron-samples/src/main/cpp/PingPong.cpp
+++ b/aeron-samples/src/main/cpp/PingPong.cpp
@@ -167,8 +167,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optFrags,          1, 1, "limit           Fragment Count Limit."));
     cp.addOption(CommandOption(optWarmupMessages, 1, 1, "number          Number of Messages for warmup."));
 
-    signal(SIGINT, sigIntHandler);
-
     std::shared_ptr<std::thread> pongThread;
 
     try
@@ -220,6 +218,9 @@ int main(int argc, char **argv)
         context.preTouchMappedMemory(true);
 
         std::shared_ptr<Aeron> aeron = Aeron::connect(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         pongSubscriptionId = aeron->addSubscription(settings.pongChannel, settings.pongStreamId);
         pingPublicationId = aeron->addPublication(settings.pingChannel, settings.pingStreamId);

--- a/aeron-samples/src/main/cpp/Pong.cpp
+++ b/aeron-samples/src/main/cpp/Pong.cpp
@@ -136,10 +136,7 @@ int main(int argc, char **argv)
         context.preTouchMappedMemory(true);
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         std::int64_t subscriptionId = aeron.addSubscription(settings.pingChannel, settings.pingStreamId);
         std::int64_t publicationId = aeron.addExclusivePublication(settings.pongChannel, settings.pongStreamId);
 

--- a/aeron-samples/src/main/cpp/RateSubscriber.cpp
+++ b/aeron-samples/src/main/cpp/RateSubscriber.cpp
@@ -131,10 +131,7 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         // add the subscription to start the process
         std::int64_t id = aeron.addSubscription(settings.channel, settings.streamId);
 

--- a/aeron-samples/src/main/cpp/RateSubscriber.cpp
+++ b/aeron-samples/src/main/cpp/RateSubscriber.cpp
@@ -95,8 +95,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optStreamId, 1, 1, "streamId        Stream ID."));
     cp.addOption(CommandOption(optFrags,    1, 1, "limit           Fragment Count Limit."));
 
-    signal(SIGINT, sigIntHandler);
-
     std::shared_ptr<std::thread> rateReporterThread;
 
     try
@@ -133,6 +131,9 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         // add the subscription to start the process
         std::int64_t id = aeron.addSubscription(settings.channel, settings.streamId);

--- a/aeron-samples/src/main/cpp/StreamingPublisher.cpp
+++ b/aeron-samples/src/main/cpp/StreamingPublisher.cpp
@@ -128,8 +128,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optLength,   1, 1, "length          Length of Messages."));
     cp.addOption(CommandOption(optLinger,   1, 1, "milliseconds    Linger timeout in milliseconds."));
 
-    signal(SIGINT, sigIntHandler);
-
     std::shared_ptr<std::thread> rateReporterThread;
 
     try
@@ -156,6 +154,9 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         std::int64_t id = aeron.addPublication(settings.channel, settings.streamId);
         std::shared_ptr<Publication> publication = aeron.findPublication(id);

--- a/aeron-samples/src/main/cpp/StreamingPublisher.cpp
+++ b/aeron-samples/src/main/cpp/StreamingPublisher.cpp
@@ -154,10 +154,7 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         std::int64_t id = aeron.addPublication(settings.channel, settings.streamId);
         std::shared_ptr<Publication> publication = aeron.findPublication(id);
 

--- a/aeron-samples/src/main/cpp/Throughput.cpp
+++ b/aeron-samples/src/main/cpp/Throughput.cpp
@@ -116,8 +116,6 @@ int main(int argc, char **argv)
     cp.addOption(CommandOption(optLinger,   1, 1, "milliseconds    Linger timeout in milliseconds."));
     cp.addOption(CommandOption(optFrags,    1, 1, "limit           Fragment Count Limit."));
 
-    signal(SIGINT, sigIntHandler);
-
     std::shared_ptr<std::thread> rateReporterThread;
     std::shared_ptr<std::thread> pollThread;
 
@@ -166,6 +164,9 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
+        struct sigaction act;
+        act.sa_handler = sigIntHandler;
+        sigaction(SIGINT, &act, NULL);
 
         std::int64_t subscriptionId = aeron.addSubscription(settings.channel, settings.streamId);
         std::int64_t publicationId = aeron.addPublication(settings.channel, settings.streamId);

--- a/aeron-samples/src/main/cpp/Throughput.cpp
+++ b/aeron-samples/src/main/cpp/Throughput.cpp
@@ -164,10 +164,7 @@ int main(int argc, char **argv)
             });
 
         Aeron aeron(context);
-        struct sigaction act;
-        act.sa_handler = sigIntHandler;
-        sigaction(SIGINT, &act, NULL);
-
+        signal(SIGINT, sigIntHandler);
         std::int64_t subscriptionId = aeron.addSubscription(settings.channel, settings.streamId);
         std::int64_t publicationId = aeron.addPublication(settings.channel, settings.streamId);
 


### PR DESCRIPTION
[C/C++] Allow SIGINT to interrupt sample code while waiting for driver connection or waiting on other resources (e.g. images from remote connections).  
[C] Remove udp_channel_transport_bindings.next_binding (unused).