### PR TITLE
Ensure that the log publication always has a consistent initial-term-id.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -27,7 +27,6 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.*;
-import io.aeron.driver.Configuration;
 import io.aeron.exceptions.AeronException;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.security.Authenticator;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -27,6 +27,7 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.*;
+import io.aeron.driver.Configuration;
 import io.aeron.exceptions.AeronException;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.security.Authenticator;
@@ -1373,6 +1374,24 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 recoveryPlan.appendedLogPosition, recoveryPlan.log.initialTermId, recoveryPlan.log.termBufferLength);
             channelUri.put(MTU_LENGTH_PARAM_NAME, Integer.toString(recoveryPlan.log.mtuLength));
         }
+        else
+        {
+            if (!channelUri.containsKey(INITIAL_TERM_ID_PARAM_NAME))
+            {
+                channelUri.put(INITIAL_TERM_ID_PARAM_NAME, "0");
+            }
+
+            if (!channelUri.containsKey(TERM_ID_PARAM_NAME))
+            {
+                channelUri.put(TERM_ID_PARAM_NAME, "0");
+            }
+
+            if (!channelUri.containsKey(TERM_OFFSET_PARAM_NAME))
+            {
+                channelUri.put(TERM_OFFSET_PARAM_NAME, "0");
+            }
+        }
+
 
         final String channel = channelUri.toString();
         final ExclusivePublication publication = aeron.addExclusivePublication(channel, ctx.logStreamId());

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -24,6 +24,7 @@ import io.aeron.cluster.client.ClusterEvent;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.ChangeType;
 import io.aeron.cluster.service.Cluster;
+import io.aeron.exceptions.AeronEvent;
 import io.aeron.exceptions.AeronException;
 import io.aeron.exceptions.TimeoutException;
 import org.agrona.CloseHelper;
@@ -404,7 +405,10 @@ class Election
                 if (NULL_POSITION != nextTermBaseLogPosition && nextTermBaseLogPosition < appendPosition)
                 {
                     consensusModuleAgent.truncateLogEntry(logLeadershipTermId, nextTermBaseLogPosition);
-                    appendPosition = consensusModuleAgent.prepareForNewLeadership(nextTermBaseLogPosition);
+                    throw new AeronEvent(
+                        "Truncating Cluster Log - leadershipTermId=" + logLeadershipTermId +
+                            " oldPosition=" + logPosition + " newPosition=" + nextTermBaseLogPosition,
+                        AeronException.Category.WARN);
                 }
 
                 this.leaderMember = leader;

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/StalledLeaderLogReplicationClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/StalledLeaderLogReplicationClusterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.log.EventLogExtension;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.cluster.TestCluster;
+import io.aeron.test.cluster.TestNode;
+import net.bytebuddy.asm.Advice;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static io.aeron.test.Tests.awaitAvailableWindow;
+import static io.aeron.test.cluster.TestCluster.aCluster;
+import static io.aeron.test.cluster.TestCluster.awaitElectionClosed;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SlowTest
+@ExtendWith({ EventLogExtension.class, InterruptingTestCallback.class })
+public class StalledLeaderLogReplicationClusterTest
+{
+    private static ClusterInstrumentor clusterInstrumentor;
+
+    @BeforeAll
+    static void beforeAll()
+    {
+        clusterInstrumentor = new ClusterInstrumentor(
+            StallLeaderLogReplicationIntercept.class, "Election", "leaderLogReplication");
+    }
+
+    @AfterAll
+    static void afterAll()
+    {
+        clusterInstrumentor.reset();
+    }
+
+    @RegisterExtension
+    public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    public static class StallLeaderLogReplicationIntercept
+    {
+        static boolean shouldStall = true;
+
+        @Advice.OnMethodEnter
+        static void leaderLogReplication(final long nowNs, @Advice.This final Object election)
+        {
+            if (shouldStall && 0 == ((Election)election).leadershipTermId())
+            {
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(2_500));
+                shouldStall = false;
+            }
+        }
+    }
+
+    @Test
+    @InterruptAfter(60)
+    void shouldHandleMultipleElections()
+    {
+        final TestCluster cluster = aCluster().withStaticNodes(3).start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader0 = cluster.awaitLeader();
+
+        final int numMessages = 3;
+        cluster.connectClient();
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages);
+        cluster.awaitServicesMessageCount(numMessages);
+
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader(leader0.index());
+        cluster.awaitNewLeadershipEvent(1);
+        awaitAvailableWindow(cluster.client().ingressPublication());
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader0.index(), false);
+        awaitElectionClosed(cluster.node(leader0.index()));
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 2);
+        cluster.awaitServicesMessageCount(numMessages * 2);
+
+        cluster.stopNode(leader1);
+        cluster.awaitLeader(leader1.index());
+        cluster.awaitNewLeadershipEvent(2);
+        awaitAvailableWindow(cluster.client().ingressPublication());
+        assertTrue(cluster.client().sendKeepAlive());
+        cluster.startStaticNode(leader1.index(), false);
+        awaitElectionClosed(cluster.node(leader1.index()));
+
+        cluster.sendMessages(numMessages);
+        cluster.awaitResponseMessageCount(numMessages * 3);
+        cluster.awaitServicesMessageCount(numMessages * 3);
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/SystemTestWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/SystemTestWatcher.java
@@ -101,6 +101,15 @@ public class SystemTestWatcher implements DriverOutputConsumer, AfterTestExecuti
         return this;
     }
 
+    /**
+     * Useful when debugging tests to get them to fail on warnings as well as errors.
+     */
+    @SuppressWarnings("unused")
+    public void showAllErrors()
+    {
+        this.logFilter = s -> true;
+    }
+
     public void afterTestExecution(final ExtensionContext context)
     {
         mediaDriverTestUtil.afterTestExecution(context);


### PR DESCRIPTION
And:
- Reset election state correctly after log truncation.