### PR TITLE
[Java] Add an admin command to trigger Cluster snapshot.

### DIFF
--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.Aeron;
+import io.aeron.RethrowingErrorHandler;
+import io.aeron.security.AuthorisationService;
+import io.aeron.security.AuthorisationServiceSupplier;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.status.AtomicCounter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static io.aeron.archive.Archive.Configuration.AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME;
+import static io.aeron.archive.Archive.Configuration.DEFAULT_AUTHORISATION_SERVICE_SUPPLIER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ArchiveContextTests
+{
+    private final Archive.Context context = new Archive.Context();
+
+    @BeforeEach
+    void beforeEach(final @TempDir Path tempDir)
+    {
+        final Aeron aeron = mock(Aeron.class);
+        final Aeron.Context aeronContext = new Aeron.Context();
+        aeronContext.subscriberErrorHandler(RethrowingErrorHandler.INSTANCE);
+        aeronContext.aeronDirectoryName("test-archive-config");
+        when(aeron.context()).thenReturn(aeronContext);
+        context
+            .aeron(aeron)
+            .errorCounter(mock(AtomicCounter.class))
+            .archiveDir(tempDir.resolve("archive-test").toFile());
+    }
+
+    @Test
+    void defaultAuthorisationServiceSupplierReturnsAnAllowAllAuthorisationService()
+    {
+        assertSame(AuthorisationService.ALLOW_ALL, DEFAULT_AUTHORISATION_SERVICE_SUPPLIER.get());
+    }
+
+    @Test
+    void shouldUseDefaultAuthorisationServiceSupplierIfTheSystemPropertyIsNotSet()
+    {
+        assertNull(context.authorisationServiceSupplier());
+
+        context.conclude();
+
+        System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        assertSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, context.authorisationServiceSupplier());
+    }
+
+    @Test
+    void shouldUseDefaultAuthorisationServiceSupplierIfTheSystemPropertyIsSetToEmptyValue()
+    {
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, "");
+        try
+        {
+            assertNull(context.authorisationServiceSupplier());
+
+            context.conclude();
+
+            assertSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, context.authorisationServiceSupplier());
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    @Test
+    void shouldInstantiateAuthorisationServiceSupplierBasedOnTheSystemProperty()
+    {
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, TestAuthorisationSupplier.class.getName());
+        try
+        {
+            context.conclude();
+            final AuthorisationServiceSupplier supplier = context.authorisationServiceSupplier();
+            assertNotSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, supplier);
+            assertInstanceOf(TestAuthorisationSupplier.class, supplier);
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    @Test
+    void shouldUseProvidedAuthorisationServiceSupplierInstance()
+    {
+        final AuthorisationServiceSupplier providedSupplier = mock(AuthorisationServiceSupplier.class);
+        context.authorisationServiceSupplier(providedSupplier);
+        assertSame(providedSupplier, context.authorisationServiceSupplier());
+
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, TestAuthorisationSupplier.class.getName());
+        try
+        {
+            context.conclude();
+            assertSame(providedSupplier, context.authorisationServiceSupplier());
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    public static class TestAuthorisationSupplier implements AuthorisationServiceSupplier
+    {
+        public AuthorisationService get()
+        {
+            return new TestAuthorisationService();
+        }
+    }
+
+    static class TestAuthorisationService implements AuthorisationService
+    {
+        public boolean isAuthorised(
+            final int commandTemplateId, final byte[] encodedCredentials, final ErrorHandler errorHandler)
+        {
+            return false;
+        }
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -20,6 +20,7 @@ import io.aeron.RethrowingErrorHandler;
 import io.aeron.security.AuthorisationService;
 import io.aeron.security.AuthorisationServiceSupplier;
 import org.agrona.concurrent.status.AtomicCounter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,6 +49,12 @@ class ArchiveContextTests
             .aeron(aeron)
             .errorCounter(mock(AtomicCounter.class))
             .archiveDir(tempDir.resolve("archive-test").toFile());
+    }
+
+    @AfterEach
+    void afterEach()
+    {
+        context.close();
     }
 
     @Test

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -131,7 +131,7 @@ class ArchiveContextTests
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int commandTemplateId, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -131,7 +131,7 @@ class ArchiveContextTests
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int templateId, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -138,7 +138,7 @@ class ArchiveContextTests
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedPrincipal)
         {
             return false;
         }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTests.java
@@ -19,7 +19,6 @@ import io.aeron.Aeron;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.security.AuthorisationService;
 import io.aeron.security.AuthorisationServiceSupplier;
-import org.agrona.ErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,8 +131,7 @@ class ArchiveContextTests
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(
-            final int commandTemplateId, final byte[] encodedCredentials, final ErrorHandler errorHandler)
+        public boolean isAuthorised(final int commandTemplateId, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -26,20 +26,23 @@ public interface AuthorisationService
     /**
      * An {@link AuthorisationService} instance that allows every command.
      */
-    AuthorisationService ALLOW_ALL = (commandTemplateId, encodedCredentials) -> true;
+    AuthorisationService ALLOW_ALL = (templateId, type, encodedCredentials) -> true;
 
     /**
      * An {@link AuthorisationService} instance that forbids all commands.
      */
-    AuthorisationService DENY_ALL = (commandTemplateId, encodedCredentials) -> false;
+    AuthorisationService DENY_ALL = (templateId, type, encodedCredentials) -> false;
 
     /**
      * Checks if the client with the specified credentials is allowed to perform an operation indicated by the
      * given {@code templateId}.
      *
-     * @param templateId  of the command being checked, i.e. an SBE message id.
+     * @param templateId         of the command being checked, i.e. an SBE message id.
+     * @param type               optional type for the command being checked, may be {@code null}. For example for
+     *                           an admin request in the cluster it will contain {@code AdminRequestType} value which
+     *                           denotes the exact kind of the request.
      * @param encodedCredentials from the Challenge Response. Will not be {@code null}, but may be 0 length.
      * @return {@code true} if the client is authorised to execute the command or {@code false} otherwise.
      */
-    boolean isAuthorised(int templateId, byte[] encodedCredentials);
+    boolean isAuthorised(int templateId, Object type, byte[] encodedCredentials);
 }

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -35,11 +35,11 @@ public interface AuthorisationService
 
     /**
      * Checks if the client with the specified credentials is allowed to perform an operation indicated by the
-     * given {@code commandTemplateId}.
+     * given {@code templateId}.
      *
-     * @param commandTemplateId  of the command being checked, i.e. an SBE message id.
+     * @param templateId  of the command being checked, i.e. an SBE message id.
      * @param encodedCredentials from the Challenge Response. Will not be {@code null}, but may be 0 length.
      * @return {@code true} if the client is authorised to execute the command or {@code false} otherwise.
      */
-    boolean isAuthorised(int commandTemplateId, byte[] encodedCredentials);
+    boolean isAuthorised(int templateId, byte[] encodedCredentials);
 }

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -15,8 +15,6 @@
  */
 package io.aeron.security;
 
-import org.agrona.ErrorHandler;
-
 /**
  * Interface for an authorisation service to handle authorisation checks of clients in a system.
  *
@@ -28,12 +26,12 @@ public interface AuthorisationService
     /**
      * An {@link AuthorisationService} instance that allows every command.
      */
-    AuthorisationService ALLOW_ALL = (commandTemplateId, encodedCredentials, errorHandler) -> true;
+    AuthorisationService ALLOW_ALL = (commandTemplateId, encodedCredentials) -> true;
 
     /**
      * An {@link AuthorisationService} instance that forbids all commands.
      */
-    AuthorisationService DENY_ALL = (commandTemplateId, encodedCredentials, errorHandler) -> false;
+    AuthorisationService DENY_ALL = (commandTemplateId, encodedCredentials) -> false;
 
     /**
      * Checks if the client with the specified credentials is allowed to perform an operation indicated by the
@@ -41,8 +39,7 @@ public interface AuthorisationService
      *
      * @param commandTemplateId  of the command being checked, i.e. an SBE message id.
      * @param encodedCredentials from the Challenge Response. Will not be {@code null}, but may be 0 length.
-     * @param errorHandler       to report errors if any.
      * @return {@code true} if the client is authorised to execute the command or {@code false} otherwise.
      */
-    boolean isAuthorised(int commandTemplateId, byte[] encodedCredentials, ErrorHandler errorHandler);
+    boolean isAuthorised(int commandTemplateId, byte[] encodedCredentials);
 }

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -37,12 +37,12 @@ public interface AuthorisationService
      * Checks if the client with the specified credentials is allowed to perform an operation indicated by the
      * given {@code templateId}.
      *
-     * @param templateId         of the command being checked, i.e. an SBE message id.
-     * @param type               optional type for the command being checked, may be {@code null}. For example for
-     *                           an admin request in the cluster it will contain {@code AdminRequestType} value which
-     *                           denotes the exact kind of the request.
-     * @param encodedCredentials from the Challenge Response. Will not be {@code null}, but may be 0 length.
+     * @param templateId       of the command being checked, i.e. an SBE message id.
+     * @param type             optional type for the command being checked, may be {@code null}. For example for
+     *                         an admin request in the cluster it will contain {@code AdminRequestType} value which
+     *                         denotes the exact kind of the request.
+     * @param encodedPrincipal that has passed authentication.
      * @return {@code true} if the client is authorised to execute the command or {@code false} otherwise.
      */
-    boolean isAuthorised(int templateId, Object type, byte[] encodedCredentials);
+    boolean isAuthorised(int templateId, Object type, byte[] encodedPrincipal);
 }

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -26,12 +26,12 @@ public interface AuthorisationService
     /**
      * An {@link AuthorisationService} instance that allows every command.
      */
-    AuthorisationService ALLOW_ALL = (templateId, type, encodedCredentials) -> true;
+    AuthorisationService ALLOW_ALL = (templateId, type, encodedPrincipal) -> true;
 
     /**
      * An {@link AuthorisationService} instance that forbids all commands.
      */
-    AuthorisationService DENY_ALL = (templateId, type, encodedCredentials) -> false;
+    AuthorisationService DENY_ALL = (templateId, type, encodedPrincipal) -> false;
 
     /**
      * Checks if the client with the specified credentials is allowed to perform an operation indicated by the

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+import org.agrona.ErrorHandler;
+
+/**
+ * Interface for an authorisation service to handle authorisation checks of clients in a system.
+ *
+ * @see AuthorisationServiceSupplier
+ */
+@FunctionalInterface
+public interface AuthorisationService
+{
+    /**
+     * An {@link AuthorisationService} instance that allows every command.
+     */
+    AuthorisationService ALLOW_ALL = (commandTemplateId, encodedCredentials, errorHandler) -> true;
+
+    /**
+     * An {@link AuthorisationService} instance that forbids all commands.
+     */
+    AuthorisationService DENY_ALL = (commandTemplateId, encodedCredentials, errorHandler) -> false;
+
+    /**
+     * Checks if the client with the specified credentials is allowed to perform an operation indicated by the
+     * given {@code commandTemplateId}.
+     *
+     * @param commandTemplateId  of the command being checked, i.e. an SBE message id.
+     * @param encodedCredentials from the Challenge Response. Will not be {@code null}, but may be 0 length.
+     * @param errorHandler       to report errors if any.
+     * @return {@code true} if the client is authorised to execute the command or {@code false} otherwise.
+     */
+    boolean isAuthorised(int commandTemplateId, byte[] encodedCredentials, ErrorHandler errorHandler);
+}

--- a/aeron-client/src/main/java/io/aeron/security/AuthorisationServiceSupplier.java
+++ b/aeron-client/src/main/java/io/aeron/security/AuthorisationServiceSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+import java.util.function.Supplier;
+
+/**
+ * Used to supply instances of {@link AuthorisationService}.
+ */
+@FunctionalInterface
+public interface AuthorisationServiceSupplier extends Supplier<AuthorisationService>
+{
+}

--- a/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+import org.agrona.ErrorHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static io.aeron.security.AuthorisationService.ALLOW_ALL;
+import static io.aeron.security.AuthorisationService.DENY_ALL;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class AuthorisationServiceTest
+{
+    @Test
+    void shouldAllowAnyCommandIfAllowAllIsUsed()
+    {
+        final byte[] encodedCredentials = { 0x1, 0x2, 0x3 };
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final int commandTemplateId = ThreadLocalRandom.current().nextInt();
+
+        assertTrue(ALLOW_ALL.isAuthorised(commandTemplateId, encodedCredentials, errorHandler));
+        verifyNoInteractions(errorHandler);
+    }
+
+    @Test
+    void shouldForbidAllCommandsIfDenyAllIsUsed()
+    {
+        final byte[] encodedCredentials = { 0x4, 0x5, 0x6 };
+        final ErrorHandler errorHandler = mock(ErrorHandler.class);
+        final int commandTemplateId = ThreadLocalRandom.current().nextInt();
+
+        assertFalse(DENY_ALL.isAuthorised(commandTemplateId, encodedCredentials, errorHandler));
+        verifyNoInteractions(errorHandler);
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
@@ -36,7 +36,7 @@ class AuthorisationServiceTest
         final ErrorHandler errorHandler = mock(ErrorHandler.class);
         final int commandTemplateId = ThreadLocalRandom.current().nextInt();
 
-        assertTrue(ALLOW_ALL.isAuthorised(commandTemplateId, encodedCredentials, errorHandler));
+        assertTrue(ALLOW_ALL.isAuthorised(commandTemplateId, encodedCredentials));
         verifyNoInteractions(errorHandler);
     }
 
@@ -47,7 +47,7 @@ class AuthorisationServiceTest
         final ErrorHandler errorHandler = mock(ErrorHandler.class);
         final int commandTemplateId = ThreadLocalRandom.current().nextInt();
 
-        assertFalse(DENY_ALL.isAuthorised(commandTemplateId, encodedCredentials, errorHandler));
+        assertFalse(DENY_ALL.isAuthorised(commandTemplateId, encodedCredentials));
         verifyNoInteractions(errorHandler);
     }
 }

--- a/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/AuthorisationServiceTest.java
@@ -34,9 +34,9 @@ class AuthorisationServiceTest
     {
         final byte[] encodedCredentials = { 0x1, 0x2, 0x3 };
         final ErrorHandler errorHandler = mock(ErrorHandler.class);
-        final int commandTemplateId = ThreadLocalRandom.current().nextInt();
+        final int templateId = ThreadLocalRandom.current().nextInt();
 
-        assertTrue(ALLOW_ALL.isAuthorised(commandTemplateId, encodedCredentials));
+        assertTrue(ALLOW_ALL.isAuthorised(templateId, null, encodedCredentials));
         verifyNoInteractions(errorHandler);
     }
 
@@ -45,9 +45,9 @@ class AuthorisationServiceTest
     {
         final byte[] encodedCredentials = { 0x4, 0x5, 0x6 };
         final ErrorHandler errorHandler = mock(ErrorHandler.class);
-        final int commandTemplateId = ThreadLocalRandom.current().nextInt();
+        final int templateId = ThreadLocalRandom.current().nextInt();
 
-        assertFalse(DENY_ALL.isAuthorised(commandTemplateId, encodedCredentials));
+        assertFalse(DENY_ALL.isAuthorised(templateId, null, encodedCredentials));
         verifyNoInteractions(errorHandler);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
@@ -23,6 +23,7 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.Header;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.ArrayUtil;
 
 class ConsensusAdapter implements FragmentHandler, AutoCloseable
 {
@@ -294,8 +295,17 @@ class ConsensusAdapter implements FragmentHandler, AutoCloseable
                     messageHeaderDecoder.version());
 
                 final String responseChannel = backupQueryDecoder.responseChannel();
-                final byte[] credentials = new byte[backupQueryDecoder.encodedCredentialsLength()];
-                backupQueryDecoder.getEncodedCredentials(credentials, 0, credentials.length);
+                final int credentialsLength = backupQueryDecoder.encodedCredentialsLength();
+                final byte[] credentials;
+                if (credentialsLength > 0)
+                {
+                    credentials = new byte[credentialsLength];
+                    backupQueryDecoder.getEncodedCredentials(credentials, 0, credentials.length);
+                }
+                else
+                {
+                    credentials = ArrayUtil.EMPTY_BYTE_ARRAY;
+                }
 
                 consensusModuleAgent.onBackupQuery(
                     backupQueryDecoder.correlationId(),

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -465,7 +465,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
             return;
         }
 
-        if (!authorisationService.isAuthorised(AdminRequestDecoder.TEMPLATE_ID, session.encodedPrincipal()))
+        if (!authorisationService.isAuthorised(
+            AdminRequestDecoder.TEMPLATE_ID, requestType, session.encodedPrincipal()))
         {
             egressPublisher.sendAdminResponse(
                 session,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -460,8 +460,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 correlationId,
                 requestType,
                 AdminResponseCode.ERROR,
-                "Invalid leadership term: expected " + this.leadershipTermId + ", got " + leadershipTermId,
-                ArrayUtil.EMPTY_BYTE_ARRAY);
+                "Invalid leadership term: expected " + this.leadershipTermId + ", got " + leadershipTermId);
             return;
         }
 
@@ -473,8 +472,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 correlationId,
                 requestType,
                 AdminResponseCode.UNAUTHORISED_ACCESS,
-                "Execution of the " + requestType + " request was not authorised",
-                ArrayUtil.EMPTY_BYTE_ARRAY);
+                "Execution of the " + requestType + " request was not authorised");
             return;
         }
 
@@ -487,8 +485,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                     correlationId,
                     requestType,
                     AdminResponseCode.OK,
-                    "",
-                    ArrayUtil.EMPTY_BYTE_ARRAY);
+                    "");
             }
             else
             {
@@ -497,8 +494,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                     correlationId,
                     requestType,
                     AdminResponseCode.ERROR,
-                    "Failed to switch ClusterControl to the ToggleState.SNAPSHOT state",
-                    ArrayUtil.EMPTY_BYTE_ARRAY);
+                    "Failed to switch ClusterControl to the ToggleState.SNAPSHOT state");
             }
         }
         else
@@ -508,8 +504,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 correlationId,
                 requestType,
                 AdminResponseCode.ERROR,
-                "Unknown request type: " + requestType,
-                ArrayUtil.EMPTY_BYTE_ARRAY);
+                "Unknown request type: " + requestType);
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
@@ -135,7 +135,7 @@ class EgressPublisher
         final ClusterSession session,
         final long correlationId,
         final AdminRequestType adminRequestType,
-        final AdminResponseCode code,
+        final AdminResponseCode responseCode,
         final String message)
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH +
@@ -155,7 +155,7 @@ class EgressPublisher
                     .clusterSessionId(session.id())
                     .correlationId(correlationId)
                     .requestType(adminRequestType)
-                    .code(code)
+                    .responseCode(responseCode)
                     .message(message)
                     .putPayload(ArrayUtil.EMPTY_BYTE_ARRAY, 0, 0);
                 bufferClaim.commit();

--- a/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/EgressPublisher.java
@@ -19,6 +19,7 @@ import io.aeron.cluster.client.AeronCluster;
 import io.aeron.cluster.codecs.*;
 import io.aeron.logbuffer.BufferClaim;
 import org.agrona.ExpandableArrayBuffer;
+import org.agrona.collections.ArrayUtil;
 
 import static io.aeron.cluster.ClusterSession.MAX_ENCODED_MEMBERSHIP_QUERY_LENGTH;
 
@@ -135,15 +136,13 @@ class EgressPublisher
         final long correlationId,
         final AdminRequestType adminRequestType,
         final AdminResponseCode code,
-        final String message,
-        final byte[] payload)
+        final String message)
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH +
             AdminResponseEncoder.BLOCK_LENGTH +
             AdminResponseEncoder.messageHeaderLength() +
             message.length() +
-            AdminResponseEncoder.payloadHeaderLength() +
-            payload.length;
+            AdminResponseEncoder.payloadHeaderLength();
 
         int attempts = SEND_ATTEMPTS;
         do
@@ -158,7 +157,7 @@ class EgressPublisher
                     .requestType(adminRequestType)
                     .code(code)
                     .message(message)
-                    .putPayload(payload, 0, payload.length);
+                    .putPayload(ArrayUtil.EMPTY_BYTE_ARRAY, 0, 0);
                 bufferClaim.commit();
 
                 return true;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -1703,7 +1703,6 @@ public final class AeronCluster implements AutoCloseable
                     correlationId = Aeron.NULL_VALUE;
                     clusterSessionId = egressPoller.clusterSessionId();
                     prepareChallengeResponse(ctx.credentialsSupplier().onChallenge(egressPoller.encodedChallenge()));
-                    step(2);
                     return;
                 }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -715,7 +715,7 @@ public final class AeronCluster implements AutoCloseable
             {
                 final long correlationId = adminResponseDecoder.correlationId();
                 final AdminRequestType requestType = adminResponseDecoder.requestType();
-                final AdminResponseCode code = adminResponseDecoder.code();
+                final AdminResponseCode responseCode = adminResponseDecoder.responseCode();
                 final String message = adminResponseDecoder.message();
                 final int payloadOffset = adminResponseDecoder.offset() +
                     AdminResponseDecoder.BLOCK_LENGTH +
@@ -727,7 +727,7 @@ public final class AeronCluster implements AutoCloseable
                     sessionId,
                     correlationId,
                     requestType,
-                    code,
+                    responseCode,
                     message,
                     buffer,
                     payloadOffset,
@@ -822,7 +822,7 @@ public final class AeronCluster implements AutoCloseable
             {
                 final long correlationId = adminResponseDecoder.correlationId();
                 final AdminRequestType requestType = adminResponseDecoder.requestType();
-                final AdminResponseCode code = adminResponseDecoder.code();
+                final AdminResponseCode responseCode = adminResponseDecoder.responseCode();
                 final String message = adminResponseDecoder.message();
                 final int payloadOffset = adminResponseDecoder.offset() +
                     AdminResponseDecoder.BLOCK_LENGTH +
@@ -834,7 +834,7 @@ public final class AeronCluster implements AutoCloseable
                     sessionId,
                     correlationId,
                     requestType,
-                    code,
+                    responseCode,
                     message,
                     buffer,
                     payloadOffset,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/ControlledEgressListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/ControlledEgressListener.java
@@ -75,7 +75,7 @@ public interface ControlledEgressListener
      * @param clusterSessionId to which the event belongs.
      * @param leadershipTermId for identifying the active term of leadership
      * @param leaderMemberId   identity of the active leader.
-     * @param ingressEndpoints  for connecting to the cluster which can be updated due to dynamic membership.
+     * @param ingressEndpoints for connecting to the cluster which can be updated due to dynamic membership.
      */
     default void onNewLeader(long clusterSessionId, long leadershipTermId, int leaderMemberId, String ingressEndpoints)
     {
@@ -87,7 +87,7 @@ public interface ControlledEgressListener
      * @param clusterSessionId to which the response belongs.
      * @param correlationId    of the admin request.
      * @param requestType      of the admin request.
-     * @param code             describing the response.
+     * @param responseCode     describing the response.
      * @param message          describing the response (e.g. error message).
      * @param payload          delivered with the response, can be empty.
      * @param payloadOffset    into the payload buffer.
@@ -97,7 +97,7 @@ public interface ControlledEgressListener
         long clusterSessionId,
         long correlationId,
         AdminRequestType requestType,
-        AdminResponseCode code,
+        AdminResponseCode responseCode,
         String message,
         DirectBuffer payload,
         int payloadOffset,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/ControlledEgressListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/ControlledEgressListener.java
@@ -15,6 +15,8 @@
  */
 package io.aeron.cluster.client;
 
+import io.aeron.cluster.codecs.AdminRequestType;
+import io.aeron.cluster.codecs.AdminResponseCode;
 import io.aeron.cluster.codecs.EventCode;
 import io.aeron.logbuffer.ControlledFragmentHandler;
 import io.aeron.logbuffer.Header;
@@ -76,6 +78,30 @@ public interface ControlledEgressListener
      * @param ingressEndpoints  for connecting to the cluster which can be updated due to dynamic membership.
      */
     default void onNewLeader(long clusterSessionId, long leadershipTermId, int leaderMemberId, String ingressEndpoints)
+    {
+    }
+
+    /**
+     * Message returned in response to an admin request.
+     *
+     * @param clusterSessionId to which the response belongs.
+     * @param correlationId    of the admin request.
+     * @param requestType      of the admin request.
+     * @param code             describing the response.
+     * @param message          describing the response (e.g. error message).
+     * @param payload          delivered with the response, can be empty.
+     * @param payloadOffset    into the payload buffer.
+     * @param payloadLength    of the payload.
+     */
+    default void onAdminResponse(
+        long clusterSessionId,
+        long correlationId,
+        AdminRequestType requestType,
+        AdminResponseCode code,
+        String message,
+        DirectBuffer payload,
+        int payloadOffset,
+        int payloadLength)
     {
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
@@ -166,7 +166,7 @@ public final class EgressAdapter implements FragmentHandler
                 {
                     final long correlationId = adminResponseDecoder.correlationId();
                     final AdminRequestType requestType = adminResponseDecoder.requestType();
-                    final AdminResponseCode code = adminResponseDecoder.code();
+                    final AdminResponseCode responseCode = adminResponseDecoder.responseCode();
                     final String message = adminResponseDecoder.message();
                     final int payloadOffset = adminResponseDecoder.offset() +
                         AdminResponseDecoder.BLOCK_LENGTH +
@@ -178,7 +178,7 @@ public final class EgressAdapter implements FragmentHandler
                         sessionId,
                         correlationId,
                         requestType,
-                        code,
+                        responseCode,
                         message,
                         buffer,
                         payloadOffset,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressAdapter.java
@@ -34,6 +34,7 @@ public final class EgressAdapter implements FragmentHandler
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     private final SessionEventDecoder sessionEventDecoder = new SessionEventDecoder();
     private final NewLeaderEventDecoder newLeaderEventDecoder = new NewLeaderEventDecoder();
+    private final AdminResponseDecoder adminResponseDecoder = new AdminResponseDecoder();
     private final SessionMessageHeaderDecoder sessionMessageHeaderDecoder = new SessionMessageHeaderDecoder();
     private final FragmentAssembler fragmentAssembler = new FragmentAssembler(this);
     private final EgressListener listener;
@@ -73,6 +74,7 @@ public final class EgressAdapter implements FragmentHandler
     /**
      * {@inheritDoc}
      */
+    @SuppressWarnings("MethodLength")
     public void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
     {
         messageHeaderDecoder.wrap(buffer, offset);
@@ -148,6 +150,41 @@ public final class EgressAdapter implements FragmentHandler
                         newLeaderEventDecoder.leaderMemberId(),
                         newLeaderEventDecoder.ingressEndpoints());
                 }
+                break;
+            }
+
+            case AdminResponseDecoder.TEMPLATE_ID:
+            {
+                adminResponseDecoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    messageHeaderDecoder.blockLength(),
+                    messageHeaderDecoder.version());
+
+                final long sessionId = adminResponseDecoder.clusterSessionId();
+                if (sessionId == clusterSessionId)
+                {
+                    final long correlationId = adminResponseDecoder.correlationId();
+                    final AdminRequestType requestType = adminResponseDecoder.requestType();
+                    final AdminResponseCode code = adminResponseDecoder.code();
+                    final String message = adminResponseDecoder.message();
+                    final int payloadOffset = adminResponseDecoder.offset() +
+                        AdminResponseDecoder.BLOCK_LENGTH +
+                        AdminResponseDecoder.messageHeaderLength() +
+                        message.length() +
+                        AdminResponseDecoder.payloadHeaderLength();
+                    final int payloadLength = adminResponseDecoder.payloadLength();
+                    listener.onAdminResponse(
+                        sessionId,
+                        correlationId,
+                        requestType,
+                        code,
+                        message,
+                        buffer,
+                        payloadOffset,
+                        payloadLength);
+                }
+
                 break;
             }
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressListener.java
@@ -83,7 +83,7 @@ public interface EgressListener
      * @param clusterSessionId to which the response belongs.
      * @param correlationId    of the admin request.
      * @param requestType      of the admin request.
-     * @param code             describing the response.
+     * @param responseCode     describing the response.
      * @param message          describing the response (e.g. error message).
      * @param payload          delivered with the response, can be empty.
      * @param payloadOffset    into the payload buffer.
@@ -93,7 +93,7 @@ public interface EgressListener
         long clusterSessionId,
         long correlationId,
         AdminRequestType requestType,
-        AdminResponseCode code,
+        AdminResponseCode responseCode,
         String message,
         DirectBuffer payload,
         int payloadOffset,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/EgressListener.java
@@ -15,6 +15,8 @@
  */
 package io.aeron.cluster.client;
 
+import io.aeron.cluster.codecs.AdminRequestType;
+import io.aeron.cluster.codecs.AdminResponseCode;
 import io.aeron.cluster.codecs.EventCode;
 import io.aeron.logbuffer.Header;
 import org.agrona.DirectBuffer;
@@ -69,9 +71,33 @@ public interface EgressListener
      * @param clusterSessionId to which the event belongs.
      * @param leadershipTermId for identifying the active term of leadership
      * @param leaderMemberId   identity of the active leader.
-     * @param ingressEndpoints  for connecting to the cluster which can be updated due to dynamic membership.
+     * @param ingressEndpoints for connecting to the cluster which can be updated due to dynamic membership.
      */
     default void onNewLeader(long clusterSessionId, long leadershipTermId, int leaderMemberId, String ingressEndpoints)
+    {
+    }
+
+    /**
+     * Message returned in response to an admin request.
+     *
+     * @param clusterSessionId to which the response belongs.
+     * @param correlationId    of the admin request.
+     * @param requestType      of the admin request.
+     * @param code             describing the response.
+     * @param message          describing the response (e.g. error message).
+     * @param payload          delivered with the response, can be empty.
+     * @param payloadOffset    into the payload buffer.
+     * @param payloadLength    of the payload.
+     */
+    default void onAdminResponse(
+        long clusterSessionId,
+        long correlationId,
+        AdminRequestType requestType,
+        AdminResponseCode code,
+        String message,
+        DirectBuffer payload,
+        int payloadOffset,
+        int payloadLength)
     {
     }
 }

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -400,7 +400,7 @@
                description="AdminRequest correlation id with which this response is associated."/>
         <field name="requestType"              id="3" type="AdminRequestType"
                description="A type of the admin request that was executed."/>
-        <field name="code"                     id="4" type="AdminResponseCode"
+        <field name="responseCode"             id="4" type="AdminResponseCode"
                description="A response code describing the result."/>
         <data name="message"                   id="5" type="varAsciiEncoding"
                description="A response message (e.g. an error message)."/>

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -60,6 +60,14 @@
             <validValue name="MICROS" description="Time unit of microseconds for timestamps.">1</validValue>
             <validValue name="NANOS" description="Time unit of nanoseconds for timestamps.">2</validValue>
         </enum>
+        <enum name="AdminRequestType" encodingType="int32" description="Admin command to execute in the cluster.">
+            <validValue name="SNAPSHOT" description="Command to snapshot state in the cluster.">0</validValue>
+        </enum>
+        <enum name="AdminResponseCode" encodingType="int32" description="Response code for an admin command request.">
+            <validValue name="OK" description="Command was submitted or executed successfully.">0</validValue>
+            <validValue name="UNAUTHORISED_ACCESS" description="Admin request was not authorised.">1</validValue>
+            <validValue name="ERROR" description="An error occurred while submitting/executing an admin request.">2</validValue>
+        </enum>
         <type name="time_t"    primitiveType="int64" description="Epoch time since 1 Jan 1970 UTC."/>
         <type name="version_t" primitiveType="int32" description="Protocol or application suite version."
               presence="optional" nullValue="0" minValue="1" maxValue="16777215"/>
@@ -279,7 +287,7 @@
 
     <sbe:message name="CancelTimer"
                  id="32"
-                 description="Cancel a scheduled timer event">
+                 description="Cancel a scheduled timer event.">
         <field name="correlationId"            id="1" type="int64"/>
     </sbe:message>
 
@@ -309,7 +317,7 @@
 
     <sbe:message name="JoinLog"
                  id="40"
-                 description="Consensus Module instructing a service to join a log">
+                 description="Consensus Module instructing a service to join a log.">
         <field name="logPosition"              id="1" type="int64"/>
         <field name="maxLogPosition"           id="2" type="int64"/>
         <field name="memberId"                 id="3" type="int32"/>
@@ -337,7 +345,7 @@
 
     <sbe:message name="ClusterMembersExtendedResponse"
                  id="43"
-                 description="Cluster Members status for active and passive members">
+                 description="Cluster Members status for active and passive members.">
         <field name="correlationId"            id="1" type="int64"/>
         <field name="currentTimeNs"            id="2" type="time_t"/>
         <field name="leaderMemberId"           id="3" type="int32"/>
@@ -366,6 +374,38 @@
             <data name="catchupEndpoint"       id="23" type="varAsciiEncoding"/>
             <data name="archiveEndpoint"       id="24" type="varAsciiEncoding"/>
         </group>
+    </sbe:message>
+
+    <sbe:message name="AdminRequest"
+                 id="44"
+                 description="Request to execute an admin command in the cluster.">
+        <field name="leadershipTermId"         id="1" type="int64"
+               description="Current leadership term identifier."/>
+        <field name="clusterSessionId"         id="2" type="int64"
+               description="Session id of the cluster client which made the request."/>
+        <field name="correlationId"            id="3" type="int64"
+               description="Correlation id with which the response could be associated with."/>
+        <field name="requestType"              id="4" type="AdminRequestType"
+               description="Type of the request to be executed."/>
+        <data name="payload"                   id="5" type="varDataEncoding"
+              description="An optional request payload, can be empty."/>
+    </sbe:message>
+
+    <sbe:message name="AdminResponse"
+                 id="45"
+                 description="Response to the admin request.">
+        <field name="clusterSessionId"         id="1" type="int64"
+               description="Session id of the cluster client which made the request."/>
+        <field name="correlationId"            id="2" type="int64"
+               description="AdminRequest correlation id with which this response is associated."/>
+        <field name="requestType"              id="3" type="AdminRequestType"
+               description="A type of the admin request that was executed."/>
+        <field name="code"                     id="4" type="AdminResponseCode"
+               description="A response code describing the result."/>
+        <data name="message"                   id="5" type="varAsciiEncoding"
+               description="A response message (e.g. an error message)."/>
+        <data name="payload"                   id="6" type="varDataEncoding"
+               description="An optional response payload, can be empty."/>
     </sbe:message>
 
 <!--
@@ -493,7 +533,7 @@
 
     <sbe:message name="SnapshotRecordings"
                  id="73"
-                 description="Response to Snapshot recording query">
+                 description="Response to Snapshot recording query.">
         <field name="correlationId"            id="1"  type="int64"/>
         <group name="snapshots"                id="3"  dimensionType="groupSizeEncoding"
                description="Snapshots of state for the consensus module and services.">

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -21,6 +21,7 @@ import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.cluster.service.ClusterMarkFile;
 import io.aeron.cluster.service.ClusterTerminationException;
+import io.aeron.security.AuthorisationService;
 import io.aeron.security.DefaultAuthenticatorSupplier;
 import io.aeron.status.ReadableCounter;
 import io.aeron.test.Tests;
@@ -72,6 +73,7 @@ public class ConsensusModuleAgentTest
         .aeron(mockAeron)
         .clusterMemberId(0)
         .authenticatorSupplier(new DefaultAuthenticatorSupplier())
+        .authorisationServiceSupplier(() -> AuthorisationService.DENY_ALL)
         .clusterMarkFile(mock(ClusterMarkFile.class))
         .archiveContext(new AeronArchive.Context())
         .logPublisher(mockLogPublisher)

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -240,7 +240,7 @@ class ConsensusModuleContextTest
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int templateId, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -240,7 +240,7 @@ class ConsensusModuleContextTest
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int commandTemplateId, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -23,7 +23,6 @@ import io.aeron.cluster.client.ClusterException;
 import io.aeron.exceptions.ConfigurationException;
 import io.aeron.security.AuthorisationService;
 import io.aeron.security.AuthorisationServiceSupplier;
-import org.agrona.ErrorHandler;
 import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.AfterEach;
@@ -241,8 +240,7 @@ class ConsensusModuleContextTest
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(
-            final int commandTemplateId, final byte[] encodedCredentials, final ErrorHandler errorHandler)
+        public boolean isAuthorised(final int commandTemplateId, final byte[] encodedCredentials)
         {
             return false;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -240,7 +240,7 @@ class ConsensusModuleContextTest
 
     static class TestAuthorisationService implements AuthorisationService
     {
-        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedCredentials)
+        public boolean isAuthorised(final int templateId, final Object type, final byte[] encodedPrincipal)
         {
             return false;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -21,6 +21,9 @@ import io.aeron.Counter;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.exceptions.ConfigurationException;
+import io.aeron.security.AuthorisationService;
+import io.aeron.security.AuthorisationServiceSupplier;
+import org.agrona.ErrorHandler;
 import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.AfterEach;
@@ -154,5 +157,94 @@ class ConsensusModuleContextTest
         assertThrows(ConfigurationException.class, () -> context.clone().logChannel(channelTermId).conclude());
         assertThrows(ConfigurationException.class, () -> context.clone().logChannel(channelInitialTermId).conclude());
         assertThrows(ConfigurationException.class, () -> context.clone().logChannel(channelTermOffset).conclude());
+    }
+
+
+    @Test
+    void defaultAuthorisationServiceSupplierReturnsADenyAllAuthorisationService()
+    {
+        assertSame(AuthorisationService.DENY_ALL, DEFAULT_AUTHORISATION_SERVICE_SUPPLIER.get());
+    }
+
+    @Test
+    void shouldUseDefaultAuthorisationServiceSupplierIfTheSystemPropertyIsNotSet()
+    {
+        assertNull(context.authorisationServiceSupplier());
+
+        context.conclude();
+
+        System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        assertSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, context.authorisationServiceSupplier());
+    }
+
+    @Test
+    void shouldUseDefaultAuthorisationServiceSupplierIfTheSystemPropertyIsSetToEmptyValue()
+    {
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, "");
+        try
+        {
+            assertNull(context.authorisationServiceSupplier());
+
+            context.conclude();
+
+            assertSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, context.authorisationServiceSupplier());
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    @Test
+    void shouldInstantiateAuthorisationServiceSupplierBasedOnTheSystemProperty()
+    {
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, TestAuthorisationSupplier.class.getName());
+        try
+        {
+            context.conclude();
+            final AuthorisationServiceSupplier supplier = context.authorisationServiceSupplier();
+            assertNotSame(DEFAULT_AUTHORISATION_SERVICE_SUPPLIER, supplier);
+            assertInstanceOf(TestAuthorisationSupplier.class, supplier);
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    @Test
+    void shouldUseProvidedAuthorisationServiceSupplierInstance()
+    {
+        final AuthorisationServiceSupplier providedSupplier = mock(AuthorisationServiceSupplier.class);
+        context.authorisationServiceSupplier(providedSupplier);
+        assertSame(providedSupplier, context.authorisationServiceSupplier());
+
+        System.setProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME, TestAuthorisationSupplier.class.getName());
+        try
+        {
+            context.conclude();
+            assertSame(providedSupplier, context.authorisationServiceSupplier());
+        }
+        finally
+        {
+            System.clearProperty(AUTHORISATION_SERVICE_SUPPLIER_PROP_NAME);
+        }
+    }
+
+    public static class TestAuthorisationSupplier implements AuthorisationServiceSupplier
+    {
+        public AuthorisationService get()
+        {
+            return new TestAuthorisationService();
+        }
+    }
+
+    static class TestAuthorisationService implements AuthorisationService
+    {
+        public boolean isAuthorised(
+            final int commandTemplateId, final byte[] encodedCredentials, final ErrorHandler errorHandler)
+        {
+            return false;
+        }
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/client/EgressAdapterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/client/EgressAdapterTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2014-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster.client;
+
+import io.aeron.Subscription;
+import io.aeron.cluster.codecs.*;
+import io.aeron.logbuffer.Header;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.cluster.client.AeronCluster.SESSION_HEADER_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class EgressAdapterTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[512]);
+    private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+    private final SessionMessageHeaderEncoder sessionMessageHeaderEncoder = new SessionMessageHeaderEncoder();
+    private final SessionEventEncoder sessionEventEncoder = new SessionEventEncoder();
+    private final NewLeaderEventEncoder newLeaderEventEncoder = new NewLeaderEventEncoder();
+    private final AdminResponseEncoder adminResponseEncoder = new AdminResponseEncoder();
+
+    @Test
+    void onFragmentShouldThrowClusterExceptionOnInvalidSchemaId()
+    {
+        final EgressAdapter adapter = new EgressAdapter(mock(EgressListener.class), 42, mock(Subscription.class), 5);
+
+        final ClusterException exception = assertThrows(ClusterException.class,
+            () -> adapter.onFragment(buffer, 0, 64, new Header(0, 0)));
+        assertEquals("ERROR - expected schemaId=" + MessageHeaderDecoder.SCHEMA_ID + ", actual=0",
+            exception.getMessage());
+    }
+
+    @Test
+    void onFragmentShouldInvokeOnMessageCallbackIfSessionIdMatches()
+    {
+        final int offset = 4;
+        final long sessionId = 2973438724L;
+        final long timestamp = -46328746238764832L;
+        sessionMessageHeaderEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(sessionId)
+            .timestamp(timestamp);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, sessionId, mock(Subscription.class), 3);
+
+        adapter.onFragment(buffer, offset, sessionMessageHeaderEncoder.encodedLength(), header);
+
+        verify(egressListener).onMessage(
+            sessionId,
+            timestamp,
+            buffer,
+            offset + SESSION_HEADER_LENGTH,
+            sessionMessageHeaderEncoder.encodedLength() - SESSION_HEADER_LENGTH, header);
+        verifyNoMoreInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentIsANoOpIfSessionIdDoesNotMatchOnSessionMessage()
+    {
+        final int offset = 18;
+        final long sessionId = 21;
+        final long timestamp = 1000;
+        sessionMessageHeaderEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(sessionId)
+            .timestamp(timestamp);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, -19, mock(Subscription.class), 3);
+
+        adapter.onFragment(buffer, offset, sessionMessageHeaderEncoder.encodedLength(), header);
+
+        verifyNoInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentShouldInvokeOnSessionEventCallbackIfSessionIdMatches()
+    {
+        final int offset = 8;
+        final long clusterSessionId = 42;
+        final long correlationId = 777;
+        final long leadershipTermId = 6;
+        final int leaderMemberId = 3;
+        final EventCode eventCode = EventCode.REDIRECT;
+        final int version = 18;
+        final String eventDetail = "Event details";
+        sessionEventEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(clusterSessionId)
+            .correlationId(correlationId)
+            .leadershipTermId(leadershipTermId)
+            .leaderMemberId(leaderMemberId)
+            .code(eventCode)
+            .version(version)
+            .detail(eventDetail);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
+
+        adapter.onFragment(buffer, offset, sessionEventEncoder.encodedLength(), header);
+
+        verify(egressListener).onSessionEvent(
+            correlationId, clusterSessionId, leadershipTermId, leaderMemberId, eventCode, eventDetail);
+        verifyNoMoreInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentIsANoOpIfSessionIdDoesNotMatchOnSessionEvent()
+    {
+        final int offset = 8;
+        final long clusterSessionId = 42;
+        final long correlationId = 777;
+        final long leadershipTermId = 6;
+        final int leaderMemberId = 3;
+        final EventCode eventCode = EventCode.REDIRECT;
+        final int version = 18;
+        final String eventDetail = "Event details";
+        sessionEventEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(clusterSessionId)
+            .correlationId(correlationId)
+            .leadershipTermId(leadershipTermId)
+            .leaderMemberId(leaderMemberId)
+            .code(eventCode)
+            .version(version)
+            .detail(eventDetail);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressAdapter adapter = new EgressAdapter(
+            egressListener, clusterSessionId + 1, mock(Subscription.class), 3);
+
+        adapter.onFragment(buffer, offset, sessionEventEncoder.encodedLength(), header);
+
+        verifyNoInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentShouldInvokeOnNewLeaderCallbackIfSessionIdMatches()
+    {
+        final int offset = 0;
+        final long clusterSessionId = 0;
+        final long leadershipTermId = 6;
+        final int leaderMemberId = 9999;
+        final String ingressEndpoints = "ingress endpoints ...";
+        newLeaderEventEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .leadershipTermId(leadershipTermId)
+            .clusterSessionId(clusterSessionId)
+            .leaderMemberId(leaderMemberId)
+            .ingressEndpoints(ingressEndpoints);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
+
+        adapter.onFragment(buffer, offset, newLeaderEventEncoder.encodedLength(), header);
+
+        verify(egressListener).onNewLeader(clusterSessionId, leadershipTermId, leaderMemberId, ingressEndpoints);
+        verifyNoMoreInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentIsANoOpIfSessionIdDoesNotMatchOnNewLeader()
+    {
+        final int offset = 0;
+        final long clusterSessionId = -100;
+        final long leadershipTermId = 6;
+        final int leaderMemberId = 9999;
+        final String ingressEndpoints = "ingress endpoints ...";
+        newLeaderEventEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .leadershipTermId(leadershipTermId)
+            .clusterSessionId(clusterSessionId)
+            .leaderMemberId(leaderMemberId)
+            .ingressEndpoints(ingressEndpoints);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, 0, mock(Subscription.class), 10);
+
+        adapter.onFragment(buffer, offset, newLeaderEventEncoder.encodedLength(), header);
+
+        verifyNoInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentShouldInvokeOnAdminResponseCallbackIfSessionIdMatches()
+    {
+        final int offset = 24;
+        final long clusterSessionId = 18;
+        final long correlationId = 3274239749237498239L;
+        final AdminRequestType type = AdminRequestType.SNAPSHOT;
+        final AdminResponseCode code = AdminResponseCode.UNAUTHORISED_ACCESS;
+        final String message = "Unauthorised access detected!";
+        final byte[] payload = new byte[]{ 0x1, 0x2, 0x3 };
+        adminResponseEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(clusterSessionId)
+            .correlationId(correlationId)
+            .requestType(type)
+            .code(code)
+            .message(message);
+        adminResponseEncoder.putPayload(payload, 0, payload.length);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
+
+        adapter.onFragment(buffer, offset, adminResponseEncoder.encodedLength(), header);
+
+        verify(egressListener).onAdminResponse(
+            clusterSessionId,
+            correlationId,
+            type,
+            code,
+            message,
+            buffer,
+            offset + MessageHeaderEncoder.ENCODED_LENGTH + adminResponseEncoder.encodedLength() - payload.length,
+            payload.length);
+        verifyNoMoreInteractions(egressListener);
+    }
+
+    @Test
+    void onFragmentIsANoOpIfSessionIdDoesNotMatchOnAdminResponse()
+    {
+        final int offset = 24;
+        final long clusterSessionId = 18;
+        final long correlationId = 3274239749237498239L;
+        final AdminRequestType type = AdminRequestType.SNAPSHOT;
+        final AdminResponseCode code = AdminResponseCode.UNAUTHORISED_ACCESS;
+        final String message = "Unauthorised access detected!";
+        final byte[] payload = new byte[]{ 0x1, 0x2, 0x3 };
+        adminResponseEncoder.wrapAndApplyHeader(buffer, offset, messageHeaderEncoder).clusterSessionId(clusterSessionId)
+            .correlationId(correlationId).requestType(type).code(code).message(message);
+        adminResponseEncoder.putPayload(payload, 0, payload.length);
+
+        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressAdapter adapter = new EgressAdapter(
+            egressListener, -clusterSessionId, mock(Subscription.class), 10);
+
+        adapter.onFragment(buffer, offset, adminResponseEncoder.encodedLength(), header);
+
+        verifyNoInteractions(egressListener);
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/client/EgressAdapterTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/client/EgressAdapterTest.java
@@ -57,7 +57,8 @@ class EgressAdapterTest
             .clusterSessionId(sessionId)
             .timestamp(timestamp);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(0, 0);
         final EgressAdapter adapter = new EgressAdapter(egressListener, sessionId, mock(Subscription.class), 3);
 
         adapter.onFragment(buffer, offset, sessionMessageHeaderEncoder.encodedLength(), header);
@@ -82,7 +83,8 @@ class EgressAdapterTest
             .clusterSessionId(sessionId)
             .timestamp(timestamp);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(0, 0);
         final EgressAdapter adapter = new EgressAdapter(egressListener, -19, mock(Subscription.class), 3);
 
         adapter.onFragment(buffer, offset, sessionMessageHeaderEncoder.encodedLength(), header);
@@ -111,7 +113,8 @@ class EgressAdapterTest
             .version(version)
             .detail(eventDetail);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(1, 3);
         final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
 
         adapter.onFragment(buffer, offset, sessionEventEncoder.encodedLength(), header);
@@ -142,7 +145,8 @@ class EgressAdapterTest
             .version(version)
             .detail(eventDetail);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(0, 0);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(0, 0);
         final EgressAdapter adapter = new EgressAdapter(
             egressListener, clusterSessionId + 1, mock(Subscription.class), 3);
 
@@ -166,7 +170,8 @@ class EgressAdapterTest
             .leaderMemberId(leaderMemberId)
             .ingressEndpoints(ingressEndpoints);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(1, 3);
         final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
 
         adapter.onFragment(buffer, offset, newLeaderEventEncoder.encodedLength(), header);
@@ -190,7 +195,8 @@ class EgressAdapterTest
             .leaderMemberId(leaderMemberId)
             .ingressEndpoints(ingressEndpoints);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(1, 3);
         final EgressAdapter adapter = new EgressAdapter(egressListener, 0, mock(Subscription.class), 10);
 
         adapter.onFragment(buffer, offset, newLeaderEventEncoder.encodedLength(), header);
@@ -205,7 +211,7 @@ class EgressAdapterTest
         final long clusterSessionId = 18;
         final long correlationId = 3274239749237498239L;
         final AdminRequestType type = AdminRequestType.SNAPSHOT;
-        final AdminResponseCode code = AdminResponseCode.UNAUTHORISED_ACCESS;
+        final AdminResponseCode responseCode = AdminResponseCode.UNAUTHORISED_ACCESS;
         final String message = "Unauthorised access detected!";
         final byte[] payload = new byte[]{ 0x1, 0x2, 0x3 };
         adminResponseEncoder
@@ -213,11 +219,12 @@ class EgressAdapterTest
             .clusterSessionId(clusterSessionId)
             .correlationId(correlationId)
             .requestType(type)
-            .code(code)
+            .responseCode(responseCode)
             .message(message);
         adminResponseEncoder.putPayload(payload, 0, payload.length);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(1, 3);
         final EgressAdapter adapter = new EgressAdapter(egressListener, clusterSessionId, mock(Subscription.class), 10);
 
         adapter.onFragment(buffer, offset, adminResponseEncoder.encodedLength(), header);
@@ -226,7 +233,7 @@ class EgressAdapterTest
             clusterSessionId,
             correlationId,
             type,
-            code,
+            responseCode,
             message,
             buffer,
             offset + MessageHeaderEncoder.ENCODED_LENGTH + adminResponseEncoder.encodedLength() - payload.length,
@@ -241,14 +248,20 @@ class EgressAdapterTest
         final long clusterSessionId = 18;
         final long correlationId = 3274239749237498239L;
         final AdminRequestType type = AdminRequestType.SNAPSHOT;
-        final AdminResponseCode code = AdminResponseCode.UNAUTHORISED_ACCESS;
+        final AdminResponseCode responseCode = AdminResponseCode.OK;
         final String message = "Unauthorised access detected!";
         final byte[] payload = new byte[]{ 0x1, 0x2, 0x3 };
-        adminResponseEncoder.wrapAndApplyHeader(buffer, offset, messageHeaderEncoder).clusterSessionId(clusterSessionId)
-            .correlationId(correlationId).requestType(type).code(code).message(message);
+        adminResponseEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(clusterSessionId)
+            .correlationId(correlationId)
+            .requestType(type)
+            .responseCode(responseCode)
+            .message(message);
         adminResponseEncoder.putPayload(payload, 0, payload.length);
 
-        final EgressListener egressListener = mock(EgressListener.class); final Header header = new Header(1, 3);
+        final EgressListener egressListener = mock(EgressListener.class);
+        final Header header = new Header(1, 3);
         final EgressAdapter adapter = new EgressAdapter(
             egressListener, -clusterSessionId, mock(Subscription.class), 10);
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1696,7 +1696,7 @@ public class ClusterTest
         cluster = aCluster()
             .withStaticNodes(3)
             .withAuthorisationServiceSupplier(() ->
-                (templateId, type, encodedCredentials) ->
+                (templateId, type, encodedPrincipal) ->
                 {
                     authorisationServiceCalled.set(true);
                     assertEquals(invalidRequestType, type);
@@ -1823,7 +1823,7 @@ public class ClusterTest
         cluster = aCluster()
             .withStaticNodes(3)
             .withAuthorisationServiceSupplier(() ->
-                (templateId, type, encodedCredentials) ->
+                (templateId, type, encodedPrincipal) ->
                 {
                     assertEquals(AdminRequestType.SNAPSHOT, type);
                     return true;

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.zip.CRC32;
 
@@ -1704,11 +1705,19 @@ public class ClusterTest
             Tests.yield();
         }
 
-        assertEquals(0, cluster.getSnapshotCount(leader));
-        for (final TestNode follower : followers)
+        long time = System.nanoTime();
+        final long deadline = time + TimeUnit.SECONDS.toNanos(2);
+        do
         {
-            assertEquals(0, cluster.getSnapshotCount(follower));
+            assertEquals(0, cluster.getSnapshotCount(leader));
+            for (final TestNode follower : followers)
+            {
+                assertEquals(0, cluster.getSnapshotCount(follower));
+            }
+            Tests.sleep(10);
+            time = System.nanoTime();
         }
+        while (time < deadline);
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1877,7 +1877,7 @@ public class ClusterTest
     private MutableBoolean injectAdminResponseEgressListener(
         final long expectedCorrelationId,
         final AdminRequestType expectedRequestType,
-        final AdminResponseCode expectedCode,
+        final AdminResponseCode expectedResponseCode,
         final String expectedMessage)
     {
         final MutableBoolean responseReceived = new MutableBoolean();
@@ -1897,7 +1897,7 @@ public class ClusterTest
                 final long clusterSessionId,
                 final long correlationId,
                 final AdminRequestType requestType,
-                final AdminResponseCode code,
+                final AdminResponseCode responseCode,
                 final String message,
                 final DirectBuffer payload,
                 final int payloadOffset,
@@ -1906,7 +1906,7 @@ public class ClusterTest
                 responseReceived.set(true);
                 assertEquals(expectedCorrelationId, correlationId);
                 assertEquals(expectedRequestType, requestType);
-                assertEquals(expectedCode, code);
+                assertEquals(expectedResponseCode, responseCode);
                 assertEquals(expectedMessage, message);
                 assertNotNull(payload);
                 final int minPayloadOffset =
@@ -1925,7 +1925,7 @@ public class ClusterTest
     private MutableBoolean injectAdminRequestControlledEgressListener(
         final long expectedCorrelationId,
         final AdminRequestType expectedRequestType,
-        final AdminResponseCode expectedCode,
+        final AdminResponseCode expectedResponseCode,
         final String expectedMessage)
     {
         final MutableBoolean responseReceived = new MutableBoolean();
@@ -1946,7 +1946,7 @@ public class ClusterTest
                 final long clusterSessionId,
                 final long correlationId,
                 final AdminRequestType requestType,
-                final AdminResponseCode code,
+                final AdminResponseCode responseCode,
                 final String message,
                 final DirectBuffer payload,
                 final int payloadOffset,
@@ -1955,7 +1955,7 @@ public class ClusterTest
                 responseReceived.set(true);
                 assertEquals(expectedCorrelationId, correlationId);
                 assertEquals(expectedRequestType, requestType);
-                assertEquals(expectedCode, code);
+                assertEquals(expectedResponseCode, responseCode);
                 assertEquals(expectedMessage, message);
                 assertNotNull(payload);
                 final int minPayloadOffset =

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1715,16 +1715,21 @@ public class ClusterTest
     @InterruptAfter(10)
     void shouldRejectAnInvalidAdminRequest()
     {
+        final AdminRequestType invalidRequestType = AdminRequestType.NULL_VAL;
         cluster = aCluster()
             .withStaticNodes(3)
-            .withAuthorisationServiceSupplier(() -> AuthorisationService.ALLOW_ALL)
+            .withAuthorisationServiceSupplier(() ->
+                (templateId, type, encodedCredentials) ->
+                {
+                    assertEquals(invalidRequestType, type);
+                    return true;
+                })
             .start();
         systemTestWatcher.cluster(cluster);
 
         cluster.awaitLeader();
 
         final long requestCorrelationId = System.nanoTime();
-        final AdminRequestType invalidRequestType = AdminRequestType.NULL_VAL;
         final MutableBoolean responseReceived = new MutableBoolean();
         cluster.egressListener(new EgressListener()
         {
@@ -1945,7 +1950,12 @@ public class ClusterTest
     {
         cluster = aCluster()
             .withStaticNodes(3)
-            .withAuthorisationServiceSupplier(() -> AuthorisationService.ALLOW_ALL)
+            .withAuthorisationServiceSupplier(() ->
+                (templateId, type, encodedCredentials) ->
+                {
+                    assertEquals(AdminRequestType.SNAPSHOT, type);
+                    return true;
+                })
             .start();
         systemTestWatcher.cluster(cluster);
 


### PR DESCRIPTION
This PR adds new API to `AeronCluster` which allows sending command to the Cluster to trigger a snapshot of the Cluster state. It includes the following:
- New `AuthorisationService` and `AuthorisationServiceSupplier` interfaces.
- `Archive.Context.authorisationServiceSupplier` and `aeron.archive.authorisation.service.supplier` property so that an `AuthorisationServiceSupplier` can be set for the Archive. Default supplier allows any command to be executed.
- `ConsensusModule.Context.authorisationServiceSupplier` and `aeron.cluster.authorisation.service.supplier` property so that an `AuthorisationServiceSupplier` can be set for the ConsensusModule. Default supplier forbids all commands.
- `AdminRequest` and `AdminResponse` messages added to the Cluster wire protocol.
- Support for `AdminResponse` was added to the client API, i.e. the `EgressListener#onAdminResponse` and `ControlledEgressListener#onAdminResponse` API.
- Support for sending `AdminRequest` of type `AdminRequestType.SNASPHOT`, i.e. `AeronCluster#sendAdminRequestToTakeASnapshot`.
- `ConsensusModuleAgent#onAdminRequest` implementation which triggers a snapshot by switching the `ClusterControl` into `ClusterControl.ToggleState.SNAPSHOT` state.