### PR TITLE
[Java] Allow specifying `interface` in the cluster members list.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
@@ -25,6 +25,7 @@ import org.agrona.collections.ArrayUtil;
 import org.agrona.collections.Int2ObjectHashMap;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
@@ -36,6 +37,9 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
  */
 public final class ClusterMember
 {
+    private static final Pattern MEMBERS_SPLIT_REGEX = Pattern.compile("(?<!\\\\)\\|");
+    private static final Pattern ESCAPED_PIPE = Pattern.compile("\\|", Pattern.LITERAL);
+
     static final ClusterMember[] EMPTY_MEMBERS = new ClusterMember[0];
 
     private boolean isBallotSent;
@@ -538,13 +542,13 @@ public final class ClusterMember
             return ClusterMember.EMPTY_MEMBERS;
         }
 
-        final String[] memberValues = value.split("\\|");
+        final String[] memberValues = MEMBERS_SPLIT_REGEX.split(value);
         final int length = memberValues.length;
         final ClusterMember[] members = new ClusterMember[length];
 
         for (int i = 0; i < length; i++)
         {
-            final String idAndEndpoints = memberValues[i];
+            final String idAndEndpoints = ESCAPED_PIPE.matcher(memberValues[i]).replaceAll("|");
             final String[] memberAttributes = idAndEndpoints.split(",");
             if (memberAttributes.length != 6)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
@@ -37,8 +37,7 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
  */
 public final class ClusterMember
 {
-    private static final Pattern MEMBERS_SPLIT_REGEX = Pattern.compile("(?<!\\\\)\\|");
-    private static final Pattern ESCAPED_PIPE = Pattern.compile("\\|", Pattern.LITERAL);
+    private static final Pattern MEMBERS_SPLIT_REGEX = Pattern.compile("\\|");
 
     static final ClusterMember[] EMPTY_MEMBERS = new ClusterMember[0];
 
@@ -548,20 +547,14 @@ public final class ClusterMember
 
         for (int i = 0; i < length; i++)
         {
-            final String idAndEndpoints = ESCAPED_PIPE.matcher(memberValues[i]).replaceAll("|");
+            final String idAndEndpoints = memberValues[i].replace('@', '|');
             final String[] memberAttributes = idAndEndpoints.split(",");
             if (memberAttributes.length != 6)
             {
                 throw new ClusterException("invalid member value: " + idAndEndpoints + " within: " + value);
             }
 
-            final String endpoints = String.join(
-                ",",
-                memberAttributes[1],
-                memberAttributes[2],
-                memberAttributes[3],
-                memberAttributes[4],
-                memberAttributes[5]);
+            final String endpoints = idAndEndpoints.substring(idAndEndpoints.indexOf(',') + 1);
 
             members[i] = new ClusterMember(
                 Integer.parseInt(memberAttributes[0]),

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -316,8 +316,8 @@ public final class ConsensusModule implements AutoCloseable
          * Property name for the comma separated list of cluster member endpoints.
          * <p>
          * <code>
-         *     0,ingress:port,consensus:port,log:port,catchup:port,archive:port| \
-         *     1,ingress:port,consensus:port,log:port,catchup:port,archive:port| ...
+         * 0,ingress:port[@interface=member0-interface],consensus:port[@interface=member0-interface],log:port[@interface=member0-interface],catchup:port[@interface=member0-interface],archive:port[@interface=member0-interface]| \
+         * 1,ingress:port[@interface=member1-interface],consensus:port[@interface=member1-interface],log:port[@interface=member1-interface],catchup:port[@interface=member1-interface],archive:port[@interface=member1-interface]| ...
          * </code>
          * <p>
          * The ingress endpoints will be used as the endpoint substituted into the
@@ -1700,8 +1700,8 @@ public final class ConsensusModule implements AutoCloseable
          * String representing the cluster members.
          * <p>
          * <code>
-         * 0,ingress:port,consensus:port,log:port,catchup:port,archive:port| \
-         * 1,ingress:port,consensus:port,log:port,catchup:port,archive:port| ...
+         * 0,ingress:port[@interface=member0-interface],consensus:port[@interface=member0-interface],log:port[@interface=member0-interface],catchup:port[@interface=member0-interface],archive:port[@interface=member0-interface]| \
+         * 1,ingress:port[@interface=member1-interface],consensus:port[@interface=member1-interface],log:port[@interface=member1-interface],catchup:port[@interface=member1-interface],archive:port[@interface=member1-interface]| ...
          * </code>
          * <p>
          * The ingress endpoints will be used as the endpoint substituted into the {@link #ingressChannel()}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
@@ -21,6 +21,7 @@ import static io.aeron.cluster.ClusterMember.quorumPosition;
 import static io.aeron.cluster.ClusterMember.quorumThreshold;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ClusterMemberTest
 {
@@ -77,5 +78,33 @@ public class ClusterMemberTest
             final long quorumPosition = quorumPosition(members, rankedPositions);
             assertThat("Test: " + i, quorumPosition, is(quorumPositions[i]));
         }
+    }
+
+    @Test
+    void parseShouldIgnoreEscapedPipe()
+    {
+        final ClusterMember[] parsedMembers = ClusterMember.parse(
+            "0,ingressEndpoint\\|interface=ingressEndpoint-interface," +
+                "consensusEndpoint\\|interface=consensusEndpoint-interface\\|mtu=2048," +
+                "logEndpoint\\|interface=logEndpoint-interface,catchupEndpoint\\|interface=catchupEndpoint-interface," +
+                "archiveEndpoint\\|interface=archiveEndpoint-interface|" +
+                "1,ingressEndpoint1,consensusEndpoint1,logEndpoint1\\|interface=logEndpoint1-interface," +
+                "catchupEndpoint1,archiveEndpoint1\\|interface=archiveEndpoint1-interface|");
+
+        final ClusterMember member0 = parsedMembers[0];
+        assertEquals(0, member0.id());
+        assertEquals("ingressEndpoint|interface=ingressEndpoint-interface", member0.ingressEndpoint());
+        assertEquals("consensusEndpoint|interface=consensusEndpoint-interface|mtu=2048", member0.consensusEndpoint());
+        assertEquals("logEndpoint|interface=logEndpoint-interface", member0.logEndpoint());
+        assertEquals("catchupEndpoint|interface=catchupEndpoint-interface", member0.catchupEndpoint());
+        assertEquals("archiveEndpoint|interface=archiveEndpoint-interface", member0.archiveEndpoint());
+
+        final ClusterMember member1 = parsedMembers[1];
+        assertEquals(1, member1.id());
+        assertEquals("ingressEndpoint1", member1.ingressEndpoint());
+        assertEquals("consensusEndpoint1", member1.consensusEndpoint());
+        assertEquals("logEndpoint1|interface=logEndpoint1-interface", member1.logEndpoint());
+        assertEquals("catchupEndpoint1", member1.catchupEndpoint());
+        assertEquals("archiveEndpoint1|interface=archiveEndpoint1-interface", member1.archiveEndpoint());
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
@@ -81,15 +81,15 @@ public class ClusterMemberTest
     }
 
     @Test
-    void parseShouldIgnoreEscapedPipe()
+    void parseShouldAllowExtraParametersAttachedToAnEndpoint()
     {
         final ClusterMember[] parsedMembers = ClusterMember.parse(
-            "0,ingressEndpoint\\|interface=ingressEndpoint-interface," +
-                "consensusEndpoint\\|interface=consensusEndpoint-interface\\|mtu=2048," +
-                "logEndpoint\\|interface=logEndpoint-interface,catchupEndpoint\\|interface=catchupEndpoint-interface," +
-                "archiveEndpoint\\|interface=archiveEndpoint-interface|" +
-                "1,ingressEndpoint1,consensusEndpoint1,logEndpoint1\\|interface=logEndpoint1-interface," +
-                "catchupEndpoint1,archiveEndpoint1\\|interface=archiveEndpoint1-interface|");
+            "0,ingressEndpoint@interface=ingressEndpoint-interface," +
+                "consensusEndpoint@interface=consensusEndpoint-interface@mtu=2048," +
+                "logEndpoint@interface=logEndpoint-interface,catchupEndpoint@interface=catchupEndpoint-interface," +
+                "archiveEndpoint@interface=archiveEndpoint-interface|" +
+                "1,ingressEndpoint1,consensusEndpoint1,logEndpoint1@interface=logEndpoint1-interface," +
+                "catchupEndpoint1,archiveEndpoint1@interface=archiveEndpoint1-interface@term-length=16k|");
 
         final ClusterMember member0 = parsedMembers[0];
         assertEquals(0, member0.id());
@@ -98,6 +98,10 @@ public class ClusterMemberTest
         assertEquals("logEndpoint|interface=logEndpoint-interface", member0.logEndpoint());
         assertEquals("catchupEndpoint|interface=catchupEndpoint-interface", member0.catchupEndpoint());
         assertEquals("archiveEndpoint|interface=archiveEndpoint-interface", member0.archiveEndpoint());
+        assertEquals("ingressEndpoint|interface=ingressEndpoint-interface," +
+            "consensusEndpoint|interface=consensusEndpoint-interface|mtu=2048," +
+            "logEndpoint|interface=logEndpoint-interface,catchupEndpoint|interface=catchupEndpoint-interface," +
+            "archiveEndpoint|interface=archiveEndpoint-interface", member0.endpoints());
 
         final ClusterMember member1 = parsedMembers[1];
         assertEquals(1, member1.id());
@@ -105,6 +109,10 @@ public class ClusterMemberTest
         assertEquals("consensusEndpoint1", member1.consensusEndpoint());
         assertEquals("logEndpoint1|interface=logEndpoint1-interface", member1.logEndpoint());
         assertEquals("catchupEndpoint1", member1.catchupEndpoint());
-        assertEquals("archiveEndpoint1|interface=archiveEndpoint1-interface", member1.archiveEndpoint());
+        assertEquals("archiveEndpoint1|interface=archiveEndpoint1-interface|term-length=16k",
+            member1.archiveEndpoint());
+        assertEquals("ingressEndpoint1,consensusEndpoint1,logEndpoint1|interface=logEndpoint1-interface," +
+            "catchupEndpoint1,archiveEndpoint1|interface=archiveEndpoint1-interface|term-length=16k",
+            member1.endpoints());
     }
 }


### PR DESCRIPTION
Previously the cluster members list could only specify the endpoints, e.g.:
```
0,localhost:20000,localhost:20001,localhost:20002,localhost:0,localhost:8010
``` 
Now it is possible to specify the `interface` param using the `@` as a separator, e.g.:
```
0,localhost:20000@interface=192.168.0.0/24,localhost:20001@interface=192.168.0.0/24,localhost:20002@interface=192.168.0.0/24,localhost:0@interface=192.168.0.0/24,localhost:8010@interface=192.168.0.0/24
```