### PR TITLE
Support importing ConsensusModule state to support transitioning.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -280,6 +280,17 @@ public final class AeronCounters
     public static final int CLUSTER_STANDBY_CONTROL_TOGGLE_TYPE_ID = 223;
 
     /**
+     * The type id of the {@link Counter} used for keeping track of the max duty cycle time of the cluster standby.
+     */
+    public static final int CLUSTER_STANDBY_MAX_CYCLE_TIME_TYPE_ID = 227;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the count of cycle time threshold exceeded of
+     * the cluster standby.
+     */
+    public static final int CLUSTER_STANDBY_CYCLE_TIME_THRESHOLD_EXCEEDED_TYPE_ID = 228;
+
+    /**
      * Counter type id for the transition module error count.
      */
     public static final int TRANSITION_MODULE_ERROR_COUNT_TYPE_ID = 226;
@@ -293,6 +304,17 @@ public final class AeronCounters
      * Transition module control toggle type id
      */
     public static final int TRANSITION_MODULE_CONTROL_TOGGLE_TYPE_ID = 225;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the max duty cycle time of the transition module.
+     */
+    public static final int TRANSITION_MODULE_MAX_CYCLE_TIME_TYPE_ID = 229;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the count of cycle time threshold exceeded of
+     * the transition module.
+     */
+    public static final int TRANSITION_MODULE_CYCLE_TIME_THRESHOLD_EXCEEDED_TYPE_ID = 230;
 
     private AeronCounters()
     {

--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -291,6 +291,12 @@ public final class AeronCounters
     public static final int CLUSTER_STANDBY_CYCLE_TIME_THRESHOLD_EXCEEDED_TYPE_ID = 228;
 
     /**
+     * The type id of the {@link Counter} to make visible the memberId that the cluster standby is currently using to
+     * as a source for the cluster log.
+     */
+    public static final int CLUSTER_STANDBY_SOURCE_MEMBER_ID_TYPE_ID = 231;
+
+    /**
      * Counter type id for the transition module error count.
      */
     public static final int TRANSITION_MODULE_ERROR_COUNT_TYPE_ID = 226;

--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -260,7 +260,7 @@ public final class AeronCounters
     public static final int CLUSTER_CLUSTERED_SERVICE_CYCLE_TIME_THRESHOLD_EXCEEDED_TYPE_ID = 219;
 
     /**
-     * The type id of the {@link Counter} used for the warm standby state.
+     * The type id of the {@link Counter} used for the cluster standby state.
      */
     public static final int CLUSTER_STANDBY_STATE_TYPE_ID = 220;
 
@@ -278,6 +278,16 @@ public final class AeronCounters
      * Standby control toggle type id
      */
     public static final int CLUSTER_STANDBY_CONTROL_TOGGLE_TYPE_ID = 223;
+
+    /**
+     * The type if of the {@link Counter} used for transition module state
+     */
+    public static final int TRANSITION_MODULE_STATE_TYPE_ID = 224;
+
+    /**
+     * Transition module control toggle type id
+     */
+    public static final int TRANSITION_MODULE_CONTROL_TOGGLE_TYPE_ID = 225;
 
     private AeronCounters()
     {

--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -280,6 +280,11 @@ public final class AeronCounters
     public static final int CLUSTER_STANDBY_CONTROL_TOGGLE_TYPE_ID = 223;
 
     /**
+     * Counter type id for the transition module error count.
+     */
+    public static final int TRANSITION_MODULE_ERROR_COUNT_TYPE_ID = 226;
+
+    /**
      * The type if of the {@link Counter} used for transition module state
      */
     public static final int TRANSITION_MODULE_STATE_TYPE_ID = 224;

--- a/aeron-client/src/test/java/io/aeron/AeronCountersTest.java
+++ b/aeron-client/src/test/java/io/aeron/AeronCountersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import org.agrona.collections.Int2ObjectHashMap;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AeronCountersTest
+{
+    @Test
+    void shouldNotHaveOverlappingCounterTypeIds()
+    {
+        final Int2ObjectHashMap<Field> fieldByTypeId = new Int2ObjectHashMap<>();
+        final Int2ObjectHashMap<List<Field>> duplicates = new Int2ObjectHashMap<>();
+        final Consumer<Field> duplicateChecker =
+            (f) ->
+            {
+                try
+                {
+                    final int typeId = (Integer)f.get(null);
+                    final Field field = fieldByTypeId.putIfAbsent(typeId, f);
+                    if (null != field)
+                    {
+                        final List<Field> duplicatesForKey = duplicates.computeIfAbsent(
+                            typeId, (s) -> new ArrayList<>());
+                        if (!duplicatesForKey.contains(f))
+                        {
+                            duplicatesForKey.add(f);
+                        }
+                        duplicatesForKey.add(field);
+                    }
+                }
+                catch (final IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            };
+
+        Arrays.stream(AeronCounters.class.getFields())
+            .filter((f) -> Modifier.isStatic(f.getModifiers()))
+            .filter((f) -> f.getName().endsWith("_TYPE_ID"))
+            .filter((f) -> Integer.TYPE.isAssignableFrom(f.getType()))
+            .forEach(duplicateChecker);
+
+        if (!duplicates.isEmpty())
+        {
+            fail("Duplicate typeIds: " + duplicates);
+        }
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1346,6 +1346,7 @@ public final class ConsensusModule implements AutoCloseable
         private AppVersionValidator appVersionValidator;
         private boolean isLogMdc;
         private boolean useAgentInvoker = false;
+        private ConsensusModuleStateExport boostrapState = null;
 
         /**
          * Perform a shallow copy of the object.
@@ -3629,6 +3630,23 @@ public final class ConsensusModule implements AutoCloseable
         boolean isLogMdc()
         {
             return isLogMdc;
+        }
+
+        /**
+         * Start up the consensus module using presupplied state skipping the recovery process.  Internal use only.
+         *
+         * @param bootstrapState to initialize the consensus module.
+         * @return this for a fluent API.
+         */
+        ConsensusModule.Context bootstrapState(final ConsensusModuleStateExport bootstrapState)
+        {
+            this.boostrapState = bootstrapState;
+            return this;
+        }
+
+        ConsensusModuleStateExport boostrapState()
+        {
+            return boostrapState;
         }
 
         private void concludeMarkFile()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3706,7 +3706,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 sessionExport.timeOfLastActivityNs,
                 sessionExport.closeReason,
                 sessionExport.responseStreamId,
-                createResponseChannel(sessionExport.responseChannel),
+                refineResponseChannel(sessionExport.responseChannel),
                 null, 0, 0);
         }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -265,7 +265,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("try")
     public void onStart()
     {
         archive = AeronArchive.connect(ctx.archiveContext().clone());
@@ -280,26 +279,13 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 archive.tryStopRecordingByIdentity(lastTermRecordingId);
             }
 
-            recoveryPlan = recordingLog.createRecoveryPlan(archive, ctx.serviceCount(), logRecordingId);
-            if (null != recoveryPlan.log)
+            if (null == ctx.boostrapState())
             {
-                logRecordingId(recoveryPlan.log.recordingId);
+                recoveryPlan = recoverFromSnapshotAndLog();
             }
-
-            try (Counter ignore = addRecoveryStateCounter(recoveryPlan))
+            else
             {
-                if (!recoveryPlan.snapshots.isEmpty())
-                {
-                    loadSnapshot(recoveryPlan.snapshots.get(0), archive);
-                }
-
-                while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))
-                {
-                    idle(consensusModuleAdapter.poll());
-                }
-
-                captureServiceClientIds();
-                ++serviceAckId;
+                recoveryPlan = recoverFromBootstrapState();
             }
 
             ClusterMember.addConsensusPublications(
@@ -3663,6 +3649,104 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 break;
             }
         }
+    }
+
+    @SuppressWarnings("try")
+    private RecordingLog.RecoveryPlan recoverFromSnapshotAndLog()
+    {
+        final RecordingLog.RecoveryPlan recoveryPlan = recordingLog.createRecoveryPlan(
+            archive, ctx.serviceCount(), logRecordingId);
+        if (null != recoveryPlan.log)
+        {
+            logRecordingId(recoveryPlan.log.recordingId);
+        }
+
+        try (Counter ignore = addRecoveryStateCounter(recoveryPlan))
+        {
+            if (!recoveryPlan.snapshots.isEmpty())
+            {
+                loadSnapshot(recoveryPlan.snapshots.get(0), archive);
+            }
+
+            while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))
+            {
+                idle(consensusModuleAdapter.poll());
+            }
+
+            captureServiceClientIds();
+            ++serviceAckId;
+        }
+        return recoveryPlan;
+    }
+
+    private RecordingLog.RecoveryPlan recoverFromBootstrapState()
+    {
+        final ConsensusModuleStateExport boostrapState = ctx.boostrapState();
+
+        logRecordingId(boostrapState.logRecordingId);
+        final RecordingLog.RecoveryPlan recoveryPlan = recordingLog.createRecoveryPlan(
+            archive, ctx.serviceCount(), logRecordingId);
+
+        expectedAckPosition = boostrapState.expectedAckPosition;
+        serviceAckId = boostrapState.serviceAckId;
+        leadershipTermId = boostrapState.leadershipTermId;
+        nextSessionId = boostrapState.nextSessionId;
+
+        for (final ConsensusModuleStateExport.TimerStateExport timer : boostrapState.timers)
+        {
+            onLoadTimer(timer.correlationId, timer.deadline, null, 0, 0);
+        }
+
+        for (final ConsensusModuleStateExport.ClusterSessionStateExport sessionExport : boostrapState.sessions)
+        {
+            onLoadClusterSession(
+                sessionExport.id,
+                sessionExport.correlationId,
+                sessionExport.openedLogPosition,
+                sessionExport.timeOfLastActivityNs,
+                sessionExport.closeReason,
+                sessionExport.responseStreamId,
+                createResponseChannel(sessionExport.responseChannel),
+                null, 0, 0);
+        }
+
+        final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+        final SessionMessageHeaderDecoder sessionMessageHeaderDecoder = new SessionMessageHeaderDecoder();
+        for (final ConsensusModuleStateExport.PendingServiceMessageTrackerStateExport tracker :
+            boostrapState.pendingMessageTrackers)
+        {
+            onLoadPendingMessageTracker(
+                tracker.nextServiceSessionId,
+                tracker.logServiceSessionId,
+                tracker.capacity,
+                tracker.serviceId,
+                null, 0, 0);
+
+            tracker.pendingMessages.forEach(
+                (buffer, offset, length, headOffset) ->
+                {
+                    sessionMessageHeaderDecoder.wrap(
+                        buffer,
+                        offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                        messageHeaderDecoder.blockLength(),
+                        messageHeaderDecoder.version());
+                    onLoadPendingMessage(
+                        sessionMessageHeaderDecoder.clusterSessionId(), buffer, offset, length);
+                    return true;
+                },
+                Integer.MAX_VALUE);
+        }
+
+        serviceProxy.requestServiceAck(expectedAckPosition);
+
+        while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))
+        {
+            idle(consensusModuleAdapter.poll());
+        }
+
+        captureServiceClientIds();
+        ++serviceAckId;
+        return recoveryPlan;
     }
 
     public String toString()

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleStateExport.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleStateExport.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.cluster.codecs.CloseReason;
+import org.agrona.ExpandableRingBuffer;
+
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+
+class ConsensusModuleStateExport
+{
+    final long logRecordingId;
+    final long leadershipTermId;
+    final long expectedAckPosition;
+    final long nextSessionId;
+    final long serviceAckId;
+    final List<TimerStateExport> timers;
+    final List<ClusterSessionStateExport> sessions;
+    final List<PendingServiceMessageTrackerStateExport> pendingMessageTrackers;
+
+    ConsensusModuleStateExport(
+        final long logRecordingId,
+        final long leadershipTermId,
+        final long expectedAckPosition,
+        final long nextSessionId,
+        final long serviceAckId,
+        final List<TimerStateExport> timers,
+        final List<ClusterSessionStateExport> sessions,
+        final List<PendingServiceMessageTrackerStateExport> pendingMessageTrackers)
+    {
+        this.logRecordingId = logRecordingId;
+        this.leadershipTermId = leadershipTermId;
+        this.expectedAckPosition = expectedAckPosition;
+        this.nextSessionId = nextSessionId;
+        this.serviceAckId = serviceAckId;
+        this.timers = unmodifiableList(timers);
+        this.sessions = unmodifiableList(sessions);
+        this.pendingMessageTrackers = unmodifiableList(pendingMessageTrackers);
+    }
+
+    static class TimerStateExport
+    {
+        final long correlationId;
+        final long deadline;
+
+        TimerStateExport(final long correlationId, final long deadline)
+        {
+            this.correlationId = correlationId;
+            this.deadline = deadline;
+        }
+    }
+
+    static class ClusterSessionStateExport
+    {
+        final long id;
+        final long correlationId;
+        final long openedLogPosition;
+        final long timeOfLastActivityNs;
+        final int responseStreamId;
+        final String responseChannel;
+        final CloseReason closeReason;
+
+        ClusterSessionStateExport(
+            final long id,
+            final long correlationId,
+            final long openedLogPosition,
+            final long timeOfLastActivityNs,
+            final int responseStreamId,
+            final String responseChannel,
+            final CloseReason closeReason)
+        {
+            this.id = id;
+            this.correlationId = correlationId;
+            this.openedLogPosition = openedLogPosition;
+            this.timeOfLastActivityNs = timeOfLastActivityNs;
+            this.responseStreamId = responseStreamId;
+            this.responseChannel = responseChannel;
+            this.closeReason = closeReason;
+        }
+    }
+
+    static class PendingServiceMessageTrackerStateExport
+    {
+        final long nextServiceSessionId;
+        final long logServiceSessionId;
+        final int capacity;
+        final int serviceId;
+        final ExpandableRingBuffer pendingMessages;
+
+        PendingServiceMessageTrackerStateExport(
+            final long nextServiceSessionId,
+            final long logServiceSessionId,
+            final int capacity,
+            final int serviceId,
+            final ExpandableRingBuffer pendingMessages)
+        {
+            this.nextServiceSessionId = nextServiceSessionId;
+            this.logServiceSessionId = logServiceSessionId;
+            this.capacity = capacity;
+            this.serviceId = serviceId;
+            this.pendingMessages = pendingMessages;
+        }
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ServiceAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ServiceAdapter.java
@@ -33,6 +33,7 @@ final class ServiceAdapter implements AutoCloseable
 
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     private final JoinLogDecoder joinLogDecoder = new JoinLogDecoder();
+    private final RequestServiceAckDecoder requestServiceAckDecoder = new RequestServiceAckDecoder();
     private final ServiceTerminationPositionDecoder serviceTerminationPositionDecoder =
         new ServiceTerminationPositionDecoder();
 
@@ -90,6 +91,16 @@ final class ServiceAdapter implements AutoCloseable
                     messageHeaderDecoder.version());
 
                 clusteredServiceAgent.onServiceTerminationPosition(serviceTerminationPositionDecoder.logPosition());
+                break;
+
+            case RequestServiceAckDecoder.TEMPLATE_ID:
+                requestServiceAckDecoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    messageHeaderDecoder.blockLength(),
+                    messageHeaderDecoder.version());
+
+                clusteredServiceAgent.onRequestServiceAck(requestServiceAckDecoder.logPosition());
                 break;
         }
     }

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -408,6 +408,12 @@
         </group>
     </sbe:message>
 
+    <sbe:message name="requestServiceAck"
+                 id="108"
+                 description="request an ack from all service container on the same node">
+        <field name="logPosition" id="1" type="int64"/>
+    </sbe:message>
+
 <!--
     Cluster Consensus Protocol
     ==========================

--- a/aeron-cluster/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/aeron-cluster/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -15,8 +15,15 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.Aeron;
+import io.aeron.ChannelUri;
+import io.aeron.ConcurrentPublication;
+import io.aeron.Counter;
+import io.aeron.ExclusivePublication;
+import io.aeron.Subscription;
+import io.aeron.UnavailableImageHandler;
 import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.ControlResponsePoller;
 import io.aeron.cluster.codecs.CloseReason;
 import io.aeron.cluster.codecs.ClusterAction;
 import io.aeron.cluster.codecs.EventCode;
@@ -36,24 +43,38 @@ import org.agrona.concurrent.CountedErrorHandler;
 import org.agrona.concurrent.NoOpIdleStrategy;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
 
-import static io.aeron.cluster.ClusterControl.ToggleState.*;
+import static io.aeron.cluster.ClusterControl.ToggleState.NEUTRAL;
+import static io.aeron.cluster.ClusterControl.ToggleState.RESUME;
+import static io.aeron.cluster.ClusterControl.ToggleState.SUSPEND;
 import static io.aeron.cluster.ConsensusModule.Configuration.SESSION_LIMIT_MSG;
 import static io.aeron.cluster.ConsensusModuleAgent.SLOW_TICK_INTERVAL_NS;
 import static io.aeron.cluster.client.AeronCluster.Configuration.PROTOCOL_SEMANTIC_VERSION;
 import static java.lang.Boolean.TRUE;
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ConsensusModuleAgentTest
 {
@@ -373,5 +394,35 @@ public class ConsensusModuleAgentTest
         verify(mockAeron).asyncAddPublication(channelCaptor.capture(), eq(responseStreamId));
 
         assertEquals(ChannelUri.parse(expectedResponseChannel), ChannelUri.parse(channelCaptor.getValue()));
+    }
+
+    @Test
+    @Disabled
+    void shouldSkipRecoveryWhenUsingBootStrapState()
+    {
+        try (MockedStatic<AeronArchive> aeronArchiveStaticMock = mockStatic(AeronArchive.class))
+        {
+            final AeronArchive aeronArchiveMock = mock(AeronArchive.class);
+            final ControlResponsePoller mockControlResponsePoller = mock(ControlResponsePoller.class);
+            final Subscription subscription = mock(Subscription.class);
+            final RecordingLog recordingLog = mock(RecordingLog.class);
+            ctx.recordingLog(recordingLog);
+            aeronArchiveStaticMock.when(() -> AeronArchive.connect(any(AeronArchive.Context.class)))
+                .thenReturn(aeronArchiveMock);
+            when(aeronArchiveMock.controlResponsePoller()).thenReturn(mockControlResponsePoller);
+            when(mockControlResponsePoller.subscription()).thenReturn(subscription);
+
+            final ConsensusModuleStateExport consensusModuleStateExport = new ConsensusModuleStateExport(
+                1, 2, 3, 4, 5, emptyList(), emptyList(), emptyList());
+
+            final TestClusterClock clock = new TestClusterClock(TimeUnit.MILLISECONDS);
+            ctx
+                .bootstrapState(consensusModuleStateExport)
+                .epochClock(clock)
+                .clusterClock(clock);
+
+            final ConsensusModuleAgent consensusModuleAgent = new ConsensusModuleAgent(ctx);
+            consensusModuleAgent.onStart();
+        }
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceAgentTest.java
@@ -17,13 +17,13 @@ package io.aeron.cluster.service;
 
 import io.aeron.Aeron;
 import io.aeron.ConcurrentPublication;
-import io.aeron.Counter;
 import io.aeron.Publication;
 import io.aeron.Subscription;
 import io.aeron.UnavailableCounterHandler;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.driver.DutyCycleTracker;
 import io.aeron.logbuffer.BufferClaim;
+import io.aeron.test.CountersAnswer;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.*;
@@ -88,19 +88,8 @@ class ClusteredServiceAgentTest
         final CountersManager countersManager = new CountersManager(
             new UnsafeBuffer(new byte[64 * 1024]), new UnsafeBuffer(new byte[16 * 1024]));
 
-        when(aeron.addCounter(anyInt(), any(), anyInt(), anyInt(), any(), anyInt(), anyInt())).then(
-            (invocation) ->
-            {
-                final int counterId = countersManager.allocate(
-                    invocation.getArgument(0, Integer.class),
-                    invocation.getArgument(1, DirectBuffer.class),
-                    invocation.getArgument(2, Integer.class),
-                    invocation.getArgument(3, Integer.class),
-                    invocation.getArgument(4, DirectBuffer.class),
-                    invocation.getArgument(5, Integer.class),
-                    invocation.getArgument(6, Integer.class));
-                return new Counter(countersManager, 0, counterId);
-            });
+        when(aeron.addCounter(anyInt(), any(), anyInt(), anyInt(), any(), anyInt(), anyInt()))
+            .then(CountersAnswer.mapTo(countersManager));
 
         RecoveryState.allocate(aeron, NULL_VALUE, 0, 0, 0, 0);
 

--- a/aeron-test-support/src/main/java/io/aeron/test/CountersAnswer.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/CountersAnswer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+import io.aeron.Counter;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.status.CountersManager;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Provide a Mockito Answer that will allow a mapping of Aeron.addCounter onto a CountersManager.
+ */
+public final class CountersAnswer implements Answer<Counter>
+{
+    private final CountersManager countersManager;
+
+    private CountersAnswer(final CountersManager countersManager)
+    {
+        this.countersManager = countersManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Counter answer(final InvocationOnMock invocation)
+    {
+        final int counterId;
+        if (2 == invocation.getArguments().length)
+        {
+            counterId = countersManager.allocate(
+                invocation.getArgument(0, String.class),
+                invocation.getArgument(1, Integer.class));
+        }
+        else if (7 == invocation.getArguments().length)
+        {
+            counterId = countersManager.allocate(
+                invocation.getArgument(0, Integer.class),
+                invocation.getArgument(1, DirectBuffer.class),
+                invocation.getArgument(2, Integer.class),
+                invocation.getArgument(3, Integer.class),
+                invocation.getArgument(4, DirectBuffer.class),
+                invocation.getArgument(5, Integer.class),
+                invocation.getArgument(6, Integer.class));
+        }
+        else
+        {
+            throw new RuntimeException(
+                "Unexpected number of arguments, should be used for Aeron::addCounter(String, int) or " +
+                "Aeron::addCounter(int, DirectBuffer, int, int, DirectBuffer, int, int)");
+        }
+
+        return new Counter(countersManager, 0, counterId);
+    }
+
+    /**
+     * Set up an answer that will map addCounter requests from addCounter methods (generally from a mocked
+     * Aeron instance).
+     *
+     * @param countersManager delegate to pass addCounter requests to.
+     * @return an Answer that will use the supplied counters manager.
+     */
+    public static CountersAnswer mapTo(final CountersManager countersManager)
+    {
+        return new CountersAnswer(countersManager);
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -1150,6 +1150,11 @@ public final class TestCluster implements AutoCloseable
         return snapshotCounter.get();
     }
 
+    public long logPosition()
+    {
+        final TestNode leader = findLeader();
+        return leader.consensusModule().context().commitPositionCounter().get();
+    }
 
     public void awaitNodeTermination(final TestNode node)
     {

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -608,6 +608,11 @@ public final class TestCluster implements AutoCloseable
         CloseHelper.closeAll(nodes);
     }
 
+    public void stopClient()
+    {
+        CloseHelper.closeAll(client, clientMediaDriver);
+    }
+
     public void restartAllNodes(final boolean cleanStart)
     {
         for (int i = 0; i < staticMemberCount; i++)

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -93,49 +93,8 @@ public final class TestCluster implements AutoCloseable
 
     private final DataCollector dataCollector = new DataCollector();
     private final ExpandableArrayBuffer msgBuffer = new ExpandableArrayBuffer();
-    private final MutableLong responseCount = new MutableLong();
-    private final MutableInteger newLeaderEvent = new MutableInteger();
-    private EgressListener egressListener = new EgressListener()
-    {
-        public void onMessage(
-            final long clusterSessionId,
-            final long timestamp,
-            final DirectBuffer buffer,
-            final int offset,
-            final int length,
-            final Header header)
-        {
-            responseCount.increment();
-        }
-
-        public void onSessionEvent(
-            final long correlationId,
-            final long clusterSessionId,
-            final long leadershipTermId,
-            final int leaderMemberId,
-            final EventCode code,
-            final String detail)
-        {
-            if (EventCode.ERROR == code)
-            {
-                throw new ClusterException(detail);
-            }
-            else if (EventCode.CLOSED == code && shouldErrorOnClientClose)
-            {
-                final String msg = "[" + System.nanoTime() / 1_000_000_000.0 + "] session closed due to " + detail;
-                throw new ClusterException(msg);
-            }
-        }
-
-        public void onNewLeader(
-            final long clusterSessionId,
-            final long leadershipTermId,
-            final int leaderMemberId,
-            final String ingressEndpoints)
-        {
-            newLeaderEvent.increment();
-        }
-    };
+    private final DefaultEgressListener defaultEgressListener = new DefaultEgressListener();
+    private EgressListener egressListener = defaultEgressListener;
     private ControlledEgressListener controlledEgressListener;
 
     private final TestNode[] nodes;
@@ -149,7 +108,6 @@ public final class TestCluster implements AutoCloseable
     private final int backupNodeIndex;
     private final IntHashSet invalidInitialResolutions;
     private final IntFunction<TestNode.TestService[]> serviceSupplier;
-    private boolean shouldErrorOnClientClose = true;
     private String logChannel;
     private String ingressChannel;
     private String egressChannel;
@@ -660,7 +618,7 @@ public final class TestCluster implements AutoCloseable
 
     public void shouldErrorOnClientClose(final boolean shouldErrorOnClose)
     {
-        this.shouldErrorOnClientClose = shouldErrorOnClose;
+        defaultEgressListener.shouldErrorOnClientClose = shouldErrorOnClose;
     }
 
     public void logChannel(final String logChannel)
@@ -926,9 +884,10 @@ public final class TestCluster implements AutoCloseable
     {
         clientKeepAlive.init();
         long count;
-        final Supplier<String> msg = () -> "expected=" + messageCount + " responseCount=" + responseCount.get();
+        final Supplier<String> msg =
+            () -> "expected=" + messageCount + " responseCount=" + defaultEgressListener.responseCount();
 
-        while ((count = responseCount.get()) < messageCount)
+        while ((count = defaultEgressListener.responseCount()) < messageCount)
         {
             client.pollEgress();
 
@@ -947,7 +906,7 @@ public final class TestCluster implements AutoCloseable
 
     public void awaitNewLeadershipEvent(final int count)
     {
-        while (newLeaderEvent.get() < count || !client.ingressPublication().isConnected())
+        while (defaultEgressListener.newLeaderEvent() < count || !client.ingressPublication().isConnected())
         {
             await(1);
             client.pollEgress();
@@ -1382,12 +1341,18 @@ public final class TestCluster implements AutoCloseable
 
     public static String ingressEndpoints(final int clusterId, final int memberCount)
     {
+        return ingressEndpoints(clusterId, 0, memberCount);
+    }
+
+    public static String ingressEndpoints(final int clusterId, final int initialMemberId, final int memberCount)
+    {
         final StringBuilder builder = new StringBuilder();
 
         for (int i = 0; i < memberCount; i++)
         {
-            builder.append(i).append('=').append(hostname(i)).append(":2").append(clusterId).append("11")
-                .append(i).append(',');
+            final int memberId = initialMemberId + i;
+            builder.append(memberId).append('=').append(hostname(memberId)).append(":2").append(clusterId).append("11")
+                .append(memberId).append(',');
         }
 
         builder.setLength(builder.length() - 1);
@@ -1936,6 +1901,62 @@ public final class TestCluster implements AutoCloseable
                 client.sendKeepAlive();
                 keepAliveDeadlineMs = nowMs + TimeUnit.SECONDS.toMillis(1);
             }
+        }
+    }
+
+    static class DefaultEgressListener implements EgressListener
+    {
+        private final MutableLong responseCount = new MutableLong();
+        private final MutableInteger newLeaderEvent = new MutableInteger();
+        private boolean shouldErrorOnClientClose = true;
+
+        public void onMessage(
+            final long clusterSessionId,
+            final long timestamp,
+            final DirectBuffer buffer,
+            final int offset,
+            final int length,
+            final Header header)
+        {
+            responseCount.increment();
+        }
+
+        public void onSessionEvent(
+            final long correlationId,
+            final long clusterSessionId,
+            final long leadershipTermId,
+            final int leaderMemberId,
+            final EventCode code,
+            final String detail)
+        {
+            if (EventCode.ERROR == code)
+            {
+                throw new ClusterException(detail);
+            }
+            else if (EventCode.CLOSED == code && shouldErrorOnClientClose)
+            {
+                final String msg = "[" + System.nanoTime() / 1_000_000_000.0 + "] session closed due to " + detail;
+                throw new ClusterException(msg);
+            }
+        }
+
+        public void onNewLeader(
+            final long clusterSessionId,
+            final long leadershipTermId,
+            final int leaderMemberId,
+            final String ingressEndpoints)
+        {
+            newLeaderEvent.increment();
+        }
+
+        long responseCount()
+        {
+            return responseCount.get();
+        }
+
+        int newLeaderEvent()
+        {
+            return newLeaderEvent.get();
         }
     }
 }


### PR DESCRIPTION
- Define structures to import state into the ConsensusModule.
- Support starting the ConsensusModuleAgent from existing state.
- Add more Standby/TransitionModule counters.
- Small testing updates and utilities.