### PR TITLE
fix build on ARM with clang

### DIFF
--- a/aeron-client/src/main/c/CMakeLists.txt
+++ b/aeron-client/src/main/c/CMakeLists.txt
@@ -186,12 +186,14 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DDISABLE_BOUNDS_CHECKS")
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(AERON_LIB_M_LIBS m)
+    set(AERON_LIB_ATOMIC_LIBS atomic)
 endif ()
 
 target_link_libraries(
     aeron
     ${CMAKE_DL_LIBS}
     ${AERON_LIB_M_LIBS}
+    ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS})
 
@@ -199,6 +201,7 @@ target_link_libraries(
     aeron_static INTERFACE
     ${CMAKE_DL_LIBS}
     ${AERON_LIB_M_LIBS}
+    ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS}
     ${AERON_STATIC_LIB_LINK_OPTS}

--- a/aeron-client/src/main/c/CMakeLists.txt
+++ b/aeron-client/src/main/c/CMakeLists.txt
@@ -186,7 +186,9 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DDISABLE_BOUNDS_CHECKS")
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     set(AERON_LIB_M_LIBS m)
-    set(AERON_LIB_ATOMIC_LIBS atomic)
+    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64")
+        set(AERON_LIB_ATOMIC_LIBS atomic)
+    endif ()
 endif ()
 
 target_link_libraries(

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -350,7 +350,9 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 
     set(AERON_LIB_M_LIBS m)
 
-    set(AERON_LIB_ATOMIC_LIBS atomic)
+    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64")
+        set(AERON_LIB_ATOMIC_LIBS atomic)
+    endif ()
 endif ()
 
 if (CYGWIN)

--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -349,6 +349,8 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
     endif ()
 
     set(AERON_LIB_M_LIBS m)
+
+    set(AERON_LIB_ATOMIC_LIBS atomic)
 endif ()
 
 if (CYGWIN)
@@ -363,6 +365,7 @@ target_link_libraries(
     ${AERON_LIB_BSD_LIBS}
     ${AERON_LIB_UUID_LIBS}
     ${AERON_LIB_M_LIBS}
+    ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS})
 
@@ -373,6 +376,7 @@ target_link_libraries(
     ${AERON_LIB_BSD_LIBS}
     ${AERON_LIB_UUID_LIBS}
     ${AERON_LIB_M_LIBS}
+    ${AERON_LIB_ATOMIC_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${AERON_LIB_WINSOCK_LIBS})
 


### PR DESCRIPTION
Add -latomic as a link dep on aeron_client & aeron_driver. This is required when building on ARM with clang.
Eg. cmake -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 ../..