### PR TITLE
[Java] Add a flag to ClusterTerminationException to say whether it was expected or not

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3184,7 +3184,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
     {
         tryStopLogRecording();
         state(ConsensusModule.State.CLOSED);
-        throw new ClusterTerminationException();
+        throw new ClusterTerminationException(true);
     }
 
     private void unexpectedTermination()
@@ -3193,7 +3193,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         serviceProxy.terminationPosition(0, ctx.countedErrorHandler());
         tryStopLogRecording();
         state(ConsensusModule.State.CLOSED);
-        throw new ClusterTerminationException();
+        throw new ClusterTerminationException(false);
     }
 
     private void tryStopLogRecording()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterTerminationException.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterTerminationException.java
@@ -18,9 +18,32 @@ package io.aeron.cluster.service;
 import org.agrona.concurrent.AgentTerminationException;
 
 /**
- * Used to terminate the {@link org.agrona.concurrent.Agent} within a cluster in an expected fashion.
+ * Used to terminate the {@link org.agrona.concurrent.Agent} within a cluster in an expected/unexpected fashion.
  */
 public class ClusterTerminationException extends AgentTerminationException
 {
     private static final long serialVersionUID = -2705156056823180407L;
+
+    private final boolean expected;
+
+    /**
+     * Construct an exception used to terminate the cluster.
+     *
+     * @param expected true if the termination is expected, i.e. it was requested
+     */
+    public ClusterTerminationException(final boolean expected)
+    {
+        super(expected ? "expected termination" : "unexpected termination");
+        this.expected = expected;
+    }
+
+    /**
+     * Whether the termination was expected.
+     *
+     * @return true if expected
+     */
+    public boolean expected()
+    {
+        return expected;
+    }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -490,7 +490,7 @@ final class ClusteredServiceAgent implements Agent, Cluster, IdleStrategy
 
         if (memberId == this.memberId && changeType == ChangeType.QUIT)
         {
-            terminate();
+            terminate(true);
         }
     }
 
@@ -955,11 +955,11 @@ final class ClusteredServiceAgent implements Agent, Cluster, IdleStrategy
                     "service terminate: logPosition=" + logPosition + " > terminationPosition=" + terminationPosition));
             }
 
-            terminate();
+            terminate(logPosition == terminationPosition);
         }
     }
 
-    private void terminate()
+    private void terminate(final boolean expectedTermination)
     {
         isServiceActive = false;
         activeLifecycleCallbackName = "onTerminate";
@@ -995,7 +995,7 @@ final class ClusteredServiceAgent implements Agent, Cluster, IdleStrategy
         }
 
         terminationPosition = NULL_VALUE;
-        throw new ClusterTerminationException();
+        throw new ClusterTerminationException(expectedTermination);
     }
 
     private void checkForLifecycleCallback()

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
@@ -59,7 +59,7 @@ public class ClusterTests
                         hasTerminated.set(true);
                     }
 
-                    throw new ClusterTerminationException();
+                    throw new ClusterTerminationException(true);
                 }
 
                 throw new AgentTerminationException();


### PR DESCRIPTION
I also added a message to the exception.  This will end up in the stack trace, where we'd like to be able to tell whether it was an expected termination or not.