### PR TITLE
[Java] Fix pending service messages snapshot state.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -652,7 +652,7 @@ abstract class ArchiveConductor
 
         if (!catalog.hasRecording(recordingId))
         {
-            final String msg = "unknown recording id " + recordingId;
+            final String msg = "unknown recording id: " + recordingId;
             controlSession.sendErrorResponse(correlationId, UNKNOWN_RECORDING, msg, controlResponseProxy);
             return;
         }
@@ -842,7 +842,7 @@ abstract class ArchiveConductor
 
         if (!catalog.hasRecording(recordingId))
         {
-            final String msg = "unknown recording " + recordingId;
+            final String msg = "unknown recording id: " + recordingId;
             controlSession.sendErrorResponse(correlationId, UNKNOWN_RECORDING, msg, controlResponseProxy);
             return null;
         }
@@ -1601,7 +1601,7 @@ abstract class ArchiveConductor
     {
         if (!catalog.hasRecording(recordingId))
         {
-            final String msg = "unknown recording " + recordingId;
+            final String msg = "unknown recording id: " + recordingId;
             session.sendErrorResponse(correlationId, UNKNOWN_RECORDING, msg, controlResponseProxy);
             return false;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -387,7 +387,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         return null != agentRoleName ? agentRoleName : "consensus-module_" + ctx.clusterId() + "_" + memberId;
     }
 
-    public void onLoadBeginSnapshot(final int appVersion, final TimeUnit timeUnit)
+    public void onLoadBeginSnapshot(
+        final int appVersion, final TimeUnit timeUnit, final DirectBuffer buffer, final int offset, final int length)
     {
         if (!ctx.appVersionValidator().isVersionCompatible(ctx.appVersion(), appVersion))
         {
@@ -404,6 +405,10 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         }
     }
 
+    public void onLoadEndSnapshot(final DirectBuffer buffer, final int offset, final int length)
+    {
+    }
+
     public void onLoadClusterSession(
         final long clusterSessionId,
         final long correlationId,
@@ -411,7 +416,10 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         final long timeOfLastActivity,
         final CloseReason closeReason,
         final int responseStreamId,
-        final String responseChannel)
+        final String responseChannel,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         final ClusterSession session = new ClusterSession(
             clusterSessionId,
@@ -434,13 +442,22 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         final long nextSessionId,
         final long nextServiceSessionId,
         final long logServiceSessionId,
-        final int pendingMessageCapacity)
+        final int pendingMessageCapacity,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         this.nextSessionId = nextSessionId;
         pendingServiceMessageTrackers[0].loadState(nextServiceSessionId, logServiceSessionId, pendingMessageCapacity);
     }
 
-    public void onLoadClusterMembers(final int memberId, final int highMemberId, final String members)
+    public void onLoadClusterMembers(
+        final int memberId,
+        final int highMemberId,
+        final String members,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         if (null == dynamicJoin && !ctx.clusterMembersIgnoreSnapshot())
         {
@@ -472,7 +489,10 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         final long nextServiceSessionId,
         final long logServiceSessionId,
         final int pendingMessageCapacity,
-        final int serviceId)
+        final int serviceId,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         if (serviceId < 0 || serviceId >= pendingServiceMessageTrackers.length)
         {
@@ -491,7 +511,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         pendingServiceMessageTrackers[index].appendMessage(buffer, offset, length);
     }
 
-    public void onLoadTimer(final long correlationId, final long deadline)
+    public void onLoadTimer(
+        final long correlationId, final long deadline, final DirectBuffer buffer, final int offset, final int length)
     {
         onScheduleTimer(correlationId, deadline);
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotAdapter.java
@@ -81,8 +81,7 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                     messageHeaderDecoder.blockLength(),
                     messageHeaderDecoder.version());
 
-                listener.onLoadPendingMessage(
-                    sessionMessageHeaderDecoder.clusterSessionId(), buffer, offset, length);
+                listener.onLoadPendingMessage(sessionMessageHeaderDecoder.clusterSessionId(), buffer, offset, length);
                 break;
 
             case SnapshotMarkerDecoder.TEMPLATE_ID:
@@ -108,7 +107,11 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                         inSnapshot = true;
 
                         listener.onLoadBeginSnapshot(
-                            snapshotMarkerDecoder.appVersion(), ClusterClock.map(snapshotMarkerDecoder.timeUnit()));
+                            snapshotMarkerDecoder.appVersion(),
+                            ClusterClock.map(snapshotMarkerDecoder.timeUnit()),
+                            buffer,
+                            offset,
+                            length);
                         return Action.CONTINUE;
 
                     case END:
@@ -116,6 +119,7 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                         {
                             throw new ClusterException("missing begin snapshot");
                         }
+                        listener.onLoadEndSnapshot(buffer, offset, length);
                         isDone = true;
                         return Action.BREAK;
                 }
@@ -135,7 +139,10 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                     clusterSessionDecoder.timeOfLastActivity(),
                     clusterSessionDecoder.closeReason(),
                     clusterSessionDecoder.responseStreamId(),
-                    clusterSessionDecoder.responseChannel());
+                    clusterSessionDecoder.responseChannel(),
+                    buffer,
+                    offset,
+                    length);
                 break;
 
             case TimerDecoder.TEMPLATE_ID:
@@ -145,7 +152,7 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                     messageHeaderDecoder.blockLength(),
                     messageHeaderDecoder.version());
 
-                listener.onLoadTimer(timerDecoder.correlationId(), timerDecoder.deadline());
+                listener.onLoadTimer(timerDecoder.correlationId(), timerDecoder.deadline(), buffer, offset, length);
                 break;
 
             case ConsensusModuleDecoder.TEMPLATE_ID:
@@ -159,7 +166,10 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                     consensusModuleDecoder.nextSessionId(),
                     consensusModuleDecoder.nextServiceSessionId(),
                     consensusModuleDecoder.logServiceSessionId(),
-                    consensusModuleDecoder.pendingMessageCapacity());
+                    consensusModuleDecoder.pendingMessageCapacity(),
+                    buffer,
+                    offset,
+                    length);
                 break;
 
             case ClusterMembersDecoder.TEMPLATE_ID:
@@ -172,7 +182,10 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                 listener.onLoadClusterMembers(
                     clusterMembersDecoder.memberId(),
                     clusterMembersDecoder.highMemberId(),
-                    clusterMembersDecoder.clusterMembers());
+                    clusterMembersDecoder.clusterMembers(),
+                    buffer,
+                    offset,
+                    length);
                 break;
 
             case PendingMessageTrackerDecoder.TEMPLATE_ID:
@@ -186,7 +199,10 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                     pendingMessageTrackerDecoder.nextServiceSessionId(),
                     pendingMessageTrackerDecoder.logServiceSessionId(),
                     pendingMessageTrackerDecoder.pendingMessageCapacity(),
-                    pendingMessageTrackerDecoder.serviceId());
+                    pendingMessageTrackerDecoder.serviceId(),
+                    buffer,
+                    offset,
+                    length);
                 break;
         }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotListener.java
@@ -22,12 +22,19 @@ import java.util.concurrent.TimeUnit;
 
 interface ConsensusModuleSnapshotListener
 {
-    void onLoadBeginSnapshot(int appVersion, TimeUnit timeUnit);
+    void onLoadBeginSnapshot(int appVersion, TimeUnit timeUnit, DirectBuffer buffer, int offset, int length);
 
     void onLoadConsensusModuleState(
-        long nextSessionId, long nextServiceSessionId, long logServiceSessionId, int pendingMessageCapacity);
+        long nextSessionId,
+        long nextServiceSessionId,
+        long logServiceSessionId,
+        int pendingMessageCapacity,
+        DirectBuffer buffer,
+        int offset,
+        int length);
 
-    void onLoadClusterMembers(int memberId, int highMemberId, String clusterMembers);
+    void onLoadClusterMembers(
+        int memberId, int highMemberId, String clusterMembers, DirectBuffer buffer, int offset, int length);
 
     void onLoadPendingMessage(long clusterSessionId, DirectBuffer buffer, int offset, int length);
 
@@ -38,10 +45,21 @@ interface ConsensusModuleSnapshotListener
         long timeOfLastActivity,
         CloseReason closeReason,
         int responseStreamId,
-        String responseChannel);
+        String responseChannel,
+        DirectBuffer buffer,
+        int offset,
+        int length);
 
-    void onLoadTimer(long correlationId, long deadline);
+    void onLoadTimer(long correlationId, long deadline, DirectBuffer buffer, int offset, int length);
 
     void onLoadPendingMessageTracker(
-        long nextServiceSessionId, long logServiceSessionId, int pendingMessageCapacity, int serviceId);
+        long nextServiceSessionId,
+        long logServiceSessionId,
+        int pendingMessageCapacity,
+        int serviceId,
+        DirectBuffer buffer,
+        int offset,
+        int length);
+
+    void onLoadEndSnapshot(DirectBuffer buffer, int offset, int length);
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPrinter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPrinter.java
@@ -30,18 +30,26 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
         this.out = out;
     }
 
-    public void onLoadBeginSnapshot(final int appVersion, final TimeUnit timeUnit)
+    public void onLoadBeginSnapshot(
+        final int appVersion, final TimeUnit timeUnit, final DirectBuffer buffer, final int offset, final int length)
     {
         out.println("Snapshot:" +
             " appVersion=" + appVersion +
             " timeUnit=" + timeUnit);
     }
 
+    public void onLoadEndSnapshot(final DirectBuffer buffer, final int offset, final int length)
+    {
+    }
+
     public void onLoadConsensusModuleState(
         final long nextSessionId,
         final long nextServiceSessionId,
         final long logServiceSessionId,
-        final int pendingMessageCapacity)
+        final int pendingMessageCapacity,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         out.println("Consensus Module State:" +
             " nextSessionId=" + nextSessionId +
@@ -50,7 +58,13 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
             " pendingMessageCapacity=" + pendingMessageCapacity);
     }
 
-    public void onLoadClusterMembers(final int memberId, final int highMemberId, final String clusterMembers)
+    public void onLoadClusterMembers(
+        final int memberId,
+        final int highMemberId,
+        final String clusterMembers,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         out.println("Cluster Members:" +
             " memberId=" + memberId +
@@ -73,7 +87,10 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
         final long timeOfLastActivity,
         final CloseReason closeReason,
         final int responseStreamId,
-        final String responseChannel)
+        final String responseChannel,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         out.println("Cluster Session:" +
             " clusterSessionId=" + clusterSessionId +
@@ -85,7 +102,8 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
             " responseChannel=" + responseChannel);
     }
 
-    public void onLoadTimer(final long correlationId, final long deadline)
+    public void onLoadTimer(
+        final long correlationId, final long deadline, final DirectBuffer buffer, final int offset, final int length)
     {
         out.println("Timer:" +
             " correlationId=" + correlationId +
@@ -96,7 +114,10 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
         final long nextServiceSessionId,
         final long logServiceSessionId,
         final int pendingMessageCapacity,
-        final int serviceId)
+        final int serviceId,
+        final DirectBuffer buffer,
+        final int offset,
+        final int length)
     {
         out.println("Pending Message Tracker:" +
             " nextServiceSessionId=" + nextServiceSessionId +

--- a/aeron-cluster/src/main/java/io/aeron/cluster/PendingServiceMessageTracker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/PendingServiceMessageTracker.java
@@ -171,9 +171,9 @@ final class PendingServiceMessageTracker
                 {
                     throw new ClusterException("snapshot has incorrect pending message:" +
                         " serviceId=" + serviceId +
-                        " nextServiceSessionId= " + nextServiceSessionId +
-                        " logServiceSessionId= " + logServiceSessionId +
-                        " clusterSessionId= " + clusterSessionId +
+                        " nextServiceSessionId=" + nextServiceSessionId +
+                        " logServiceSessionId=" + logServiceSessionId +
+                        " clusterSessionId=" + clusterSessionId +
                         " pendingMessageIndex=" + messageCount.get(),
                         AeronException.Category.FATAL);
                 }
@@ -187,8 +187,8 @@ final class PendingServiceMessageTracker
         {
             throw new ClusterException("snapshot has incorrect pending message state:" +
                 " serviceId=" + serviceId +
-                " nextServiceSessionId= " + nextServiceSessionId +
-                " logServiceSessionId= " + logServiceSessionId +
+                " nextServiceSessionId=" + nextServiceSessionId +
+                " logServiceSessionId=" + logServiceSessionId +
                 " pendingMessageCount=" + messageCount.get(),
                 AeronException.Category.FATAL);
         }

--- a/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
+++ b/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
@@ -525,7 +525,10 @@ public class ConsensusModuleSnapshotPendingServiceMessagesPatch
             final long position,
             final RecordingSignal signal)
         {
-            this.recordingId = recordingId;
+            if (NULL_VALUE != recordingId)
+            {
+                this.recordingId = recordingId;
+            }
             this.signal = signal;
         }
 

--- a/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
+++ b/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.ChannelUri;
+import io.aeron.CommonContext;
+import io.aeron.ExclusivePublication;
+import io.aeron.Image;
+import io.aeron.Subscription;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.RecordingDescriptorConsumer;
+import io.aeron.archive.client.RecordingSignalConsumer;
+import io.aeron.archive.codecs.RecordingSignal;
+import io.aeron.archive.status.RecordingPos;
+import io.aeron.cluster.client.ClusterException;
+import io.aeron.cluster.codecs.CloseReason;
+import io.aeron.cluster.codecs.ConsensusModuleEncoder;
+import io.aeron.cluster.codecs.MessageHeaderEncoder;
+import io.aeron.cluster.codecs.SessionMessageHeaderEncoder;
+import io.aeron.cluster.service.ClusterNodeControlProperties;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.concurrent.status.CountersReader;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static io.aeron.CommonContext.IPC_CHANNEL;
+import static io.aeron.CommonContext.NULL_SESSION_ID;
+import static io.aeron.Publication.*;
+
+/**
+ * A tool to patch the latest consensus module snapshot if it has divergence in the pending service messages state.
+ * This tool patches the state on a single node. It is recommended to run the tool on the leader node and distribute
+ * the patched snapshot to all other nodes in a cluster.
+ * <p>
+ * The tool will attempt to connect to the running MediaDriver and the Archive of the cluster node.
+ * <p>
+ * <em>Note: Run the tool only if the cluster is suspended or completely stopped!</em>
+ */
+public class ConsensusModuleSnapshotPendingServiceMessagesPatch
+{
+    static final int SNAPSHOT_REPLAY_STREAM_ID = 103;
+
+    /**
+     * Execute the code to patch the latest snapshot.
+     *
+     * @param clusterDir of the cluster node to run the patch tool on.
+     * @return {@code true} if the patch was applied or {@code false} if consensus module state was already correct.
+     * @throws NullPointerException     if {@code null == clusterDir}.
+     * @throws IllegalArgumentException if {@code clusterDir} does not exist or is not a directory.
+     * @throws ClusterException         if {@code clusterDir} does not contain a recording log or if the log does not
+     *                                  contain a valid snapshot.
+     */
+    public boolean execute(final File clusterDir)
+    {
+        if (!clusterDir.exists() || !clusterDir.isDirectory())
+        {
+            throw new IllegalArgumentException("invalid cluster directory: " + clusterDir.getAbsolutePath());
+        }
+
+        final RecordingLog.Entry entry = ClusterTool.findLatestValidSnapshot(clusterDir);
+        if (null == entry)
+        {
+            throw new ClusterException("no valid snapshot found");
+        }
+
+        final long recordingId = entry.recordingId;
+        final ClusterNodeControlProperties properties = ClusterTool.loadControlProperties(clusterDir);
+        final RecordingSignalInfo recordingSignalInfo = new RecordingSignalInfo();
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(properties.aeronDirectoryName));
+            AeronArchive archive = AeronArchive.connect(new AeronArchive.Context()
+                .controlRequestChannel(IPC_CHANNEL)
+                .controlResponseChannel(IPC_CHANNEL)
+                .recordingSignalConsumer(recordingSignalInfo)
+                .aeron(aeron)))
+        {
+            final SnapshotReader snapshotReader = new SnapshotReader();
+            replayLocalSnapshotRecording(aeron, archive, recordingId, snapshotReader);
+            final long targetNextServiceSessionId =
+                snapshotReader.logServiceSessionId + 1 + snapshotReader.pendingServiceMessagesCount;
+            if (targetNextServiceSessionId != snapshotReader.nextServiceSessionId)
+            {
+                final long tempRecordingId =
+                    createNewSnapshotRecording(aeron, archive, recordingId, targetNextServiceSessionId);
+
+                final long stopPosition = awaitRecordingStopPosition(archive, recordingId);
+                final long newStopPosition = awaitRecordingStopPosition(archive, tempRecordingId);
+                if (stopPosition != newStopPosition)
+                {
+                    throw new ClusterException("new snapshot recording incomplete: expectedStopPosition=" +
+                        stopPosition + ", actualStopPosition=" + newStopPosition);
+                }
+
+                archive.truncateRecording(recordingId, 0);
+                awaitRecordingSignal(archive, recordingSignalInfo, recordingId, RecordingSignal.DELETE);
+
+                archive.replicate(
+                    tempRecordingId,
+                    recordingId,
+                    archive.context().controlRequestStreamId(),
+                    IPC_CHANNEL,
+                    null);
+                awaitRecordingSignal(archive, recordingSignalInfo, recordingId, RecordingSignal.REPLICATE_END);
+                awaitRecordingSignal(archive, recordingSignalInfo, recordingId, RecordingSignal.STOP);
+                final long replicatedStopPosition = awaitRecordingStopPosition(archive, recordingId);
+                if (stopPosition != replicatedStopPosition)
+                {
+                    throw new ClusterException("incomplete replication of the new recording: expectedStopPosition=" +
+                        stopPosition + ", replicatedStopPosition=" + replicatedStopPosition);
+                }
+
+                archive.purgeRecording(tempRecordingId);
+                awaitRecordingSignal(archive, recordingSignalInfo, tempRecordingId, RecordingSignal.DELETE);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static void replayLocalSnapshotRecording(
+        final Aeron aeron,
+        final AeronArchive archive,
+        final long snapshotRecordingId,
+        final ConsensusModuleSnapshotListener listener)
+    {
+        final String channel = IPC_CHANNEL;
+        final int streamId = SNAPSHOT_REPLAY_STREAM_ID;
+        final int sessionId = (int)archive.startReplay(
+            snapshotRecordingId, 0, AeronArchive.NULL_LENGTH, channel, streamId);
+        try
+        {
+            final String replayChannel = ChannelUri.addSessionId(channel, sessionId);
+            try (Subscription subscription = aeron.addSubscription(replayChannel, streamId))
+            {
+                Image image;
+                while (null == (image = subscription.imageBySessionId(sessionId)))
+                {
+                    archive.checkForErrorResponse();
+                    Thread.yield();
+                }
+
+                final ConsensusModuleSnapshotAdapter adapter = new ConsensusModuleSnapshotAdapter(image, listener);
+                while (true)
+                {
+                    final int fragments = adapter.poll();
+                    if (0 == fragments)
+                    {
+                        if (adapter.isDone())
+                        {
+                            break;
+                        }
+
+                        if (image.isClosed())
+                        {
+                            throw new ClusterException("snapshot ended unexpectedly: " + image);
+                        }
+
+                        archive.checkForErrorResponse();
+                        Thread.yield();
+                    }
+                }
+            }
+        }
+        finally
+        {
+            archive.stopAllReplays(snapshotRecordingId);
+        }
+    }
+
+    private static long createNewSnapshotRecording(
+        final Aeron aeron,
+        final AeronArchive archive,
+        final long oldRecordingId,
+        final long targetNextServiceSessionId)
+    {
+        final RecordingInfo oldRecordingInfo = loadRecordingInfo(archive, oldRecordingId);
+
+        final ChannelUri channelUri = ChannelUri.parse(IPC_CHANNEL);
+        channelUri.put(CommonContext.ALIAS_PARAM_NAME, "snapshot-patch");
+        channelUri.put(CommonContext.MTU_LENGTH_PARAM_NAME, Integer.toString(oldRecordingInfo.mtuLength));
+        channelUri.initialPosition(0, oldRecordingInfo.initialTermId, oldRecordingInfo.termBufferLength);
+        final String channel = channelUri.toString();
+        final int streamId = oldRecordingInfo.streamId;
+
+        try (ExclusivePublication snapshotPublication = archive.addRecordedExclusivePublication(channel, streamId))
+        {
+            try
+            {
+                final int publicationSessionId = snapshotPublication.sessionId();
+                final CountersReader countersReader = aeron.countersReader();
+                final int counterId = awaitRecordingCounter(publicationSessionId, countersReader);
+                final long newRecordingId = RecordingPos.getRecordingId(countersReader, counterId);
+
+                replayLocalSnapshotRecording(
+                    aeron,
+                    archive,
+                    oldRecordingId,
+                    new SnapshotWriter(snapshotPublication, targetNextServiceSessionId));
+
+                awaitRecordingComplete(countersReader, counterId, snapshotPublication.position(), newRecordingId);
+                return newRecordingId;
+            }
+            finally
+            {
+                archive.stopRecording(snapshotPublication);
+            }
+        }
+    }
+
+    private static RecordingInfo loadRecordingInfo(final AeronArchive archive, final long oldRecordingId)
+    {
+        final RecordingInfo recordingInfo = new RecordingInfo();
+        if (1 != archive.listRecording(oldRecordingId, recordingInfo))
+        {
+            throw new ClusterException("failed to read recording descriptor for id: " + oldRecordingId);
+        }
+        return recordingInfo;
+    }
+
+    private static int awaitRecordingCounter(final int publicationSessionId, final CountersReader countersReader)
+    {
+        int counterId;
+        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(countersReader, publicationSessionId)))
+        {
+            Thread.yield();
+        }
+        return counterId;
+    }
+
+    private static void awaitRecordingComplete(
+        final CountersReader counters, final int counterId, final long position, final long recordingId)
+    {
+        while (counters.getCounterValue(counterId) < position)
+        {
+            Thread.yield();
+            if (!RecordingPos.isActive(counters, counterId, recordingId))
+            {
+                throw new ClusterException("recording has stopped unexpectedly: " + recordingId);
+            }
+        }
+    }
+
+    private static long awaitRecordingStopPosition(final AeronArchive archive, final long recordingId)
+    {
+        long stopPosition;
+        while (NULL_VALUE == (stopPosition = archive.getStopPosition(recordingId)))
+        {
+            Thread.yield();
+        }
+        return stopPosition;
+    }
+
+    private static void awaitRecordingSignal(
+        final AeronArchive archive,
+        final RecordingSignalInfo signalInfo,
+        final long recordingId,
+        final RecordingSignal expectedSignal)
+    {
+        signalInfo.reset();
+        while (recordingId != signalInfo.recordingId || expectedSignal != signalInfo.signal)
+        {
+            if (0 == archive.pollForRecordingSignals())
+            {
+                Thread.yield();
+            }
+        }
+    }
+
+    /**
+     * Entry point to launch the tool. Requires a single parameter of a cluster directory.
+     *
+     * @param args for the tool.
+     */
+    public static void main(final String[] args)
+    {
+        if (1 != args.length)
+        {
+            System.out.println("Usage: <cluster-dir>");
+            System.exit(-1);
+        }
+        new ConsensusModuleSnapshotPendingServiceMessagesPatch().execute(new File(args[0]));
+    }
+
+    private static final class SnapshotReader implements ConsensusModuleSnapshotListener
+    {
+        private long nextServiceSessionId = NULL_SESSION_ID;
+        private long logServiceSessionId = NULL_SESSION_ID;
+        private int pendingServiceMessagesCount = 0;
+
+        public void onLoadBeginSnapshot(
+            final int appVersion,
+            final TimeUnit timeUnit,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadConsensusModuleState(
+            final long nextSessionId,
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            this.nextServiceSessionId = nextServiceSessionId;
+            this.logServiceSessionId = logServiceSessionId;
+        }
+
+        public void onLoadPendingMessage(
+            final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
+        {
+            pendingServiceMessagesCount++;
+        }
+
+        public void onLoadClusterMembers(
+            final int memberId,
+            final int highMemberId,
+            final String clusterMembers,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadClusterSession(
+            final long clusterSessionId,
+            final long correlationId,
+            final long openedLogPosition,
+            final long timeOfLastActivity,
+            final CloseReason closeReason,
+            final int responseStreamId,
+            final String responseChannel,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadTimer(
+            final long correlationId,
+            final long deadline,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadPendingMessageTracker(
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final int serviceId,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadEndSnapshot(final DirectBuffer buffer, final int offset, final int length)
+        {
+        }
+    }
+
+    private static final class SnapshotWriter implements ConsensusModuleSnapshotListener
+    {
+        private final ExpandableArrayBuffer tempBuffer = new ExpandableArrayBuffer(1024);
+        private final ConsensusModuleEncoder consensusModuleEncoder = new ConsensusModuleEncoder();
+        private final SessionMessageHeaderEncoder sessionMessageHeaderEncoder = new SessionMessageHeaderEncoder();
+        private final ExclusivePublication snapshotPublication;
+        private final long targetNextServiceSessionId;
+        private long nextClusterSessionId;
+
+        SnapshotWriter(
+            final ExclusivePublication snapshotPublication,
+            final long targetNextServiceSessionId)
+        {
+            this.snapshotPublication = snapshotPublication;
+            this.targetNextServiceSessionId = targetNextServiceSessionId;
+        }
+
+        public void onLoadBeginSnapshot(
+            final int appVersion,
+            final TimeUnit timeUnit,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        public void onLoadConsensusModuleState(
+            final long nextSessionId,
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            nextClusterSessionId = logServiceSessionId + 1;
+
+            tempBuffer.putBytes(0, buffer, offset, length);
+            consensusModuleEncoder
+                .wrap(tempBuffer, MessageHeaderEncoder.ENCODED_LENGTH)
+                .nextServiceSessionId(targetNextServiceSessionId);
+
+            writeToASnapshot(tempBuffer, 0, length);
+        }
+
+        public void onLoadClusterMembers(
+            final int memberId,
+            final int highMemberId,
+            final String clusterMembers,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        public void onLoadPendingMessage(
+            final long clusterSessionId,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            tempBuffer.putBytes(0, buffer, offset, length);
+            sessionMessageHeaderEncoder
+                .wrap(tempBuffer, MessageHeaderEncoder.ENCODED_LENGTH)
+                .clusterSessionId(nextClusterSessionId++);
+
+            writeToASnapshot(tempBuffer, 0, length);
+        }
+
+        public void onLoadClusterSession(
+            final long clusterSessionId,
+            final long correlationId,
+            final long openedLogPosition,
+            final long timeOfLastActivity,
+            final CloseReason closeReason,
+            final int responseStreamId,
+            final String responseChannel,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        public void onLoadTimer(
+            final long correlationId,
+            final long deadline,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        public void onLoadPendingMessageTracker(
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final int serviceId,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        public void onLoadEndSnapshot(final DirectBuffer buffer, final int offset, final int length)
+        {
+            writeToASnapshot(buffer, offset, length);
+        }
+
+        private void writeToASnapshot(
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+            long result;
+            while ((result = snapshotPublication.offer(buffer, offset, length)) < 0)
+            {
+                if (result == CLOSED ||
+                    result == NOT_CONNECTED ||
+                    result == MAX_POSITION_EXCEEDED)
+                {
+                    throw new ClusterException("can't offer into a snapshot: " + result);
+                }
+                Thread.yield();
+            }
+        }
+    }
+
+    private static final class RecordingSignalInfo implements RecordingSignalConsumer
+    {
+        long recordingId;
+        RecordingSignal signal;
+
+        public void onSignal(
+            final long controlSessionId,
+            final long correlationId,
+            final long recordingId,
+            final long subscriptionId,
+            final long position,
+            final RecordingSignal signal)
+        {
+            this.recordingId = recordingId;
+            this.signal = signal;
+        }
+
+        void reset()
+        {
+            recordingId = NULL_VALUE;
+            signal = null;
+        }
+    }
+
+    private static final class RecordingInfo implements RecordingDescriptorConsumer
+    {
+        int initialTermId;
+        int termBufferLength;
+        int mtuLength;
+        int streamId;
+
+        public void onRecordingDescriptor(
+            final long controlSessionId,
+            final long correlationId,
+            final long recordingId,
+            final long startTimestamp,
+            final long stopTimestamp,
+            final long startPosition,
+            final long stopPosition,
+            final int initialTermId,
+            final int segmentFileLength,
+            final int termBufferLength,
+            final int mtuLength,
+            final int sessionId,
+            final int streamId,
+            final String strippedChannel,
+            final String originalChannel,
+            final String sourceIdentity)
+        {
+            this.initialTermId = initialTermId;
+            this.termBufferLength = termBufferLength;
+            this.mtuLength = mtuLength;
+            this.streamId = streamId;
+        }
+    }
+}

--- a/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
+++ b/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Aeron;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.cluster.client.ClusterException;
+import io.aeron.cluster.codecs.CloseReason;
+import io.aeron.cluster.codecs.ConsensusModuleDecoder;
+import io.aeron.cluster.codecs.ConsensusModuleEncoder;
+import io.aeron.cluster.codecs.MessageHeaderDecoder;
+import io.aeron.cluster.codecs.MessageHeaderEncoder;
+import io.aeron.cluster.codecs.SessionMessageHeaderDecoder;
+import io.aeron.cluster.codecs.SessionMessageHeaderEncoder;
+import io.aeron.logbuffer.BufferClaim;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.cluster.TestCluster;
+import io.aeron.test.cluster.TestNode;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.IoUtil;
+import org.agrona.collections.IntArrayList;
+import org.agrona.collections.LongArrayList;
+import org.agrona.collections.MutableBoolean;
+import org.agrona.collections.MutableInteger;
+import org.agrona.collections.MutableLong;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.aeron.CommonContext.IPC_CHANNEL;
+import static io.aeron.CommonContext.NULL_SESSION_ID;
+import static io.aeron.cluster.ConsensusModuleSnapshotPendingServiceMessagesPatch.replayLocalSnapshotRecording;
+import static io.aeron.test.cluster.TestCluster.aCluster;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(InterruptingTestCallback.class)
+class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
+{
+    private final BufferClaim bufferClaim = new BufferClaim();
+
+    @RegisterExtension
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    @BeforeEach
+    void setUp()
+    {
+        systemTestWatcher.ignoreErrorsMatching(
+            (s) -> s.contains("ats_gcm_decrypt final_ex: error:00000000:lib(0):func(0):reason(0)"));
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        TestNode.MessageTrackingService.delaySessionMessageProcessing(false);
+    }
+
+    @Test
+    void executeThrowsNullPointerExceptionIfClusterDirIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new ConsensusModuleSnapshotPendingServiceMessagesPatch().execute(null));
+    }
+
+    @Test
+    void executeThrowsIllegalArgumentExceptionIfClusterDirDoesNotExist()
+    {
+        final File clusterDir = new File("non-existing-file-blah-blah");
+
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> new ConsensusModuleSnapshotPendingServiceMessagesPatch().execute(clusterDir));
+        assertEquals("invalid cluster directory: " + clusterDir.getAbsolutePath(), exception.getMessage());
+    }
+
+    @Test
+    void executeThrowsIllegalArgumentExceptionIfClusterDirIsNotADirectory(
+        final @TempDir File tempDir) throws IOException
+    {
+        final File clusterDir = new File(tempDir, "file.txt");
+        assertTrue(clusterDir.createNewFile());
+
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> new ConsensusModuleSnapshotPendingServiceMessagesPatch().execute(clusterDir));
+        assertEquals("invalid cluster directory: " + clusterDir.getAbsolutePath(), exception.getMessage());
+    }
+
+    @Test
+    void executeThrowsClusterExceptionIfClusterDirDoesNotContainARecordingLog(final @TempDir File tempDir)
+    {
+        final File clusterDir = new File(tempDir, "cluster-dir");
+        assertTrue(clusterDir.mkdir());
+
+        final ClusterException exception = assertThrowsExactly(
+            ClusterException.class,
+            () -> new ConsensusModuleSnapshotPendingServiceMessagesPatch().execute(clusterDir));
+        final Throwable cause = exception.getCause();
+        assertInstanceOf(IOException.class, cause);
+    }
+
+    @Test
+    @SlowTest
+    @InterruptAfter(30)
+    void executeIsANoOpIfTheSnapshotIsInValidState()
+    {
+        final TestCluster cluster = aCluster()
+            .withStaticNodes(3)
+            .withTimerServiceSupplier(new PriorityHeapTimerServiceSupplier())
+            .withServiceSupplier((i) -> new TestNode.TestService[]{
+                new TestNode.MessageTrackingService(1, i),
+                new TestNode.MessageTrackingService(2, i) })
+            .start();
+        systemTestWatcher.cluster(cluster);
+        final int serviceCount = cluster.node(0).services().length;
+
+        final TestNode leader = cluster.awaitLeader();
+        cluster.connectClient();
+
+        TestNode.MessageTrackingService.delaySessionMessageProcessing(true);
+        int messageCount = 0;
+        final ExpandableArrayBuffer msgBuffer = cluster.msgBuffer();
+        for (int i = 0; i < 2222; i++)
+        {
+            msgBuffer.putInt(0, ++messageCount, LITTLE_ENDIAN);
+            cluster.pollUntilMessageSent(SIZE_OF_INT);
+        }
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
+        TestNode.MessageTrackingService.delaySessionMessageProcessing(false);
+
+        cluster.awaitResponseMessageCount(messageCount * serviceCount);
+        awaitServiceMessages(cluster, serviceCount, messageCount);
+        stopConsensusModulesAndServices(cluster);
+
+        final File leaderClusterDir = leader.consensusModule().context().clusterDir();
+        final RecordingLog.Entry leaderSnapshot = ClusterTool.findLatestValidSnapshot(leaderClusterDir);
+        assertNotNull(leaderSnapshot);
+
+        final MutableLong mutableNextSessionId = new MutableLong(NULL_SESSION_ID);
+        final MutableLong mutableNextServiceSessionId = new MutableLong(NULL_SESSION_ID);
+        final MutableLong mutableLogServiceSessionId = new MutableLong(NULL_SESSION_ID);
+        final LongArrayList pendingMessageClusterSessionIds = new LongArrayList();
+        final ConsensusModuleSnapshotListener stateReader = new NoOpConsensusModuleSnapshotListener()
+        {
+            public void onLoadConsensusModuleState(
+                final long nextSessionId,
+                final long nextServiceSessionId,
+                final long logServiceSessionId,
+                final int pendingMessageCapacity,
+                final DirectBuffer buffer,
+                final int offset,
+                final int length)
+            {
+                mutableNextSessionId.set(nextSessionId);
+                mutableNextServiceSessionId.set(nextServiceSessionId);
+                mutableLogServiceSessionId.set(logServiceSessionId);
+            }
+
+            public void onLoadPendingMessage(
+                final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
+            {
+                pendingMessageClusterSessionIds.add(clusterSessionId);
+            }
+        };
+        readSnapshotRecording(leader, leaderSnapshot.recordingId, stateReader);
+        final long beforeNextSessionId = mutableNextSessionId.get();
+        final long beforeNextServiceSessionId = mutableNextServiceSessionId.get();
+        final long beforeLogServiceSessionId = mutableLogServiceSessionId.get();
+        final long[] beforeClusterSessionIds = pendingMessageClusterSessionIds.toLongArray();
+        assertNotEquals(NULL_SESSION_ID, beforeNextSessionId);
+        assertNotEquals(NULL_SESSION_ID, beforeNextServiceSessionId);
+        assertNotEquals(NULL_SESSION_ID, beforeLogServiceSessionId);
+        assertNotEquals(beforeNextSessionId, beforeNextServiceSessionId);
+        assertNotEquals(beforeNextSessionId, beforeLogServiceSessionId);
+        assertNotEquals(beforeNextServiceSessionId, beforeLogServiceSessionId);
+        assertNotEquals(0, beforeClusterSessionIds.length);
+
+        final ConsensusModuleSnapshotPendingServiceMessagesPatch snapshotPatch =
+            new ConsensusModuleSnapshotPendingServiceMessagesPatch();
+        assertFalse(snapshotPatch.execute(leaderClusterDir));
+
+        mutableNextSessionId.set(NULL_SESSION_ID);
+        mutableNextServiceSessionId.set(NULL_SESSION_ID);
+        mutableLogServiceSessionId.set(NULL_SESSION_ID);
+        pendingMessageClusterSessionIds.clear();
+        readSnapshotRecording(leader, leaderSnapshot.recordingId, stateReader);
+        assertEquals(beforeNextSessionId, mutableNextSessionId.get());
+        assertEquals(beforeNextServiceSessionId, mutableNextServiceSessionId.get());
+        assertEquals(beforeLogServiceSessionId, mutableLogServiceSessionId.get());
+        assertArrayEquals(beforeClusterSessionIds, pendingMessageClusterSessionIds.toLongArray());
+    }
+
+    @Test
+    @SlowTest
+    @InterruptAfter(30)
+    @SuppressWarnings("MethodLength")
+    void executeShouldPatchTheStateOfTheLeaderSnapshot()
+    {
+        final TestCluster cluster = aCluster()
+            .withStaticNodes(3)
+            .withTimerServiceSupplier(new PriorityHeapTimerServiceSupplier())
+            .withServiceSupplier((i) -> new TestNode.TestService[]{
+                new TestNode.MessageTrackingService(1, i),
+                new TestNode.MessageTrackingService(2, i) })
+            .start();
+        systemTestWatcher.cluster(cluster);
+        final int serviceCount = cluster.node(0).services().length;
+
+        final TestNode leader = cluster.awaitLeader();
+        cluster.connectClient();
+
+        TestNode.MessageTrackingService.delaySessionMessageProcessing(true);
+        int messageCount = 0;
+        final ExpandableArrayBuffer msgBuffer = cluster.msgBuffer();
+        for (int i = 0; i < 2222; i++)
+        {
+            msgBuffer.putInt(0, ++messageCount, LITTLE_ENDIAN);
+            cluster.pollUntilMessageSent(SIZE_OF_INT);
+        }
+        cluster.takeSnapshot(leader);
+        cluster.awaitSnapshotCount(1);
+        TestNode.MessageTrackingService.delaySessionMessageProcessing(false);
+
+        cluster.awaitResponseMessageCount(messageCount * serviceCount);
+        awaitServiceMessages(cluster, serviceCount, messageCount);
+        stopConsensusModulesAndServices(cluster);
+
+        final File leaderClusterDir = leader.consensusModule().context().clusterDir();
+        final RecordingLog.Entry leaderSnapshot = ClusterTool.findLatestValidSnapshot(leaderClusterDir);
+        assertNotNull(leaderSnapshot);
+
+        final MutableLong mutableNextSessionId = new MutableLong();
+        final MutableLong mutableNextServiceSessionId = new MutableLong();
+        final MutableLong mutableLogServiceSessionId = new MutableLong();
+        final MutableInteger consensusModuleStateOffset = new MutableInteger();
+        final IntArrayList pendingMessageOffsets = new IntArrayList();
+        readSnapshotRecording(leader, leaderSnapshot.recordingId, new NoOpConsensusModuleSnapshotListener()
+        {
+            public void onLoadConsensusModuleState(
+                final long nextSessionId,
+                final long nextServiceSessionId,
+                final long logServiceSessionId,
+                final int pendingMessageCapacity,
+                final DirectBuffer buffer,
+                final int offset,
+                final int length)
+            {
+                mutableNextSessionId.set(nextSessionId);
+                mutableNextServiceSessionId.set(nextServiceSessionId);
+                mutableLogServiceSessionId.set(logServiceSessionId);
+                consensusModuleStateOffset.set(offset);
+                assertEquals(MessageHeaderDecoder.ENCODED_LENGTH + ConsensusModuleDecoder.BLOCK_LENGTH, length);
+            }
+
+            public void onLoadPendingMessage(
+                final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
+            {
+                pendingMessageOffsets.addInt(offset);
+                assertEquals(
+                    MessageHeaderDecoder.ENCODED_LENGTH + SessionMessageHeaderDecoder.BLOCK_LENGTH + SIZE_OF_INT,
+                    length);
+            }
+        });
+        assertNotEquals(0, consensusModuleStateOffset.get());
+        assertNotEquals(0, pendingMessageOffsets.size());
+
+        final long expectedNextSessionId = mutableNextSessionId.get();
+        final long expectedLogServiceSessionId = mutableLogServiceSessionId.get();
+        final long invalidNextSessionId = Long.MAX_VALUE;
+        assertNotEquals(mutableNextServiceSessionId.get(), invalidNextSessionId);
+
+        modifySnapshot(
+            leader,
+            leaderSnapshot,
+            consensusModuleStateOffset,
+            pendingMessageOffsets,
+            invalidNextSessionId);
+
+        final ConsensusModuleSnapshotPendingServiceMessagesPatch snapshotPatch =
+            new ConsensusModuleSnapshotPendingServiceMessagesPatch();
+        assertTrue(snapshotPatch.execute(leaderClusterDir));
+
+        final MutableBoolean onLoadConsensusModuleState = new MutableBoolean();
+        final MutableInteger onLoadPendingMessageCount = new MutableInteger();
+        readSnapshotRecording(leader, leaderSnapshot.recordingId, new NoOpConsensusModuleSnapshotListener()
+        {
+            long nextClusterSessionId = expectedLogServiceSessionId + 1;
+
+            public void onLoadConsensusModuleState(
+                final long nextSessionId,
+                final long nextServiceSessionId,
+                final long logServiceSessionId,
+                final int pendingMessageCapacity,
+                final DirectBuffer buffer,
+                final int offset,
+                final int length)
+            {
+                assertEquals(expectedNextSessionId, nextSessionId);
+                assertEquals(expectedLogServiceSessionId, logServiceSessionId);
+                assertEquals(expectedLogServiceSessionId + 1 + pendingMessageOffsets.size(), nextServiceSessionId);
+                onLoadConsensusModuleState.set(true);
+            }
+
+            public void onLoadPendingMessage(
+                final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
+            {
+                assertEquals(nextClusterSessionId++, clusterSessionId, "Invalid pending message header!");
+                onLoadPendingMessageCount.increment();
+            }
+        });
+        assertTrue(onLoadConsensusModuleState.get());
+        assertEquals(pendingMessageOffsets.size(), onLoadPendingMessageCount.get());
+
+        cluster.stopAllNodes();
+        cluster.restartAllNodes(false);
+        cluster.connectClient();
+
+        for (int i = 0; i < 10; i++)
+        {
+            msgBuffer.putInt(0, ++messageCount, LITTLE_ENDIAN);
+            cluster.pollUntilMessageSent(SIZE_OF_INT);
+        }
+        cluster.awaitResponseMessageCount(messageCount * serviceCount);
+        awaitServiceMessages(cluster, serviceCount, messageCount);
+    }
+
+    private static void awaitServiceMessages(final TestCluster cluster, final int serviceCount, final int messageCount)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            final TestNode node = cluster.node(i);
+            final TestNode.TestService[] services = node.services();
+            for (final TestNode.TestService service : services)
+            {
+                // 1 client message + 3 service messages x number of services
+                cluster.awaitServiceMessageCount(node, service, messageCount + (messageCount * 3 * serviceCount));
+                // 2 timers x number of services
+                cluster.awaitTimerEventCount(node, service, messageCount * 2 * serviceCount);
+            }
+        }
+    }
+
+    private static void stopConsensusModulesAndServices(final TestCluster cluster)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            final TestNode node = cluster.node(i);
+            if (null != node)
+            {
+                node.stopServiceContainers();
+                node.consensusModule().close();
+            }
+        }
+    }
+
+    private static void modifySnapshot(
+        final TestNode leader,
+        final RecordingLog.Entry leaderSnapshot,
+        final MutableInteger consensusModuleStateOffset,
+        final IntArrayList pendingMessageOffsets,
+        final long invalidNextServiceSessionId)
+    {
+        final ArrayList<File> segmentFiles = listSegmentFiles(leader, leaderSnapshot.recordingId);
+        assertEquals(1, segmentFiles.size());
+        final MappedByteBuffer mappedByteBuffer =
+            IoUtil.mapExistingFile(segmentFiles.get(0), "snapshot file");
+        try
+        {
+            final UnsafeBuffer snapshotBuffer = new UnsafeBuffer(mappedByteBuffer);
+            final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
+
+            // Set the ConsensusModuleState values
+            final ConsensusModuleEncoder consensusModuleEncoder = new ConsensusModuleEncoder();
+            consensusModuleEncoder
+                .wrapAndApplyHeader(snapshotBuffer, consensusModuleStateOffset.get(), messageHeaderEncoder)
+                .nextServiceSessionId(invalidNextServiceSessionId);
+
+            // Now randomize clusterSessionId of every pending service message
+            final SessionMessageHeaderEncoder sessionMessageHeaderEncoder = new SessionMessageHeaderEncoder();
+            pendingMessageOffsets.forEachInt((offset) -> sessionMessageHeaderEncoder
+                .wrapAndApplyHeader(snapshotBuffer, offset, messageHeaderEncoder)
+                .clusterSessionId(ThreadLocalRandom.current().nextLong()));
+        }
+        finally
+        {
+            IoUtil.unmap(mappedByteBuffer);
+        }
+    }
+
+    private static void readSnapshotRecording(
+        final TestNode node,
+        final long recordingId,
+        final ConsensusModuleSnapshotListener snapshotListener)
+    {
+        try (Aeron aeron = Aeron.connect(new Aeron.Context()
+            .aeronDirectoryName(node.mediaDriver().aeronDirectoryName()));
+            AeronArchive archive = AeronArchive.connect(new AeronArchive.Context()
+                .controlRequestChannel(IPC_CHANNEL)
+                .controlResponseChannel(IPC_CHANNEL)
+                .aeron(aeron)))
+        {
+            replayLocalSnapshotRecording(
+                aeron,
+                archive,
+                recordingId,
+                snapshotListener);
+        }
+    }
+
+    private static ArrayList<File> listSegmentFiles(final TestNode node, final long recordingId)
+    {
+        final File[] files = node.archive().context().archiveDir().listFiles();
+        assertNotNull(files);
+        final String segmentFileNamePrefix = recordingId + "-";
+        final ArrayList<File> segmentFiles = new ArrayList<>();
+        for (final File file : files)
+        {
+            if (null != file)
+            {
+                final String fileName = file.getName();
+                if (fileName.startsWith(segmentFileNamePrefix) && fileName.endsWith(".rec"))
+                {
+                    segmentFiles.add(file);
+                }
+            }
+        }
+        return segmentFiles;
+    }
+
+    private static class NoOpConsensusModuleSnapshotListener implements ConsensusModuleSnapshotListener
+    {
+        public void onLoadBeginSnapshot(
+            final int appVersion,
+            final TimeUnit timeUnit,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadConsensusModuleState(
+            final long nextSessionId,
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadClusterMembers(
+            final int memberId,
+            final int highMemberId,
+            final String clusterMembers,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadPendingMessage(
+            final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
+        {
+        }
+
+        public void onLoadClusterSession(
+            final long clusterSessionId,
+            final long correlationId,
+            final long openedLogPosition,
+            final long timeOfLastActivity,
+            final CloseReason closeReason,
+            final int responseStreamId,
+            final String responseChannel,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadTimer(
+            final long correlationId,
+            final long deadline,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadPendingMessageTracker(
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int pendingMessageCapacity,
+            final int serviceId,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length)
+        {
+        }
+
+        public void onLoadEndSnapshot(final DirectBuffer buffer, final int offset, final int length)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new tool `ConsensusModuleSnapshotPendingServiceMessagesPatch` that can fix consensus module snapshot state if the divergence in pending service messages is detected.