### PR TITLE
[Java] Allow `replicate` to overwrite an empty recording.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -721,14 +721,17 @@ final class Catalog implements AutoCloseable
                     }
                 }
             }
+
+            catalogBuffer.wrap(catalogByteBuffer, recordingOffset, newFrameLength);
         }
         else
         {
             length = oldFrameLength - DESCRIPTOR_HEADER_LENGTH;
             checksumLength = newFrameLength - DESCRIPTOR_HEADER_LENGTH;
+            catalogBuffer.wrap(catalogByteBuffer, recordingOffset, oldFrameLength);
+            catalogBuffer.setMemory(newFrameLength, oldFrameLength - newFrameLength, (byte)0);
         }
 
-        catalogBuffer.wrap(catalogByteBuffer, recordingOffset, newFrameLength);
         descriptorEncoder
             .wrap(catalogBuffer, DESCRIPTOR_HEADER_LENGTH)
             .recordingId(recordingId)

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -57,7 +57,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
     private long srcStopPosition = NULL_POSITION;
     private long srcRecordingPosition = NULL_POSITION;
     private final long dstStopPosition;
-    private final boolean dstRecordingIsEmpty;
+    private final boolean isDestinationRecordingEmpty;
     private long timeOfLastActionMs;
     private final long actionTimeoutMs;
     private final long replicationId;
@@ -128,11 +128,11 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         {
             replayPosition = recordingSummary.stopPosition;
             replayStreamId = recordingSummary.streamId;
-            dstRecordingIsEmpty = recordingSummary.startPosition == recordingSummary.stopPosition;
+            isDestinationRecordingEmpty = recordingSummary.startPosition == recordingSummary.stopPosition;
         }
         else
         {
-            dstRecordingIsEmpty = false;
+            isDestinationRecordingEmpty = false;
         }
     }
 
@@ -294,7 +294,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
 
             signal(startPosition, REPLICATE);
         }
-        else if (dstRecordingIsEmpty)
+        else if (isDestinationRecordingEmpty)
         {
             replayPosition = startPosition;
             catalog.replaceRecording(

--- a/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ReplicationSession.java
@@ -57,6 +57,7 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
     private long srcStopPosition = NULL_POSITION;
     private long srcRecordingPosition = NULL_POSITION;
     private final long dstStopPosition;
+    private final boolean dstRecordingIsEmpty;
     private long timeOfLastActionMs;
     private final long actionTimeoutMs;
     private final long replicationId;
@@ -127,6 +128,11 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         {
             replayPosition = recordingSummary.stopPosition;
             replayStreamId = recordingSummary.streamId;
+            dstRecordingIsEmpty = recordingSummary.startPosition == recordingSummary.stopPosition;
+        }
+        else
+        {
+            dstRecordingIsEmpty = false;
         }
     }
 
@@ -287,6 +293,25 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
                 sourceIdentity);
 
             signal(startPosition, REPLICATE);
+        }
+        else if (dstRecordingIsEmpty)
+        {
+            replayPosition = startPosition;
+            catalog.replaceRecording(
+                dstRecordingId,
+                startPosition,
+                startPosition,
+                startTimestamp,
+                startTimestamp,
+                initialTermId,
+                segmentFileLength,
+                termBufferLength,
+                mtuLength,
+                sessionId,
+                streamId,
+                strippedChannel,
+                originalChannel,
+                sourceIdentity);
         }
 
         State nextState = State.EXTEND;
@@ -565,12 +590,13 @@ class ReplicationSession implements Session, RecordingDescriptorConsumer
         final boolean isClosed = image.isClosed();
         final boolean isEndOfStream = image.isEndOfStream();
         final long position = image.position();
+        final boolean isSynced = NULL_POSITION != srcStopPosition && position >= srcStopPosition;
 
-        if ((NULL_POSITION != srcStopPosition && position >= srcStopPosition) ||
+        if (isSynced ||
             (NULL_POSITION != dstStopPosition && position >= dstStopPosition) ||
             isEndOfStream || isClosed)
         {
-            if (NULL_POSITION != srcStopPosition && position >= srcStopPosition)
+            if (isSynced)
             {
                 signal(position, SYNC);
             }

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -205,17 +205,56 @@ class CatalogTest
     {
         try (Catalog catalog = new Catalog(archiveDir, clock))
         {
-            verifyRecordingForId(catalog, recordingOneId, 160, 6, 1, "channelG", "sourceA");
-            verifyRecordingForId(catalog, recordingTwoId, 160, 7, 2, "channelH", "sourceV");
+            verifyRecordingForId(
+                catalog,
+                recordingOneId,
+                160,
+                0L,
+                NULL_POSITION,
+                0L,
+                NULL_TIMESTAMP,
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                6,
+                1,
+                "channelG",
+                "channelG?tag=f",
+                "sourceA");
+
+            verifyRecordingForId(
+                catalog,
+                recordingTwoId,
+                160,
+                0L,
+                NULL_POSITION,
+                0L,
+                NULL_TIMESTAMP,
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                7,
+                2,
+                "channelH",
+                "channelH?tag=f",
+                "sourceV");
+
             verifyRecordingForId(
                 catalog,
                 recordingThreeId,
                 352,
-                8,
+                0L,
+                NULL_POSITION,
+                0L,
+                NULL_TIMESTAMP,
+                0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 8,
                 3,
                 "channelThatIsVeryLongAndShouldNotBeTruncated",
-                "source can also be a very very very long String and it will not be truncated even " +
-                "if gets very very long");
+                "channelThatIsVeryLongAndShouldNotBeTruncated?tag=f",
+                "source can also be a very very very long String and it will not be truncated even if gets " +
+                "very very long");
         }
     }
 
@@ -226,13 +265,58 @@ class CatalogTest
         try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, () -> 3L, null, segmentFileBuffer))
         {
             newRecordingId = catalog.addNewRecording(
-                0L, 0L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 9, 4, "channelJ", "channelJ?tag=f", "sourceN");
+                32,
+                128,
+                21,
+                42,
+                5,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                9,
+                4,
+                "channelJ",
+                "channelJ?tag=f",
+                "sourceN");
         }
 
         try (Catalog catalog = new Catalog(archiveDir, clock))
         {
-            verifyRecordingForId(catalog, recordingOneId, 160, 6, 1, "channelG", "sourceA");
-            verifyRecordingForId(catalog, newRecordingId, 160, 9, 4, "channelJ", "sourceN");
+            verifyRecordingForId(
+                catalog,
+                recordingOneId,
+                160,
+                0L,
+                0L, // updated from NULL_POSITION when Catalog was created for write
+                0L,
+                3L, // updated from NULL_TIMESTAMP when Catalog was created for write
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                6,
+                1,
+                "channelG",
+                "channelG?tag=f",
+                "sourceA");
+
+            verifyRecordingForId(
+                catalog,
+                newRecordingId,
+                160,
+                32,
+                128,
+                21,
+                42,
+                5,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                9,
+                4,
+                "channelJ",
+                "channelJ?tag=f",
+                "sourceN");
         }
     }
 
@@ -803,11 +887,11 @@ class CatalogTest
         final Checksum checksum = crc32();
         try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
         {
-            assertChecksum(catalog, recordingOneId, 0);
+            assertChecksum(catalog, recordingOneId, 160, 0, null);
 
             catalog.recordingStopped(recordingOneId, 140, 231723682323L);
 
-            assertChecksum(catalog, recordingOneId, 1656993099);
+            assertChecksum(catalog, recordingOneId, 160, 1656993099, checksum);
         }
     }
 
@@ -817,11 +901,11 @@ class CatalogTest
         final Checksum checksum = crc32();
         try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
         {
-            assertChecksum(catalog, recordingTwoId, 0);
+            assertChecksum(catalog, recordingTwoId, 160, 0, null);
 
             catalog.stopPosition(recordingTwoId, 7777);
 
-            assertChecksum(catalog, recordingTwoId, -1985007076);
+            assertChecksum(catalog, recordingTwoId, 160, -1985007076, checksum);
         }
     }
 
@@ -831,11 +915,11 @@ class CatalogTest
         final Checksum checksum = crc32();
         try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
         {
-            assertChecksum(catalog, recordingThreeId, 0);
+            assertChecksum(catalog, recordingThreeId, 352, 0, null);
 
             catalog.startPosition(recordingThreeId, 123);
 
-            assertChecksum(catalog, recordingThreeId, -160510802);
+            assertChecksum(catalog, recordingThreeId, 352, -160510802, checksum);
         }
     }
 
@@ -847,19 +931,355 @@ class CatalogTest
         {
             final long recordingId = catalog.addNewRecording(
                 0L, 0L, 0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 6, 1, "channelNew", "channelNew?tag=X", "sourceX");
-            assertChecksum(catalog, recordingId, 1691549102);
+            assertChecksum(catalog, recordingId, 160, 1691549102, checksum);
 
             catalog.extendRecording(recordingId, 555, 13, 31);
 
-            assertChecksum(catalog, recordingId, -1694749833);
+            assertChecksum(catalog, recordingId, 160, -1694749833, checksum);
         }
     }
 
-    private void assertChecksum(final Catalog catalog, final long recordingId, final int expectedChecksum)
+    @Test
+    void replaceThrowsArchiveExceptionIfRecordingIdIsUnknown()
+    {
+        final Checksum checksum = crc32();
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            catalog.startPosition(recordingOneId, 0);
+            catalog.startPosition(recordingTwoId, 0);
+            catalog.startPosition(recordingThreeId, 0);
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+            assertChecksum(catalog, recordingTwoId, 160, -1947831311, checksum);
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            final int unknownRecordingId = 1_000_000;
+            final ArchiveException exception = assertThrowsExactly(
+                ArchiveException.class, () -> catalog.replaceRecording(
+                unknownRecordingId,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                "11",
+                "12",
+                "13"));
+            assertEquals("ERROR - unknown recording id: " + unknownRecordingId, exception.getMessage());
+
+            assertEquals(1024, catalog.capacity());
+            assertEquals(3, catalog.index().size());
+            assertEquals(recordingThreeId + 1, catalog.nextRecordingId());
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+            assertChecksum(catalog, recordingTwoId, 160, -1947831311, checksum);
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+    }
+
+    @Test
+    void replaceRecordingUpdateCatalogFileWhenNewMetadataDoesNotFit()
+    {
+        final Checksum checksum = crc32();
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            catalog.startPosition(recordingOneId, 0);
+            catalog.startPosition(recordingTwoId, 0);
+            catalog.startPosition(recordingThreeId, 0);
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+            assertChecksum(catalog, recordingTwoId, 160, -1947831311, checksum);
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            catalog.replaceRecording(
+                recordingTwoId,
+                1024,
+                16 * 1024,
+                3252535612L,
+                6238423648L,
+                777,
+                SEGMENT_LENGTH * 4,
+                TERM_LENGTH * 2,
+                1344,
+                -19,
+                42,
+                "suppose to be a short description of the channel but can be whatever and surprising. Veni, vidi, vici",
+                "aeron:ipc?tag=15|alias=that is very very very long and will overflow the originally assigned length " +
+                "for sure and then some",
+                "and the source identity changes as well and is also quite a long one funny thing, that used to be " +
+                "a known fact but is now forgotten.");
+
+            assertEquals(recordingThreeId + 1, catalog.nextRecordingId());
+            verifyRecordingForId(
+                catalog,
+                recordingOneId,
+                160,
+                0L,
+                0L,
+                0L,
+                1L,
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                6,
+                1,
+                "channelG",
+                "channelG?tag=f",
+                "sourceA");
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingTwoId,
+                480,
+                1024,
+                16 * 1024,
+                3252535612L,
+                6238423648L,
+                777,
+                SEGMENT_LENGTH * 4,
+                TERM_LENGTH * 2,
+                1344,
+                -19,
+                42,
+                "suppose to be a short description of the channel but can be whatever and surprising. Veni, vidi, vici",
+                "aeron:ipc?tag=15|alias=that is very very very long and will overflow the originally assigned length " +
+                "for sure and then some",
+                "and the source identity changes as well and is also quite a long one funny thing, that used to be " +
+                "a known fact but is now forgotten.");
+            assertChecksum(catalog, recordingTwoId, 480, -116239158, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingThreeId,
+                352,
+                0L,
+                0L,
+                0L,
+                1L,
+                0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 8,
+                3,
+                "channelThatIsVeryLongAndShouldNotBeTruncated",
+                "channelThatIsVeryLongAndShouldNotBeTruncated?tag=f",
+                "source can also be a very very very long String and it will not be truncated even if gets " +
+                "very very long");
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+    }
+
+    @Test
+    void replaceRecordingUpdateCatalogFileWhenNewMetadataDoesNotFitAndDifferenceInSizeIsSmall()
+    {
+        final Checksum checksum = crc32();
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            catalog.startPosition(recordingOneId, 0);
+            catalog.startPosition(recordingTwoId, 0);
+            catalog.startPosition(recordingThreeId, 0);
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+            assertChecksum(catalog, recordingTwoId, 160, -1947831311, checksum);
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+
+        try (Catalog catalog = new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            catalog.replaceRecording(
+                recordingTwoId,
+                1024,
+                16 * 1024,
+                3252535612L,
+                6238423648L,
+                777,
+                SEGMENT_LENGTH * 4,
+                TERM_LENGTH * 2,
+                1344,
+                -19,
+                42,
+                "channelH",
+                "channelH?tag=f",
+                "to source or not to source that is the question");
+
+            assertEquals(recordingThreeId + 1, catalog.nextRecordingId());
+            verifyRecordingForId(
+                catalog,
+                recordingOneId,
+                160,
+                0L,
+                0L,
+                0L,
+                1L,
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                6,
+                1,
+                "channelG",
+                "channelG?tag=f",
+                "sourceA");
+            assertChecksum(catalog, recordingOneId, 160, -866186973, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingTwoId,
+                224,
+                1024,
+                16 * 1024,
+                3252535612L,
+                6238423648L,
+                777,
+                SEGMENT_LENGTH * 4,
+                TERM_LENGTH * 2,
+                1344,
+                -19,
+                42,
+                "channelH",
+                "channelH?tag=f",
+                "to source or not to source that is the question");
+            assertChecksum(catalog, recordingTwoId, 224, -1059517110, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingThreeId,
+                352,
+                0L,
+                0L,
+                0L,
+                1L,
+                0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 8,
+                3,
+                "channelThatIsVeryLongAndShouldNotBeTruncated",
+                "channelThatIsVeryLongAndShouldNotBeTruncated?tag=f",
+                "source can also be a very very very long String and it will not be truncated even if gets " +
+                "very very long");
+            assertChecksum(catalog, recordingThreeId, 352, -529628341, checksum);
+        }
+    }
+
+    @Test
+    void replaceRecordingShouldUpdateMetadataInPlaceWhenShorterThanTheOldOne()
+    {
+        final long updateTime = 555555L;
+        final Checksum checksum = crc32();
+        try (Catalog catalog =
+            new Catalog(archiveDir, null, 0, CAPACITY, () -> updateTime, checksum, segmentFileBuffer))
+        {
+            catalog.startPosition(recordingOneId, 0);
+            catalog.startPosition(recordingTwoId, 0);
+            catalog.startPosition(recordingThreeId, 0);
+            assertChecksum(catalog, recordingOneId, 160, 729050496, checksum);
+            assertChecksum(catalog, recordingTwoId, 160, 1825380178, checksum);
+            assertChecksum(catalog, recordingThreeId, 352, -1553583482, checksum);
+        }
+
+        try (Catalog catalog =
+            new Catalog(archiveDir, null, 0, CAPACITY, clock, checksum, segmentFileBuffer))
+        {
+            final long originalCapacity = catalog.capacity();
+
+            catalog.replaceRecording(
+                recordingOneId,
+                128,
+                512,
+                111L,
+                222L,
+                -19091,
+                SEGMENT_LENGTH * 16,
+                TERM_LENGTH * 4,
+                1372,
+                21,
+                8,
+                "A",
+                "B",
+                "C");
+
+            assertEquals(recordingThreeId + 1, catalog.nextRecordingId());
+            assertEquals(originalCapacity, catalog.capacity());
+            verifyRecordingForId(
+                catalog,
+                recordingOneId,
+                160,
+                128,
+                512,
+                111L,
+                222L,
+                -19091,
+                SEGMENT_LENGTH * 16,
+                TERM_LENGTH * 4,
+                1372,
+                21,
+                8,
+                "A",
+                "B",
+                "C");
+            assertChecksum(catalog, recordingOneId, 96, 1488471744, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingTwoId,
+                160,
+                0L,
+                0L,
+                0L,
+                updateTime,
+                0,
+                SEGMENT_LENGTH,
+                TERM_LENGTH,
+                MTU_LENGTH,
+                7,
+                2,
+                "channelH",
+                "channelH?tag=f",
+                "sourceV");
+            assertChecksum(catalog, recordingTwoId, 160, 1825380178, checksum);
+
+            verifyRecordingForId(
+                catalog,
+                recordingThreeId,
+                352,
+                0L,
+                0L,
+                0L,
+                updateTime,
+                0, SEGMENT_LENGTH, TERM_LENGTH, MTU_LENGTH, 8,
+                3,
+                "channelThatIsVeryLongAndShouldNotBeTruncated",
+                "channelThatIsVeryLongAndShouldNotBeTruncated?tag=f",
+                "source can also be a very very very long String and it will not be truncated even if gets " +
+                "very very long");
+            assertChecksum(catalog, recordingThreeId, 352, -1553583482, checksum);
+        }
+    }
+
+    private static void assertChecksum(
+        final Catalog catalog,
+        final long recordingId,
+        final int alignedChecksumLength,
+        final int expectedChecksum,
+        final Checksum checksum)
     {
         catalog.forEntry(recordingId,
             (recordingDescriptorOffset, headerEncoder, headerDecoder, descriptorEncoder, descriptorDecoder) ->
-            assertEquals(expectedChecksum, headerDecoder.checksum()));
+            {
+                assertEquals(expectedChecksum, headerDecoder.checksum());
+                if (null != checksum)
+                {
+                    final int computedChecksum = checksum.compute(
+                        descriptorDecoder.buffer().addressOffset(),
+                        RecordingDescriptorHeaderDecoder.BLOCK_LENGTH,
+                        alignedChecksumLength);
+                    assertEquals(expectedChecksum, computedChecksum);
+                }
+            });
     }
 
     private void testInvalidateRecording(final long recordingId)
@@ -888,9 +1308,18 @@ class CatalogTest
         final Catalog catalog,
         final long id,
         final int length,
+        final long startPosition,
+        final long stopPosition,
+        final long startTimestamp,
+        final long stopTimestamp,
+        final int initialTermId,
+        final int segmentFileLength,
+        final int termBufferLength,
+        final int mtuLength,
         final int sessionId,
         final int streamId,
         final String strippedChannel,
+        final String originalChannel,
         final String sourceIdentity)
     {
         assertTrue(catalog.wrapDescriptor(id, unsafeBuffer));
@@ -911,10 +1340,18 @@ class CatalogTest
             RecordingDescriptorDecoder.SCHEMA_VERSION);
 
         assertEquals(id, recordingDescriptorDecoder.recordingId());
+        assertEquals(startPosition, recordingDescriptorDecoder.startPosition());
+        assertEquals(stopPosition, recordingDescriptorDecoder.stopPosition());
+        assertEquals(startTimestamp, recordingDescriptorDecoder.startTimestamp());
+        assertEquals(stopTimestamp, recordingDescriptorDecoder.stopTimestamp());
+        assertEquals(initialTermId, recordingDescriptorDecoder.initialTermId());
+        assertEquals(segmentFileLength, recordingDescriptorDecoder.segmentFileLength());
+        assertEquals(termBufferLength, recordingDescriptorDecoder.termBufferLength());
+        assertEquals(mtuLength, recordingDescriptorDecoder.mtuLength());
         assertEquals(sessionId, recordingDescriptorDecoder.sessionId());
         assertEquals(streamId, recordingDescriptorDecoder.streamId());
         assertEquals(strippedChannel, recordingDescriptorDecoder.strippedChannel());
-        assertEquals(strippedChannel + "?tag=f", recordingDescriptorDecoder.originalChannel());
+        assertEquals(originalChannel, recordingDescriptorDecoder.originalChannel());
         assertEquals(sourceIdentity, recordingDescriptorDecoder.sourceIdentity());
     }
 

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -1204,10 +1204,11 @@ class CatalogTest
 
             assertEquals(recordingThreeId + 1, catalog.nextRecordingId());
             assertEquals(originalCapacity, catalog.capacity());
+            final int oldFrameLength = 160;
             verifyRecordingForId(
                 catalog,
                 recordingOneId,
-                160,
+                oldFrameLength,
                 128,
                 512,
                 111L,
@@ -1221,7 +1222,13 @@ class CatalogTest
                 "A",
                 "B",
                 "C");
-            assertChecksum(catalog, recordingOneId, 96, 1488471744, checksum);
+            final int newFrameLength = 96;
+            assertChecksum(catalog, recordingOneId, newFrameLength, 1488471744, checksum);
+            // verify that the excessive old data was erased
+            for (int i = newFrameLength; i < oldFrameLength; i++)
+            {
+                assertEquals(0, unsafeBuffer.getByte(RecordingDescriptorHeaderDecoder.BLOCK_LENGTH + i));
+            }
 
             verifyRecordingForId(
                 catalog,

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -1223,12 +1223,8 @@ class CatalogTest
                 "B",
                 "C");
             final int newFrameLength = 96;
+            verifyOldExcessiveDataWasErased(oldFrameLength, newFrameLength);
             assertChecksum(catalog, recordingOneId, newFrameLength, 1488471744, checksum);
-            // verify that the excessive old data was erased
-            for (int i = newFrameLength; i < oldFrameLength; i++)
-            {
-                assertEquals(0, unsafeBuffer.getByte(RecordingDescriptorHeaderDecoder.BLOCK_LENGTH + i));
-            }
 
             verifyRecordingForId(
                 catalog,
@@ -1264,6 +1260,15 @@ class CatalogTest
                 "source can also be a very very very long String and it will not be truncated even if gets " +
                 "very very long");
             assertChecksum(catalog, recordingThreeId, 352, -1553583482, checksum);
+        }
+    }
+
+    private void verifyOldExcessiveDataWasErased(final int oldFrameLength, final int newFrameLength)
+    {
+        assertTrue(oldFrameLength > newFrameLength);
+        for (int i = newFrameLength; i < oldFrameLength; i++)
+        {
+            assertEquals(0, unsafeBuffer.getByte(RecordingDescriptorHeaderDecoder.BLOCK_LENGTH + i));
         }
     }
 


### PR DESCRIPTION
This PR changes how the `replicate` Archive API will treat an empty destination recording (i.e. whose `startPosition == stopPosition`). In such a case the source recording will completely overwrite such recording.