### PR TITLE
[Java] Cluster interface config.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -1466,7 +1466,7 @@ abstract class ArchiveConductor
     private static ChannelUriStringBuilder strippedChannelBuilder(final ChannelUri channelUri)
     {
         return new ChannelUriStringBuilder()
-            .media(channelUri.media())
+            .media(channelUri)
             .endpoint(channelUri)
             .networkInterface(channelUri)
             .controlEndpoint(channelUri)

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -440,7 +440,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         {
             if (isMds)
             {
-                replayDestination = "aeron:udp?endpoint=" + endpoint;
+                replayDestination = ChannelUri.createDestinationUri(replicationChannel, endpoint);
                 recordingSubscription.asyncAddDestination(replayDestination);
             }
 

--- a/aeron-client/src/main/java/io/aeron/ChannelUri.java
+++ b/aeron-client/src/main/java/io/aeron/ChannelUri.java
@@ -20,7 +20,10 @@ import org.agrona.AsciiEncoding;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.collections.Object2ObjectHashMap;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import static io.aeron.CommonContext.*;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
@@ -36,6 +39,7 @@ import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
  * </pre>
  * <p>
  * Multiple params with the same key are allowed, the last value specified takes precedence.
+ *
  * @see ChannelUriStringBuilder
  */
 public final class ChannelUri
@@ -505,6 +509,28 @@ public final class ChannelUri
     {
         return isTagged(paramValue) ?
             AsciiEncoding.parseLongAscii(paramValue, 4, paramValue.length() - 4) : INVALID_TAG;
+    }
+
+    /**
+     * Create a channel URI for a destination, i.e. a channel that uses {@code media} and {@code interface} parameters
+     * of the original channel and adds specified {@code endpoint} to it. For example given the input channel is
+     * {@code aeron:udp?mtu=1440|ttl=0|endpoint=localhost:8090|term-length=128k|interface=eth0} and the endpoint is
+     * {@code 192.168.0.14} the output of this method will be {@code aeron:udp?endpoint=192.168.0.14|interface=eth0}.
+     *
+     * @param channel  for which the destination is being added.
+     * @param endpoint for the target destination.
+     * @return new channel URI for a destination.
+     */
+    public static String createDestinationUri(final String channel, final String endpoint)
+    {
+        final ChannelUri channelUri = ChannelUri.parse(channel);
+        final String uri = AERON_PREFIX + channelUri.media() + "?" + ENDPOINT_PARAM_NAME + "=" + endpoint;
+        final String networkInterface = channelUri.get(INTERFACE_PARAM_NAME);
+        if (null != networkInterface)
+        {
+            return uri + "|" + INTERFACE_PARAM_NAME + "=" + networkInterface;
+        }
+        return uri;
     }
 
     private static void validateMedia(final String media)

--- a/aeron-client/src/test/java/io/aeron/ChannelUriTest.java
+++ b/aeron-client/src/test/java/io/aeron/ChannelUriTest.java
@@ -18,6 +18,7 @@ package io.aeron;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
@@ -176,6 +177,20 @@ public class ChannelUriTest
         {
             assertNotEquals(parsedUri1.hashCode(), parsedUri2.hashCode());
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "aeron:udp?endpoint=poison|interface=iface|mtu=4444, dest1, aeron:udp?endpoint=dest1|interface=iface",
+        "aeron:ipc, dest2, aeron:ipc?endpoint=dest2",
+        "aeron:udp, localhost, aeron:udp?endpoint=localhost",
+        "aeron:ipc?interface=here, there, aeron:ipc?endpoint=there|interface=here",
+        "aeron-spy:aeron:udp?eol=true|interface=none, abc, aeron:udp?endpoint=abc|interface=none",
+        "aeron:udp?interface=eth0|term-length=64k|ttl=0|endpoint=some, vm1, aeron:udp?endpoint=vm1|interface=eth0" })
+    void createDestinationUriTest(final String channel, final String endpoint, final String expected)
+    {
+        final String destinationUri = ChannelUri.createDestinationUri(channel, endpoint);
+        assertEquals(expected, destinationUri);
     }
 
     private static List<Arguments> equalityValues()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/DynamicJoin.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/DynamicJoin.java
@@ -15,8 +15,10 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
-import io.aeron.archive.client.*;
+import io.aeron.ChannelUri;
+import io.aeron.Counter;
+import io.aeron.ExclusivePublication;
+import io.aeron.archive.client.AeronArchive;
 import io.aeron.archive.codecs.RecordingSignal;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.cluster.codecs.SnapshotRecordingsDecoder;
@@ -283,7 +285,7 @@ final class DynamicJoin
                 RecordingPos.NULL_RECORDING_ID,
                 AeronArchive.NULL_LENGTH,
                 ctx.archiveContext().controlRequestStreamId(),
-                "aeron:udp?term-length=64k|endpoint=" + leaderMember.archiveEndpoint(),
+                leaderArchiveControlRequestChannel(),
                 null,
                 ctx.replicationChannel());
 
@@ -315,7 +317,7 @@ final class DynamicJoin
                         snapshotReplication.recordingId(),
                         AeronArchive.NULL_LENGTH,
                         ctx.archiveContext().controlRequestStreamId(),
-                        "aeron:udp?term-length=64k|endpoint=" + leaderMember.archiveEndpoint(),
+                        leaderArchiveControlRequestChannel(),
                         null,
                         ctx.replicationChannel());
 
@@ -326,6 +328,11 @@ final class DynamicJoin
         }
 
         return workCount;
+    }
+
+    private String leaderArchiveControlRequestChannel()
+    {
+        return ChannelUri.createDestinationUri(ctx.leaderArchiveControlChannel(), leaderMember.archiveEndpoint());
     }
 
     private int snapshotLoad(final long nowNs)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -38,8 +38,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.Aeron.NULL_VALUE;
-import static io.aeron.CommonContext.MDC_CONTROL_MODE_MANUAL;
-import static io.aeron.CommonContext.NULL_SESSION_ID;
+import static io.aeron.CommonContext.*;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.cluster.ClusterMember.compareLog;
 import static io.aeron.cluster.ElectionState.*;
@@ -1161,11 +1160,8 @@ class Election
     private Subscription addFollowerSubscription()
     {
         final Aeron aeron = ctx.aeron();
-        final ChannelUri logChannel = ChannelUri.parse(ctx.logChannel());
-
         final String channel = new ChannelUriStringBuilder()
-            .media(logChannel)
-            .networkInterface(logChannel)
+            .media(UDP_MEDIA)
             .tags(aeron.nextCorrelationId() + "," + aeron.nextCorrelationId())
             .controlMode(MDC_CONTROL_MODE_MANUAL)
             .sessionId(logSessionId)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogReplication.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogReplication.java
@@ -48,7 +48,7 @@ final class LogReplication
         final long srcRecordingId,
         final long dstRecordingId,
         final long stopPosition,
-        final String srcArchiveEndpoint,
+        final String srcArchiveChannel,
         final String replicationChannel,
         final long progressCheckTimeoutNs,
         final long progressCheckIntervalNs,
@@ -61,14 +61,11 @@ final class LogReplication
         this.progressDeadlineNs = nowNs + progressCheckTimeoutNs;
         this.progressCheckDeadlineNs = nowNs + progressCheckIntervalNs;
 
-        final String srcArchiveChannel = "aeron:udp?endpoint=" + srcArchiveEndpoint;
-        final int srcControlStreamId = archive.context().controlRequestStreamId();
-
         replicationId = archive.replicate(
             srcRecordingId,
             dstRecordingId,
             stopPosition,
-            srcControlStreamId,
+            archive.context().controlRequestStreamId(),
             srcArchiveChannel,
             null,
             replicationChannel);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -17,7 +17,9 @@ package io.aeron.cluster;
 
 import io.aeron.*;
 import io.aeron.archive.client.AeronArchive;
-import io.aeron.cluster.codecs.*;
+import io.aeron.cluster.codecs.CloseReason;
+import io.aeron.cluster.codecs.ClusterAction;
+import io.aeron.cluster.codecs.EventCode;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.cluster.service.ClusterMarkFile;
 import io.aeron.cluster.service.ClusterTerminationException;
@@ -27,13 +29,18 @@ import io.aeron.status.ReadableCounter;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestClusterClock;
 import org.agrona.collections.MutableLong;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.AgentInvoker;
+import org.agrona.concurrent.CountedErrorHandler;
+import org.agrona.concurrent.NoOpIdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
 
@@ -42,7 +49,8 @@ import static io.aeron.cluster.ConsensusModule.Configuration.SESSION_LIMIT_MSG;
 import static io.aeron.cluster.ConsensusModuleAgent.SLOW_TICK_INTERVAL_NS;
 import static io.aeron.cluster.client.AeronCluster.Configuration.PROTOCOL_SEMANTIC_VERSION;
 import static java.lang.Boolean.TRUE;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class ConsensusModuleAgentTest
@@ -329,5 +337,36 @@ public class ConsensusModuleAgentTest
 
         assertThrows(ClusterTerminationException.class,
             () -> agent.onServiceAck(1024, 100, 0, 55, 0));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "null, aeron:udp?endpoint=acme:2040, aeron:udp?endpoint=acme:2040",
+        ", aeron:ipc, aeron:ipc",
+        "aeron:udp?endpoint=host1:5050|interface=eth0|mtu=1440, aeron:udp?endpoint=localhost:8080|mtu=8000, " +
+            "aeron:udp?endpoint=localhost:8080|interface=eth0|mtu=1440",
+        "aeron:udp?endpoint=node0:21300|eos=false, aeron:udp?mtu=8000|interface=if1|eos=true|ttl=100, " +
+            "aeron:udp?endpoint=node0:21300|eos=false"
+    }, nullValues = "null")
+    void responseChannelIsBuiltBasedOnTheEgressChannel(
+        final String egressChannel, final String responseChannel, final String expectedResponseChannel)
+    {
+        final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+        ctx.epochClock(clock).clusterClock(clock);
+        ctx.egressChannel(egressChannel);
+
+        final ConsensusModuleAgent agent = new ConsensusModuleAgent(ctx);
+        agent.state(ConsensusModule.State.ACTIVE);
+        agent.role(Cluster.Role.LEADER);
+
+        final long correlationId = 1L;
+        final int responseStreamId = 42;
+        agent.onSessionConnect(
+            correlationId, responseStreamId, PROTOCOL_SEMANTIC_VERSION, responseChannel, new byte[0]);
+
+        final ArgumentCaptor<String> channelCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockAeron).asyncAddPublication(channelCaptor.capture(), eq(responseStreamId));
+
+        assertEquals(ChannelUri.parse(expectedResponseChannel), ChannelUri.parse(channelCaptor.getValue()));
     }
 }


### PR DESCRIPTION
This PR makes it possible to configure `interface` params for _all_ of the Cluster channels. To that end it:
- Replaces all of the ad hoc channels used for defining destinations with the call to `ChannelUri#createDestinationUri`.
- Adds two new configuration properties `aeron.cluster.follower.catchup.channel` and `aeron.cluster.leader.archive.control.channel`. The former is used to create the replay channel when doing a catch up on the follower node. And the latter is used for creating a control request channel to the leader archive.
- Adds an `egressChannel` configuration option to the `ConsensusModule` which is using the same configuration property as the `AeronCluster` (i.e. `aeron.cluster.egress.channel`). When the `egressChannel` is not defined then response channel from the leader to the client is based on the `responseChannel` sent by the client. However if it defined then it is used a basis for the response channel, i.e. if the client `responseChannel` contains an `endpoint` parameter then it will be used to set/substitute the value in the `egressChannel` of the leader node and otherwise leader's `egressChannel` is used as is.