### PR TITLE
Prevent timeout warnings with dynamic nodes and log replication

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -77,7 +77,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
     private long serviceAckId = 0;
     private long terminationPosition = NULL_POSITION;
     private long notifiedCommitPosition = 0;
-    private long lastAppendPosition = 0;
+    private long lastAppendPosition = NULL_POSITION;
     private long timeOfLastLogUpdateNs = 0;
     private long timeOfLastAppendPositionUpdateNs = 0;
     private long timeOfLastAppendPositionSendNs = 0;
@@ -300,6 +300,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
             election = new Election(
                 true,
                 recoveryPlan.lastLeadershipTermId,
+                recoveryPlan.lastTermBaseLogPosition,
                 commitPosition.getWeak(),
                 recoveryPlan.appendedLogPosition,
                 activeMembers,
@@ -1744,9 +1745,12 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
 
         dynamicJoin = null;
 
+        assert recoveryPlan.lastLeadershipTermId == leadershipTermId;
+
         election = new Election(
             false,
             leadershipTermId,
+            recoveryPlan.lastTermBaseLogPosition,
             commitPosition.getWeak(),
             recoveryPlan.appendedLogPosition,
             activeMembers,
@@ -2951,9 +2955,14 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
 
         role(Cluster.Role.FOLLOWER);
 
+        final RecordingLog.Entry termEntry = recordingLog.findTermEntry(leadershipTermId);
+        final long termBaseLogPosition = null != termEntry ?
+            termEntry.termBaseLogPosition : recoveryPlan.lastTermBaseLogPosition;
+
         election = new Election(
             false,
             leadershipTermId,
+            termBaseLogPosition,
             commitPosition.getWeak(),
             null != appendPosition ? appendPosition.get() : recoveryPlan.appendedLogPosition,
             activeMembers,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3317,11 +3317,30 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
         {
             final RecordingLog.Snapshot lastSnapshot = dynamicJoinSnapshots.get(dynamicJoinSnapshots.size() - 1);
 
-            recordingLog.appendTerm(
-                logRecordingId,
-                lastSnapshot.leadershipTermId,
-                lastSnapshot.termBaseLogPosition,
-                lastSnapshot.timestamp);
+            final RecordingLog.Entry termEntry = recordingLog.findTermEntry(lastSnapshot.leadershipTermId);
+
+            if (null == termEntry)
+            {
+                recordingLog.appendTerm(
+                    logRecordingId,
+                    lastSnapshot.leadershipTermId,
+                    lastSnapshot.termBaseLogPosition,
+                    lastSnapshot.timestamp);
+            }
+            else
+            {
+                if (termEntry.recordingId != logRecordingId ||
+                    termEntry.termBaseLogPosition != lastSnapshot.termBaseLogPosition)
+                {
+                    throw new ClusterException(
+                        "Unexpected termEntry found leadershipTermId=" + termEntry.leadershipTermId +
+                        " recordingId=" + termEntry.recordingId +
+                        " termBaseLogPosition=" + termEntry.termBaseLogPosition +
+                        " expected leadershipTermId=" + lastSnapshot.leadershipTermId +
+                        " recordingId=" + logRecordingId +
+                        " termBaseLogPosition=" + lastSnapshot.termBaseLogPosition);
+                }
+            }
 
             for (int i = dynamicJoinSnapshots.size() - 1; i >= 0; i--)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2833,6 +2833,14 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler
                 consensusPublisher.commitPosition(member.publication(), leadershipTermId, commitPosition, memberId);
             }
         }
+
+        for (final ClusterMember member : passiveMembers)
+        {
+            if (member.id() != memberId && member.hasRequestedJoin())
+            {
+                consensusPublisher.commitPosition(member.publication(), leadershipTermId, commitPosition, memberId);
+            }
+        }
     }
 
     LogReplication newLogReplication(

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -1328,6 +1328,31 @@ class Election
         final long nowNs)
     {
         final long recordingId = consensusModuleAgent.logRecordingId();
+        final long initialTermBaseLogPosition = this.initialTermBaseLogPosition;
+        final long initialLogLeadershipTermId = this.initialLogLeadershipTermId;
+        final ConsensusModule.Context ctx = this.ctx;
+
+        ensureRecordingLogCoherent(
+            ctx,
+            recordingId,
+            initialLogLeadershipTermId,
+            initialTermBaseLogPosition,
+            leadershipTermId,
+            logTermBasePosition,
+            logPosition,
+            nowNs);
+    }
+
+    static void ensureRecordingLogCoherent(
+        final ConsensusModule.Context ctx,
+        final long recordingId,
+        final long initialLogLeadershipTermId,
+        final long initialTermBaseLogPosition,
+        final long leadershipTermId,
+        final long logTermBasePosition,
+        final long logPosition,
+        final long nowNs)
+    {
         if (NULL_VALUE == recordingId)
         {
             if (0 == logPosition)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -50,6 +50,8 @@ import static java.lang.Math.max;
 class Election
 {
     private final boolean isNodeStartup;
+    private final long initialLogLeadershipTermId;
+    private final long initialTermBaseLogPosition;
     private boolean isFirstInit = true;
     private boolean isLeaderStartup;
     private boolean isExtendedCanvass;
@@ -88,6 +90,7 @@ class Election
     Election(
         final boolean isNodeStartup,
         final long leadershipTermId,
+        final long termBaseLogPosition,
         final long logPosition,
         final long appendPosition,
         final ClusterMember[] clusterMembers,
@@ -102,6 +105,8 @@ class Election
         this.logPosition = logPosition;
         this.appendPosition = appendPosition;
         this.logLeadershipTermId = leadershipTermId;
+        this.initialLogLeadershipTermId = leadershipTermId;
+        this.initialTermBaseLogPosition = termBaseLogPosition;
         this.leadershipTermId = leadershipTermId;
         this.candidateTermId = leadershipTermId;
         this.clusterMembers = clusterMembers;
@@ -464,9 +469,8 @@ class Election
                             ", nextTermBaseLogPosition = " + nextTermBaseLogPosition +
                             ", nextLogPosition = " + nextLogPosition + ", leadershipTermId = " + leadershipTermId +
                             ", termBaseLogPosition = " + termBaseLogPosition + ", logPosition = " + logPosition +
-                            ", leaderRecordingId = " + leaderRecordingId + ", timestamp = " + timestamp +
-                            ", leaderMemberId = " + leaderMemberId + ", logSessionId = " + logSessionId +
-                            ", isStartup = " + isStartup);
+                            ", leaderRecordingId = " + leaderRecordingId + ", leaderMemberId = " + leaderMemberId +
+                            ", logSessionId = " + logSessionId + ", isStartup = " + isStartup);
                     }
                 }
                 else
@@ -590,7 +594,7 @@ class Election
             isFirstInit = false;
             if (!isNodeStartup)
             {
-                appendPosition = consensusModuleAgent.prepareForNewLeadership(logPosition, nowNs);
+                prepareForNewLeadership(nowNs);
             }
         }
         else
@@ -598,7 +602,7 @@ class Election
             cleanupLogReplication();
             resetCatchup();
 
-            appendPosition = consensusModuleAgent.prepareForNewLeadership(logPosition, nowNs);
+            prepareForNewLeadership(nowNs);
             logSessionId = NULL_SESSION_ID;
             cleanupReplay();
             CloseHelper.close(logSubscription);
@@ -617,6 +621,15 @@ class Election
         }
 
         return 1;
+    }
+
+    private void prepareForNewLeadership(final long nowNs)
+    {
+        final long lastAppendPosition = consensusModuleAgent.prepareForNewLeadership(logPosition, nowNs);
+        if (NULL_POSITION != lastAppendPosition)
+        {
+            appendPosition = lastAppendPosition;
+        }
     }
 
     private int canvass(final long nowNs)
@@ -1330,13 +1343,13 @@ class Election
         RecordingLog.Entry lastTerm = recordingLog.findLastTerm();
         if (null == lastTerm)
         {
-            for (long termId = 0; termId < leadershipTermId; termId++)
+            for (long termId = initialLogLeadershipTermId; termId < leadershipTermId; termId++)
             {
-                recordingLog.appendTerm(recordingId, termId, 0, timestamp);
-                recordingLog.commitLogPosition(termId, 0);
+                recordingLog.appendTerm(recordingId, termId, initialTermBaseLogPosition, timestamp);
+                recordingLog.commitLogPosition(termId, initialTermBaseLogPosition);
             }
 
-            recordingLog.appendTerm(recordingId, leadershipTermId, 0, timestamp);
+            recordingLog.appendTerm(recordingId, leadershipTermId, initialTermBaseLogPosition, timestamp);
             if (NULL_VALUE != logPosition)
             {
                 recordingLog.commitLogPosition(leadershipTermId, logPosition);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -80,8 +80,6 @@ class Election
     private final ConsensusModule.Context ctx;
     private final ConsensusModuleAgent consensusModuleAgent;
     private LogReplication logReplication = null;
-    private long replicationCommitPosition = 0;
-    private long replicationDeadlineNs = 0;
     private long replicationTermBaseLogPosition;
     private long lastPublishedCommitPosition;
 
@@ -479,11 +477,6 @@ class Election
                 state(CANVASS, ctx.clusterClock().timeNanos());
             }
         }
-
-        if (state == FOLLOWER_LOG_REPLICATION && leaderMemberId == this.leaderMember.id())
-        {
-            replicationDeadlineNs = ctx.clusterClock().timeNanos() + ctx.leaderHeartbeatTimeoutNs();
-        }
     }
 
     void onAppendPosition(
@@ -526,11 +519,10 @@ class Election
         {
             catchupCommitPosition = max(catchupCommitPosition, logPosition);
         }
-        else if (FOLLOWER_LOG_REPLICATION == state && leaderMemberId == leaderMember.id())
-        {
-            replicationCommitPosition = max(replicationCommitPosition, logPosition);
-            replicationDeadlineNs = ctx.clusterClock().timeNanos() + ctx.leaderHeartbeatTimeoutNs();
-        }
+//        else if (FOLLOWER_LOG_REPLICATION == state && leaderMemberId == leaderMember.id())
+//        {
+//            // No-op
+//        }
         else if (leadershipTermId > this.leadershipTermId && LEADER_READY == state)
         {
             throw new ClusterEvent("new leader detected due to commit position");
@@ -840,7 +832,6 @@ class Election
             {
                 logReplication = consensusModuleAgent.newLogReplication(
                     leaderMember.archiveEndpoint(), leaderRecordingId, replicationStopPosition, nowNs);
-                replicationDeadlineNs = nowNs + ctx.leaderHeartbeatTimeoutNs();
                 workCount++;
             }
             else
@@ -860,19 +851,12 @@ class Election
 
             if (replicationDone)
             {
-                if (replicationCommitPosition >= appendPosition)
-                {
-                    appendPosition = logReplication.position();
-                    cleanupLogReplication();
-                    updateRecordingLogForReplication(
-                        replicationLeadershipTermId, replicationTermBaseLogPosition, replicationStopPosition, nowNs);
-                    state(CANVASS, nowNs);
-                    workCount++;
-                }
-                else if (nowNs >= replicationDeadlineNs)
-                {
-                    throw new TimeoutException("timeout awaiting commit position", AeronException.Category.WARN);
-                }
+                appendPosition = logReplication.position();
+                cleanupLogReplication();
+                updateRecordingLogForReplication(
+                    replicationLeadershipTermId, replicationTermBaseLogPosition, replicationStopPosition, nowNs);
+                state(CANVASS, nowNs);
+                workCount++;
             }
         }
 
@@ -1298,8 +1282,6 @@ class Election
             logReplication.close();
             logReplication = null;
         }
-        replicationCommitPosition = 0;
-        replicationDeadlineNs = 0;
         lastPublishedCommitPosition = 0;
     }
 
@@ -1421,6 +1403,7 @@ class Election
         return (nowNs - previousTimestampForIntervalNs) >= intervalNs;
     }
 
+    @SuppressWarnings("unused")
     private void logStateChange(
         final ElectionState oldState,
         final ElectionState newState,

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -18,6 +18,7 @@ package io.aeron.cluster;
 import io.aeron.*;
 import io.aeron.cluster.service.Cluster;
 import io.aeron.cluster.service.ClusterMarkFile;
+import io.aeron.exceptions.TimeoutException;
 import io.aeron.test.cluster.TestClusterClock;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.MutableLong;
@@ -36,6 +37,7 @@ import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
 import static io.aeron.cluster.ConsensusModuleAgent.APPEND_POSITION_FLAG_NONE;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class ElectionTest
@@ -751,7 +753,93 @@ public class ElectionTest
 
         verify(electionStateCounter, times(2)).setOrdered(ElectionState.CANVASS.code());
         followerElection.doWork(clock.nanoTime());
+
+        verify(consensusPublisher).appendPosition(
+            liveLeader.publication(), term2Id, term2BaseLogPosition, thisMember.id(), APPEND_POSITION_FLAG_NONE);
+        verify(electionStateCounter, times(2)).setOrdered(ElectionState.CANVASS.code());
+
+        followerElection.onCommitPosition(term2Id, term2BaseLogPosition, leaderId);
+        followerElection.doWork(++t1);
         verify(electionStateCounter, times(3)).setOrdered(ElectionState.CANVASS.code());
+    }
+
+    @Test
+    void followerShouldTimeoutLeaderIfReplicateLogPositionIsNotCommittedByLeader()
+    {
+        final long term1Id = 1;
+        final long term2Id = 2;
+        final long term1BaseLogPosition = 60;
+        final long term2BaseLogPosition = 120;
+        final long localRecordingId = 2390485;
+        final ClusterMember[] clusterMembers = prepareClusterMembers();
+        final ClusterMember thisMember = clusterMembers[1];
+        final ClusterMember liveLeader = clusterMembers[0];
+        final int leaderId = liveLeader.id();
+        final LogReplication logReplication = mock(LogReplication.class);
+
+        when(consensusModuleAgent.role()).thenReturn(Cluster.Role.FOLLOWER);
+        when(consensusModuleAgent.prepareForNewLeadership(anyLong(), anyLong())).thenReturn(term1BaseLogPosition);
+
+        final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap = new Int2ObjectHashMap<>();
+        ClusterMember.addClusterMemberIds(clusterMembers, clusterMemberByIdMap);
+
+        final Election election = new Election(
+            true,
+            term1Id,
+            term1BaseLogPosition,
+            term1BaseLogPosition,
+            clusterMembers,
+            clusterMemberByIdMap,
+            thisMember,
+            consensusPublisher,
+            ctx,
+            consensusModuleAgent);
+
+        election.doWork(clock.increment(1));
+        verify(electionStateCounter).setOrdered(ElectionState.CANVASS.code());
+
+        election.onRequestVote(term1Id, term2BaseLogPosition, term2Id, leaderId);
+        verify(electionStateCounter).setOrdered(ElectionState.FOLLOWER_BALLOT.code());
+
+        election.onNewLeadershipTerm(
+            term1Id,
+            term2Id,
+            term2BaseLogPosition,
+            term2BaseLogPosition,
+            term2Id,
+            term2BaseLogPosition,
+            term2BaseLogPosition,
+            RECORDING_ID,
+            clock.nanoTime(),
+            leaderId,
+            0,
+            true);
+
+        verify(electionStateCounter).setOrdered(ElectionState.FOLLOWER_LOG_REPLICATION.code());
+
+        when(consensusModuleAgent.newLogReplication(any(), anyLong(), anyLong(), anyLong())).thenReturn(logReplication);
+        election.doWork(clock.increment(1));
+
+        verify(consensusModuleAgent, times(1)).newLogReplication(
+            liveLeader.archiveEndpoint(), RECORDING_ID, term2BaseLogPosition, clock.nanoTime());
+
+        when(logReplication.isDone(anyLong())).thenReturn(true);
+        when(logReplication.position()).thenReturn(term2BaseLogPosition);
+        when(logReplication.recordingId()).thenReturn(localRecordingId);
+        when(consensusPublisher.appendPosition(
+            liveLeader.publication(), term1Id, term2BaseLogPosition, thisMember.id(), APPEND_POSITION_FLAG_NONE))
+            .thenReturn(true);
+        clock.increment(ctx.leaderHeartbeatIntervalNs());
+        election.doWork(clock.nanoTime());
+
+        verify(consensusModuleAgent, atLeastOnce()).pollArchiveEvents();
+        verify(consensusPublisher).appendPosition(
+            liveLeader.publication(), term2Id, term2BaseLogPosition, thisMember.id(), APPEND_POSITION_FLAG_NONE);
+        verify(electionStateCounter, never()).setOrdered(ElectionState.FOLLOWER_REPLAY.code());
+        reset(countedErrorHandler);
+
+        clock.increment(ctx.leaderHeartbeatTimeoutNs());
+        assertThrows(TimeoutException.class, () -> election.doWork(clock.nanoTime()));
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -367,7 +367,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @InterruptAfter(40)
+    @InterruptAfter(60)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithLogReplicationAndCatchup()
     {
         final int messageCount = 10;
@@ -408,7 +408,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @InterruptAfter(30)
+    @InterruptAfter(60)
     public void shouldDynamicallyJoinClusterOfThreeWithSnapshotWithDynamicLeader(final TestInfo testInfo)
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(3).start();
@@ -627,7 +627,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @InterruptAfter(40)
+    @InterruptAfter(60)
     public void shouldDynamicallyJoinMemberAfterSnapshotOnNonZeroTermAndSubsequentLeadershipTerms()
     {
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -367,7 +367,7 @@ public class DynamicMembershipTest
     }
 
     @Test
-    @InterruptAfter(30)
+    @InterruptAfter(40)
     public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithLogReplicationAndCatchup()
     {
         final int messageCount = 10;

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.List;
+
 import static io.aeron.cluster.service.Cluster.Role.FOLLOWER;
 import static io.aeron.test.cluster.TestCluster.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -362,5 +364,132 @@ public class DynamicMembershipTest
 
         awaitElectionClosed(staticMember);
         cluster.awaitServiceMessageCount(cluster.node(3), messageCount);
+    }
+
+    @Test
+    @InterruptAfter(30)
+    public void shouldDynamicallyJoinClusterOfThreeNoSnapshotsWithLogReplicationAndCatchup()
+    {
+        final int messageCount = 10;
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
+        systemTestWatcher.cluster(cluster);
+        systemTestWatcher.showAllErrors();
+        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("expected termination"));
+        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("leader heartbeat timeout"));
+
+        final TestNode leader0 = cluster.awaitLeader();
+
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
+        cluster.takeSnapshot(leader0);
+        cluster.awaitSnapshotCount(1);
+
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader();
+        cluster.startStaticNode(leader0.index(), false);
+        TestCluster.awaitElectionClosed(cluster.node(leader0.index()));
+
+        cluster.reconnectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(2 * messageCount);
+        cluster.awaitServicesMessageCount(2 * messageCount);
+
+        cluster.stopNode(leader1);
+        final TestNode leader2 = cluster.awaitLeader();
+        cluster.startStaticNode(leader1.index(), false);
+        TestCluster.awaitElectionClosed(cluster.node(leader1.index()));
+
+        cluster.reconnectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(3 * messageCount);
+        cluster.awaitServicesMessageCount(3 * messageCount);
+
+        final TestNode dynamicMember = cluster.startDynamicNode(3, true);
+        cluster.awaitServiceMessageCount(dynamicMember, 3 * messageCount);
+    }
+
+    @Test
+    @InterruptAfter(30)
+    public void shouldDynamicallyJoinClusterOfThreeWithSnapshotWithDynamicLeader(final TestInfo testInfo)
+    {
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(3).start();
+        systemTestWatcher.cluster(cluster);
+        systemTestWatcher.showAllErrors();
+        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("expected termination"));
+
+        final TestNode staticLeader = cluster.awaitLeader();
+        final List<TestNode> staticFollowers = cluster.followers();
+        final TestNode staticFollowerA = staticFollowers.get(0);
+        final TestNode staticFollowerB = staticFollowers.get(1);
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.takeSnapshot(staticLeader);
+        cluster.awaitSnapshotCount(1);
+
+        staticFollowerA.isTerminationExpected(true);
+        staticLeader.removeMember(staticFollowerA.index(), false);
+
+        cluster.awaitNodeTermination(staticFollowerA);
+        cluster.stopNode(staticFollowerA);
+
+        awaitMembershipSize(staticLeader, 2);
+
+        final TestNode dynamicMemberA = cluster.startDynamicNode(3, true);
+
+        awaitElectionClosed(dynamicMemberA);
+        assertEquals(FOLLOWER, dynamicMemberA.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberA);
+        assertEquals(messageCount, dynamicMemberA.service().messageCount());
+
+        awaitMembershipSize(staticLeader, 3);
+
+        staticFollowerB.isTerminationExpected(true);
+        staticLeader.removeMember(staticFollowerB.index(), false);
+
+        cluster.awaitNodeTermination(staticFollowerB);
+        cluster.stopNode(staticFollowerB);
+
+        awaitMembershipSize(staticLeader, 2);
+
+        final TestNode dynamicMemberB = cluster.startDynamicNode(4, true);
+
+        awaitElectionClosed(dynamicMemberB);
+        assertEquals(FOLLOWER, dynamicMemberB.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberB);
+        assertEquals(messageCount, dynamicMemberB.service().messageCount());
+
+        awaitMembershipSize(staticLeader, 3);
+
+        final int initialLeaderIndex = staticLeader.index();
+        staticLeader.isTerminationExpected(true);
+        staticLeader.removeMember(initialLeaderIndex, false);
+
+        cluster.awaitNodeTermination(staticLeader);
+        cluster.stopNode(staticLeader);
+
+        final TestNode newLeader = cluster.awaitLeader(initialLeaderIndex);
+
+        awaitMembershipSize(newLeader, 2);
+
+        final TestNode dynamicMemberC = cluster.startDynamicNodeConsensusEndpoints(5, true);
+
+        awaitElectionClosed(dynamicMemberC);
+        assertEquals(FOLLOWER, dynamicMemberC.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberC);
+        assertEquals(messageCount, dynamicMemberC.service().messageCount());
+
+        awaitMembershipSize(newLeader, 3);
+
+        awaitElectionClosed(dynamicMemberC);
+        assertEquals(FOLLOWER, dynamicMemberC.role());
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/DynamicMembershipTest.java
@@ -373,9 +373,6 @@ public class DynamicMembershipTest
         final int messageCount = 10;
         cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
         systemTestWatcher.cluster(cluster);
-        systemTestWatcher.showAllErrors();
-        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("expected termination"));
-        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("leader heartbeat timeout"));
 
         final TestNode leader0 = cluster.awaitLeader();
 
@@ -491,5 +488,196 @@ public class DynamicMembershipTest
 
         awaitElectionClosed(dynamicMemberC);
         assertEquals(FOLLOWER, dynamicMemberC.role());
+    }
+
+    @Test
+    @InterruptAfter(10)
+    public void shouldDynamicallyJoinMemberAfterRecyclingAllStaticNodes(final TestInfo testInfo)
+    {
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(4).start();
+        systemTestWatcher.cluster(cluster);
+        systemTestWatcher.showAllErrors();
+        systemTestWatcher.ignoreErrorsMatching((s) -> s.contains("expected termination"));
+
+        final TestNode staticLeader = cluster.awaitLeader();
+        final List<TestNode> staticFollowers = cluster.followers();
+        final TestNode staticFollowerA = staticFollowers.get(0);
+        final TestNode staticFollowerB = staticFollowers.get(1);
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+
+        cluster.takeSnapshot(staticLeader);
+        cluster.awaitSnapshotCount(1);
+
+        staticFollowerA.isTerminationExpected(true);
+        staticLeader.removeMember(staticFollowerA.index(), false);
+
+        cluster.awaitNodeTermination(staticFollowerA);
+        cluster.stopNode(staticFollowerA);
+
+        awaitMembershipSize(staticLeader, 2);
+
+        final TestNode dynamicMemberA = cluster.startDynamicNode(3, true);
+
+        awaitElectionClosed(dynamicMemberA);
+        assertEquals(FOLLOWER, dynamicMemberA.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberA);
+        assertEquals(messageCount, dynamicMemberA.service().messageCount());
+
+        awaitMembershipSize(staticLeader, 3);
+
+        staticFollowerB.isTerminationExpected(true);
+        staticLeader.removeMember(staticFollowerB.index(), false);
+
+        cluster.awaitNodeTermination(staticFollowerB);
+        cluster.stopNode(staticFollowerB);
+
+        awaitMembershipSize(staticLeader, 2);
+
+        final TestNode dynamicMemberB = cluster.startDynamicNode(4, true);
+
+        awaitElectionClosed(dynamicMemberB);
+        assertEquals(FOLLOWER, dynamicMemberB.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberB);
+        assertEquals(messageCount, dynamicMemberB.service().messageCount());
+
+        awaitMembershipSize(staticLeader, 3);
+
+        final int initialLeaderIndex = staticLeader.index();
+        staticLeader.isTerminationExpected(true);
+        staticLeader.removeMember(initialLeaderIndex, false);
+
+        cluster.awaitNodeTermination(staticLeader);
+        cluster.stopNode(staticLeader);
+
+        final TestNode newLeader = cluster.awaitLeader(initialLeaderIndex);
+
+        awaitMembershipSize(newLeader, 2);
+
+        final TestNode dynamicMemberC = cluster.startDynamicNodeConsensusEndpoints(5, true);
+
+        awaitElectionClosed(dynamicMemberC);
+        assertEquals(FOLLOWER, dynamicMemberC.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMemberC);
+        assertEquals(messageCount, dynamicMemberC.service().messageCount());
+
+        awaitMembershipSize(newLeader, 3);
+
+        final long snapshotCount = cluster.getSnapshotCount(newLeader);
+        cluster.takeSnapshot(newLeader);
+        cluster.awaitSnapshotCount(snapshotCount + 1);
+
+        final List<TestNode> dynamicFollowers = cluster.followers();
+        final TestNode dynamicFollowerA = dynamicFollowers.get(0);
+
+        dynamicFollowerA.isTerminationExpected(true);
+        newLeader.removeMember(dynamicFollowerA.index(), false);
+        cluster.awaitNodeTermination(dynamicFollowerA);
+        cluster.stopNode(dynamicFollowerA);
+
+        awaitMembershipSize(newLeader, 2);
+
+        final TestNode dynamicMemberD = cluster.startDynamicNodeConsensusEndpoints(6, true);
+
+        awaitElectionClosed(dynamicMemberD);
+        assertEquals(FOLLOWER, dynamicMemberD.role());
+        cluster.awaitSnapshotLoadedForService(dynamicMemberD);
+        assertEquals(messageCount, dynamicMemberD.service().messageCount());
+        awaitMembershipSize(newLeader, 3);
+    }
+
+    @Test
+    @InterruptAfter(30)
+    public void shouldDynamicallyJoinMemberAfterSnapshotOnNonZeroTerm(final TestInfo testInfo)
+    {
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader0 = cluster.awaitLeader();
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
+
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader();
+        leader1.removeMember(leader0.index(), false);
+
+        awaitMembershipSize(leader1, 2);
+
+        cluster.takeSnapshot(leader1);
+        cluster.awaitSnapshotCount(1);
+
+        final TestNode dynamicMember0 = cluster.startDynamicNode(3, true);
+        awaitElectionClosed(dynamicMember0);
+        assertEquals(FOLLOWER, dynamicMember0.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMember0);
+        assertEquals(messageCount, dynamicMember0.service().messageCount());
+
+        awaitMembershipSize(leader1, 3);
+    }
+
+    @Test
+    @InterruptAfter(40)
+    public void shouldDynamicallyJoinMemberAfterSnapshotOnNonZeroTermAndSubsequentLeadershipTerms()
+    {
+        cluster = aCluster().withStaticNodes(3).withDynamicNodes(1).start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader0 = cluster.awaitLeader();
+
+        final int messageCount = 10;
+        cluster.connectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(messageCount);
+        cluster.awaitServicesMessageCount(messageCount);
+
+        cluster.stopNode(leader0);
+        final TestNode leader1 = cluster.awaitLeader();
+        cluster.startStaticNode(leader0.index(), false);
+        TestCluster.awaitElectionClosed(leader0);
+
+        cluster.takeSnapshot(leader1);
+        cluster.awaitSnapshotCount(1);
+
+        cluster.reconnectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(2 * messageCount);
+        cluster.awaitServicesMessageCount(2 * messageCount);
+
+        cluster.stopNode(leader1);
+        final TestNode leader2 = cluster.awaitLeader();
+        cluster.startStaticNode(leader1.index(), false);
+        TestCluster.awaitElectionClosed(leader1);
+
+        cluster.reconnectClient();
+        cluster.sendMessages(messageCount);
+        cluster.awaitResponseMessageCount(3 * messageCount);
+        cluster.awaitServicesMessageCount(3 * messageCount);
+
+        final TestNode follower = cluster.followers().get(0);
+        follower.isTerminationExpected(true);
+        leader2.removeMember(follower.index(), false);
+        cluster.awaitNodeTermination(follower);
+        cluster.stopNode(follower);
+
+        awaitMembershipSize(leader2, 2);
+
+        final TestNode dynamicMember0 = cluster.startDynamicNode(3, true);
+        awaitElectionClosed(dynamicMember0);
+        assertEquals(FOLLOWER, dynamicMember0.role());
+
+        cluster.awaitSnapshotLoadedForService(dynamicMember0);
+        cluster.awaitServiceMessageCount(dynamicMember0, 3 * messageCount);
+        awaitMembershipSize(leader2, 3);
     }
 }


### PR DESCRIPTION
Remove replicationCommitPosition which was used to verify a leader had committed a position equal or higher than the log replicated position. This is not required as replication should only proceed to the end of previous term which will already be committed. It allows dynamic nodes to work more cleanly with log replication as they don't receive commit position messages until after catch up and they have offically joined the cluster.