### PR TITLE
[C] Align ring buffer implementations with Java.

### DIFF
--- a/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
@@ -29,7 +29,7 @@ int aeron_mpsc_rb_init(aeron_mpsc_rb_t *ring_buffer, void *buffer, size_t length
         ring_buffer->buffer = buffer;
         ring_buffer->capacity = capacity;
         ring_buffer->descriptor = (aeron_rb_descriptor_t *)(ring_buffer->buffer + ring_buffer->capacity);
-        ring_buffer->max_message_length = AERON_RB_MAX_MESSAGE_LENGTH(ring_buffer->capacity);
+        ring_buffer->max_message_length = AERON_RB_MAX_MESSAGE_LENGTH(ring_buffer->capacity, AERON_MPSC_RB_MIN_CAPACITY);
         result = 0;
     }
     else

--- a/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.c
@@ -24,7 +24,7 @@ int aeron_mpsc_rb_init(aeron_mpsc_rb_t *ring_buffer, void *buffer, size_t length
     const size_t capacity = length - AERON_RB_TRAILER_LENGTH;
     int result = -1;
 
-    if (AERON_RB_IS_CAPACITY_VALID(capacity))
+    if (AERON_RB_IS_CAPACITY_VALID(capacity, AERON_MPSC_RB_MIN_CAPACITY))
     {
         ring_buffer->buffer = buffer;
         ring_buffer->capacity = capacity;

--- a/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_mpsc_rb.h
@@ -19,6 +19,8 @@
 
 #include "concurrent/aeron_rb.h"
 
+#define AERON_MPSC_RB_MIN_CAPACITY (AERON_RB_RECORD_HEADER_LENGTH)
+
 typedef struct aeron_mpsc_rb_stct
 {
     uint8_t *buffer;

--- a/aeron-client/src/main/c/concurrent/aeron_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_rb.h
@@ -54,7 +54,7 @@ aeron_rb_record_descriptor_t;
 #define AERON_RB_MESSAGE_OFFSET(index) ((index) + sizeof(aeron_rb_record_descriptor_t))
 #define AERON_RB_RECORD_HEADER_LENGTH (sizeof(aeron_rb_record_descriptor_t))
 
-#define AERON_RB_MAX_MESSAGE_LENGTH(capacity) ((capacity) / 8)
+#define AERON_RB_MAX_MESSAGE_LENGTH(capacity, min_capacity) (capacity) == (min_capacity) ? 0 : ((capacity) / 8)
 #define AERON_RB_INVALID_MSG_TYPE_ID(id) ((id) < 1)
 #define AERON_RB_PADDING_MSG_TYPE_ID (-1)
 

--- a/aeron-client/src/main/c/concurrent/aeron_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_rb.h
@@ -51,11 +51,11 @@ aeron_rb_record_descriptor_t;
 
 #define AERON_RB_ALIGNMENT (2 * sizeof(int32_t))
 
-#define AERON_RB_MESSAGE_OFFSET(index) (index + sizeof(aeron_rb_record_descriptor_t))
+#define AERON_RB_MESSAGE_OFFSET(index) ((index) + sizeof(aeron_rb_record_descriptor_t))
 #define AERON_RB_RECORD_HEADER_LENGTH (sizeof(aeron_rb_record_descriptor_t))
 
-#define AERON_RB_MAX_MESSAGE_LENGTH(capacity) (capacity / 8)
-#define AERON_RB_INVALID_MSG_TYPE_ID(id) (id < 1)
+#define AERON_RB_MAX_MESSAGE_LENGTH(capacity) ((capacity) / 8)
+#define AERON_RB_INVALID_MSG_TYPE_ID(id) ((id) < 1)
 #define AERON_RB_PADDING_MSG_TYPE_ID (-1)
 
 typedef enum aeron_rb_write_result_stct
@@ -68,6 +68,6 @@ aeron_rb_write_result_t;
 
 typedef void (*aeron_rb_handler_t)(int32_t, const void *, size_t, void *);
 
-#define AERON_RB_IS_CAPACITY_VALID(capacity) AERON_IS_POWER_OF_TWO(capacity)
+#define AERON_RB_IS_CAPACITY_VALID(capacity, min_capacity) AERON_IS_POWER_OF_TWO(capacity) && (capacity) >= (min_capacity)
 
 #endif //AERON_RB_H

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
@@ -24,12 +24,12 @@ int aeron_spsc_rb_init(aeron_spsc_rb_t *ring_buffer, void *buffer, size_t length
     const size_t capacity = length - AERON_RB_TRAILER_LENGTH;
     int result = -1;
 
-    if (AERON_RB_IS_CAPACITY_VALID(capacity, ARON_SPSC_RB_MIN_CAPACITY))
+    if (AERON_RB_IS_CAPACITY_VALID(capacity, AERON_SPSC_RB_MIN_CAPACITY))
     {
         ring_buffer->buffer = buffer;
         ring_buffer->capacity = capacity;
         ring_buffer->descriptor = (aeron_rb_descriptor_t *)(ring_buffer->buffer + ring_buffer->capacity);
-        ring_buffer->max_message_length = AERON_RB_MAX_MESSAGE_LENGTH(ring_buffer->capacity);
+        ring_buffer->max_message_length = AERON_RB_MAX_MESSAGE_LENGTH(ring_buffer->capacity, AERON_SPSC_RB_MIN_CAPACITY);
         result = 0;
     }
     else

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_rb.c
@@ -14,20 +14,27 @@
  * limitations under the License.
  */
 
+#include <errno.h>
+#include <inttypes.h>
 #include "aeron_spsc_rb.h"
+#include "util/aeron_error.h"
 
 int aeron_spsc_rb_init(aeron_spsc_rb_t *ring_buffer, void *buffer, size_t length)
 {
     const size_t capacity = length - AERON_RB_TRAILER_LENGTH;
     int result = -1;
 
-    if (AERON_RB_IS_CAPACITY_VALID(capacity))
+    if (AERON_RB_IS_CAPACITY_VALID(capacity, ARON_SPSC_RB_MIN_CAPACITY))
     {
         ring_buffer->buffer = buffer;
         ring_buffer->capacity = capacity;
         ring_buffer->descriptor = (aeron_rb_descriptor_t *)(ring_buffer->buffer + ring_buffer->capacity);
         ring_buffer->max_message_length = AERON_RB_MAX_MESSAGE_LENGTH(ring_buffer->capacity);
         result = 0;
+    }
+    else
+    {
+        AERON_SET_ERR(EINVAL, "Invalid capacity: %" PRIu64, (uint64_t)capacity);
     }
 
     return result;

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_rb.h
@@ -29,7 +29,7 @@ struct iovec
 };
 #endif
 
-#define ARON_SPSC_RB_MIN_CAPACITY (2 * AERON_RB_RECORD_HEADER_LENGTH)
+#define AERON_SPSC_RB_MIN_CAPACITY (2 * AERON_RB_RECORD_HEADER_LENGTH)
 
 typedef struct aeron_spsc_rb_stct
 {

--- a/aeron-client/src/main/c/concurrent/aeron_spsc_rb.h
+++ b/aeron-client/src/main/c/concurrent/aeron_spsc_rb.h
@@ -29,6 +29,8 @@ struct iovec
 };
 #endif
 
+#define ARON_SPSC_RB_MIN_CAPACITY (2 * AERON_RB_RECORD_HEADER_LENGTH)
+
 typedef struct aeron_spsc_rb_stct
 {
     uint8_t *buffer;

--- a/aeron-client/src/test/c/concurrent/aeron_mpsc_rb_test.cpp
+++ b/aeron-client/src/test/c/concurrent/aeron_mpsc_rb_test.cpp
@@ -87,6 +87,15 @@ TEST_F(MpscRbTest, shouldErrorWhenMaxMessageSizeExceeded)
     EXPECT_EQ(aeron_mpsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), rb.max_message_length + 1), AERON_RB_ERROR);
 }
 
+TEST_F(MpscRbTest, shouldErrorWhenMinCapacityIsUsedAndMessageSizeIsNotZero)
+{
+    aeron_mpsc_rb_t rb;
+    ASSERT_EQ(aeron_mpsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + AERON_MPSC_RB_MIN_CAPACITY), 0);
+
+    EXPECT_EQ(0, rb.max_message_length);
+    EXPECT_EQ(aeron_mpsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), 1), AERON_RB_ERROR);
+}
+
 TEST_F(MpscRbTest, shouldErrorWhenMessageTypeIsNegative)
 {
     aeron_mpsc_rb_t rb;

--- a/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
+++ b/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
@@ -72,10 +72,10 @@ TEST_F(SpscRbTest, shouldErrorForCapacityLessThanTheMinCapacity)
     const size_t capacity = (AERON_SPSC_RB_MIN_CAPACITY / 2);
 
     ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + capacity), -1);
-    ASSERT_EQ(EINVAL, aeron_errcode());
+    ASSERT_EQ(aeron_errcode(), EINVAL);
     const std::string expected_err_msg = "Invalid capacity: " + std::to_string(capacity);
     const std::string actual_err_msg = std::string(aeron_errmsg());
-    ASSERT_NE(std::string::npos, actual_err_msg.find(expected_err_msg));
+    ASSERT_NE(actual_err_msg.find(expected_err_msg), std::string::npos);
 }
 
 TEST_F(SpscRbTest, shouldErrorWhenMaxMessageSizeExceeded)
@@ -91,8 +91,23 @@ TEST_F(SpscRbTest, shouldErrorWhenMinCapacityIsUsedAndMessageSizeIsNotZero)
     aeron_spsc_rb_t rb;
     ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + AERON_SPSC_RB_MIN_CAPACITY), 0);
 
-    EXPECT_EQ(0, rb.max_message_length);
+    EXPECT_EQ(rb.max_message_length, 0);
     EXPECT_EQ(aeron_spsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), 1), AERON_RB_ERROR);
+}
+
+TEST_F(SpscRbTest, shouldWriteAnEmptyMessageWhenMinCapacityIsUsed)
+{
+    aeron_spsc_rb_t rb;
+    ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + AERON_SPSC_RB_MIN_CAPACITY), 0);
+
+    EXPECT_EQ(0, rb.max_message_length);
+    EXPECT_EQ(aeron_spsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), 0), AERON_RB_SUCCESS);
+
+    auto *record = (aeron_rb_record_descriptor_t *)(m_buffer.data());
+
+    EXPECT_EQ(record->length, (int32_t)AERON_RB_RECORD_HEADER_LENGTH);
+    EXPECT_EQ(record->msg_type_id, (int32_t)MSG_TYPE_ID);
+    EXPECT_EQ(rb.descriptor->tail_position, (int64_t)(AERON_RB_ALIGNMENT));
 }
 
 TEST_F(SpscRbTest, shouldErrorWhenMessageTypeIsNegative)

--- a/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
+++ b/aeron-client/src/test/c/concurrent/aeron_spsc_rb_test.cpp
@@ -69,7 +69,7 @@ TEST_F(SpscRbTest, shouldErrorForCapacityNotPowerOfTwo)
 TEST_F(SpscRbTest, shouldErrorForCapacityLessThanTheMinCapacity)
 {
     aeron_spsc_rb_t rb;
-    const size_t capacity = (ARON_SPSC_RB_MIN_CAPACITY / 2);
+    const size_t capacity = (AERON_SPSC_RB_MIN_CAPACITY / 2);
 
     ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + capacity), -1);
     ASSERT_EQ(EINVAL, aeron_errcode());
@@ -84,6 +84,15 @@ TEST_F(SpscRbTest, shouldErrorWhenMaxMessageSizeExceeded)
     ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), m_buffer.size()), 0);
 
     EXPECT_EQ(aeron_spsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), rb.max_message_length + 1), AERON_RB_ERROR);
+}
+
+TEST_F(SpscRbTest, shouldErrorWhenMinCapacityIsUsedAndMessageSizeIsNotZero)
+{
+    aeron_spsc_rb_t rb;
+    ASSERT_EQ(aeron_spsc_rb_init(&rb, m_buffer.data(), AERON_RB_TRAILER_LENGTH + AERON_SPSC_RB_MIN_CAPACITY), 0);
+
+    EXPECT_EQ(0, rb.max_message_length);
+    EXPECT_EQ(aeron_spsc_rb_write(&rb, MSG_TYPE_ID, m_srcBuffer.data(), 1), AERON_RB_ERROR);
 }
 
 TEST_F(SpscRbTest, shouldErrorWhenMessageTypeIsNegative)


### PR DESCRIPTION
This PR updates the C implementations of the one to one and one to many ring buffers and aligns them with the Java:
- Add a notion of minimum capacity which for mspc is one record header and for spsc is two record headers as it does pre-zeroing.
- Change capacity validation and calculation of the maxMessageLength.
- Allow fitting a message at the end of the buffer for spsc without padding.