### PR TITLE
Extend recording concurrent publications

### DIFF
--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTests.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTests.java
@@ -21,8 +21,6 @@ import io.aeron.archive.codecs.ControlResponseCode;
 import io.aeron.test.Tests;
 import org.agrona.IoUtil;
 import org.agrona.SystemUtil;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestWatcher;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -143,14 +141,4 @@ public class ArchiveTests
         Tests.await(() -> controlResponseAdapter.poll() != 0, TIMEOUT_NS);
     }
 
-    public static TestWatcher newWatcher(final long seed)
-    {
-        return new TestWatcher()
-        {
-            public void testFailed(final ExtensionContext context, final Throwable cause)
-            {
-                System.err.println(context.getDisplayName() + " failed with random seed: " + seed);
-            }
-        };
-    }
 }

--- a/aeron-client/src/main/c/aeron_exclusive_publication.h
+++ b/aeron-client/src/main/c/aeron_exclusive_publication.h
@@ -82,7 +82,7 @@ void aeron_exclusive_publication_force_close(aeron_exclusive_publication_t *publ
 inline void aeron_exclusive_publication_rotate_term(aeron_exclusive_publication_t *publication)
 {
     const int32_t next_term_id = publication->term_id + 1;
-    const int32_t next_term_count = next_term_id - publication->initial_term_id;
+    const int32_t next_term_count = aeron_logbuffer_compute_term_count(next_term_id, publication->initial_term_id);
     const size_t next_index = aeron_logbuffer_index_by_term(publication->initial_term_id, next_term_id);
 
     publication->active_partition_index = next_index;

--- a/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.c
+++ b/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.c
@@ -83,6 +83,7 @@ int aeron_logbuffer_check_page_size(uint64_t page_size)
     return 0;
 }
 
+extern int64_t aeron_logbuffer_compute_term_count(int32_t term_id, int32_t initial_term_id);
 extern uint64_t aeron_logbuffer_compute_log_length(uint64_t term_length, uint64_t page_size);
 extern int32_t aeron_logbuffer_term_offset(int64_t raw_tail, int32_t term_length);
 extern int32_t aeron_logbuffer_term_id(int64_t raw_tail);

--- a/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
+++ b/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
@@ -21,6 +21,7 @@
 #include <string.h>
 #include "protocol/aeron_udp_protocol.h"
 #include "util/aeron_bitutil.h"
+#include "util/aeron_math.h"
 #include "concurrent/aeron_atomic.h"
 
 #define AERON_LOGBUFFER_PARTITION_COUNT (3)
@@ -107,8 +108,7 @@ inline size_t aeron_logbuffer_index_by_term_count(int64_t term_count)
 inline int64_t aeron_logbuffer_compute_position(
     int32_t active_term_id, int32_t term_offset, size_t position_bits_to_shift, int32_t initial_term_id)
 {
-    int64_t term_count = active_term_id - initial_term_id;
-
+    int64_t term_count = aeron_sub_wrap_i32(active_term_id, initial_term_id);
     return (term_count << position_bits_to_shift) + term_offset;
 }
 

--- a/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
+++ b/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
@@ -115,15 +115,13 @@ inline int64_t aeron_logbuffer_compute_position(
 inline int64_t aeron_logbuffer_compute_term_begin_position(
     int32_t active_term_id, size_t position_bits_to_shift, int32_t initial_term_id)
 {
-    int64_t term_count = active_term_id - initial_term_id;
-
-    return (term_count << position_bits_to_shift);
+    return aeron_logbuffer_compute_position(active_term_id, 0, position_bits_to_shift, initial_term_id);
 }
 
 inline int32_t aeron_logbuffer_compute_term_id_from_position(
     int64_t position, size_t position_bits_to_shift, int32_t initial_term_id)
 {
-    return (int32_t)(position >> position_bits_to_shift) + initial_term_id;
+    return aeron_add_wrap_i32((int32_t)(position >> position_bits_to_shift), initial_term_id);
 }
 
 inline int32_t aeron_logbuffer_compute_term_offset_from_position(int64_t position, size_t position_bits_to_shift)

--- a/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
+++ b/aeron-client/src/main/c/concurrent/aeron_logbuffer_descriptor.h
@@ -90,6 +90,11 @@ inline int32_t aeron_logbuffer_term_id(int64_t raw_tail)
     return (int32_t)(raw_tail >> 32);
 }
 
+inline int64_t aeron_logbuffer_compute_term_count(int32_t term_id, int32_t initial_term_id)
+{
+    return aeron_sub_wrap_i32(term_id, initial_term_id);
+}
+
 inline size_t aeron_logbuffer_index_by_position(int64_t position, size_t position_bits_to_shift)
 {
     return (size_t)((position >> position_bits_to_shift) % AERON_LOGBUFFER_PARTITION_COUNT);
@@ -97,7 +102,8 @@ inline size_t aeron_logbuffer_index_by_position(int64_t position, size_t positio
 
 inline size_t aeron_logbuffer_index_by_term(int32_t initial_term_id, int32_t active_term_id)
 {
-    return (size_t)((active_term_id - initial_term_id) % AERON_LOGBUFFER_PARTITION_COUNT);
+    int64_t term_count = aeron_logbuffer_compute_term_count(active_term_id, initial_term_id);
+    return (size_t)(term_count % AERON_LOGBUFFER_PARTITION_COUNT);
 }
 
 inline size_t aeron_logbuffer_index_by_term_count(int64_t term_count)
@@ -108,7 +114,7 @@ inline size_t aeron_logbuffer_index_by_term_count(int64_t term_count)
 inline int64_t aeron_logbuffer_compute_position(
     int32_t active_term_id, int32_t term_offset, size_t position_bits_to_shift, int32_t initial_term_id)
 {
-    int64_t term_count = aeron_sub_wrap_i32(active_term_id, initial_term_id);
+    int64_t term_count = aeron_logbuffer_compute_term_count(active_term_id, initial_term_id);
     return (term_count << position_bits_to_shift) + term_offset;
 }
 

--- a/aeron-client/src/main/java/io/aeron/ChannelUriStringBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/ChannelUriStringBuilder.java
@@ -1563,9 +1563,14 @@ public final class ChannelUriStringBuilder
      */
     public ChannelUriStringBuilder initialPosition(final long position, final int initialTermId, final int termLength)
     {
-        if (position < 0 || 0 != (position & (FRAME_ALIGNMENT - 1)))
+        if (position < 0)
         {
-            throw new IllegalArgumentException("invalid position: " + position);
+            throw new IllegalArgumentException("invalid position=" + position + " < 0");
+        }
+        if (0 != (position & (FRAME_ALIGNMENT - 1)))
+        {
+            throw new IllegalArgumentException(
+                "invalid position=" + position + " does not have frame alignment=" + FRAME_ALIGNMENT);
         }
 
         final int bitsToShift = LogBufferDescriptor.positionBitsToShift(termLength);

--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -101,7 +101,7 @@ int aeron_ipc_publication_create(
     if (params->has_position)
     {
         int64_t term_id = params->term_id;
-        int32_t term_count = aeron_sub_wrap_i32(params->term_id, initial_term_id);
+        int32_t term_count = aeron_logbuffer_compute_term_count(params->term_id, initial_term_id);
         size_t active_index = aeron_logbuffer_index_by_term_count(term_count);
 
         _pub->log_meta_data->term_tail_counters[active_index] =

--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -101,7 +101,7 @@ int aeron_ipc_publication_create(
     if (params->has_position)
     {
         int64_t term_id = params->term_id;
-        int32_t term_count = params->term_id - initial_term_id;
+        int32_t term_count = aeron_sub_wrap_i32(params->term_id, initial_term_id);
         size_t active_index = aeron_logbuffer_index_by_term_count(term_count);
 
         _pub->log_meta_data->term_tail_counters[active_index] =

--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -163,6 +163,8 @@ int aeron_ipc_publication_create(
     _pub->pub_pos_position.counter_id = pub_pos_position->counter_id;
     _pub->pub_pos_position.value_addr = pub_pos_position->value_addr;
     _pub->initial_term_id = initial_term_id;
+    _pub->starting_term_id = params->has_position ? params->term_id : initial_term_id;
+    _pub->starting_term_offset = params->has_position ? params->term_offset : 0;
     _pub->position_bits_to_shift = (size_t)aeron_number_of_trailing_zeroes((int32_t)params->term_length);
     _pub->term_window_length = (int64_t)aeron_producer_window_length(
         context->ipc_publication_window_length, params->term_length);

--- a/aeron-driver/src/main/c/aeron_ipc_publication.h
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.h
@@ -65,6 +65,8 @@ typedef struct aeron_ipc_publication_stct
     int32_t session_id;
     int32_t stream_id;
     int32_t initial_term_id;
+    int32_t starting_term_id;
+    size_t starting_term_offset;
     size_t log_file_name_length;
     size_t position_bits_to_shift;
     bool is_exclusive;

--- a/aeron-driver/src/main/c/aeron_loss_detector.c
+++ b/aeron-driver/src/main/c/aeron_loss_detector.c
@@ -60,7 +60,7 @@ int32_t aeron_loss_detector_scan(
         const int32_t rebuild_term_count = (int32_t)(rebuild_position >> position_bits_to_shift);
         const int32_t hwm_term_count = (int32_t)(hwm_position >> position_bits_to_shift);
 
-        const int32_t rebuild_term_id = initial_term_id + rebuild_term_count;
+        const int32_t rebuild_term_id = aeron_add_wrap_i32(initial_term_id, rebuild_term_count);
         const int32_t hwm_term_offset = (int32_t)(hwm_position & term_length_mask);
         const int32_t limit_offset = rebuild_term_count == hwm_term_count ?
             hwm_term_offset : (int32_t)(term_length_mask + 1);

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -122,7 +122,7 @@ int aeron_network_publication_create(
     if (params->has_position)
     {
         int64_t term_id = params->term_id;
-        int32_t term_count = params->term_id - initial_term_id;
+        int32_t term_count = aeron_sub_wrap_i32(params->term_id, initial_term_id);
         size_t active_index = aeron_logbuffer_index_by_term_count(term_count);
 
         _pub->log_meta_data->term_tail_counters[active_index] =

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -195,6 +195,8 @@ int aeron_network_publication_create(
     _pub->snd_bpe_counter.value_addr = snd_bpe_counter->value_addr;
     _pub->tag = params->entity_tag;
     _pub->initial_term_id = initial_term_id;
+    _pub->starting_term_id = params->has_position ? params->term_id : initial_term_id;
+    _pub->starting_term_offset = params->has_position ? params->term_offset : 0;
     _pub->term_buffer_length = _pub->log_meta_data->term_length;
     _pub->term_length_mask = (int32_t)params->term_length - 1;
     _pub->position_bits_to_shift = (size_t)aeron_number_of_trailing_zeroes((int32_t)params->term_length);

--- a/aeron-driver/src/main/c/aeron_network_publication.c
+++ b/aeron-driver/src/main/c/aeron_network_publication.c
@@ -122,7 +122,7 @@ int aeron_network_publication_create(
     if (params->has_position)
     {
         int64_t term_id = params->term_id;
-        int32_t term_count = aeron_sub_wrap_i32(params->term_id, initial_term_id);
+        int32_t term_count = aeron_logbuffer_compute_term_count(params->term_id, initial_term_id);
         size_t active_index = aeron_logbuffer_index_by_term_count(term_count);
 
         _pub->log_meta_data->term_tail_counters[active_index] =

--- a/aeron-driver/src/main/c/aeron_network_publication.h
+++ b/aeron-driver/src/main/c/aeron_network_publication.h
@@ -85,7 +85,9 @@ typedef struct aeron_network_publication_stct
     int32_t session_id;
     int32_t stream_id;
     int32_t initial_term_id;
+    int32_t starting_term_id;
     int32_t term_length_mask;
+    size_t starting_term_offset;
     size_t log_file_name_length;
     size_t position_bits_to_shift;
     size_t mtu_length;

--- a/aeron-driver/src/main/c/uri/aeron_driver_uri.c
+++ b/aeron-driver/src/main/c/uri/aeron_driver_uri.c
@@ -42,6 +42,7 @@ int aeron_uri_get_term_length_param(aeron_uri_params_t *uri_params, aeron_driver
         }
 
         params->term_length = value;
+        params->has_term_length = true;
     }
 
     return 0;
@@ -67,6 +68,7 @@ int aeron_uri_get_mtu_length_param(aeron_uri_params_t *uri_params, aeron_driver_
         }
 
         params->mtu_length = value;
+        params->has_mtu_length = true;
     }
 
     return 0;
@@ -158,7 +160,9 @@ int aeron_diver_uri_publication_params(
 
     params->linger_timeout_ns = context->publication_linger_timeout_ns;
     params->term_length = AERON_URI_IPC == uri->type ? context->ipc_term_buffer_length : context->term_buffer_length;
+    params->has_term_length = false;
     params->mtu_length = AERON_URI_IPC == uri->type ? context->ipc_mtu_length : context->mtu_length;
+    params->has_mtu_length = false;
     params->initial_term_id = 0;
     params->term_offset = 0;
     params->term_id = 0;
@@ -235,16 +239,6 @@ int aeron_diver_uri_publication_params(
     {
         char *end_ptr = NULL;
 
-        if (!is_exclusive)
-        {
-            AERON_SET_ERR(
-                EINVAL,
-                "params: %s %s %s are not supported for concurrent publications",
-                AERON_URI_INITIAL_TERM_ID_KEY,
-                AERON_URI_TERM_ID_KEY,
-                AERON_URI_TERM_OFFSET_KEY);
-            return -1;
-        }
         if (count < 3)
         {
             AERON_SET_ERR(

--- a/aeron-driver/src/main/c/uri/aeron_driver_uri.h
+++ b/aeron-driver/src/main/c/uri/aeron_driver_uri.h
@@ -27,7 +27,9 @@ typedef struct aeron_driver_uri_publication_params_stct
     bool is_sparse;
     bool signal_eos;
     bool spies_simulate_connection;
+    bool has_mtu_length;
     size_t mtu_length;
+    bool has_term_length;
     size_t term_length;
     size_t term_offset;
     int32_t initial_term_id;

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -476,7 +476,16 @@ public final class DriverConductor implements Agent
         }
         else
         {
-            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId(), publication.channel());
+            confirmMatch(
+                channelUri,
+                params,
+                publication.rawLog(),
+                publication.sessionId(),
+                publication.channel(),
+                publication.initialTermId(),
+                publication.startingTermId(),
+                publication.startingTermOffset());
+
             validateSpiesSimulateConnection(
                 params, publication.spiesSimulateConnection(), channel, publication.channel());
         }
@@ -674,7 +683,15 @@ public final class DriverConductor implements Agent
         }
         else
         {
-            confirmMatch(channelUri, params, publication.rawLog(), publication.sessionId(), publication.channel());
+            confirmMatch(
+                channelUri,
+                params,
+                publication.rawLog(),
+                publication.sessionId(),
+                publication.channel(),
+                publication.initialTermId(),
+                publication.startingTermId(),
+                publication.startingTermOffset());
         }
 
         publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
@@ -1797,7 +1814,8 @@ public final class DriverConductor implements Agent
                 publisherLimit,
                 rawLog,
                 Configuration.producerWindowLength(params.termLength, ctx.ipcPublicationTermWindowLength()),
-                isExclusive);
+                isExclusive,
+                params);
 
             ipcPublications.add(publication);
             activeSessionSet.add(new SessionKey(sessionId, streamId, IPC_MEDIA));

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -59,6 +59,8 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
     private final int termWindowLength;
     private final int positionBitsToShift;
     private final int initialTermId;
+    private final int startingTermId;
+    private final int startingTermOffset;
     private final ErrorHandler errorHandler;
     private long tripLimit;
     private long consumerPosition;
@@ -89,7 +91,8 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
         final Position publisherLimit,
         final RawLog rawLog,
         final int termWindowLength,
-        final boolean isExclusive)
+        final boolean isExclusive,
+        final PublicationParams params)
     {
         this.registrationId = registrationId;
         this.channel = channel;
@@ -98,7 +101,9 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
         this.streamId = streamId;
         this.isExclusive = isExclusive;
         this.termBuffers = rawLog.termBuffers();
-        this.initialTermId = initialTermId(rawLog.metaData());
+        this.initialTermId = LogBufferDescriptor.initialTermId(rawLog.metaData());
+        this.startingTermId = params.termId;
+        this.startingTermOffset = params.termOffset;
         this.errorHandler = ctx.errorHandler();
 
         final int termLength = rawLog.termLength();
@@ -164,6 +169,21 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
     boolean isExclusive()
     {
         return isExclusive;
+    }
+
+    int initialTermId()
+    {
+        return initialTermId;
+    }
+
+    int startingTermId()
+    {
+        return startingTermId;
+    }
+
+    int startingTermOffset()
+    {
+        return startingTermOffset;
     }
 
     RawLog rawLog()

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -102,8 +102,8 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
         this.isExclusive = isExclusive;
         this.termBuffers = rawLog.termBuffers();
         this.initialTermId = LogBufferDescriptor.initialTermId(rawLog.metaData());
-        this.startingTermId = params.termId;
-        this.startingTermOffset = params.termOffset;
+        this.startingTermId = params.hasPosition ? params.termId : initialTermId;
+        this.startingTermOffset = params.hasPosition ? params.termOffset : 0;
         this.errorHandler = ctx.errorHandler();
 
         final int termLength = rawLog.termLength();

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -202,8 +202,8 @@ public final class NetworkPublication
         this.spiesSimulateConnection = params.spiesSimulateConnection;
         this.signalEos = params.signalEos;
         this.isExclusive = isExclusive;
-        this.startingTermId = params.termId;
-        this.startingTermOffset = params.termOffset;
+        this.startingTermId = params.hasPosition ? params.termId : initialTermId;
+        this.startingTermOffset = params.hasPosition ? params.termOffset : 0;
 
         metaDataBuffer = rawLog.metaData();
         setupBuffer = threadLocals.setupBuffer();

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -115,6 +115,8 @@ public final class NetworkPublication
     private final long tag;
     private final int positionBitsToShift;
     private final int initialTermId;
+    private final int startingTermId;
+    private final int startingTermOffset;
     private final int termBufferLength;
     private final int termLengthMask;
     private final int mtuLength;
@@ -200,6 +202,8 @@ public final class NetworkPublication
         this.spiesSimulateConnection = params.spiesSimulateConnection;
         this.signalEos = params.signalEos;
         this.isExclusive = isExclusive;
+        this.startingTermId = params.termId;
+        this.startingTermOffset = params.termOffset;
 
         metaDataBuffer = rawLog.metaData();
         setupBuffer = threadLocals.setupBuffer();
@@ -566,6 +570,21 @@ public final class NetworkPublication
     boolean spiesSimulateConnection()
     {
         return spiesSimulateConnection;
+    }
+
+    int initialTermId()
+    {
+        return initialTermId;
+    }
+
+    int startingTermId()
+    {
+        return startingTermId;
+    }
+
+    int startingTermOffset()
+    {
+        return startingTermOffset;
     }
 
     boolean isAcceptingSubscriptions()

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationParams.java
@@ -76,12 +76,6 @@ final class PublicationParams
 
         if (count > 0)
         {
-            if (!isExclusive)
-            {
-                throw new IllegalArgumentException("params: " + INITIAL_TERM_ID_PARAM_NAME + " " + TERM_ID_PARAM_NAME +
-                    " " + TERM_OFFSET_PARAM_NAME + " are not supported for concurrent publications: channel=" +
-                    channelUri);
-            }
             if (count < 3)
             {
                 throw new IllegalArgumentException("params must be used as a complete set: " +
@@ -206,33 +200,87 @@ final class PublicationParams
         }
     }
 
+    private static String formatMatchError(
+        final String paramName,
+        final String existingValue,
+        final String newValue,
+        final String existingChannelUri,
+        final String newChannelUri)
+    {
+        return "existing publication has different '" + paramName + "': existing=" +
+            existingValue + " requested=" + newValue + " existingChannel=" + existingChannelUri +
+            " channel=" + newChannelUri;
+    }
+
     static void confirmMatch(
         final ChannelUri channelUri,
         final PublicationParams params,
         final RawLog rawLog,
         final int existingSessionId,
-        final String existingChannel)
+        final String existingChannel,
+        final int existingInitialTermId,
+        final int existingTermId,
+        final int existingTermOffset)
     {
         final int mtuLength = LogBufferDescriptor.mtuLength(rawLog.metaData());
         if (channelUri.containsKey(MTU_LENGTH_PARAM_NAME) && mtuLength != params.mtuLength)
         {
-            throw new IllegalStateException("existing publication has different MTU length: existing=" +
-                mtuLength + " requested=" + params.mtuLength + " existingChannel=" + existingChannel +
-                " channel=" + channelUri);
+            throw new IllegalStateException(formatMatchError(
+                MTU_LENGTH_PARAM_NAME,
+                String.valueOf(mtuLength),
+                String.valueOf(params.mtuLength),
+                existingChannel,
+                channelUri.toString()));
         }
 
         if (channelUri.containsKey(TERM_LENGTH_PARAM_NAME) && rawLog.termLength() != params.termLength)
         {
-            throw new IllegalStateException("existing publication has different term length: existing=" +
-                rawLog.termLength() + " requested=" + params.termLength + " existingChannel=" + existingChannel +
-                " channel=" + channelUri);
+            throw new IllegalStateException(formatMatchError(
+                TERM_LENGTH_PARAM_NAME,
+                String.valueOf(rawLog.termLength()),
+                String.valueOf(params.termLength),
+                existingChannel,
+                channelUri.toString()));
         }
 
         if (channelUri.containsKey(SESSION_ID_PARAM_NAME) && params.sessionId != existingSessionId)
         {
-            throw new IllegalStateException("existing publication has different session id: existing=" +
-                existingSessionId + " requested=" + params.sessionId + " existingChannel=" + existingChannel +
-                " channel=" + channelUri);
+            throw new IllegalStateException(formatMatchError(
+                SESSION_ID_PARAM_NAME,
+                String.valueOf(existingSessionId),
+                String.valueOf(params.sessionId),
+                existingChannel,
+                channelUri.toString()));
+        }
+
+        if (channelUri.containsKey(INITIAL_TERM_ID_PARAM_NAME) && params.initialTermId != existingInitialTermId)
+        {
+            throw new IllegalStateException(formatMatchError(
+                INITIAL_TERM_ID_PARAM_NAME,
+                String.valueOf(existingInitialTermId),
+                String.valueOf(params.initialTermId),
+                existingChannel,
+                channelUri.toString()));
+        }
+
+        if (channelUri.containsKey(TERM_ID_PARAM_NAME) && params.termId != existingTermId)
+        {
+            throw new IllegalStateException(formatMatchError(
+                TERM_ID_PARAM_NAME,
+                String.valueOf(existingTermId),
+                String.valueOf(params.termId),
+                existingChannel,
+                channelUri.toString()));
+        }
+
+        if (channelUri.containsKey(TERM_OFFSET_PARAM_NAME) && params.termOffset != existingTermOffset)
+        {
+            throw new IllegalStateException(formatMatchError(
+                TERM_OFFSET_PARAM_NAME,
+                String.valueOf(existingTermOffset),
+                String.valueOf(params.termOffset),
+                existingChannel,
+                channelUri.toString()));
         }
     }
 

--- a/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
@@ -66,7 +66,8 @@ public class UntetheredSubscriptionTest
             publisherLimit,
             rawLog,
             TERM_WINDOW_LENGTH,
-            true);
+            true,
+            new PublicationParams());
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/SpecifiedPositionPublicationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/SpecifiedPositionPublicationTest.java
@@ -18,41 +18,177 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
 import io.aeron.exceptions.RegistrationException;
+import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.protocol.DataHeaderFlyweight;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.RandomWatcher;
 import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.driver.TestMediaDriver;
-import org.agrona.ErrorHandler;
-import org.junit.jupiter.api.Test;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class SpecifiedPositionPublicationTest
 {
     @RegisterExtension
     final SystemTestWatcher testWatcher = new SystemTestWatcher();
+    @RegisterExtension
+    final RandomWatcher randomWatcher = new RandomWatcher();
 
-    @Test
-    void shouldRejectSpecifiedPositionForConcurrentPublications()
+    @InterruptAfter(5)
+    @ParameterizedTest
+    @CsvSource({
+        CommonContext.IPC_CHANNEL + ",true",
+        "aeron:udp?endpoint=localhost:24325,true",
+        CommonContext.IPC_CHANNEL + ",false",
+        "aeron:udp?endpoint=localhost:24325,false"
+    })
+    void shouldStartAtSpecifiedPositionForPublications(final String initialUri, final boolean exclusive)
     {
-        final ErrorHandler mockErrorHandler = mock(ErrorHandler.class);
         final MediaDriver.Context context = new MediaDriver.Context()
-            .errorHandler(mockErrorHandler)
             .dirDeleteOnStart(true)
             .ipcPublicationTermWindowLength(LogBufferDescriptor.TERM_MIN_LENGTH)
             .threadingMode(ThreadingMode.SHARED);
+        final DirectBuffer msg = new UnsafeBuffer(new byte[64]);
+
+        final int termLength = 1 << 16;
+        final int initialTermId = randomWatcher.random().nextInt();
+        final int activeTermId = initialTermId + randomWatcher.random().nextInt(Integer.MAX_VALUE);
+        final int positionBitsToShift = LogBufferDescriptor.positionBitsToShift(termLength);
+        final int termOffset = randomWatcher.random().nextInt(termLength) & -FrameDescriptor.FRAME_ALIGNMENT;
+        final long startPosition = LogBufferDescriptor.computePosition(
+            activeTermId,
+            termOffset,
+            positionBitsToShift,
+            initialTermId);
+        final long nextPosition = startPosition + DataHeaderFlyweight.HEADER_LENGTH + msg.capacity();
+
+        final String channel = new ChannelUriStringBuilder(initialUri)
+            .initialPosition(startPosition, initialTermId, termLength)
+            .build();
+
+        final int streamId = 1001;
+        final Function<Aeron, Publication> publicationSupplier = exclusive ?
+            (a) -> a.addExclusivePublication(channel, streamId) : (a) -> a.addPublication(channel, streamId);
 
         try (
             TestMediaDriver mediaDriver = TestMediaDriver.launch(context, testWatcher);
-            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(mediaDriver.aeronDirectoryName())))
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(mediaDriver.aeronDirectoryName()));
+            Subscription subscription = aeron.addSubscription(initialUri, streamId);
+            Publication publication = publicationSupplier.apply(aeron))
         {
-            final String channel = new ChannelUriStringBuilder()
-                .media("ipc")
-                .initialPosition(1024, -873648623, 65536)
-                .build();
+            Tests.awaitConnected(subscription);
+            Tests.awaitConnected(publication);
 
-            assertThrows(RegistrationException.class, () -> aeron.addPublication(channel, 1001));
+            assertEquals(startPosition, publication.position());
+
+            Tests.await(() -> publication.offer(msg) > 0);
+            assertEquals(nextPosition, publication.position());
+
+            final FragmentHandler fragmentHandler =
+                (buffer, offset, length, header) -> assertEquals(nextPosition, header.position());
+
+            Tests.await(() -> subscription.poll(fragmentHandler, 1) == 1);
+        }
+        finally
+        {
+            context.deleteDirectory();
+        }
+    }
+
+    @InterruptAfter(5)
+    @ParameterizedTest
+    @CsvSource({
+        CommonContext.IPC_CHANNEL,
+        "aeron:udp?endpoint=localhost:24325"
+    })
+    void shouldValidateSpecifiedPositionForConcurrentPublications(final String initialUri)
+    {
+        final MediaDriver.Context context = new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .ipcPublicationTermWindowLength(LogBufferDescriptor.TERM_MIN_LENGTH)
+            .threadingMode(ThreadingMode.SHARED);
+        final DirectBuffer msg = new UnsafeBuffer(new byte[64]);
+
+        final int termLength = 1 << 16;
+        final int initialTermId = randomWatcher.random().nextInt();
+        final int activeTermId = initialTermId + randomWatcher.random().nextInt(Integer.MAX_VALUE);
+        final int positionBitsToShift = LogBufferDescriptor.positionBitsToShift(termLength);
+        final int termOffset = randomWatcher.random().nextInt(termLength) & -FrameDescriptor.FRAME_ALIGNMENT;
+        final long startPosition = LogBufferDescriptor.computePosition(
+            activeTermId,
+            termOffset,
+            positionBitsToShift,
+            initialTermId);
+        final long positionMsg1 = startPosition + DataHeaderFlyweight.HEADER_LENGTH + msg.capacity();
+        final long positionMsg2 = positionMsg1 + DataHeaderFlyweight.HEADER_LENGTH + msg.capacity();
+        final long positionMsg3 = positionMsg2 + DataHeaderFlyweight.HEADER_LENGTH + msg.capacity();
+
+        final String channel = new ChannelUriStringBuilder(initialUri)
+            .initialPosition(startPosition, initialTermId, termLength)
+            .build();
+
+        final String invalidPositionUri = new ChannelUriStringBuilder(initialUri)
+            .initialPosition(startPosition + FrameDescriptor.FRAME_ALIGNMENT, initialTermId, termLength)
+            .build();
+        final String invalidInitialTermIdUri = new ChannelUriStringBuilder(initialUri)
+            .initialPosition(startPosition, initialTermId + 1, termLength)
+            .build();
+        final String invalidTermLengthUri = new ChannelUriStringBuilder(initialUri)
+            .initialPosition(startPosition, initialTermId, termLength << 1)
+            .build();
+
+        final int streamId = 1001;
+
+        try (
+            TestMediaDriver mediaDriver = TestMediaDriver.launch(context, testWatcher);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(mediaDriver.aeronDirectoryName()));
+            Subscription subscription = aeron.addSubscription(initialUri, streamId);
+            Publication publication = aeron.addPublication(channel, streamId))
+        {
+            Tests.awaitConnected(subscription);
+            Tests.awaitConnected(publication);
+
+            assertEquals(startPosition, publication.position());
+
+            Tests.await(() -> publication.offer(msg) > 0);
+            assertEquals(positionMsg1, publication.position());
+
+            Tests.await(() -> subscription.poll((buffer, offset, length, header) -> {}, 1) == 1);
+
+            try (Publication publication2 = aeron.addPublication(channel, streamId))
+            {
+                assertEquals(positionMsg1, publication2.position());
+                Tests.await(() -> publication.offer(msg) > 0);
+                assertEquals(positionMsg2, publication2.position());
+                final FragmentHandler fragmentHandler =
+                    (buffer, offset, length, header) -> assertEquals(positionMsg2, header.position());
+                Tests.await(() -> subscription.poll(fragmentHandler, 1) == 1);
+            }
+
+            try (Publication publication3 = aeron.addPublication(initialUri, streamId))
+            {
+                assertEquals(positionMsg2, publication3.position());
+                Tests.await(() -> publication.offer(msg) > 0);
+                assertEquals(positionMsg3, publication3.position());
+                final FragmentHandler fragmentHandler =
+                    (buffer, offset, length, header) -> assertEquals(positionMsg3, header.position());
+                Tests.await(() -> subscription.poll(fragmentHandler, 1) == 1);
+            }
+
+            assertThrows(RegistrationException.class, () -> aeron.addPublication(invalidPositionUri, streamId));
+            assertThrows(RegistrationException.class, () -> aeron.addPublication(invalidInitialTermIdUri, streamId));
+            assertThrows(RegistrationException.class, () -> aeron.addPublication(invalidTermLengthUri, streamId));
         }
         finally
         {

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveDeleteAndRestartTest.java
@@ -52,7 +52,7 @@ public class ArchiveDeleteAndRestartTest
     private final long seed = System.nanoTime();
 
     @RegisterExtension
-    public final TestWatcher randomSeedWatcher = ArchiveTests.newWatcher(seed);
+    public final TestWatcher randomSeedWatcher = Tests.seedWatcher(seed);
 
     @RegisterExtension
     public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -81,7 +81,7 @@ public class ArchiveTest
     private final long seed = System.nanoTime();
 
     @RegisterExtension
-    public final TestWatcher randomSeedWatcher = ArchiveTests.newWatcher(seed);
+    public final TestWatcher randomSeedWatcher = Tests.seedWatcher(seed);
 
     @RegisterExtension
     public final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();

--- a/aeron-test-support/src/main/java/io/aeron/test/RandomWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/RandomWatcher.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.util.Random;
+
+public class RandomWatcher implements TestWatcher
+{
+    private final long seed = System.nanoTime();
+    private final Random random = new Random();
+
+    public void testFailed(final ExtensionContext context, final Throwable cause)
+    {
+        System.err.println(context.getDisplayName() + " failed with random seed: " + seed);
+    }
+
+    public Random random()
+    {
+        return random;
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -27,6 +27,8 @@ import org.agrona.concurrent.SleepingMillisIdleStrategy;
 import org.agrona.concurrent.YieldingIdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -667,5 +669,16 @@ public class Tests
         {
             LangUtil.rethrowUnchecked(ex);
         }
+    }
+
+    public static TestWatcher seedWatcher(final long seed)
+    {
+        return new TestWatcher()
+        {
+            public void testFailed(final ExtensionContext context, final Throwable cause)
+            {
+                System.err.println(context.getDisplayName() + " failed with random seed: " + seed);
+            }
+        };
     }
 }


### PR DESCRIPTION
- Allows initialTermId, termId, and termOffset for concurrent publications and use those fields for matching concurrent publications (C and Java Drivers).
- If values are not specified with subsequent publications, then addition of publications is allowed.
- Make C driver mtu and termLength parameter matching consistent with the Java driver.