### PR TITLE
Reduce sharing on image endpoint

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.h
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.h
@@ -719,22 +719,6 @@ inline aeron_network_publication_t *aeron_driver_conductor_find_network_publicat
     return NULL;
 }
 
-inline aeron_publication_image_t * aeron_driver_conductor_find_publication_image(
-    aeron_driver_conductor_t *conductor, aeron_receive_channel_endpoint_t *endpoint, int32_t stream_id)
-{
-    for (size_t i = 0, length = conductor->publication_images.length; i < length; i++)
-    {
-        aeron_publication_image_t *image = conductor->publication_images.array[i].image;
-
-        if (endpoint == image->endpoint && stream_id == image->stream_id)
-        {
-            return image;
-        }
-    }
-
-    return NULL;
-}
-
 inline void aeron_driver_init_subscription_channel(size_t uri_length, const char *uri, aeron_subscription_link_t *link)
 {
     size_t copy_length = sizeof(link->channel) - 1;

--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -480,12 +480,13 @@ void aeron_driver_receiver_on_add_publication_image(void *clientd, void *item)
 {
     aeron_driver_receiver_t *receiver = (aeron_driver_receiver_t *)clientd;
     aeron_command_publication_image_t *cmd = (aeron_command_publication_image_t *)item;
-    aeron_receive_channel_endpoint_t *endpoint = (aeron_receive_channel_endpoint_t *)cmd->endpoint;
+    aeron_publication_image_t *image = cmd->image;
 
     int ensure_capacity_result = 0;
     AERON_ARRAY_ENSURE_CAPACITY(ensure_capacity_result, receiver->images, aeron_driver_receiver_image_entry_t)
 
-    if (ensure_capacity_result < 0 || aeron_receive_channel_endpoint_on_add_publication_image(endpoint, cmd->image) < 0)
+    if (ensure_capacity_result < 0 ||
+        aeron_receive_channel_endpoint_on_add_publication_image(image->endpoint, image) < 0)
     {
         AERON_APPEND_ERR("%s", "receiver on_add_publication_image");
         aeron_driver_receiver_log_error(receiver);
@@ -500,10 +501,10 @@ void aeron_driver_receiver_on_remove_publication_image(void *clientd, void *item
 {
     aeron_driver_receiver_t *receiver = (aeron_driver_receiver_t *)clientd;
     aeron_command_publication_image_t *cmd = (aeron_command_publication_image_t *)item;
-    aeron_receive_channel_endpoint_t *endpoint = (aeron_receive_channel_endpoint_t *)cmd->endpoint;
     aeron_publication_image_t *image = (aeron_publication_image_t *)cmd->image;
 
-    if (NULL != endpoint && aeron_receive_channel_endpoint_on_remove_publication_image(endpoint, image) < 0)
+    if (NULL != image->endpoint &&
+        aeron_receive_channel_endpoint_on_remove_publication_image(image->endpoint, image) < 0)
     {
         AERON_APPEND_ERR("%s", "receiver on_remove_publication_image");
         aeron_driver_receiver_log_error(receiver);

--- a/aeron-driver/src/main/c/aeron_driver_receiver_proxy.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver_proxy.c
@@ -334,7 +334,6 @@ void aeron_driver_receiver_proxy_on_add_publication_image(
         aeron_command_publication_image_t cmd =
             {
                 .base = { .func = aeron_driver_receiver_on_add_publication_image, .item = NULL },
-                .endpoint = endpoint,
                 .image = image
             };
 
@@ -352,7 +351,6 @@ void aeron_driver_receiver_proxy_on_add_publication_image(
 
         cmd->base.func = aeron_driver_receiver_on_add_publication_image;
         cmd->base.item = NULL;
-        cmd->endpoint = endpoint;
         cmd->image = image;
 
         aeron_driver_receiver_proxy_offer(receiver_proxy, cmd);
@@ -361,7 +359,6 @@ void aeron_driver_receiver_proxy_on_add_publication_image(
 
 void aeron_driver_receiver_proxy_on_remove_publication_image(
     aeron_driver_receiver_proxy_t *receiver_proxy,
-    aeron_receive_channel_endpoint_t *endpoint,
     aeron_publication_image_t *image)
 {
     if (AERON_THREADING_MODE_IS_SHARED_OR_INVOKER(receiver_proxy->threading_mode))
@@ -369,7 +366,6 @@ void aeron_driver_receiver_proxy_on_remove_publication_image(
         aeron_command_publication_image_t cmd =
             {
                 .base = { .func = aeron_driver_receiver_on_remove_publication_image, .item = NULL },
-                .endpoint = endpoint,
                 .image = image
             };
 
@@ -387,7 +383,6 @@ void aeron_driver_receiver_proxy_on_remove_publication_image(
 
         cmd->base.func = aeron_driver_receiver_on_remove_publication_image;
         cmd->base.item = NULL;
-        cmd->endpoint = endpoint;
         cmd->image = image;
 
         aeron_driver_receiver_proxy_offer(receiver_proxy, cmd);

--- a/aeron-driver/src/main/c/aeron_driver_receiver_proxy.h
+++ b/aeron-driver/src/main/c/aeron_driver_receiver_proxy.h
@@ -103,7 +103,6 @@ void aeron_driver_receiver_proxy_on_remove_destination(
 typedef struct aeron_command_publication_image_stct
 {
     aeron_command_base_t base;
-    void *endpoint;
     void *image;
 }
 aeron_command_publication_image_t;
@@ -123,7 +122,6 @@ void aeron_driver_receiver_proxy_on_add_publication_image(
     aeron_publication_image_t *image);
 void aeron_driver_receiver_proxy_on_remove_publication_image(
     aeron_driver_receiver_proxy_t *receiver_proxy,
-    aeron_receive_channel_endpoint_t *endpoint,
     aeron_publication_image_t *image);
 void aeron_driver_receiver_proxy_on_remove_cool_down(
     aeron_driver_receiver_proxy_t *receiver_proxy,

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -56,6 +56,7 @@ typedef struct aeron_publication_image_stct
         int64_t time_of_last_state_change_ns;
         int64_t liveness_timeout_ns;
         int64_t clean_position;
+        aeron_receive_channel_endpoint_t *endpoint;
     }
     conductor_fields;
 
@@ -275,6 +276,11 @@ inline bool aeron_publication_image_is_accepting_subscriptions(aeron_publication
 inline void aeron_publication_image_disconnect_endpoint(aeron_publication_image_t *image)
 {
     image->endpoint = NULL;
+}
+
+inline void aeron_publication_image_conductor_disconnect_endpoint(aeron_publication_image_t *image)
+{
+    image->conductor_fields.endpoint = NULL;
 }
 
 inline const char *aeron_publication_image_log_file_name(aeron_publication_image_t *image)

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.c
@@ -944,7 +944,7 @@ int aeron_receive_channel_endpoint_add_pending_setup(
 {
     for (size_t i = 0, len = endpoint->destinations.length; i < len; i++)
     {
-        aeron_receive_destination_t *destination = endpoint->destinations.array[0].destination;
+        aeron_receive_destination_t *destination = endpoint->destinations.array[i].destination;
         if (aeron_receive_channel_endpoint_add_pending_setup_destination(endpoint, receiver, destination) < 0)
         {
             AERON_APPEND_ERR("%s", "");

--- a/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
+++ b/aeron-driver/src/test/c/aeron_driver_conductor_network_test.cpp
@@ -26,6 +26,22 @@ using testing::AnyNumber;
 
 class DriverConductorNetworkTest : public DriverConductorTest, public testing::Test
 {
+protected:
+    aeron_publication_image_t *aeron_driver_conductor_find_publication_image(
+        aeron_driver_conductor_t *conductor, aeron_receive_channel_endpoint_t *endpoint, int32_t stream_id)
+    {
+        for (size_t i = 0, length = conductor->publication_images.length; i < length; i++)
+        {
+            aeron_publication_image_t *image = conductor->publication_images.array[i].image;
+
+            if (endpoint == image->endpoint && stream_id == image->stream_id)
+            {
+                return image;
+            }
+        }
+
+        return NULL;
+    }
 };
 
 TEST_F(DriverConductorNetworkTest, shouldBeAbleToAddMultipleNetworkSubscriptionsWithDifferentChannelSameStreamId)


### PR DESCRIPTION
- Fix bug where 0 was used instead of index when iterating over destinations.
- Move method into tests that was only used by tests.
- Include two pointers on image for the endpoint, one to be used by the receiver the other to be used by the conductor.