### PR TITLE
egress open message should be published before container messages

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2258,8 +2258,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
 
                 if (ConsensusModule.State.ACTIVE == state)
                 {
-                    workCount += processPendingSessions(pendingSessions, nowNs);
                     workCount += checkSessions(sessions, nowNs);
+                    workCount += processPendingSessions(pendingSessions, nowNs);
                     workCount += processPassiveMembers(passiveMembers);
 
                     if (!ClusterMember.hasActiveQuorum(activeMembers, nowNs, leaderHeartbeatTimeoutNs))

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2459,12 +2459,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                         {
                             // this has to be sent to client before then to service
                             workCount += sendSessionOpenEvent(session);
-                        }
-                        if (!session.hasOpenEventPending() && appendSessionAndOpen(session, nowNs))
-                        {
                             ArrayListUtil.fastUnorderedRemove(pendingSessions, i, lastIndex--);
                             addSession(session);
-                            workCount += 1;
                         }
                         break;
                     }
@@ -2658,6 +2654,14 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                     sessionByIdMap.remove(session.id());
                     session.close(aeron, ctx.countedErrorHandler());
                     workCount++;
+                }
+            }
+            else if (session.state() == AUTHENTICATED)
+            {
+                // session blocks in this state for messages: onIngressMessage
+                if (appendSessionAndOpen(session, nowNs))
+                {
+                    workCount += 1;
                 }
             }
             else if (session.hasNewLeaderEventPending())

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2457,10 +2457,12 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                     {
                         if (session.hasOpenEventPending())
                         {
-                            // this has to be sent to client before then to service
-                            workCount += sendSessionOpenEvent(session);
-                            ArrayListUtil.fastUnorderedRemove(pendingSessions, i, lastIndex--);
-                            addSession(session);
+                            if (sendSessionOpenEvent(session))
+                            {
+                                workCount += 1;
+                                ArrayListUtil.fastUnorderedRemove(pendingSessions, i, lastIndex--);
+                                addSession(session);
+                            }
                         }
                         break;
                     }
@@ -2713,15 +2715,15 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         return 0;
     }
 
-    private int sendSessionOpenEvent(final ClusterSession session)
+    private boolean sendSessionOpenEvent(final ClusterSession session)
     {
         if (egressPublisher.sendEvent(session, leadershipTermId, memberId, EventCode.OK, ""))
         {
             session.clearOpenEventPending();
-            return 1;
+            return true;
         }
 
-        return 0;
+        return false;
     }
 
     private boolean appendSessionAndOpen(final ClusterSession session, final long nowNs)


### PR DESCRIPTION
Right now it is possible first message on session open is sent to cluster, then it is responded within service, and only then cluster sends egress event message. In this case the message sent from service is lost, because AeronCluster will poll everything before the egress event.