### PR TITLE
[Java] Fix race conditions in the ArchiveTest.

### DIFF
--- a/aeron-archive/src/test/java/io/aeron/archive/FailControlResponseListener.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/FailControlResponseListener.java
@@ -29,7 +29,8 @@ public class FailControlResponseListener implements ControlResponseListener
         final ControlResponseCode code,
         final String errorMessage)
     {
-        fail();
+        fail("controlSessionId=" + controlSessionId + ", correlationId=" + correlationId + ", relevantId=" +
+            relevantId + ", responseCode=" + code + ", errorMessage=" + errorMessage);
     }
 
     public void onRecordingDescriptor(
@@ -50,6 +51,21 @@ public class FailControlResponseListener implements ControlResponseListener
         final String originalChannel,
         final String sourceIdentity)
     {
-        fail();
+        fail("controlSessionId=" + controlSessionId +
+            ", correlationId=" + correlationId +
+            ", recordingId=" + recordingId +
+            ", startTimestamp=" + startTimestamp +
+            ", stopTimestamp=" + stopTimestamp +
+            ", startPosition=" + startPosition +
+            ", stopPosition=" + stopPosition +
+            ", initialTermId=" + initialTermId +
+            ", segmentFileLength=" + segmentFileLength +
+            ", termBufferLength=" + termBufferLength +
+            ", mtuLength=" + mtuLength +
+            ", sessionId=" + sessionId +
+            ", streamId=" + streamId +
+            ", strippedChannel=" + strippedChannel +
+            ", originalChannel=" + originalChannel +
+            ", sourceIdentity=" + sourceIdentity);
     }
 }

--- a/aeron-archive/src/test/java/io/aeron/archive/FailRecordingEventsListener.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/FailRecordingEventsListener.java
@@ -29,16 +29,17 @@ public class FailRecordingEventsListener implements RecordingEventsListener
         final String channel,
         final String sourceIdentity)
     {
-        fail();
+        fail("recordingId=" + recordingId + ", startPosition=" + startPosition + ", sessionId=" + sessionId +
+            ", streamId=" + streamId + ", channel=" + channel + ", sourceIdentity=" + sourceIdentity);
     }
 
     public void onProgress(final long recordingId, final long startPosition, final long position)
     {
-        fail();
+        fail("recordingId=" + recordingId + ", startPosition=" + startPosition + ", position=" + position);
     }
 
     public void onStop(final long recordingId, final long startPosition, final long stopPosition)
     {
-        fail();
+        fail("recordingId=" + recordingId + ", startPosition=" + startPosition + ", stopPosition=" + stopPosition);
     }
 }


### PR DESCRIPTION
This PR fixes race conditions in the `io.aeron.archive.ArchiveTest` from the system tests and adds diagnostic output to the `fail` calls.