### PR TITLE
[C] Remove loop through destinations nested within receive_channel_endpoint_send

### DIFF
--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -480,7 +480,14 @@ int aeron_data_packet_dispatcher_on_rttm(
                     &endpoint->conductor_fields.udp_channel->remote_control : addr;
 
                 return aeron_receive_channel_endpoint_send_rttm(
-                    endpoint, control_addr, header->stream_id, header->session_id, header->echo_timestamp, 0, false);
+                    endpoint,
+                    destination,
+                    control_addr,
+                    header->stream_id,
+                    header->session_id,
+                    header->echo_timestamp,
+                    0,
+                    false);
             }
             else
             {
@@ -516,8 +523,10 @@ int aeron_data_packet_dispatcher_elicit_setup_from_source(
         return -1;
     }
 
+    // TODO (MB): Needs to send to single destination
     if (aeron_receive_channel_endpoint_send_sm(
-        endpoint, control_addr, stream_id, session_id, 0, 0, 0, AERON_STATUS_MESSAGE_HEADER_SEND_SETUP_FLAG) < 0)
+        endpoint, destination, control_addr, stream_id, session_id, 0, 0, 0,
+        AERON_STATUS_MESSAGE_HEADER_SEND_SETUP_FLAG) < 0)
     {
         return -1;
     }

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -227,8 +227,10 @@ int aeron_driver_receiver_do_work(void *clientd)
             }
             else if (aeron_receive_channel_endpoint_should_elicit_setup_message(entry->endpoint))
             {
+                // TODO (MB): Check pending entries control_addr is populated correctly...
                 if (aeron_receive_channel_endpoint_send_sm(
                     entry->endpoint,
+                    entry->destination,
                     &entry->control_addr,
                     entry->stream_id,
                     entry->session_id,
@@ -415,6 +417,8 @@ void aeron_driver_receiver_on_add_destination(void *clientd, void *item)
 
     if (destination->conductor_fields.udp_channel->has_explicit_control)
     {
+        printf("Adding destination: %s\n", destination->conductor_fields.udp_channel->original_uri);
+
         if (aeron_receive_channel_endpoint_add_pending_setup_destination(endpoint, receiver, destination) < 0)
         {
             AERON_APPEND_ERR("%s", "on_add_destination, pending_setup");

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -417,8 +417,6 @@ void aeron_driver_receiver_on_add_destination(void *clientd, void *item)
 
     if (destination->conductor_fields.udp_channel->has_explicit_control)
     {
-        printf("Adding destination: %s\n", destination->conductor_fields.udp_channel->original_uri);
-
         if (aeron_receive_channel_endpoint_add_pending_setup_destination(endpoint, receiver, destination) < 0)
         {
             AERON_APPEND_ERR("%s", "on_add_destination, pending_setup");

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -571,6 +571,7 @@ int aeron_publication_image_send_pending_status_message(aeron_publication_image_
                 {
                     int send_sm_result = aeron_receive_channel_endpoint_send_sm(
                         image->endpoint,
+                        connection->destination,
                         connection->control_addr,
                         image->stream_id,
                         image->session_id,
@@ -633,6 +634,7 @@ int aeron_publication_image_send_pending_loss(aeron_publication_image_t *image)
                     {
                         int send_nak_result = aeron_receive_channel_endpoint_send_nak(
                             image->endpoint,
+                            connection->destination,
                             connection->control_addr,
                             image->stream_id,
                             image->session_id,
@@ -685,6 +687,7 @@ int aeron_publication_image_initiate_rttm(aeron_publication_image_t *image, int6
             {
                 int send_rttm_result = aeron_receive_channel_endpoint_send_rttm(
                     image->endpoint,
+                    connection->destination,
                     connection->control_addr,
                     image->stream_id,
                     image->session_id,

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
@@ -95,12 +95,14 @@ int aeron_receive_channel_endpoint_close(aeron_receive_channel_endpoint_t *endpo
 
 int aeron_receive_channel_endpoint_send(
     aeron_receive_channel_endpoint_t *endpoint,
+    aeron_receive_destination_t *destination,
     struct sockaddr_storage *address,
     struct iovec *iov);
 
 int aeron_receive_channel_endpoint_send_sm(
     aeron_receive_channel_endpoint_t *endpoint,
-    struct sockaddr_storage *addr,
+    aeron_receive_destination_t *destination,
+    struct sockaddr_storage *control_addr,
     int32_t stream_id,
     int32_t session_id,
     int32_t term_id,
@@ -110,6 +112,7 @@ int aeron_receive_channel_endpoint_send_sm(
 
 int aeron_receive_channel_endpoint_send_nak(
     aeron_receive_channel_endpoint_t *endpoint,
+    aeron_receive_destination_t *destination,
     struct sockaddr_storage *addr,
     int32_t stream_id,
     int32_t session_id,
@@ -119,6 +122,7 @@ int aeron_receive_channel_endpoint_send_nak(
 
 int aeron_receive_channel_endpoint_send_rttm(
     aeron_receive_channel_endpoint_t *endpoint,
+    aeron_receive_destination_t *destination,
     struct sockaddr_storage *addr,
     int32_t stream_id,
     int32_t session_id,

--- a/aeron-driver/src/test/c/CMakeLists.txt
+++ b/aeron-driver/src/test/c/CMakeLists.txt
@@ -76,6 +76,10 @@ aeron_driver_test(c_system_test aeron_c_system_test.cpp)
 set_tests_properties(c_system_test PROPERTIES TIMEOUT 60)
 set_tests_properties(c_system_test PROPERTIES RUN_SERIAL TRUE)
 
+aeron_driver_test(c_multi_destination_test aeron_c_multi_destination_test.cpp)
+set_tests_properties(c_multi_destination_test PROPERTIES TIMEOUT 60)
+set_tests_properties(c_multi_destination_test PROPERTIES RUN_SERIAL TRUE)
+
 aeron_driver_test(c_local_addresses_test aeron_c_local_addresses_test.cpp)
 set_tests_properties(c_local_addresses_test PROPERTIES TIMEOUT 60)
 set_tests_properties(c_local_addresses_test PROPERTIES RUN_SERIAL TRUE)

--- a/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <functional>
+
+#include <gtest/gtest.h>
+
+#include "aeron_test_base.h"
+
+extern "C"
+{
+#include "concurrent/aeron_atomic.h"
+#include "agent/aeron_driver_agent.h"
+#include "aeron_driver_context.h"
+}
+
+#define PUB_URI_1 "aeron:udp?endpoint=localhost:24324"
+#define PUB_URI_2 "aeron:udp?endpoint=localhost:24325"
+#define MDC_URI "aeron:udp?control=localhost:24326"
+#define MDC_DEST_URI (MDC_URI "|endpoint=localhost:24327")
+#define MDS_URI "aeron:udp?control-mode=manual"
+#define STREAM_ID (117)
+
+class CMultiDestinationTest : public CSystemTestBase, public testing::Test
+{
+protected:
+    CMultiDestinationTest() : CSystemTestBase(
+        std::vector<std::pair<std::string, std::string>>
+            {
+            })
+    {
+    }
+};
+
+//static int64_t set_reserved_value(void *clientd, uint8_t *buffer, size_t frame_length)
+//{
+//    return *(int64_t *)clientd;
+//}
+
+static void mdsParameters(
+    aeron_exclusive_publication_t *pub,
+    std::int32_t *initialTermId,
+    std::int32_t *termId,
+    std::int32_t *termOffset,
+    std::int32_t *sessionId)
+{
+    aeron_publication_constants_t pubConstants = {};
+    aeron_exclusive_publication_constants(pub, &pubConstants);
+
+    int64_t position = aeron_exclusive_publication_position(pub);
+    *initialTermId = pubConstants.initial_term_id;
+    *termId = aeron_logbuffer_compute_term_id_from_position(
+        position, pubConstants.position_bits_to_shift, pubConstants.initial_term_id);
+    *termOffset = (int32_t)(position & (pubConstants.term_buffer_length - 1));
+    *sessionId = pubConstants.session_id;
+}
+
+TEST_F(CMultiDestinationTest, shouldAddTwoPublicationDestinationsForMds)
+{
+    aeron_async_add_subscription_t *async_sub = nullptr;
+
+    ASSERT_TRUE(connect());
+
+    aeron_async_add_exclusive_publication_t *async_pub1 = nullptr;
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&async_pub1, m_aeron, PUB_URI_1, STREAM_ID), 0);
+    aeron_exclusive_publication_t *pub1 = awaitExclusivePublicationOrError(async_pub1);
+    ASSERT_TRUE(pub1) << aeron_errmsg();
+
+    std::int32_t initialTermId;
+    std::int32_t termId;
+    std::int32_t termOffset;
+    std::int32_t sessionId;
+    mdsParameters(pub1, &initialTermId, &termId, &termOffset, &sessionId);
+
+    auto pubUri2 = std::string(PUB_URI_2)
+        .append("|init-term-id=" + std::to_string(initialTermId))
+        .append("|term-id=" + std::to_string(termId))
+        .append("|term-offset=" + std::to_string(termOffset))
+        .append("|session-id=" + std::to_string(sessionId));
+
+    aeron_async_add_exclusive_publication_t *async_pub2 = nullptr;
+    ASSERT_EQ(0, aeron_async_add_exclusive_publication(&async_pub2, m_aeron, pubUri2.c_str(), STREAM_ID));
+    aeron_exclusive_publication_t *pub2 = awaitExclusivePublicationOrError(async_pub2);
+    ASSERT_TRUE(pub2) << aeron_errmsg();
+
+
+    ASSERT_EQ(0, aeron_async_add_subscription(
+        &async_sub, m_aeron, MDS_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr));
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(async_sub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+
+    aeron_async_destination_t *dest1;
+    aeron_subscription_async_add_destination(&dest1, m_aeron, subscription, PUB_URI_1);
+    ASSERT_TRUE(awaitDestinationOrError(dest1)) << aeron_errmsg();
+
+    aeron_async_destination_t *dest2;
+    aeron_subscription_async_add_destination(&dest2, m_aeron, subscription, PUB_URI_2);
+    ASSERT_TRUE(awaitDestinationOrError(dest2)) << aeron_errmsg();
+
+    awaitConnected(subscription);
+
+    sleep(5);
+
+    EXPECT_EQ(aeron_exclusive_publication_close(pub1, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_exclusive_publication_close(pub2, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}
+
+TEST_F(CMultiDestinationTest, shouldAddPublicationAndMdcPublicationForMds)
+{
+    aeron_async_add_subscription_t *async_sub = nullptr;
+
+    ASSERT_TRUE(connect());
+
+    aeron_async_add_exclusive_publication_t *async_pub1 = nullptr;
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&async_pub1, m_aeron, MDC_URI, STREAM_ID), 0);
+    aeron_exclusive_publication_t *pub1 = awaitExclusivePublicationOrError(async_pub1);
+    ASSERT_TRUE(pub1) << aeron_errmsg();
+
+    std::int32_t initialTermId;
+    std::int32_t termId;
+    std::int32_t termOffset;
+    std::int32_t sessionId;
+    mdsParameters(pub1, &initialTermId, &termId, &termOffset, &sessionId);
+
+    auto pubUri2 = std::string(PUB_URI_2)
+        .append("|init-term-id=" + std::to_string(initialTermId))
+        .append("|term-id=" + std::to_string(termId))
+        .append("|term-offset=" + std::to_string(termOffset))
+        .append("|session-id=" + std::to_string(sessionId));
+
+    aeron_async_add_exclusive_publication_t *async_pub2 = nullptr;
+    ASSERT_EQ(0, aeron_async_add_exclusive_publication(&async_pub2, m_aeron, pubUri2.c_str(), STREAM_ID));
+    aeron_exclusive_publication_t *pub2 = awaitExclusivePublicationOrError(async_pub2);
+    ASSERT_TRUE(pub2) << aeron_errmsg();
+
+
+    ASSERT_EQ(0, aeron_async_add_subscription(
+        &async_sub, m_aeron, MDS_URI, STREAM_ID, nullptr, nullptr, nullptr, nullptr));
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(async_sub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+
+    aeron_async_destination_t *dest1;
+    aeron_subscription_async_add_destination(&dest1, m_aeron, subscription, MDC_DEST_URI);
+    ASSERT_TRUE(awaitDestinationOrError(dest1)) << aeron_errmsg();
+
+    aeron_async_destination_t *dest2;
+    aeron_subscription_async_add_destination(&dest2, m_aeron, subscription, PUB_URI_2);
+    ASSERT_TRUE(awaitDestinationOrError(dest2)) << aeron_errmsg();
+
+    awaitConnected(subscription);
+
+    sleep(5);
+
+    EXPECT_EQ(aeron_exclusive_publication_close(pub1, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_exclusive_publication_close(pub2, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}

--- a/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
@@ -112,8 +112,6 @@ TEST_F(CMultiDestinationTest, shouldAddTwoPublicationDestinationsForMds)
 
     awaitConnected(subscription);
 
-    sleep(5);
-
     EXPECT_EQ(aeron_exclusive_publication_close(pub1, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_exclusive_publication_close(pub2, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);

--- a/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
@@ -163,8 +163,6 @@ TEST_F(CMultiDestinationTest, shouldAddPublicationAndMdcPublicationForMds)
 
     awaitConnected(subscription);
 
-    sleep(5);
-
     EXPECT_EQ(aeron_exclusive_publication_close(pub1, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_exclusive_publication_close(pub2, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);

--- a/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
@@ -45,11 +45,6 @@ protected:
     }
 };
 
-//static int64_t set_reserved_value(void *clientd, uint8_t *buffer, size_t frame_length)
-//{
-//    return *(int64_t *)clientd;
-//}
-
 static void mdsParameters(
     aeron_exclusive_publication_t *pub,
     std::int32_t *initialTermId,
@@ -86,10 +81,10 @@ TEST_F(CMultiDestinationTest, shouldAddTwoPublicationDestinationsForMds)
     mdsParameters(pub1, &initialTermId, &termId, &termOffset, &sessionId);
 
     auto pubUri2 = std::string(PUB_URI_2)
-        .append("|init-term-id=" + std::to_string(initialTermId))
-        .append("|term-id=" + std::to_string(termId))
-        .append("|term-offset=" + std::to_string(termOffset))
-        .append("|session-id=" + std::to_string(sessionId));
+        .append("|init-term-id=").append(std::to_string(initialTermId))
+        .append("|term-id=").append(std::to_string(termId))
+        .append("|term-offset=").append(std::to_string(termOffset))
+        .append("|session-id=").append(std::to_string(sessionId));
 
     aeron_async_add_exclusive_publication_t *async_pub2 = nullptr;
     ASSERT_EQ(0, aeron_async_add_exclusive_publication(&async_pub2, m_aeron, pubUri2.c_str(), STREAM_ID));
@@ -135,10 +130,10 @@ TEST_F(CMultiDestinationTest, shouldAddPublicationAndMdcPublicationForMds)
     mdsParameters(pub1, &initialTermId, &termId, &termOffset, &sessionId);
 
     auto pubUri2 = std::string(PUB_URI_2)
-        .append("|init-term-id=" + std::to_string(initialTermId))
-        .append("|term-id=" + std::to_string(termId))
-        .append("|term-offset=" + std::to_string(termOffset))
-        .append("|session-id=" + std::to_string(sessionId));
+        .append("|init-term-id=").append(std::to_string(initialTermId))
+        .append("|term-id=").append(std::to_string(termId))
+        .append("|term-offset=").append(std::to_string(termOffset))
+        .append("|session-id=").append(std::to_string(sessionId));
 
     aeron_async_add_exclusive_publication_t *async_pub2 = nullptr;
     ASSERT_EQ(0, aeron_async_add_exclusive_publication(&async_pub2, m_aeron, pubUri2.c_str(), STREAM_ID));

--- a/aeron-driver/src/test/c/aeron_c_system_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_system_test.cpp
@@ -566,3 +566,27 @@ TEST_P(CSystemTest, shouldAllowImageToGoUnavailableWithPollAfter)
 
     EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
 }
+
+TEST_P(CSystemTest, shouldAddMdsSubscription)
+{
+    aeron_async_add_publication_t *async_pub = nullptr;
+    aeron_async_add_subscription_t *async_sub = nullptr;
+
+    ASSERT_TRUE(connect());
+
+    ASSERT_EQ(aeron_async_add_publication(&async_pub, m_aeron, std::get<0>(GetParam()), STREAM_ID), 0);
+
+    aeron_publication_t *publication = awaitPublicationOrError(async_pub);
+    ASSERT_TRUE(publication) << aeron_errmsg();
+
+    ASSERT_EQ(aeron_async_add_subscription(
+        &async_sub, m_aeron, std::get<0>(GetParam()), STREAM_ID, nullptr, nullptr, nullptr, nullptr), 0);
+
+    aeron_subscription_t *subscription = awaitSubscriptionOrError(async_sub);
+    ASSERT_TRUE(subscription) << aeron_errmsg();
+
+    awaitConnected(subscription);
+
+    EXPECT_EQ(aeron_publication_close(publication, nullptr, nullptr), 0);
+    EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}

--- a/aeron-driver/src/test/c/aeron_publication_image_test.cpp
+++ b/aeron-driver/src/test/c/aeron_publication_image_test.cpp
@@ -138,18 +138,20 @@ TEST_F(PublicationImageTest, shouldSendControlMessagesToAllDestinations)
     ASSERT_EQ(AERON_PUBLICATION_IMAGE_STATE_ACTIVE, image->conductor_fields.state);
     image->congestion_control->should_measure_rtt = always_measure_rtt;
 
-    auto *test_bindings_state = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
+    auto *bindings_state_dest1 = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
+    auto *bindings_state_dest2 = static_cast<aeron_test_udp_bindings_state_t *>(dest_2->transport.bindings_clientd);
 
     aeron_publication_image_schedule_status_message(image, 0, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, 1000000000);
-    ASSERT_EQ(1, test_bindings_state->sm_count);
+    ASSERT_EQ(1, bindings_state_dest1->sm_count);
+    ASSERT_EQ(0, bindings_state_dest2->sm_count);
 
     aeron_publication_image_on_gap_detected(image, 0, 0, 1);
     aeron_publication_image_send_pending_loss(image);
-    ASSERT_EQ(1, test_bindings_state->nak_count);
+    ASSERT_EQ(1, bindings_state_dest1->nak_count);
 
     aeron_publication_image_initiate_rttm(image, 1000000000);
-    ASSERT_EQ(1, test_bindings_state->rttm_count);
+    ASSERT_EQ(1, bindings_state_dest1->rttm_count);
 
     message->stream_id = stream_id;
     message->session_id = session_id;
@@ -161,16 +163,18 @@ TEST_F(PublicationImageTest, shouldSendControlMessagesToAllDestinations)
 
     aeron_publication_image_schedule_status_message(image, 1, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, 2000000000);
-    ASSERT_EQ(3, test_bindings_state->sm_count);
+    ASSERT_EQ(2, bindings_state_dest1->sm_count);
+    ASSERT_EQ(1, bindings_state_dest2->sm_count);
     ASSERT_EQ(3, aeron_counter_get(image->status_messages_sent_counter));
 
     aeron_publication_image_on_gap_detected(image, 0, 0, 1);
     aeron_publication_image_send_pending_loss(image);
-    ASSERT_EQ(3, test_bindings_state->nak_count);
+    ASSERT_EQ(2, bindings_state_dest1->nak_count);
+    ASSERT_EQ(1, bindings_state_dest2->nak_count);
     ASSERT_EQ(3, aeron_counter_get(image->nak_messages_sent_counter));
 
     aeron_publication_image_initiate_rttm(image, 2000000000);
-    ASSERT_EQ(3, test_bindings_state->rttm_count);
+    ASSERT_EQ(2, bindings_state_dest1->rttm_count);
 }
 
 TEST_F(PublicationImageTest, shouldHandleEosAcrossDestinations)
@@ -272,7 +276,7 @@ TEST_F(PublicationImageTest, shouldNotSendControlMessagesToAllDestinationThatHav
     ASSERT_EQ(AERON_PUBLICATION_IMAGE_STATE_ACTIVE, image->conductor_fields.state);
     image->congestion_control->should_measure_rtt = always_measure_rtt;
 
-    auto *test_bindings_state = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
+    auto *bindings_state_dest1 = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
 
     size_t message_length = 64;
 
@@ -294,14 +298,14 @@ TEST_F(PublicationImageTest, shouldNotSendControlMessagesToAllDestinationThatHav
 
     aeron_publication_image_schedule_status_message(image, 1, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, t1_ns);
-    EXPECT_EQ(1, test_bindings_state->sm_count);
+    EXPECT_EQ(0, bindings_state_dest1->sm_count);
 
     aeron_publication_image_on_gap_detected(image, 0, 0, 1);
     aeron_publication_image_send_pending_loss(image);
-    EXPECT_EQ(1, test_bindings_state->nak_count);
+    EXPECT_EQ(0, bindings_state_dest1->nak_count);
 
     aeron_publication_image_initiate_rttm(image, t1_ns);
-    EXPECT_EQ(1, test_bindings_state->rttm_count);
+    EXPECT_EQ(0, bindings_state_dest1->rttm_count);
 }
 
 TEST_F(PublicationImageTest, shouldTrackActiveTransportAccountBasedOnFrames)
@@ -424,11 +428,12 @@ TEST_F(PublicationImageTest, shouldTrackUnderRunningTransportsWithLastSmAndRecei
     ASSERT_EQ(AERON_PUBLICATION_IMAGE_STATE_ACTIVE, image->conductor_fields.state);
     image->congestion_control->should_measure_rtt = always_measure_rtt;
 
-    auto *test_bindings_state = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
+    auto *bindings_state_dest1 = static_cast<aeron_test_udp_bindings_state_t *>(dest_1->transport.bindings_clientd);
+    auto *bindings_state_dest2 = static_cast<aeron_test_udp_bindings_state_t *>(dest_2->transport.bindings_clientd);
 
     aeron_publication_image_schedule_status_message(image, 0, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, t0_ns);
-    ASSERT_EQ(1, test_bindings_state->sm_count);
+    ASSERT_EQ(1, bindings_state_dest1->sm_count);
 
     aeron_clock_update_cached_nano_time(m_context->receiver_cached_clock, t1_ns);
 
@@ -443,12 +448,13 @@ TEST_F(PublicationImageTest, shouldTrackUnderRunningTransportsWithLastSmAndRecei
     aeron_publication_image_schedule_status_message(image, message_length, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, t1_ns);
 
-    ASSERT_EQ(2, test_bindings_state->sm_count);
+    ASSERT_EQ(1, bindings_state_dest1->sm_count);
 
     aeron_publication_image_insert_packet(image, dest_1, 0, 0, data, message_length, &addr);
 
     aeron_publication_image_schedule_status_message(image, message_length, TERM_BUFFER_SIZE);
     aeron_publication_image_send_pending_status_message(image, t1_ns);
 
-    ASSERT_EQ(4, test_bindings_state->sm_count);
+    ASSERT_EQ(2, bindings_state_dest1->sm_count);
+    ASSERT_EQ(2, bindings_state_dest2->sm_count);
 }

--- a/aeron-driver/src/test/c/aeron_test_udp_bindings.h
+++ b/aeron-driver/src/test/c/aeron_test_udp_bindings.h
@@ -75,55 +75,6 @@ int aeron_test_udp_channel_transport_recvmmsg(
     return 0;
 }
 
-int aeron_test_udp_channel_transport_sendmmsg(
-    aeron_udp_channel_data_paths_t *data_paths,
-    aeron_udp_channel_transport_t *transport,
-    struct mmsghdr *msgvec,
-    size_t vlen)
-{
-    aeron_test_udp_bindings_state_t *state = (aeron_test_udp_bindings_state_t *)transport->bindings_clientd;
-    state->mmsg_count++;
-    return 0;
-}
-
-int aeron_test_udp_channel_transport_sendmsg(
-    aeron_udp_channel_data_paths_t *data_paths,
-    aeron_udp_channel_transport_t *transport,
-    struct msghdr *message)
-{
-    aeron_test_udp_bindings_state_t *state = (aeron_test_udp_bindings_state_t *)transport->bindings_clientd;
-    state->msg_count++;
-
-    aeron_frame_header_t *header = (aeron_frame_header_t *)message->msg_iov->iov_base;
-
-    switch (header->type)
-    {
-        case AERON_HDR_TYPE_SETUP:
-            state->setup_count++;
-            break;
-
-        case AERON_HDR_TYPE_SM:
-            state->sm_count++;
-            break;
-
-        case AERON_HDR_TYPE_NAK:
-            state->nak_count++;
-            break;
-
-        case AERON_HDR_TYPE_RTTM:
-            state->rttm_count++;
-            break;
-
-        case AERON_HDR_TYPE_DATA:
-            state->heartbeat_count++;
-
-        default:
-            break;
-    }
-
-    return 0;
-}
-
 int aeron_test_udp_channel_transport_send(
     aeron_udp_channel_data_paths_t *data_paths,
     aeron_udp_channel_transport_t *transport,


### PR DESCRIPTION
Looping is already covered at a higher point in the call stack (generally by connection per image).  Use specific sends for setup eliciting SM so that only the correct destination is targeted.