### PR TITLE
[Java] Rename then delete the segment files in the Archive.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -887,21 +887,11 @@ abstract class ArchiveConductor
                 files.addLast(segmentFileName(recordingId, p));
             }
 
-            if (!files.isEmpty())
+            if (addDeleteSegmentsSession(correlationId, recordingId, controlSession, files) < 0)
             {
-                if (addDeleteSegmentsSession(correlationId, recordingId, controlSession, files) < 0)
-                {
-                    return;
-                }
-                controlSession.sendOkResponse(correlationId, controlResponseProxy);
+                return;
             }
-            else
-            {
-                controlSession.sendOkResponse(correlationId, controlResponseProxy);
-                // TODO: Why truncate has a signal but others do not?
-                controlSession.attemptSignal(
-                    correlationId, recordingId, Aeron.NULL_VALUE, Aeron.NULL_VALUE, RecordingSignal.DELETE);
-            }
+            controlSession.sendOkResponse(correlationId, controlResponseProxy);
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/DeleteSegmentsSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/DeleteSegmentsSession.java
@@ -27,8 +27,7 @@ class DeleteSegmentsSession implements Session
 {
     private final long recordingId;
     private final long correlationId;
-    private final ArrayDeque<String> files;
-    private final File archiveDir;
+    private final ArrayDeque<File> files;
     private final ControlSession controlSession;
     private final ControlResponseProxy controlResponseProxy;
     private final ErrorHandler errorHandler;
@@ -36,8 +35,7 @@ class DeleteSegmentsSession implements Session
     DeleteSegmentsSession(
         final long recordingId,
         final long correlationId,
-        final ArrayDeque<String> files,
-        final File archiveDir,
+        final ArrayDeque<File> files,
         final ControlSession controlSession,
         final ControlResponseProxy controlResponseProxy,
         final ErrorHandler errorHandler)
@@ -45,7 +43,6 @@ class DeleteSegmentsSession implements Session
         this.recordingId = recordingId;
         this.correlationId = correlationId;
         this.files = files;
-        this.archiveDir = archiveDir;
         this.controlSession = controlSession;
         this.controlResponseProxy = controlResponseProxy;
         this.errorHandler = errorHandler;
@@ -58,14 +55,10 @@ class DeleteSegmentsSession implements Session
     {
         while (!files.isEmpty())
         {
-            final String fileName = files.pollFirst();
-            if (null != fileName)
+            final File file = files.pollFirst();
+            if (null != file && file.exists() && !file.delete())
             {
-                final File file = new File(archiveDir, fileName);
-                if (file.exists() && !file.delete())
-                {
-                    errorHandler.onError(new ArchiveEvent("segment delete failed for recording: " + recordingId));
-                }
+                errorHandler.onError(new ArchiveEvent("segment delete failed for recording: " + recordingId));
             }
         }
     }
@@ -99,11 +92,9 @@ class DeleteSegmentsSession implements Session
     public int doWork()
     {
         int workCount = 0;
-        final String fileName = files.pollFirst();
-
-        if (null != fileName)
+        final File file = files.pollFirst();
+        if (null != file)
         {
-            final File file = new File(archiveDir, fileName);
             if (file.exists() && !file.delete())
             {
                 final String errorMessage = "unable to delete segment file: " + file;


### PR DESCRIPTION
The segment file deletion is now split into two parts:

1. Rename/move the source file by adding a `.del` suffix.
   If the rename of any file fails then the whole operation fails as well and the error response is sent to the client.

   _Note: when the delete list is being created both the original segment files as well as the renamed files are considered so that the partial deletes can be completed by a subsequent operation._
2. Delete renamed files in the background.

