### PR TITLE
[C/Java] Extend channel re-use validation in the driver to show existing/current channels.

### DIFF
--- a/aeron-client/src/main/c/aeron_client.c
+++ b/aeron-client/src/main/c/aeron_client.c
@@ -205,7 +205,7 @@ void aeron_print_counters_format(
     char buffer[AERON_MAX_PATH];
     aeron_print_counters_stream_out_t *out = (aeron_print_counters_stream_out_t *)clientd;
 
-    snprintf(buffer, AERON_MAX_PATH - 1, "%3" PRId32 ": %20" PRId64 " - %*s\r\n",
+    snprintf(buffer, AERON_MAX_PATH - 1, "%3" PRId32 ": %20" PRId64 " - %.*s\r\n",
         id, value, (int)label_length, label);
     out->stream_out(buffer);
 }
@@ -364,7 +364,7 @@ int aeron_async_add_publication_poll(aeron_publication_t **publication, aeron_as
         {
             AERON_SET_ERR(
                 -async->error_code,
-                "async_add_publication registration\n== Driver Error ==\n%*s",
+                "async_add_publication registration\n== Driver Error ==\n%.*s",
                 (int)async->error_message_length,
                 async->error_message);
             aeron_async_cmd_free(async);
@@ -432,7 +432,7 @@ int aeron_async_add_exclusive_publication_poll(
         {
             AERON_SET_ERR(
                 -async->error_code,
-                "async_add_exclusive_publication registration\n== Driver Error ==\n%*s",
+                "async_add_exclusive_publication registration\n== Driver Error ==\n%.*s",
                 (int)async->error_message_length,
                 async->error_message);
             aeron_async_cmd_free(async);
@@ -629,7 +629,7 @@ int aeron_async_add_counter_poll(aeron_counter_t **counter, aeron_async_add_coun
         {
             AERON_SET_ERR(
                 -async->error_code,
-                "async_add_counter registration\n== Driver Error ==\n%*s",
+                "async_add_counter registration\n== Driver Error ==\n%.*s",
                 (int)async->error_message_length,
                 async->error_message);
             aeron_async_cmd_free(async);
@@ -694,7 +694,7 @@ static int aeron_async_destination_poll(aeron_async_destination_t *async)
         {
             AERON_SET_ERR(
                 -async->error_code,
-                "async_add_destination registration\n== Driver Error ==\n%*s",
+                "async_add_destination registration\n== Driver Error ==\n%.*s",
                 (int)async->error_message_length,
                 async->error_message);
             aeron_async_cmd_free(async);

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -465,7 +465,7 @@ public final class DriverConductor implements Agent
         {
             if (params.hasSessionId)
             {
-                checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm());
+                checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm(), channel);
             }
 
             publication = newNetworkPublication(
@@ -1685,7 +1685,7 @@ public final class DriverConductor implements Agent
         {
             if (params.hasSessionId)
             {
-                checkForSessionClash(params.sessionId, streamId, IPC_MEDIA);
+                checkForSessionClash(params.sessionId, streamId, IPC_MEDIA, channel);
             }
 
             validateMtuForMaxMessage(params, channel);
@@ -1812,12 +1812,13 @@ public final class DriverConductor implements Agent
         return ipcPublication;
     }
 
-    private void checkForSessionClash(final int sessionId, final int streamId, final String channel)
+    private void checkForSessionClash(
+        final int sessionId, final int streamId, final String channel, final String originalChannel)
     {
         if (activeSessionSet.contains(new SessionKey(sessionId, streamId, channel)))
         {
             throw new InvalidChannelException("existing publication has clashing sessionId=" + sessionId +
-                " for streamId=" + streamId + " channel=" + channel);
+                " for streamId=" + streamId + " channel=" + originalChannel);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1419,7 +1419,7 @@ public final class DriverConductor implements Agent
                 !udpChannel.channelUri().containsKey(CommonContext.ENDPOINT_PARAM_NAME))
             {
                 throw new InvalidChannelException(
-                    "URI must have explicit control, endpoint, or be manual control-mode when original: " +
+                    "URI must have explicit control, endpoint, or be manual control-mode when original: channel=" +
                     udpChannel.originalUriString());
             }
         }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1382,7 +1382,7 @@ public final class DriverConductor implements Agent
         {
             throw new InvalidChannelException(
                 "option conflicts with existing subscription: " + CHANNEL_SEND_TIMESTAMP_OFFSET_PARAM_NAME + "=" +
-                udpChannel.channelReceiveTimestampOffset() +
+                udpChannel.channelSendTimestampOffset() +
                 " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
                 udpChannel.originalUriString());
         }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -32,7 +32,10 @@ import io.aeron.exceptions.ControlProtocolException;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import io.aeron.status.ChannelEndpointStatus;
-import org.agrona.*;
+import org.agrona.BitUtil;
+import org.agrona.CloseHelper;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Object2ObjectHashMap;
 import org.agrona.collections.ObjectHashSet;
 import org.agrona.concurrent.*;
@@ -448,7 +451,7 @@ public final class DriverConductor implements Agent
         final ChannelUri channelUri = udpChannel.channelUri();
         final PublicationParams params = getPublicationParams(channelUri, ctx, this, isExclusive, false);
         validateEndpointForPublication(udpChannel);
-        validateMtuForMaxMessage(params);
+        validateMtuForMaxMessage(params, channel);
 
         final SendChannelEndpoint channelEndpoint = getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
 
@@ -470,8 +473,9 @@ public final class DriverConductor implements Agent
         }
         else
         {
-            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId());
-            validateSpiesSimulateConnection(params, publication.spiesSimulateConnection());
+            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId(), publication.channel());
+            validateSpiesSimulateConnection(
+                params, publication.spiesSimulateConnection(), channel, publication.channel());
         }
 
         publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
@@ -1329,7 +1333,12 @@ public final class DriverConductor implements Agent
 
                 channelEndpoint.localSocketAddressIndicator(localSocketAddressIndicator);
 
-                validateMtuForSndbuf(params, channelEndpoint.socketSndbufLength(), ctx);
+                validateMtuForSndbuf(
+                    params,
+                    channelEndpoint.socketSndbufLength(),
+                    ctx,
+                    udpChannel.originalUriString(),
+                    channelEndpoint.originalUriString());
                 sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
                 senderProxy.registerSendChannelEndpoint(channelEndpoint);
             }
@@ -1342,17 +1351,24 @@ public final class DriverConductor implements Agent
         else
         {
             validateChannelSendTimestampOffset(udpChannel, channelEndpoint);
-            validateMtuForSndbuf(params, channelEndpoint.socketSndbufLength(), ctx);
+            validateMtuForSndbuf(
+                params,
+                channelEndpoint.socketSndbufLength(),
+                ctx,
+                udpChannel.originalUriString(),
+                channelEndpoint.originalUriString());
             validateChannelBufferLength(
                 SOCKET_RCVBUF_PARAM_NAME,
                 udpChannel.socketRcvbufLength(),
                 channelEndpoint.socketRcvbufLength(),
-                udpChannel.originalUriString());
+                udpChannel.originalUriString(),
+                channelEndpoint.originalUriString());
             validateChannelBufferLength(
                 SOCKET_SNDBUF_PARAM_NAME,
                 udpChannel.socketSndbufLength(),
                 channelEndpoint.socketSndbufLength(),
-                udpChannel.originalUriString());
+                udpChannel.originalUriString(),
+                channelEndpoint.originalUriString());
         }
 
         return channelEndpoint;
@@ -1366,7 +1382,9 @@ public final class DriverConductor implements Agent
         {
             throw new InvalidChannelException(
                 "option conflicts with existing subscription: " + CHANNEL_SEND_TIMESTAMP_OFFSET_PARAM_NAME + "=" +
-                udpChannel.channelReceiveTimestampOffset());
+                udpChannel.channelReceiveTimestampOffset() +
+                " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                udpChannel.originalUriString());
         }
     }
 
@@ -1378,7 +1396,9 @@ public final class DriverConductor implements Agent
         {
             throw new InvalidChannelException(
                 "option conflicts with existing subscription: " + CHANNEL_RECEIVE_TIMESTAMP_OFFSET_PARAM_NAME + "=" +
-                udpChannel.channelReceiveTimestampOffset());
+                udpChannel.channelReceiveTimestampOffset() +
+                " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                udpChannel.originalUriString());
         }
     }
 
@@ -1432,13 +1452,17 @@ public final class DriverConductor implements Agent
                     if (params.isReliable != subscription.isReliable())
                     {
                         throw new InvalidChannelException(
-                            "option conflicts with existing subscription: reliable=" + params.isReliable);
+                            "option conflicts with existing subscription: reliable=" + params.isReliable +
+                            "existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            udpChannel.originalUriString());
                     }
 
                     if (params.isRejoin != subscription.isRejoin())
                     {
                         throw new InvalidChannelException(
-                            "option conflicts with existing subscription: rejoin=" + params.isRejoin);
+                            "option conflicts with existing subscription: rejoin=" + params.isRejoin +
+                            "existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            udpChannel.originalUriString());
                     }
                 }
             }
@@ -1581,12 +1605,14 @@ public final class DriverConductor implements Agent
                 SOCKET_RCVBUF_PARAM_NAME,
                 udpChannel.socketRcvbufLength(),
                 channelEndpoint.socketRcvbufLength(),
-                udpChannel.originalUriString());
+                udpChannel.originalUriString(),
+                channelEndpoint.originalUriString());
             validateChannelBufferLength(
                 SOCKET_SNDBUF_PARAM_NAME,
                 udpChannel.socketSndbufLength(),
                 channelEndpoint.socketSndbufLength(),
-                udpChannel.originalUriString());
+                udpChannel.originalUriString(),
+                channelEndpoint.originalUriString());
         }
 
         return channelEndpoint;
@@ -1662,12 +1688,12 @@ public final class DriverConductor implements Agent
                 checkForSessionClash(params.sessionId, streamId, IPC_MEDIA);
             }
 
-            validateMtuForMaxMessage(params);
+            validateMtuForMaxMessage(params, channel);
             publication = addIpcPublication(correlationId, clientId, streamId, channel, isExclusive, params);
         }
         else
         {
-            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId());
+            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId(), publication.channel());
         }
 
         return publication;
@@ -1940,14 +1966,18 @@ public final class DriverConductor implements Agent
     }
 
     private static void validateChannelBufferLength(
-        final String paramName, final int newLength, final int existingLength, final String channel)
+        final String paramName,
+        final int newLength,
+        final int existingLength,
+        final String channel,
+        final String existingChannel)
     {
         if (0 != newLength && newLength != existingLength)
         {
-            final String existingValue = 0 == existingLength ? "OS default" : Integer.toString(existingLength);
-
+            final Object existingValue = 0 == existingLength ? "OS default" : existingLength;
             throw new InvalidChannelException(
-                paramName + "=" + newLength + " does not match existing value of " + existingValue + " uri=" + channel);
+                paramName + "=" + newLength + " does not match existing value of " + existingValue +
+                ": existingChannel=" + existingChannel + " channel=" + channel);
         }
     }
 
@@ -1958,7 +1988,8 @@ public final class DriverConductor implements Agent
             udpChannel.hasExplicitEndpoint() &&
             0 == udpChannel.remoteData().getPort())
         {
-            throw new IllegalArgumentException(ENDPOINT_PARAM_NAME + " has port=0 for publication");
+            throw new IllegalArgumentException(ENDPOINT_PARAM_NAME + " has port=0 for publication: channel=" +
+                udpChannel.originalUriString());
         }
     }
 
@@ -1967,7 +1998,8 @@ public final class DriverConductor implements Agent
         if (udpChannel.hasExplicitControl() &&
             0 == udpChannel.localControl().getPort())
         {
-            throw new IllegalArgumentException(MDC_CONTROL_PARAM_NAME + " has port=0 for subscription");
+            throw new IllegalArgumentException(MDC_CONTROL_PARAM_NAME + " has port=0 for subscription: channel=" +
+                udpChannel.originalUriString());
         }
     }
 
@@ -1977,7 +2009,7 @@ public final class DriverConductor implements Agent
         {
             throw new InvalidChannelException(
                 "Media timestamps '" + MEDIA_RCV_TIMESTAMP_OFFSET_PARAM_NAME +
-                "' are not supported in the Java driver");
+                "' are not supported in the Java driver: channel=" + udpChannel.originalUriString());
         }
     }
 
@@ -1985,7 +2017,8 @@ public final class DriverConductor implements Agent
     {
         if (SPY_QUALIFIER.equals(uri.prefix()))
         {
-            throw new InvalidChannelException("Aeron spies are invalid as send destinations: " + destinationUri);
+            throw new InvalidChannelException("Aeron spies are invalid as send destinations: channel=" +
+                destinationUri);
         }
 
         for (final String invalidKey : INVALID_DESTINATION_KEYS)
@@ -1993,7 +2026,7 @@ public final class DriverConductor implements Agent
             if (uri.containsKey(invalidKey))
             {
                 throw new InvalidChannelException(
-                    "destinations must not contain the key: " + invalidKey + " uri=" + destinationUri);
+                    "destinations must not contain the key: " + invalidKey + " channel=" + destinationUri);
             }
         }
     }
@@ -2004,7 +2037,8 @@ public final class DriverConductor implements Agent
 
         if (null != endpoint && endpoint.endsWith(":0"))
         {
-            throw new InvalidChannelException(ENDPOINT_PARAM_NAME + " has port=0 for send destination");
+            throw new InvalidChannelException(ENDPOINT_PARAM_NAME + " has port=0 for send destination: channel=" +
+                destinationUri);
         }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1334,11 +1334,7 @@ public final class DriverConductor implements Agent
                 channelEndpoint.localSocketAddressIndicator(localSocketAddressIndicator);
 
                 validateMtuForSndbuf(
-                    params,
-                    channelEndpoint.socketSndbufLength(),
-                    ctx,
-                    udpChannel.originalUriString(),
-                    channelEndpoint.originalUriString());
+                    params, channelEndpoint.socketSndbufLength(), ctx, udpChannel.originalUriString(), null);
                 sendChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
                 senderProxy.registerSendChannelEndpoint(channelEndpoint);
             }
@@ -1587,7 +1583,7 @@ public final class DriverConductor implements Agent
                     channelEndpoint.localSocketAddressIndicator(localSocketAddressIndicator);
                 }
 
-                validateInitialWindowForRcvBuf(params, udpChannel, channelEndpoint.socketRcvbufLength(), ctx);
+                validateInitialWindowForRcvBuf(params, channel, channelEndpoint.socketRcvbufLength(), ctx, null);
 
                 receiveChannelEndpointByChannelMap.put(udpChannel.canonicalForm(), channelEndpoint);
                 receiverProxy.registerReceiveChannelEndpoint(channelEndpoint);
@@ -1600,7 +1596,12 @@ public final class DriverConductor implements Agent
         }
         else
         {
-            validateInitialWindowForRcvBuf(params, udpChannel, channelEndpoint.socketRcvbufLength(), ctx);
+            validateInitialWindowForRcvBuf(
+                params,
+                udpChannel.originalUriString(),
+                channelEndpoint.socketRcvbufLength(),
+                ctx,
+                channelEndpoint.originalUriString());
             validateChannelBufferLength(
                 SOCKET_RCVBUF_PARAM_NAME,
                 udpChannel.socketRcvbufLength(),

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1453,7 +1453,7 @@ public final class DriverConductor implements Agent
                     {
                         throw new InvalidChannelException(
                             "option conflicts with existing subscription: reliable=" + params.isReliable +
-                            "existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
                             udpChannel.originalUriString());
                     }
 
@@ -1461,7 +1461,7 @@ public final class DriverConductor implements Agent
                     {
                         throw new InvalidChannelException(
                             "option conflicts with existing subscription: rejoin=" + params.isRejoin +
-                            "existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
                             udpChannel.originalUriString());
                     }
                 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1453,7 +1453,7 @@ public final class DriverConductor implements Agent
                     {
                         throw new InvalidChannelException(
                             "option conflicts with existing subscription: reliable=" + params.isReliable +
-                            " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            " existingChannel=" + subscription.channel() + " channel=" +
                             udpChannel.originalUriString());
                     }
 
@@ -1461,7 +1461,7 @@ public final class DriverConductor implements Agent
                     {
                         throw new InvalidChannelException(
                             "option conflicts with existing subscription: rejoin=" + params.isRejoin +
-                            " existingChannel=" + channelEndpoint.originalUriString() + " channel=" +
+                            " existingChannel=" + subscription.channel() + " channel=" +
                             udpChannel.originalUriString());
                     }
                 }

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
@@ -79,12 +79,14 @@ final class PublicationParams
             if (!isExclusive)
             {
                 throw new IllegalArgumentException("params: " + INITIAL_TERM_ID_PARAM_NAME + " " + TERM_ID_PARAM_NAME +
-                    " " + TERM_OFFSET_PARAM_NAME + " are not supported for concurrent publications");
+                    " " + TERM_OFFSET_PARAM_NAME + " are not supported for concurrent publications: channel=" +
+                    channelUri);
             }
             if (count < 3)
             {
                 throw new IllegalArgumentException("params must be used as a complete set: " +
-                    INITIAL_TERM_ID_PARAM_NAME + " " + TERM_ID_PARAM_NAME + " " + TERM_OFFSET_PARAM_NAME);
+                    INITIAL_TERM_ID_PARAM_NAME + " " + TERM_ID_PARAM_NAME + " " + TERM_OFFSET_PARAM_NAME + " channel=" +
+                    channelUri);
             }
 
             params.initialTermId = Integer.parseInt(initialTermIdStr);
@@ -95,26 +97,29 @@ final class PublicationParams
             {
                 throw new IllegalArgumentException(
                     TERM_OFFSET_PARAM_NAME + "=" + params.termOffset + " > " +
-                    TERM_LENGTH_PARAM_NAME + "=" + params.termLength);
+                    TERM_LENGTH_PARAM_NAME + "=" + params.termLength + ": channel=" + channelUri);
             }
 
             if (params.termOffset < 0 || params.termOffset > LogBufferDescriptor.TERM_MAX_LENGTH)
             {
                 throw new IllegalArgumentException(
-                    TERM_OFFSET_PARAM_NAME + "=" + params.termOffset + " out of range");
+                    TERM_OFFSET_PARAM_NAME + "=" + params.termOffset + " out of range: channel=" + channelUri);
             }
 
             if ((params.termOffset & (FrameDescriptor.FRAME_ALIGNMENT - 1)) != 0)
             {
                 throw new IllegalArgumentException(
-                    TERM_OFFSET_PARAM_NAME + "=" + params.termOffset + " must be a multiple of FRAME_ALIGNMENT");
+                    TERM_OFFSET_PARAM_NAME + "=" + params.termOffset +
+                    " must be a multiple of FRAME_ALIGNMENT: channel=" +
+                    channelUri);
             }
 
             if (params.termId - params.initialTermId < 0)
             {
                 throw new IllegalStateException(
                     "difference greater than 2^31 - 1: " + INITIAL_TERM_ID_PARAM_NAME + "=" +
-                    params.initialTermId + " when " + TERM_ID_PARAM_NAME + "=" + params.termId);
+                    params.initialTermId + " when " + TERM_ID_PARAM_NAME + "=" + params.termId + " channel=" +
+                    channelUri);
             }
 
             params.hasPosition = true;
@@ -137,7 +142,7 @@ final class PublicationParams
         if (null != tagParam)
         {
             final long entityTag = Long.parseLong(tagParam);
-            validateEntityTag(entityTag, driverConductor);
+            validateEntityTag(entityTag, driverConductor, channelUri);
             this.entityTag = entityTag;
         }
     }
@@ -149,7 +154,7 @@ final class PublicationParams
         {
             final int termLength = (int)SystemUtil.parseSize(TERM_LENGTH_PARAM_NAME, termLengthParam);
             LogBufferDescriptor.checkTermLength(termLength);
-            validateTermLength(this, termLength);
+            validateTermLength(this, termLength, channelUri);
             this.termLength = termLength;
         }
     }
@@ -161,12 +166,12 @@ final class PublicationParams
         {
             final int mtuLength = (int)SystemUtil.parseSize(MTU_LENGTH_PARAM_NAME, mtuParam);
             Configuration.validateMtuLength(mtuLength);
-            validateMtuLength(this, mtuLength);
+            validateMtuLength(this, mtuLength, channelUri);
             this.mtuLength = mtuLength;
         }
     }
 
-    static void validateMtuForMaxMessage(final PublicationParams params)
+    static void validateMtuForMaxMessage(final PublicationParams params, final String channel)
     {
         final int termLength = params.termLength;
         final int maxMessageLength = FrameDescriptor.computeMaxMessageLength(termLength);
@@ -174,25 +179,30 @@ final class PublicationParams
         if (params.mtuLength > maxMessageLength)
         {
             throw new IllegalStateException("MTU greater than max message length for term length: mtu=" +
-                params.mtuLength + " maxMessageLength=" + maxMessageLength + " termLength=" + termLength);
+                params.mtuLength + " maxMessageLength=" + maxMessageLength + " termLength=" + termLength + " channel=" +
+                channel);
         }
     }
 
-    static void validateTermLength(final PublicationParams params, final int explicitTermLength)
+    static void validateTermLength(
+        final PublicationParams params, final int explicitTermLength, final ChannelUri channelUri)
     {
         if (params.isSessionIdTagged && explicitTermLength != params.termLength)
         {
             throw new IllegalArgumentException(
-                TERM_LENGTH_PARAM_NAME + "=" + explicitTermLength + " does not match session-id tag value");
+                TERM_LENGTH_PARAM_NAME + "=" + explicitTermLength + " does not match session-id tag value: channel=" +
+                channelUri);
         }
     }
 
-    static void validateMtuLength(final PublicationParams params, final int explicitMtuLength)
+    static void validateMtuLength(
+        final PublicationParams params, final int explicitMtuLength, final ChannelUri channelUri)
     {
         if (params.isSessionIdTagged && explicitMtuLength != params.mtuLength)
         {
             throw new IllegalArgumentException(
-                MTU_LENGTH_PARAM_NAME + "=" + explicitMtuLength + " does not match session-id tag value");
+                MTU_LENGTH_PARAM_NAME + "=" + explicitMtuLength + " does not match session-id tag value: channel=" +
+                    channelUri);
         }
     }
 
@@ -200,52 +210,68 @@ final class PublicationParams
         final ChannelUri channelUri,
         final PublicationParams params,
         final RawLog rawLog,
-        final int existingSessionId)
+        final int existingSessionId,
+        final String existingChannel)
     {
         final int mtuLength = LogBufferDescriptor.mtuLength(rawLog.metaData());
         if (channelUri.containsKey(MTU_LENGTH_PARAM_NAME) && mtuLength != params.mtuLength)
         {
             throw new IllegalStateException("existing publication has different MTU length: existing=" +
-                mtuLength + " requested=" + params.mtuLength);
+                mtuLength + " requested=" + params.mtuLength + " existingChannel=" + existingChannel +
+                " channel=" + channelUri);
         }
 
         if (channelUri.containsKey(TERM_LENGTH_PARAM_NAME) && rawLog.termLength() != params.termLength)
         {
             throw new IllegalStateException("existing publication has different term length: existing=" +
-                rawLog.termLength() + " requested=" + params.termLength);
+                rawLog.termLength() + " requested=" + params.termLength + " existingChannel=" + existingChannel +
+                " channel=" + channelUri);
         }
 
         if (channelUri.containsKey(SESSION_ID_PARAM_NAME) && params.sessionId != existingSessionId)
         {
             throw new IllegalStateException("existing publication has different session id: existing=" +
-                existingSessionId + " requested=" + params.sessionId);
+                existingSessionId + " requested=" + params.sessionId + " existingChannel=" + existingChannel +
+                " channel=" + channelUri);
         }
     }
 
     static void validateSpiesSimulateConnection(
-        final PublicationParams params, final boolean existingSpiesSimulateConnection)
+        final PublicationParams params,
+        final boolean existingSpiesSimulateConnection,
+        final String channel,
+        final String existingChannel)
     {
         if (params.spiesSimulateConnection != existingSpiesSimulateConnection)
         {
             throw new IllegalStateException("existing publication has different spiesSimulateConnection: existing=" +
-                existingSpiesSimulateConnection + " requested=" + params.spiesSimulateConnection);
+                existingSpiesSimulateConnection + " requested=" + params.spiesSimulateConnection +
+                " existingChannel=" + existingChannel + " channel=" + channel);
         }
     }
 
     static void validateMtuForSndbuf(
-        final PublicationParams params, final int channelSocketSndbufLength, final MediaDriver.Context ctx)
+        final PublicationParams params,
+        final int channelSocketSndbufLength,
+        final MediaDriver.Context ctx,
+        final String channel,
+        final String endpointChannel)
     {
         if (0 != channelSocketSndbufLength && params.mtuLength > channelSocketSndbufLength)
         {
             throw new IllegalStateException(
                 "MTU greater than SO_SNDBUF for channel: mtu=" + params.mtuLength +
-                " so-sndbuf=" + channelSocketSndbufLength);
+                    " so-sndbuf=" + channelSocketSndbufLength +
+                    (channel.equals(endpointChannel) ? "" : (" existingChannel=" + endpointChannel)) +
+                    " channel=" + channel);
         }
         else if (0 == channelSocketSndbufLength && params.mtuLength > ctx.osDefaultSocketSndbufLength())
         {
             throw new IllegalStateException(
                 "MTU greater than SO_SNDBUF for channel: mtu=" + params.mtuLength +
-                " so-sndbuf=" + ctx.osDefaultSocketSndbufLength() + " (OS default)");
+                    " so-sndbuf=" + ctx.osDefaultSocketSndbufLength() + " (OS default)" +
+                    (channel.equals(endpointChannel) ? "" : (" existingChannel=" + endpointChannel)) +
+                    " channel=" + channel);
         }
     }
 
@@ -272,7 +298,8 @@ final class PublicationParams
                 if (null == publication)
                 {
                     throw new IllegalArgumentException(
-                        SESSION_ID_PARAM_NAME + "=" + sessionIdStr + " must reference a network publication");
+                        SESSION_ID_PARAM_NAME + "=" + sessionIdStr + " must reference a network publication: channel=" +
+                        channelUri);
                 }
 
                 sessionId = publication.sessionId();
@@ -309,17 +336,25 @@ final class PublicationParams
         spiesSimulateConnection = null != sscStr ? "true".equals(sscStr) : ctx.spiesSimulateConnection();
     }
 
-    private static void validateEntityTag(final long entityTag, final DriverConductor driverConductor)
+    private static void validateEntityTag(
+        final long entityTag, final DriverConductor driverConductor, final ChannelUri channelUri)
     {
         if (INVALID_TAG == entityTag)
         {
-            throw new IllegalArgumentException(INVALID_TAG + " tag is reserved");
+            throw new IllegalArgumentException(INVALID_TAG + " tag is reserved: channel=" + channelUri);
         }
 
-        if (null != driverConductor.findNetworkPublicationByTag(entityTag) ||
-            null != driverConductor.findIpcPublicationByTag(entityTag))
+        final NetworkPublication networkPublication = driverConductor.findNetworkPublicationByTag(entityTag);
+        if (null != networkPublication)
         {
-            throw new IllegalArgumentException(entityTag + " entityTag already in use");
+            throw new IllegalArgumentException(entityTag + " entityTag already in use: existingChannel=" +
+                networkPublication.channel() + " channel=" + channelUri);
+        }
+        final IpcPublication ipcPublication = driverConductor.findIpcPublicationByTag(entityTag);
+        if (null != ipcPublication)
+        {
+            throw new IllegalArgumentException(entityTag + " entityTag already in use: existingChannel=" +
+                ipcPublication.channel() + " channel=" + channelUri);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
@@ -255,23 +255,23 @@ final class PublicationParams
         final int channelSocketSndbufLength,
         final MediaDriver.Context ctx,
         final String channel,
-        final String endpointChannel)
+        final String existingChannel)
     {
         if (0 != channelSocketSndbufLength && params.mtuLength > channelSocketSndbufLength)
         {
             throw new IllegalStateException(
                 "MTU greater than SO_SNDBUF for channel: mtu=" + params.mtuLength +
-                    " so-sndbuf=" + channelSocketSndbufLength +
-                    (channel.equals(endpointChannel) ? "" : (" existingChannel=" + endpointChannel)) +
-                    " channel=" + channel);
+                " so-sndbuf=" + channelSocketSndbufLength +
+                (null == existingChannel ? "" : (" existingChannel=" + existingChannel)) +
+                " channel=" + channel);
         }
         else if (0 == channelSocketSndbufLength && params.mtuLength > ctx.osDefaultSocketSndbufLength())
         {
             throw new IllegalStateException(
                 "MTU greater than SO_SNDBUF for channel: mtu=" + params.mtuLength +
-                    " so-sndbuf=" + ctx.osDefaultSocketSndbufLength() + " (OS default)" +
-                    (channel.equals(endpointChannel) ? "" : (" existingChannel=" + endpointChannel)) +
-                    " channel=" + channel);
+                " so-sndbuf=" + ctx.osDefaultSocketSndbufLength() + " (OS default)" +
+                (null == existingChannel ? "" : (" existingChannel=" + existingChannel)) +
+                " channel=" + channel);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -674,7 +674,7 @@ public final class UdpChannel
         }
 
         throw new IllegalArgumentException(
-            "matching tag=" + tag + " has explicit endpoint or control - " + uriStr + " <> " + udpChannel.uriStr);
+            "matching tag=" + tag + " has explicit endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
     }
 
     /**

--- a/aeron-samples/src/main/c/basic_subscriber.c
+++ b/aeron-samples/src/main/c/basic_subscriber.c
@@ -75,7 +75,7 @@ void poll_handler(void *clientd, const uint8_t *buffer, size_t length, aeron_hea
     aeron_header_values(header, &header_values);
 
     printf(
-        "Message to stream %" PRId32 " from session %" PRId32 " (%" PRIu64 " bytes) <<%*s>>\n",
+        "Message to stream %" PRId32 " from session %" PRId32 " (%" PRIu64 " bytes) <<%.*s>>\n",
         subscription_constants.stream_id,
         header_values.frame.session_id,
         (uint64_t)length,


### PR DESCRIPTION
This PR contains the following changes:
- [C/Java] Extend driver validation of channel re-use to show both channel in the error message when validation fails, i.e. append  `existingChannel=... channel=...` to the end of the message.
- [C] Align error message texts to those of the Java driver.
- [C] Fix string format specifier to be `%.*s`.