### PR TITLE
[Java] Delay election state transitions if there is an active leader.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
@@ -972,7 +972,7 @@ public final class ClusterMember
      * @param candidateTermId for the vote.
      * @return {@code true} if all members voted positively.
      */
-    public static boolean isUnanimousVote(final ClusterMember[] clusterMembers, final long candidateTermId)
+    public static boolean hasUnanimousVotes(final ClusterMember[] clusterMembers, final long candidateTermId)
     {
         for (final ClusterMember member : clusterMembers)
         {
@@ -992,7 +992,7 @@ public final class ClusterMember
      * @param candidateTermId for the vote.
      * @return {@code true} if sufficient positive votes being counted for a majority and no negative votes.
      */
-    public static boolean isQuorumVote(final ClusterMember[] clusterMembers, final long candidateTermId)
+    public static boolean hasQuorumVotes(final ClusterMember[] clusterMembers, final long candidateTermId)
     {
         int votes = 0;
         for (final ClusterMember member : clusterMembers)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterMember.java
@@ -15,7 +15,10 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.*;
+import io.aeron.Aeron;
+import io.aeron.ChannelUri;
+import io.aeron.ExclusivePublication;
+import io.aeron.Publication;
 import io.aeron.cluster.client.ClusterEvent;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.exceptions.RegistrationException;
@@ -963,13 +966,33 @@ public final class ClusterMember
     }
 
     /**
+     * Has all the members voted positively.
+     *
+     * @param clusterMembers  to check for votes.
+     * @param candidateTermId for the vote.
+     * @return {@code true} if all members voted positively.
+     */
+    public static boolean isUnanimousVote(final ClusterMember[] clusterMembers, final long candidateTermId)
+    {
+        for (final ClusterMember member : clusterMembers)
+        {
+            if (candidateTermId != member.candidateTermId || !Boolean.TRUE.equals(member.vote))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Has sufficient positive votes being counted for a majority and no negative votes.
      *
      * @param clusterMembers  to check for votes.
      * @param candidateTermId for the vote.
-     * @return true if sufficient positive votes being counted for a majority and no negative votes.
+     * @return {@code true} if sufficient positive votes being counted for a majority and no negative votes.
      */
-    public static boolean hasWonVote(final ClusterMember[] clusterMembers, final long candidateTermId)
+    public static boolean isQuorumVote(final ClusterMember[] clusterMembers, final long candidateTermId)
     {
         int votes = 0;
         for (final ClusterMember member : clusterMembers)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1371,8 +1371,6 @@ public final class ConsensusModule implements AutoCloseable
         @SuppressWarnings("MethodLength")
         public void conclude()
         {
-            final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
-
             if (0 != IS_CONCLUDED_UPDATER.getAndSet(this, 1))
             {
                 throw new ConcurrentConcludeException();
@@ -1398,6 +1396,12 @@ public final class ConsensusModule implements AutoCloseable
             if (!clusterDir.exists() && !clusterDir.mkdirs())
             {
                 throw new ClusterException("failed to create cluster dir: " + clusterDir.getAbsolutePath());
+            }
+
+            if (startupCanvassTimeoutNs <= leaderHeartbeatTimeoutNs)
+            {
+                throw new ClusterException("startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
+                    " must be greater than leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
             }
 
             if (null == clusterClock)
@@ -1499,6 +1503,8 @@ public final class ConsensusModule implements AutoCloseable
                     aeron.context().errorHandler(countedErrorHandler);
                 }
             }
+
+            final ExpandableArrayBuffer buffer = new ExpandableArrayBuffer();
 
             if (null == moduleStateCounter)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1401,7 +1401,7 @@ public final class ConsensusModule implements AutoCloseable
             if (startupCanvassTimeoutNs / leaderHeartbeatTimeoutNs < 2)
             {
                 throw new ClusterException("startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
-                    " must be multiples of the leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
+                    " must be a multiple of leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
             }
 
             if (null == clusterClock)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1398,10 +1398,10 @@ public final class ConsensusModule implements AutoCloseable
                 throw new ClusterException("failed to create cluster dir: " + clusterDir.getAbsolutePath());
             }
 
-            if (startupCanvassTimeoutNs <= leaderHeartbeatTimeoutNs)
+            if (startupCanvassTimeoutNs / leaderHeartbeatTimeoutNs < 2)
             {
                 throw new ClusterException("startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
-                    " must be greater than leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
+                    " must be multiples of the leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs);
             }
 
             if (null == clusterClock)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -87,7 +87,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
     private long timeOfLastLogUpdateNs = 0;
     private long timeOfLastAppendPositionUpdateNs = 0;
     private long timeOfLastAppendPositionSendNs = 0;
-    private long timeOfLastLeaderMessageReceivedNs;
+    private long timeOfLastLeaderUpdateNs;
     private long slowTickDeadlineNs = 0;
     private long markFileUpdateDeadlineNs = 0;
 
@@ -864,7 +864,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         }
 
         final long nowNs = clusterClock.timeNanos();
-        timeOfLastLeaderMessageReceivedNs = nowNs;
+        timeOfLastLeaderUpdateNs = nowNs;
 
         if (null != election)
         {
@@ -925,7 +925,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         logOnCommitPosition(memberId, leadershipTermId, logPosition, leaderMemberId);
 
         final long nowNs = clusterClock.timeNanos();
-        timeOfLastLeaderMessageReceivedNs = nowNs;
+        timeOfLastLeaderUpdateNs = nowNs;
 
         if (null != election)
         {
@@ -3052,9 +3052,9 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         return ClusterMember.quorumPosition(activeMembers, rankedPositions);
     }
 
-    long timeOfLastLeaderMessageReceivedNs()
+    long timeOfLastLeaderUpdateNs()
     {
-        return timeOfLastLeaderMessageReceivedNs;
+        return timeOfLastLeaderUpdateNs;
     }
 
     int updateLeaderPosition(final long nowNs, final long position)

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -709,7 +709,7 @@ class Election
     {
         int workCount = 0;
 
-        if (ClusterMember.hasWonVote(clusterMembers, candidateTermId))
+        if (ClusterMember.isQuorumVote(clusterMembers, candidateTermId))
         {
             leaderMember = thisMember;
             leadershipTermId = candidateTermId;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -678,7 +678,7 @@ class Election
         }
 
         final long deadlineNs = isExtendedCanvass ? timeOfLastStateChangeNs + ctx.startupCanvassTimeoutNs() :
-            consensusModuleAgent.timeOfLastLeaderMessageReceivedNs() + ctx.leaderHeartbeatTimeoutNs();
+            consensusModuleAgent.timeOfLastLeaderUpdateNs() + ctx.leaderHeartbeatTimeoutNs();
 
         if (ClusterMember.isUnanimousCandidate(clusterMembers, thisMember) ||
             (nowNs >= deadlineNs && ClusterMember.isQuorumCandidate(clusterMembers, thisMember)))
@@ -711,7 +711,7 @@ class Election
         int workCount = 0;
 
         if (ClusterMember.hasUnanimousVotes(clusterMembers, candidateTermId) ||
-            (nowNs >= (consensusModuleAgent.timeOfLastLeaderMessageReceivedNs() + ctx.electionTimeoutNs()) &&
+            (nowNs >= (consensusModuleAgent.timeOfLastLeaderUpdateNs() + ctx.electionTimeoutNs()) &&
             ClusterMember.hasQuorumVotes(clusterMembers, candidateTermId)))
         {
             leaderMember = thisMember;

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -710,9 +710,9 @@ class Election
     {
         int workCount = 0;
 
-        if (ClusterMember.isUnanimousVote(clusterMembers, candidateTermId) ||
+        if (ClusterMember.hasUnanimousVotes(clusterMembers, candidateTermId) ||
             (nowNs >= (timeOfLastStateChangeNs + ctx.electionTimeoutNs()) &&
-            ClusterMember.isQuorumVote(clusterMembers, candidateTermId)))
+            ClusterMember.hasQuorumVotes(clusterMembers, candidateTermId)))
         {
             leaderMember = thisMember;
             leadershipTermId = candidateTermId;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
@@ -157,7 +157,7 @@ public class ClusterMemberTest
     }
 
     @Test
-    void isQuorumVoteReturnsTrueWhenQuorumIsReached()
+    void hasQuorumVotesReturnsTrueWhenQuorumIsReached()
     {
         final int candidateTermId = -5;
         final ClusterMember[] members = new ClusterMember[]
@@ -169,11 +169,11 @@ public class ClusterMemberTest
             newMember(5).candidateTermId(candidateTermId).vote(Boolean.TRUE)
         };
 
-        assertTrue(isQuorumVote(members, candidateTermId));
+        assertTrue(hasQuorumVotes(members, candidateTermId));
     }
 
     @Test
-    void isQuorumVoteReturnsFalseIfAtLeastOneNegativeVoteIsDetected()
+    void hasQuorumVotesReturnsFalseIfAtLeastOneNegativeVoteIsDetected()
     {
         final int candidateTermId = 8;
         final ClusterMember[] members = new ClusterMember[]
@@ -183,11 +183,11 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
         };
 
-        assertFalse(isQuorumVote(members, candidateTermId));
+        assertFalse(hasQuorumVotes(members, candidateTermId));
     }
 
     @Test
-    void isQuorumVoteReturnsFalseWhenQuorumIsNotReached()
+    void hasQuorumVotesReturnsFalseWhenQuorumIsNotReached()
     {
         final int candidateTermId = 2;
         final ClusterMember[] members = new ClusterMember[]
@@ -197,11 +197,11 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId + 5).vote(Boolean.TRUE)
         };
 
-        assertFalse(isQuorumVote(members, candidateTermId));
+        assertFalse(hasQuorumVotes(members, candidateTermId));
     }
 
     @Test
-    void isUnanimousVoteReturnsFalseIfThereIsAtLeastOneNegativeVoteForAGivenCandidateTerm()
+    void hasUnanimousVotesReturnsFalseIfThereIsAtLeastOneNegativeVoteForAGivenCandidateTerm()
     {
         final int candidateTermId = 42;
         final ClusterMember[] members = new ClusterMember[]
@@ -211,11 +211,11 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId).vote(Boolean.FALSE)
         };
 
-        assertFalse(isUnanimousVote(members, candidateTermId));
+        assertFalse(hasUnanimousVotes(members, candidateTermId));
     }
 
     @Test
-    void isUnanimousVoteReturnsFalseIfNotAllNodesVotedPositively()
+    void hasUnanimousVotesReturnsFalseIfNotAllNodesVotedPositively()
     {
         final int candidateTermId = 2;
         final ClusterMember[] members = new ClusterMember[]
@@ -225,11 +225,11 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
         };
 
-        assertFalse(isUnanimousVote(members, candidateTermId));
+        assertFalse(hasUnanimousVotes(members, candidateTermId));
     }
 
     @Test
-    void isUnanimousVoteReturnsFalseIfNotAllNodesHadTheExpectedCandidateTermId()
+    void hasUnanimousVotesReturnsFalseIfNotAllNodesHadTheExpectedCandidateTermId()
     {
         final int candidateTermId = 2;
         final ClusterMember[] members = new ClusterMember[]
@@ -239,11 +239,11 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
         };
 
-        assertFalse(isUnanimousVote(members, candidateTermId));
+        assertFalse(hasUnanimousVotes(members, candidateTermId));
     }
 
     @Test
-    void isUnanimousVoteReturnsTrueIfAllNodesVotedWithTrue()
+    void hasUnanimousVotesReturnsTrueIfAllNodesVotedWithTrue()
     {
         final int candidateTermId = 42;
         final ClusterMember[] members = new ClusterMember[]
@@ -253,7 +253,7 @@ public class ClusterMemberTest
             newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
         };
 
-        assertTrue(isUnanimousVote(members, candidateTermId));
+        assertTrue(hasUnanimousVotes(members, candidateTermId));
     }
 
     @ParameterizedTest

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterMemberTest.java
@@ -16,11 +16,14 @@
 package io.aeron.cluster;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static io.aeron.cluster.ClusterMember.quorumPosition;
-import static io.aeron.cluster.ClusterMember.quorumThreshold;
+import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
+import static io.aeron.cluster.ClusterMember.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ClusterMemberTest
 {
@@ -77,5 +80,213 @@ public class ClusterMemberTest
             final long quorumPosition = quorumPosition(members, rankedPositions);
             assertThat("Test: " + i, quorumPosition, is(quorumPositions[i]));
         }
+    }
+
+    @Test
+    void isUnanimousCandidateReturnFalseIfThereIsAMemberWithoutLogPosition()
+    {
+        final ClusterMember candidate = newMember(4, 100, 1000);
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1, 2, 100),
+            newMember(2, 8, NULL_POSITION),
+            newMember(3, 1, 1)
+        };
+
+        assertFalse(isUnanimousCandidate(members, candidate));
+    }
+
+    @Test
+    void isUnanimousCandidateReturnFalseIfThereIsAMemberWithMoreUpToDateLog()
+    {
+        final ClusterMember candidate = newMember(4, 10, 800);
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1, 2, 100),
+            newMember(2, 8, 6),
+            newMember(3, 11, 1000)
+        };
+
+        assertFalse(isUnanimousCandidate(members, candidate));
+    }
+
+    @Test
+    void isUnanimousCandidateReturnTrueIfTheCandidateHasTheMostUpToDateLog()
+    {
+        final ClusterMember candidate = newMember(2, 10, 800);
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(10, 2, 100),
+            newMember(20, 8, 6),
+            newMember(30, 10, 800)
+        };
+
+        assertTrue(isUnanimousCandidate(members, candidate));
+    }
+
+    @Test
+    void isQuorumCandidateReturnFalseWhenQuorumIsNotReached()
+    {
+        final ClusterMember candidate = newMember(2, 10, 800);
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(10, 2, 100),
+            newMember(20, 18, 6),
+            newMember(30, 10, 800),
+            newMember(40, 19, 800),
+            newMember(50, 10, 1000),
+        };
+
+        assertFalse(isQuorumCandidate(members, candidate));
+    }
+
+    @Test
+    void isQuorumCandidateReturnTrueWhenQuorumIsReached()
+    {
+        final ClusterMember candidate = newMember(2, 10, 800);
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(10, 2, 100),
+            newMember(20, 18, 6),
+            newMember(30, 10, 800),
+            newMember(40, 9, 800),
+            newMember(50, 10, 700)
+        };
+
+        assertTrue(isQuorumCandidate(members, candidate));
+    }
+
+    @Test
+    void isQuorumVoteReturnsTrueWhenQuorumIsReached()
+    {
+        final int candidateTermId = -5;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId * 2).vote(Boolean.FALSE),
+            newMember(3).candidateTermId(candidateTermId).vote(null),
+            newMember(4).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(5).candidateTermId(candidateTermId).vote(Boolean.TRUE)
+        };
+
+        assertTrue(isQuorumVote(members, candidateTermId));
+    }
+
+    @Test
+    void isQuorumVoteReturnsFalseIfAtLeastOneNegativeVoteIsDetected()
+    {
+        final int candidateTermId = 8;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId).vote(Boolean.FALSE),
+            newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
+        };
+
+        assertFalse(isQuorumVote(members, candidateTermId));
+    }
+
+    @Test
+    void isQuorumVoteReturnsFalseWhenQuorumIsNotReached()
+    {
+        final int candidateTermId = 2;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId).vote(null),
+            newMember(3).candidateTermId(candidateTermId + 5).vote(Boolean.TRUE)
+        };
+
+        assertFalse(isQuorumVote(members, candidateTermId));
+    }
+
+    @Test
+    void isUnanimousVoteReturnsFalseIfThereIsAtLeastOneNegativeVoteForAGivenCandidateTerm()
+    {
+        final int candidateTermId = 42;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(3).candidateTermId(candidateTermId).vote(Boolean.FALSE)
+        };
+
+        assertFalse(isUnanimousVote(members, candidateTermId));
+    }
+
+    @Test
+    void isUnanimousVoteReturnsFalseIfNotAllNodesVotedPositively()
+    {
+        final int candidateTermId = 2;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId).vote(null),
+            newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
+        };
+
+        assertFalse(isUnanimousVote(members, candidateTermId));
+    }
+
+    @Test
+    void isUnanimousVoteReturnsFalseIfNotAllNodesHadTheExpectedCandidateTermId()
+    {
+        final int candidateTermId = 2;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId + 1).vote(Boolean.TRUE),
+            newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
+        };
+
+        assertFalse(isUnanimousVote(members, candidateTermId));
+    }
+
+    @Test
+    void isUnanimousVoteReturnsTrueIfAllNodesVotedWithTrue()
+    {
+        final int candidateTermId = 42;
+        final ClusterMember[] members = new ClusterMember[]
+        {
+            newMember(1).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(2).candidateTermId(candidateTermId).vote(Boolean.TRUE),
+            newMember(3).candidateTermId(candidateTermId).vote(Boolean.TRUE)
+        };
+
+        assertTrue(isUnanimousVote(members, candidateTermId));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "5,1000,3,999999,1",
+        "-100,99999,4,0,-1",
+        "42,371239192371239,42,1001,1",
+        "3,-777,3,273291846723894,-1",
+        "1,1024,1,1024,0",
+    })
+    void compareLogReturnsResult(
+        final long lhsLogLeadershipTermId,
+        final long lhsLogPosition,
+        final long rhsLogLeadershipTermId,
+        final long rhsLogPosition,
+        final int expectedResult)
+    {
+        assertEquals(
+            expectedResult,
+            compareLog(lhsLogLeadershipTermId, lhsLogPosition, rhsLogLeadershipTermId, rhsLogPosition));
+        assertEquals(expectedResult, compareLog(
+            newMember(5, lhsLogLeadershipTermId, lhsLogPosition),
+            newMember(100, rhsLogLeadershipTermId, rhsLogPosition)));
+    }
+
+    private static ClusterMember newMember(final int id, final long leadershipTermId, final long logPosition)
+    {
+        final ClusterMember clusterMember = newMember(id);
+        return clusterMember.leadershipTermId(leadershipTermId).logPosition(logPosition);
+    }
+
+    private static ClusterMember newMember(final int id)
+    {
+        return new ClusterMember(id, null, null, null, null, null, null);
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleAgentTest.java
@@ -427,7 +427,7 @@ public class ConsensusModuleAgentTest
         final int leadershipTermId = 2;
         final ConsensusModuleAgent consensusModuleAgent = new ConsensusModuleAgent(ctx);
         consensusModuleAgent.leadershipTermId(leadershipTermId);
-        assertEquals(0, consensusModuleAgent.timeOfLastLeaderMessageReceivedNs());
+        assertEquals(0, consensusModuleAgent.timeOfLastLeaderUpdateNs());
 
         clock.increment(12345);
 
@@ -446,7 +446,7 @@ public class ConsensusModuleAgentTest
             777,
             false);
 
-        assertEquals(12345, consensusModuleAgent.timeOfLastLeaderMessageReceivedNs());
+        assertEquals(12345, consensusModuleAgent.timeOfLastLeaderUpdateNs());
     }
 
     @Test
@@ -459,12 +459,12 @@ public class ConsensusModuleAgentTest
         final int leadershipTermId = 42;
         final ConsensusModuleAgent consensusModuleAgent = new ConsensusModuleAgent(ctx);
         consensusModuleAgent.leadershipTermId(leadershipTermId);
-        assertEquals(0, consensusModuleAgent.timeOfLastLeaderMessageReceivedNs());
+        assertEquals(0, consensusModuleAgent.timeOfLastLeaderUpdateNs());
 
         clock.increment(444);
 
         consensusModuleAgent.onCommitPosition(leadershipTermId, 555, 0);
 
-        assertEquals(444, consensusModuleAgent.timeOfLastLeaderMessageReceivedNs());
+        assertEquals(444, consensusModuleAgent.timeOfLastLeaderUpdateNs());
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -403,7 +403,7 @@ class ConsensusModuleContextTest
 
         final ClusterException exception = assertThrows(ClusterException.class, context::conclude);
         assertEquals("ERROR - startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
-            " must be multiples of the leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs,
+            " must be a multiple of leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs,
             exception.getMessage());
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
@@ -389,6 +390,20 @@ class ConsensusModuleContextTest
         final Throwable cause = exception.getCause();
         assertInstanceOf(IllegalStateException.class, cause);
         assertEquals("active Mark file detected", cause.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0, 1000", "123632842384368, 123632842384368" })
+    void startupCanvassTimeoutMustBeGreaterThanTheLeaderHeartbeatTimeout(
+        final long startupCanvassTimeoutNs, final long leaderHeartbeatTimeoutNs)
+    {
+        context.startupCanvassTimeoutNs(startupCanvassTimeoutNs)
+            .leaderHeartbeatTimeoutNs(leaderHeartbeatTimeoutNs);
+
+        final ClusterException exception = assertThrows(ClusterException.class, context::conclude);
+        assertEquals("ERROR - startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
+            " must be greater than leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs,
+            exception.getMessage());
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import static io.aeron.cluster.ConsensusModule.Configuration.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -393,8 +394,8 @@ class ConsensusModuleContextTest
     }
 
     @ParameterizedTest
-    @CsvSource({ "0, 1000", "123632842384368, 123632842384368" })
-    void startupCanvassTimeoutMustBeGreaterThanTheLeaderHeartbeatTimeout(
+    @CsvSource({ "0, 1000", "5000,5000", "2000000000, 1000000001" })
+    void startupCanvassTimeoutMustBeMultiplesOfTheLeaderHeartbeatTimeout(
         final long startupCanvassTimeoutNs, final long leaderHeartbeatTimeoutNs)
     {
         context.startupCanvassTimeoutNs(startupCanvassTimeoutNs)
@@ -402,8 +403,17 @@ class ConsensusModuleContextTest
 
         final ClusterException exception = assertThrows(ClusterException.class, context::conclude);
         assertEquals("ERROR - startupCanvassTimeoutNs=" + startupCanvassTimeoutNs +
-            " must be greater than leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs,
+            " must be multiples of the leaderHeartbeatTimeoutNs=" + leaderHeartbeatTimeoutNs,
             exception.getMessage());
+    }
+
+    @Test
+    void startupCanvassTimeoutMustCanBeSetToBeMultiplesOfTheLeaderHeartbeatTimeout()
+    {
+        context.startupCanvassTimeoutNs(TimeUnit.SECONDS.toNanos(30))
+            .leaderHeartbeatTimeoutNs(TimeUnit.SECONDS.toNanos(5));
+
+        context.conclude();
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -591,7 +591,7 @@ public class ElectionTest
 
         election.onCanvassPosition(leadershipTermId, logPosition, leadershipTermId, 0, VERSION);
 
-        clock.increment(ctx.electionTimeoutNs());
+        clock.increment(ctx.leaderHeartbeatTimeoutNs());
         election.doWork(clock.nanoTime());
         inOrder.verify(electionStateCounter).setOrdered(ElectionState.NOMINATE.code());
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterNetworkTopologyTest.java
@@ -68,7 +68,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ClusterNetworkTopologyTest
 {
     private static final int REMOTE_LAUNCH_PORT = 11112;
-    private static final long CLUSTER_START_ELECTION_TIMEOUT_S = 10;
+    private static final long STARTUP_CANVASS_TIMEOUT_S = 15;
     private static final List<String> HOSTNAMES = Arrays.asList("10.42.0.10", "10.42.0.11", "10.42.0.12");
     private static final List<String> INTERNAL_HOSTNAMES = Arrays.asList("10.42.1.10", "10.42.1.11", "10.42.1.12");
 
@@ -268,7 +268,7 @@ class ClusterNetworkTopologyTest
                 .dirDeleteOnStart(true)
                 .dirDeleteOnShutdown(true));
             AeronCluster.AsyncConnect asyncConnect = AeronCluster.asyncConnect(new AeronCluster.Context()
-                .messageTimeoutNs(TimeUnit.SECONDS.toNanos(CLUSTER_START_ELECTION_TIMEOUT_S * 2))
+                .messageTimeoutNs(TimeUnit.SECONDS.toNanos(STARTUP_CANVASS_TIMEOUT_S * 2))
                 .egressListener(egressListener)
                 .egressChannel("aeron:udp?endpoint=10.42.0.1:0")
                 .aeronDirectoryName(mediaDriver.aeronDirectoryName())
@@ -464,7 +464,7 @@ class ClusterNetworkTopologyTest
         command.add("-Daeron.event.cluster.log.disable=CANVASS_POSITION,APPEND_POSITION,COMMIT_POSITION");
         command.add("-Daeron.event.log.filename=" + new File(clusterDir, "event.log").getAbsolutePath());
         command.add("-Daeron.driver.resolver.name=node" + nodeId);
-        command.add("-Daeron.cluster.startup.canvass.timeout=" + CLUSTER_START_ELECTION_TIMEOUT_S + "s");
+        command.add("-Daeron.cluster.startup.canvass.timeout=" + STARTUP_CANVASS_TIMEOUT_S + "s");
 
         if (null != ingressChannel)
         {

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1015,11 +1015,7 @@ class ClusterTest
         cluster.stopAllNodes();
 
         final TestNode oldLeader = cluster.startStaticNode(leader.index(), false);
-        oldLeader.awaitElectionState(ElectionState.CANVASS);
-
         final TestNode oldFollower1 = cluster.startStaticNode(followers.get(0).index(), true);
-        oldFollower1.awaitElectionState(ElectionState.CLOSED);
-
         final TestNode oldFollower2 = cluster.startStaticNode(followers.get(1).index(), true);
 
         final TestNode newLeader = cluster.awaitLeader();

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -293,7 +293,7 @@ class ClusterTest
     }
 
     @Test
-    @InterruptAfter(20)
+    @InterruptAfter(40)
     void shouldHandleClusterStartWhenANameIsNotResolvable()
     {
         final int initiallyUnresolvableNodeId = 1;

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -111,7 +111,8 @@ public final class TestCluster implements AutoCloseable
     static final String ARCHIVE_LOCAL_CONTROL_CHANNEL = "aeron:ipc";
     static final String EGRESS_CHANNEL = "aeron:udp?term-length=128k|endpoint=localhost:0";
     static final String INGRESS_CHANNEL = "aeron:udp?term-length=128k|alias=ingress";
-    static final long STARTUP_CANVASS_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(5);
+    static final long LEADER_HEARTBEAT_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(10);
+    static final long STARTUP_CANVASS_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_NS + TimeUnit.SECONDS.toNanos(5);
 
     public static final String DEFAULT_NODE_MAPPINGS =
         "node0,localhost,localhost|" +
@@ -294,6 +295,7 @@ public final class TestCluster implements AutoCloseable
             .clusterMemberId(index)
             .clusterMembers(staticClusterMembers)
             .startupCanvassTimeoutNs(STARTUP_CANVASS_TIMEOUT_NS)
+            .leaderHeartbeatTimeoutNs(LEADER_HEARTBEAT_TIMEOUT_NS)
             .appointedLeaderId(appointedLeaderId)
             .clusterDir(new File(baseDirName, "consensus-module"))
             .ingressChannel(ingressChannel)
@@ -473,6 +475,7 @@ public final class TestCluster implements AutoCloseable
             .clusterMemberId(index)
             .clusterMembers(clusterMembers(0, staticMemberCount + 1))
             .startupCanvassTimeoutNs(STARTUP_CANVASS_TIMEOUT_NS)
+            .leaderHeartbeatTimeoutNs(LEADER_HEARTBEAT_TIMEOUT_NS)
             .appointedLeaderId(appointedLeaderId)
             .clusterDir(new File(baseDirName, "consensus-module"))
             .ingressChannel(ingressChannel)

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -112,7 +112,7 @@ public final class TestCluster implements AutoCloseable
     static final String EGRESS_CHANNEL = "aeron:udp?term-length=128k|endpoint=localhost:0";
     static final String INGRESS_CHANNEL = "aeron:udp?term-length=128k|alias=ingress";
     static final long LEADER_HEARTBEAT_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(10);
-    static final long STARTUP_CANVASS_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_NS + TimeUnit.SECONDS.toNanos(5);
+    static final long STARTUP_CANVASS_TIMEOUT_NS = LEADER_HEARTBEAT_TIMEOUT_NS * 2;
 
     public static final String DEFAULT_NODE_MAPPINGS =
         "node0,localhost,localhost|" +

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestClusterClock.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestClusterClock.java
@@ -47,6 +47,21 @@ public class TestClusterClock implements ClusterClock, EpochClock, NanoClock
         return timeUnit.toNanos(tick.get());
     }
 
+    public long timeMillis()
+    {
+        return timeUnit.toMillis(tick.get());
+    }
+
+    public long timeMicros()
+    {
+        return timeUnit.toMicros(tick.get());
+    }
+
+    public long timeNanos()
+    {
+        return timeUnit.toNanos(tick.get());
+    }
+
     public void update(final long tick, final TimeUnit tickTimeUnit)
     {
         this.tick.set(tickTimeUnit.convert(tick, tickTimeUnit));


### PR DESCRIPTION
The transition from `CANVASS` to `NOMINATE` and from `CANDIDATE_BALLOT` to `LEADER_LOG_REPLICATION` in case the corresponding vote/candidacy check is not unanimous is done with a timeout that is based on the time of the last message received from the leader. Which is tracked upon receiving the `onCommitPosition` and `onNewLeadershipTerm` messages.
The delay is necessary to prevent the non-eligible majority of forming a quorum and electing a new leader.
