### PR TITLE
Split catchupPosition into catchupJoinPosition and catchupCommitPosition

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1771,14 +1771,10 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 throw new ClusterEvent(
                     "unexpected image close during catchup: position=" + logAdapter.image().position());
             }
-        }
 
-        final long appendPosition = logAdapter.position();
-        if (appendPosition > lastAppendPosition || nowNs > (timeOfLastAppendPositionSendNs + leaderHeartbeatIntervalNs))
-        {
-            commitPosition.proposeMaxOrdered(appendPosition);
             final ExclusivePublication publication = election.leader().publication();
-            tryUpdateAppendPosition(publication, nowNs, replayLeadershipTermId, appendPosition);
+            tryUpdateAppendPosition(publication, nowNs, replayLeadershipTermId, appendPosition.get());
+            commitPosition.proposeMaxOrdered(logAdapter.position());
         }
 
         if (nowNs > (timeOfLastAppendPositionUpdateNs + leaderHeartbeatTimeoutNs) &&

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1773,7 +1773,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
             }
 
             final ExclusivePublication publication = election.leader().publication();
-            tryUpdateAppendPosition(publication, nowNs, replayLeadershipTermId, appendPosition.get());
+            workCount += updateFollowerPosition(publication, nowNs, replayLeadershipTermId, appendPosition.get());
             commitPosition.proposeMaxOrdered(logAdapter.position());
         }
 
@@ -2516,25 +2516,36 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         return true;
     }
 
-    private boolean tryUpdateAppendPosition(
+    private int updateFollowerPosition(final long nowNs)
+    {
+        final long recordedPosition = null != appendPosition ? appendPosition.get() : logRecordedPosition;
+        return updateFollowerPosition(leaderMember.publication(), nowNs, this.leadershipTermId, recordedPosition);
+    }
+
+    private int updateFollowerPosition(
         final ExclusivePublication publication,
         final long nowNs,
         final long leadershipTermId,
-        final long position)
+        final long appendPosition)
     {
-        if (consensusPublisher.appendPosition(publication, leadershipTermId, position, memberId))
+        final long position = Math.max(appendPosition, lastAppendPosition);
+        if ((position > lastAppendPosition ||
+            nowNs >= (timeOfLastAppendPositionSendNs + leaderHeartbeatIntervalNs)))
         {
-            if (position > lastAppendPosition)
+            if (consensusPublisher.appendPosition(publication, leadershipTermId, position, memberId))
             {
-                lastAppendPosition = position;
-                timeOfLastAppendPositionUpdateNs = nowNs;
-            }
-            timeOfLastAppendPositionSendNs = nowNs;
+                if (position > lastAppendPosition)
+                {
+                    lastAppendPosition = position;
+                    timeOfLastAppendPositionUpdateNs = nowNs;
+                }
+                timeOfLastAppendPositionSendNs = nowNs;
 
-            return true;
+                return 1;
+            }
         }
 
-        return false;
+        return 0;
     }
 
     private void loadSnapshot(final RecordingLog.Snapshot snapshot, final AeronArchive archive)
@@ -2742,21 +2753,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
             ctx.leaderHeartbeatTimeoutNs(),
             ctx.leaderHeartbeatIntervalNs(),
             nowNs);
-    }
-
-    private int updateFollowerPosition(final long nowNs)
-    {
-        final long recordedPosition = null != appendPosition ? appendPosition.get() : logRecordedPosition;
-        final long position = Math.max(recordedPosition, lastAppendPosition);
-
-        if ((recordedPosition > lastAppendPosition ||
-            nowNs >= (timeOfLastAppendPositionSendNs + leaderHeartbeatIntervalNs)) &&
-            tryUpdateAppendPosition(leaderMember.publication(), nowNs, leadershipTermId, position))
-        {
-            return 1;
-        }
-
-        return 0;
     }
 
     private void clearSessionsAfter(final long logPosition)


### PR DESCRIPTION
Split catchupPosition into catchupJoinPosition - based on logPosition from new leadership term and catchCommitPosition - based on commit position messages received from the leader during catchup.  Use catchupCommitPosition as the limitPosition for processing messages from the LogAdapter during catchup.  Use the max of the two to determine that the follower is close enough to join the live stream and leave the catchup state.