### PR TITLE
Handle backup queries from cluster followers only

### DIFF
--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -274,6 +274,11 @@ public final class AeronCounters
      */
     public static final int CLUSTER_STANDBY_HEARTBEAT_RESPONSE_COUNT_TYPE_ID = 222;
 
+    /**
+     * Standby control toggle type id
+     */
+    public static final int CLUSTER_STANDBY_CONTROL_TOGGLE_TYPE_ID = 223;
+
     private AeronCounters()
     {
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -86,6 +86,7 @@ public final class ClusterBackupAgent implements Agent
     private final long coolDownIntervalMs;
     private final long unavailableCounterHandlerRegistrationId;
     private final PublicationGroup<ExclusivePublication> consensusPublicationGroup;
+    private final LogSourceValidator logSourceValidator;
 
     private ClusterBackup.State state = BACKUP_QUERY;
 
@@ -149,6 +150,7 @@ public final class ClusterBackupAgent implements Agent
         stateCounter = ctx.stateCounter();
         liveLogPositionCounter = ctx.liveLogPositionCounter();
         nextQueryDeadlineMsCounter = ctx.nextQueryDeadlineMsCounter();
+        logSourceValidator = new LogSourceValidator(ctx.sourceType());
     }
 
     /**
@@ -437,7 +439,7 @@ public final class ClusterBackupAgent implements Agent
         final int memberId,
         final BackupResponseDecoder backupResponseDecoder)
     {
-        if (NULL_VALUE != leaderMemberId && leaderMemberId == memberId)
+        if (!logSourceValidator.isAcceptable(leaderMemberId, memberId))
         {
             consensusPublicationGroup.closeAndExcludeCurrent();
             state(RESET_BACKUP, epochClock.time());

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
@@ -339,7 +339,7 @@ class ConsensusAdapter implements FragmentHandler, AutoCloseable
                 final byte[] credentials = new byte[challengeResponseDecoder.encodedCredentialsLength()];
                 challengeResponseDecoder.getEncodedCredentials(credentials, 0, credentials.length);
 
-                consensusModuleAgent.onChallengeResponse(
+                consensusModuleAgent.onConsensusChallengeResponse(
                     challengeResponseDecoder.correlationId(),
                     challengeResponseDecoder.clusterSessionId(),
                     credentials);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusPublisher.java
@@ -627,6 +627,7 @@ final class ConsensusPublisher
         final ClusterSession session,
         final int commitPositionCounterId,
         final int leaderMemberId,
+        final int memberId,
         final RecordingLog.Entry lastEntry,
         final RecordingLog.RecoveryPlan recoveryPlan,
         final String clusterMembers)
@@ -639,7 +640,8 @@ final class ConsensusPublisher
             .lastLeadershipTermId(lastEntry.leadershipTermId)
             .lastTermBaseLogPosition(lastEntry.termBaseLogPosition)
             .commitPositionCounterId(commitPositionCounterId)
-            .leaderMemberId(leaderMemberId);
+            .leaderMemberId(leaderMemberId)
+            .memberId(memberId);
 
         final BackupResponseEncoder.SnapshotsEncoder snapshotsEncoder =
             backupResponseEncoder.snapshotsCount(recoveryPlan.snapshots.size());

--- a/aeron-cluster/src/main/java/io/aeron/cluster/IngressAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/IngressAdapter.java
@@ -160,7 +160,7 @@ class IngressAdapter implements ControlledFragmentHandler, AutoCloseable
                 final byte[] credentials = new byte[challengeResponseDecoder.encodedCredentialsLength()];
                 challengeResponseDecoder.getEncodedCredentials(credentials, 0, credentials.length);
 
-                consensusModuleAgent.onChallengeResponse(
+                consensusModuleAgent.onIngressChallengeResponse(
                     challengeResponseDecoder.correlationId(),
                     challengeResponseDecoder.clusterSessionId(),
                     credentials);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogSourceValidator.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogSourceValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import static io.aeron.Aeron.NULL_VALUE;
+
+class LogSourceValidator
+{
+    private final ClusterBackup.SourceType sourceType;
+
+    LogSourceValidator(final ClusterBackup.SourceType sourceType)
+    {
+        this.sourceType = sourceType;
+    }
+
+    boolean isAcceptable(final long leaderMemberId, final long memberId)
+    {
+        switch (sourceType)
+        {
+            case LEADER:
+                return NULL_VALUE != leaderMemberId && leaderMemberId == memberId;
+            case FOLLOWER:
+                return NULL_VALUE == leaderMemberId || leaderMemberId != memberId;
+            case ANY:
+                return true;
+        }
+
+        throw new IllegalStateException("Unknown sourceType=" + sourceType);
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/PublicationGroup.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/PublicationGroup.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.ChannelUri;
+import io.aeron.Publication;
+import org.agrona.CloseHelper;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
+
+class PublicationGroup<P extends Publication> implements AutoCloseable
+{
+    private final String[] endpoints;
+    private final String channelTemplate;
+    private final int streamId;
+    private final PublicationFactory<P> publicationFactory;
+    private int cursor = 0;
+    private int excludedPublicationCursorValue = -1;
+    private P current;
+
+    PublicationGroup(
+        final String[] endpoints,
+        final String channelTemplate,
+        final int streamId,
+        final PublicationFactory<P> publicationFactory)
+    {
+
+        this.endpoints = endpoints;
+        this.channelTemplate = channelTemplate;
+        this.streamId = streamId;
+        this.publicationFactory = publicationFactory;
+    }
+
+
+    P next(final Aeron aeron)
+    {
+        final int cursor = nextCursor();
+        final String endpoint = endpoints[cursor];
+
+        final ChannelUri channelUri = ChannelUri.parse(channelTemplate);
+        channelUri.put(ENDPOINT_PARAM_NAME, endpoint);
+        final String channel = channelUri.toString();
+
+        CloseHelper.quietClose(current);
+        current = publicationFactory.addPublication(aeron, channel, streamId);
+        return current;
+    }
+
+    private int nextCursor()
+    {
+        do
+        {
+            ++cursor;
+            if (endpoints.length <= cursor)
+            {
+                cursor = 0;
+            }
+        }
+        while (cursor == excludedPublicationCursorValue);
+
+        return cursor;
+    }
+
+    P current()
+    {
+        return current;
+    }
+
+    void clearExclusion()
+    {
+        excludedPublicationCursorValue = -1;
+    }
+
+    void closeAndExcludeCurrent()
+    {
+        excludedPublicationCursorValue = cursor;
+        CloseHelper.quietClose(current);
+    }
+
+    void shuffle()
+    {
+        close();
+        clearExclusion();
+        final Random random = ThreadLocalRandom.current();
+        for (int i = endpoints.length; --i > -1;)
+        {
+            final int j = random.nextInt(i + 1);
+            final String tmp = endpoints[i];
+            endpoints[i] = endpoints[j];
+            endpoints[j] = tmp;
+        }
+    }
+
+    public void close()
+    {
+        CloseHelper.quietClose(current);
+    }
+
+    interface PublicationFactory<P>
+    {
+        P addPublication(Aeron aeron, String channel, int streamId);
+    }
+
+    public String toString()
+    {
+        return "PublicationGroup{" +
+            "endpoints=" + Arrays.toString(endpoints) +
+            ", channelTemplate='" + channelTemplate + '\'' +
+            ", streamId=" + streamId +
+            ", publicationFactory=" + publicationFactory +
+            ", cursor=" + cursor +
+            ", excludedPublicationCursorValue=" + excludedPublicationCursorValue +
+            ", current=" + current +
+            '}';
+    }
+}

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="io.aeron.cluster.codecs"
                    id="111"
-                   version="9"
+                   version="10"
                    semanticVersion="5.3"
                    description="Message Codecs for communicating with, and within, an Aeron Cluster."
                    byteOrder="littleEndian">
@@ -593,6 +593,8 @@
         <field name="lastTermBaseLogPosition"  id="6"  type="int64"/>
         <field name="commitPositionCounterId"  id="7"  type="int32"/>
         <field name="leaderMemberId"           id="8"  type="int32"/>
+        <field name="memberId"                 id="17" type="int32" sinceVersion="10"
+               description="id of member providing the response."/>
         <group name="snapshots"                id="9"  dimensionType="groupSizeEncoding"
                description="Snapshots of state for the consensus module and services.">
             <field name="recordingId"          id="10" type="int64"/>

--- a/aeron-cluster/src/test/java/io/aeron/cluster/LogSourceValidatorTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/LogSourceValidatorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogSourceValidatorTest
+{
+    @Test
+    void leaderLogSourceTypeShouldOnlyAcceptLeader()
+    {
+        final LogSourceValidator logSourceValidator = new LogSourceValidator(ClusterBackup.SourceType.LEADER);
+
+        final long leaderMemberId = 123;
+        final long followerMemberId = 456;
+
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, leaderMemberId));
+        assertFalse(logSourceValidator.isAcceptable(leaderMemberId, followerMemberId));
+        assertFalse(logSourceValidator.isAcceptable(NULL_VALUE, NULL_VALUE));
+        assertFalse(logSourceValidator.isAcceptable(leaderMemberId, NULL_VALUE));
+        assertFalse(logSourceValidator.isAcceptable(NULL_VALUE, followerMemberId));
+    }
+
+    @Test
+    void followerLogSourceTypeShouldOnlyAcceptFollowerAndUnknown()
+    {
+        final LogSourceValidator logSourceValidator = new LogSourceValidator(ClusterBackup.SourceType.FOLLOWER);
+
+        final long leaderMemberId = 123;
+        final long followerMemberId = 456;
+
+        assertFalse(logSourceValidator.isAcceptable(leaderMemberId, leaderMemberId));
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, followerMemberId));
+        assertTrue(logSourceValidator.isAcceptable(NULL_VALUE, NULL_VALUE));
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, NULL_VALUE));
+        assertTrue(logSourceValidator.isAcceptable(NULL_VALUE, followerMemberId));
+    }
+
+
+    @Test
+    void anyLogSourceTypeShouldAny()
+    {
+        final LogSourceValidator logSourceValidator = new LogSourceValidator(ClusterBackup.SourceType.ANY);
+
+        final long leaderMemberId = 123;
+        final long followerMemberId = 456;
+
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, leaderMemberId));
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, followerMemberId));
+        assertTrue(logSourceValidator.isAcceptable(NULL_VALUE, NULL_VALUE));
+        assertTrue(logSourceValidator.isAcceptable(leaderMemberId, NULL_VALUE));
+        assertTrue(logSourceValidator.isAcceptable(NULL_VALUE, followerMemberId));
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.cluster;
 
 import io.aeron.Aeron;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
@@ -1,0 +1,135 @@
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.ExclusivePublication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PublicationGroupTest
+
+
+{
+    private final String channelTemplate = "aeron:udp?term-length=64k";
+    private final int streamId = 10000;
+    private final String[] endpoints = { "localhost:1001", "localhost:1002", "localhost:1003" };
+    private final PublicationGroup<ExclusivePublication> publicationGroup = new PublicationGroup<>(
+        endpoints, channelTemplate, streamId, Aeron::addExclusivePublication);
+    private final Aeron mockAeron = mock(Aeron.class);
+    private final List<ExclusivePublication> publications = Arrays.asList(
+        mock(ExclusivePublication.class, "pub_localhost:1001"),
+        mock(ExclusivePublication.class, "pub_localhost:1002"),
+        mock(ExclusivePublication.class, "pub_localhost:1003"));
+
+    @BeforeEach
+    void setUp()
+    {
+        when(mockAeron.addExclusivePublication(matches(".*localhost:1001.*"), anyInt()))
+            .thenReturn(publications.get(0));
+        when(mockAeron.addExclusivePublication(matches(".*localhost:1002.*"), anyInt()))
+            .thenReturn(publications.get(1));
+        when(mockAeron.addExclusivePublication(matches(".*localhost:1003.*"), anyInt()))
+            .thenReturn(publications.get(2));
+    }
+
+    @Test
+    void shouldUseAllPublicationsInListWhenGettingNextPublication()
+    {
+        publicationGroup.next(mockAeron);
+        publicationGroup.next(mockAeron);
+        publicationGroup.next(mockAeron);
+
+        verify(mockAeron).addExclusivePublication("aeron:udp?endpoint=localhost:1001|term-length=64k", streamId);
+        verify(mockAeron).addExclusivePublication("aeron:udp?endpoint=localhost:1002|term-length=64k", streamId);
+        verify(mockAeron).addExclusivePublication("aeron:udp?endpoint=localhost:1003|term-length=64k", streamId);
+    }
+
+    @Test
+    void shouldNextPublicationAndReturnSameWithCurrent()
+    {
+        final ExclusivePublication pubNext = publicationGroup.next(mockAeron);
+        final ExclusivePublication pubCurrent1 = publicationGroup.current();
+        final ExclusivePublication pubCurrent2 = publicationGroup.current();
+
+        assertSame(pubNext, pubCurrent1);
+        assertSame(pubNext, pubCurrent2);
+
+        verify(mockAeron, times(1)).addExclusivePublication(anyString(), anyInt());
+    }
+
+    @Test
+    void shouldResultNullWhenCurrentCalledWithoutNext()
+    {
+        assertNull(publicationGroup.current());
+    }
+
+    @Test
+    void shouldCloseWhenCurrentIsNotNullWhenNextIsCalled()
+    {
+        assertNull(publicationGroup.current());
+        final ExclusivePublication current = publicationGroup.next(mockAeron);
+
+        assertNotNull(publicationGroup.next(mockAeron));
+        verify(current).close();
+    }
+
+    @Test
+    void shouldExcludeCurrentPublication()
+    {
+        final ExclusivePublication toExclude = publicationGroup.next(mockAeron);
+        publicationGroup.closeAndExcludeCurrent();
+
+        for (int i = 0; i < 100; i++)
+        {
+            assertNotSame(toExclude, publicationGroup.next(mockAeron));
+        }
+    }
+
+    @Test
+    void shouldClearExclusion()
+    {
+        final ExclusivePublication toExclude = publicationGroup.next(mockAeron);
+        publicationGroup.closeAndExcludeCurrent();
+        assertNotSame(toExclude, publicationGroup.next(mockAeron));
+
+        for (int i = 0; i < publications.size(); i++)
+        {
+            assertNotSame(toExclude, publicationGroup.next(mockAeron));
+        }
+
+        publicationGroup.clearExclusion();
+
+        boolean found = false;
+        for (int i = 0; i < publications.size(); i++)
+        {
+            if (toExclude == publicationGroup.next(mockAeron))
+            {
+                found = true;
+            }
+        }
+
+        assertTrue(found);
+    }
+
+    @Test
+    void shouldClosePublicationOnClose()
+    {
+        final ExclusivePublication pub = publicationGroup.next(mockAeron);
+        publicationGroup.close();
+        verify(pub).close();
+    }
+
+    @Test
+    void name()
+    {
+        System.out.println(publicationGroup);
+        publicationGroup.shuffle();
+
+        System.out.println(publicationGroup);
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/PublicationGroupTest.java
@@ -125,11 +125,16 @@ class PublicationGroupTest
     }
 
     @Test
-    void name()
+    void shouldEventuallyGetADifferentOrderAfterShuffle()
     {
-        System.out.println(publicationGroup);
-        publicationGroup.shuffle();
+        final String[] originalOrder = Arrays.copyOf(endpoints, endpoints.length);
+        int differenceCount = 0;
+        for (int i = 0; i < 100; i++)
+        {
+            publicationGroup.shuffle();
+            differenceCount += !Arrays.equals(originalOrder, endpoints) ? 1 : 0;
+        }
 
-        System.out.println(publicationGroup);
+        assertNotEquals(0, differenceCount);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterBackupTest.java
@@ -32,6 +32,8 @@ import org.agrona.concurrent.errors.ErrorLogReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static io.aeron.test.cluster.TestCluster.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -66,9 +68,10 @@ class ClusterBackupTest
         assertFalse(node.service().wasSnapshotLoaded());
     }
 
-    @Test
     @InterruptAfter(30)
-    void shouldBackupClusterNoSnapshotsAndNonEmptyLog()
+    @ParameterizedTest()
+    @EnumSource(value = ClusterBackup.SourceType.class)
+    void shouldBackupClusterNoSnapshotsAndNonEmptyLog(final ClusterBackup.SourceType sourceType)
     {
         final TestCluster cluster = aCluster().withStaticNodes(3).start();
         systemTestWatcher.cluster(cluster);
@@ -81,7 +84,7 @@ class ClusterBackupTest
 
         final long logPosition = leader.service().cluster().logPosition();
 
-        cluster.startClusterBackupNode(true);
+        cluster.startClusterBackupNode(true, sourceType);
 
         cluster.awaitBackupState(ClusterBackup.State.BACKING_UP);
         cluster.awaitBackupLiveLogPosition(logPosition);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -1385,9 +1385,14 @@ public final class TestCluster implements AutoCloseable
 
     public static String clusterMembers(final int clusterId, final int memberCount)
     {
+        return clusterMembers(clusterId, 0, memberCount);
+    }
+
+    private static String clusterMembers(final int clusterId, final int initialMemberId, final int memberCount)
+    {
         final StringBuilder builder = new StringBuilder();
 
-        for (int i = 0; i < memberCount; i++)
+        for (int i = initialMemberId; i < (initialMemberId + memberCount); i++)
         {
             builder
                 .append(i).append(',')


### PR DESCRIPTION
- The leader will send a redirect in response to backup queries (indicating that the leader should not be used).
- ClusterBackup will try a different node in response to a redirect
- Create a separate collection of sessions for backup requests & auth ("backup sessions" vs "user sessions").  Process backup sessions on both leader and follower.  Do not persist backup sessions.
- Randomise the starting node for backup queries in the ClusterBackup.