### PR TITLE
Ensure catchup times out with lack of progress

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -755,10 +755,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                     logRecordingId, logPosition, Long.MAX_VALUE, channel, ctx.logStreamId()));
                 follower.catchupReplayCorrelationId(archive.lastCorrelationId());
             }
-            else if (null != follower)
-            {
-                System.out.println("Existing catchup already running: " + follower);
-            }
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -75,7 +75,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
     private long notifiedCommitPosition = 0;
     private long lastAppendPosition = 0;
     private long timeOfLastLogUpdateNs = 0;
-    private long timeOfLastAppendPositionNs = 0;
+    private long timeOfLastAppendPositionUpdateNs = 0;
+    private long timeOfLastAppendPositionSendNs = 0;
     private long slowTickDeadlineNs = 0;
     private long markFileUpdateDeadlineNs = 0;
     private int pendingServiceMessageHeadOffset = 0;
@@ -753,6 +754,10 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 follower.catchupReplaySessionId(archive.startReplay(
                     logRecordingId, logPosition, Long.MAX_VALUE, channel, ctx.logStreamId()));
                 follower.catchupReplayCorrelationId(archive.lastCorrelationId());
+            }
+            else if (null != follower)
+            {
+                System.out.println("Existing catchup already running: " + follower);
             }
         }
     }
@@ -1668,7 +1673,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         else
         {
             timeOfLastLogUpdateNs = nowNs;
-            timeOfLastAppendPositionNs = nowNs;
+            timeOfLastAppendPositionUpdateNs = nowNs;
+            timeOfLastAppendPositionSendNs = nowNs;
         }
 
         recoveryPlan = recordingLog.createRecoveryPlan(archive, ctx.serviceCount(), logRecordingId);
@@ -1749,7 +1755,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
 
     void catchupInitiated(final long nowNs)
     {
-        timeOfLastAppendPositionNs = nowNs;
+        timeOfLastAppendPositionUpdateNs = nowNs;
+        timeOfLastAppendPositionSendNs = nowNs;
     }
 
     int catchupPoll(final long limitPosition, final long nowNs)
@@ -1768,18 +1775,15 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         }
 
         final long appendPosition = logAdapter.position();
-        if (appendPosition > lastAppendPosition || nowNs > (timeOfLastAppendPositionNs + leaderHeartbeatIntervalNs))
+        if (appendPosition > lastAppendPosition || nowNs > (timeOfLastAppendPositionSendNs + leaderHeartbeatIntervalNs))
         {
             commitPosition.proposeMaxOrdered(appendPosition);
             final ExclusivePublication publication = election.leader().publication();
-            if (consensusPublisher.appendPosition(publication, replayLeadershipTermId, appendPosition, memberId))
-            {
-                lastAppendPosition = appendPosition;
-                timeOfLastAppendPositionNs = nowNs;
-            }
+            tryUpdateAppendPosition(publication, nowNs, replayLeadershipTermId, appendPosition);
         }
 
-        if (nowNs > (timeOfLastAppendPositionNs + leaderHeartbeatTimeoutNs) && ConsensusModule.State.ACTIVE == state)
+        if (nowNs > (timeOfLastAppendPositionUpdateNs + leaderHeartbeatTimeoutNs) &&
+            ConsensusModule.State.ACTIVE == state)
         {
             throw new ClusterEvent("no catchup progress");
         }
@@ -2517,6 +2521,29 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         return true;
     }
 
+    private boolean tryUpdateAppendPosition(
+        final ExclusivePublication publication,
+        final long nowNs,
+        final long leadershipTermId,
+        final long position)
+    {
+        boolean positionSent = false;
+
+        if (consensusPublisher.appendPosition(publication, leadershipTermId, position, memberId))
+        {
+            if (position > lastAppendPosition)
+            {
+                lastAppendPosition = position;
+                timeOfLastAppendPositionUpdateNs = nowNs;
+            }
+            timeOfLastAppendPositionSendNs = nowNs;
+
+            positionSent = true;
+        }
+
+        return positionSent;
+    }
+
     private void loadSnapshot(final RecordingLog.Snapshot snapshot, final AeronArchive archive)
     {
         final String channel = ctx.replayChannel();
@@ -2730,11 +2757,9 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         final long position = Math.max(recordedPosition, lastAppendPosition);
 
         if ((recordedPosition > lastAppendPosition ||
-            nowNs >= (timeOfLastAppendPositionNs + leaderHeartbeatIntervalNs)) &&
-            consensusPublisher.appendPosition(leaderMember.publication(), leadershipTermId, position, memberId))
+            nowNs >= (timeOfLastAppendPositionSendNs + leaderHeartbeatIntervalNs)) &&
+            tryUpdateAppendPosition(leaderMember.publication(), nowNs, leadershipTermId, position))
         {
-            lastAppendPosition = position;
-            timeOfLastAppendPositionNs = nowNs;
             return 1;
         }
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/RacingCatchupClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/RacingCatchupClusterTest.java
@@ -90,7 +90,7 @@ public class RacingCatchupClusterTest
     }
 
     @Test
-    @InterruptAfter(20)
+    @InterruptAfter(40)
     @Disabled
     public void shouldCatchupIfLogPositionMovesForwardBeforeFollowersCommitPositionWhenCatchingUpNodeIsOnlyFollower()
     {


### PR DESCRIPTION
Separate timestamps of AppendPosition into send and update, use send to track resends and update to track/timeout progress.