### PR TITLE
Differentiate aliases for consensus module/service container subscriptions.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -1237,7 +1237,7 @@ class Election
             .rejoin(Boolean.FALSE)
             .socketRcvbufLength(logChannelUri)
             .receiverWindowLength(logChannelUri)
-            .alias("log")
+            .alias("log-cm")
             .build();
 
         return aeron.addSubscription(channel, ctx.logStreamId());


### PR DESCRIPTION
Aliases to easily differentiate between different log subscriptions.

- Archive: `|alias=log`
- Consensus module: `|alias=log-cm`
- Service container(s): `|alias=log-sc-0`