### PR TITLE
[Java] Handle data bigger than the `maxPayloadSize` when taking the Cluster snapshot.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotTaker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotTaker.java
@@ -18,6 +18,7 @@ package io.aeron.cluster;
 import io.aeron.ExclusivePublication;
 import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.SnapshotTaker;
+import org.agrona.ExpandableArrayBuffer;
 import org.agrona.ExpandableRingBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.AgentInvoker;
@@ -29,6 +30,7 @@ class ConsensusModuleSnapshotTaker
 {
     private static final int ENCODED_TIMER_LENGTH = MessageHeaderEncoder.ENCODED_LENGTH + TimerEncoder.BLOCK_LENGTH;
 
+    private final ExpandableArrayBuffer offerBuffer = new ExpandableArrayBuffer(1024);
     private final ClusterSessionEncoder clusterSessionEncoder = new ClusterSessionEncoder();
     private final TimerEncoder timerEncoder = new TimerEncoder();
     private final ConsensusModuleEncoder consensusModuleEncoder = new ConsensusModuleEncoder();
@@ -44,18 +46,7 @@ class ConsensusModuleSnapshotTaker
 
     public boolean onMessage(final MutableDirectBuffer buffer, final int offset, final int length, final int headOffset)
     {
-        idleStrategy.reset();
-        while (true)
-        {
-            final long result = publication.offer(buffer, offset, length);
-            if (result > 0)
-            {
-                break;
-            }
-
-            checkResultAndIdle(result);
-        }
-
+        offer(buffer, offset, length);
         return true;
     }
 
@@ -94,27 +85,28 @@ class ConsensusModuleSnapshotTaker
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterSessionEncoder.BLOCK_LENGTH +
             ClusterSessionEncoder.responseChannelHeaderLength() + responseChannel.length();
 
-        idleStrategy.reset();
-        while (true)
+        if (length <= publication.maxPayloadLength())
         {
-            final long result = publication.tryClaim(length, bufferClaim);
-            if (result > 0)
+            idleStrategy.reset();
+            while (true)
             {
-                clusterSessionEncoder
-                    .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
-                    .clusterSessionId(session.id())
-                    .correlationId(session.correlationId())
-                    .openedLogPosition(session.openedLogPosition())
-                    .timeOfLastActivity(session.timeOfLastActivityNs())
-                    .closeReason(session.closeReason())
-                    .responseStreamId(session.responseStreamId())
-                    .responseChannel(responseChannel);
+                final long result = publication.tryClaim(length, bufferClaim);
+                if (result > 0)
+                {
+                    encodeSession(session, responseChannel, bufferClaim.buffer(), bufferClaim.offset());
+                    bufferClaim.commit();
+                    break;
+                }
 
-                bufferClaim.commit();
-                break;
+                checkResultAndIdle(result);
             }
-
-            checkResultAndIdle(result);
+        }
+        else
+        {
+            final ExpandableArrayBuffer buffer = offerBuffer;
+            final int offset = 0;
+            encodeSession(session, responseChannel, buffer, offset);
+            offer(buffer, offset, length);
         }
     }
 
@@ -143,24 +135,29 @@ class ConsensusModuleSnapshotTaker
     {
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterMembersEncoder.BLOCK_LENGTH +
             ClusterMembersEncoder.clusterMembersHeaderLength() + clusterMembers.length();
-
-        idleStrategy.reset();
-        while (true)
+        if (length <= publication.maxPayloadLength())
         {
-            final long result = publication.tryClaim(length, bufferClaim);
-            if (result > 0)
+            idleStrategy.reset();
+            while (true)
             {
-                clusterMembersEncoder
-                    .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
-                    .memberId(memberId)
-                    .highMemberId(highMemberId)
-                    .clusterMembers(clusterMembers);
+                final long result = publication.tryClaim(length, bufferClaim);
+                if (result > 0)
+                {
+                    encodeClusterMembers(
+                        memberId, highMemberId, clusterMembers, bufferClaim.buffer(), bufferClaim.offset());
+                    bufferClaim.commit();
+                    break;
+                }
 
-                bufferClaim.commit();
-                break;
+                checkResultAndIdle(result);
             }
-
-            checkResultAndIdle(result);
+        }
+        else
+        {
+            final ExpandableArrayBuffer buffer = offerBuffer;
+            final int offset = 0;
+            encodeClusterMembers(memberId, highMemberId, clusterMembers, buffer, offset);
+            offer(buffer, offset, length);
         }
     }
 
@@ -189,5 +186,48 @@ class ConsensusModuleSnapshotTaker
         }
 
         tracker.pendingMessages().forEach(this, Integer.MAX_VALUE);
+    }
+
+    private void offer(final MutableDirectBuffer buffer, final int offset, final int length)
+    {
+        idleStrategy.reset();
+        while (true)
+        {
+            final long result = publication.offer(buffer, offset, length);
+            if (result > 0)
+            {
+                break;
+            }
+
+            checkResultAndIdle(result);
+        }
+    }
+
+    private void encodeSession(
+        final ClusterSession session, final String responseChannel, final MutableDirectBuffer buffer, final int offset)
+    {
+        clusterSessionEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .clusterSessionId(session.id())
+            .correlationId(session.correlationId())
+            .openedLogPosition(session.openedLogPosition())
+            .timeOfLastActivity(session.timeOfLastActivityNs())
+            .closeReason(session.closeReason())
+            .responseStreamId(session.responseStreamId())
+            .responseChannel(responseChannel);
+    }
+
+    private void encodeClusterMembers(
+        final int memberId,
+        final int highMemberId,
+        final String clusterMembers,
+        final MutableDirectBuffer buffer,
+        final int offset)
+    {
+        clusterMembersEncoder
+            .wrapAndApplyHeader(buffer, offset, messageHeaderEncoder)
+            .memberId(memberId)
+            .highMemberId(highMemberId)
+            .clusterMembers(clusterMembers);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotTaker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotTaker.java
@@ -188,21 +188,6 @@ class ConsensusModuleSnapshotTaker
         tracker.pendingMessages().forEach(this, Integer.MAX_VALUE);
     }
 
-    private void offer(final MutableDirectBuffer buffer, final int offset, final int length)
-    {
-        idleStrategy.reset();
-        while (true)
-        {
-            final long result = publication.offer(buffer, offset, length);
-            if (result > 0)
-            {
-                break;
-            }
-
-            checkResultAndIdle(result);
-        }
-    }
-
     private void encodeSession(
         final ClusterSession session, final String responseChannel, final MutableDirectBuffer buffer, final int offset)
     {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/SnapshotTaker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/SnapshotTaker.java
@@ -22,6 +22,7 @@ import io.aeron.cluster.codecs.MessageHeaderEncoder;
 import io.aeron.cluster.codecs.SnapshotMark;
 import io.aeron.cluster.codecs.SnapshotMarkerEncoder;
 import io.aeron.logbuffer.BufferClaim;
+import org.agrona.DirectBuffer;
 import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.IdleStrategy;
@@ -209,6 +210,28 @@ public class SnapshotTaker
         if (null != aeronAgentInvoker)
         {
             aeronAgentInvoker.invoke();
+        }
+    }
+
+    /**
+     * Helper method to offer a message into the snapshot publication.
+     *
+     * @param buffer containing the message.
+     * @param offset at which the message begins.
+     * @param length of the message.
+     */
+    protected final void offer(final DirectBuffer buffer, final int offset, final int length)
+    {
+        idleStrategy.reset();
+        while (true)
+        {
+            final long result = publication.offer(buffer, offset, length);
+            if (result > 0)
+            {
+                break;
+            }
+
+            checkResultAndIdle(result);
         }
     }
 }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import io.aeron.Counter;
+import io.aeron.ExclusivePublication;
+import io.aeron.cluster.codecs.*;
+import io.aeron.cluster.service.ClusterClock;
+import io.aeron.logbuffer.BufferClaim;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+
+import static io.aeron.Publication.ADMIN_ACTION;
+import static io.aeron.Publication.BACK_PRESSURED;
+import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static org.agrona.BitUtil.align;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class ConsensusModuleSnapshotTakerTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+    private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+    private final ConsensusModuleDecoder consensusModuleDecoder = new ConsensusModuleDecoder();
+    private final PendingMessageTrackerDecoder pendingMessageTrackerDecoder = new PendingMessageTrackerDecoder();
+    private final TimerDecoder timerDecoder = new TimerDecoder();
+    private final ClusterSessionDecoder clusterSessionDecoder = new ClusterSessionDecoder();
+    private final ClusterMembersDecoder clusterMembersDecoder = new ClusterMembersDecoder();
+    private final ExclusivePublication publication = mock(ExclusivePublication.class);
+    private final IdleStrategy idleStrategy = mock(IdleStrategy.class);
+
+    private final ConsensusModuleSnapshotTaker snapshotTaker = new ConsensusModuleSnapshotTaker(
+        publication, idleStrategy, null);
+
+    @Test
+    void snapshotConsensusModuleState()
+    {
+        final int offset = 32;
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ConsensusModuleEncoder.BLOCK_LENGTH;
+        final long nextSessionId = 42;
+        final long nextServiceSessionId = -4_000_000_001L;
+        final long logServiceSessionId = -4_000_000_000L;
+        final int pendingMessageCapacity = 4096;
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
+            .thenAnswer(mockTryClaim(offset));
+
+        snapshotTaker.snapshotConsensusModuleState(
+            nextSessionId, nextServiceSessionId, logServiceSessionId, pendingMessageCapacity);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verifyNoMoreInteractions();
+
+        consensusModuleDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(nextSessionId, consensusModuleDecoder.nextSessionId());
+        assertEquals(nextServiceSessionId, consensusModuleDecoder.nextServiceSessionId());
+        assertEquals(logServiceSessionId, consensusModuleDecoder.logServiceSessionId());
+        assertEquals(pendingMessageCapacity, consensusModuleDecoder.pendingMessageCapacity());
+    }
+
+    @Test
+    void snapshotPendingServiceMessageTracker()
+    {
+        final int offset = 108;
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + PendingMessageTrackerEncoder.BLOCK_LENGTH;
+        final int serviceId = 6;
+        final PendingServiceMessageTracker pendingServiceMessageTracker = new PendingServiceMessageTracker(
+            serviceId, mock(Counter.class), mock(LogPublisher.class), mock(ClusterClock.class));
+        pendingServiceMessageTracker.enqueueMessage(buffer, 32, 0);
+        final int capacity = pendingServiceMessageTracker.size();
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(ADMIN_ACTION)
+            .thenAnswer(mockTryClaim(offset));
+        when(publication.offer(any(), anyInt(), anyInt()))
+            .thenReturn(BACK_PRESSURED, 9L);
+
+        snapshotTaker.snapshot(pendingServiceMessageTracker);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verifyNoMoreInteractions();
+
+        pendingMessageTrackerDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(-8791026472627208190L, pendingMessageTrackerDecoder.nextServiceSessionId());
+        assertEquals(-8791026472627208192L, pendingMessageTrackerDecoder.logServiceSessionId());
+        assertEquals(capacity, pendingMessageTrackerDecoder.pendingMessageCapacity());
+        assertEquals(serviceId, pendingMessageTrackerDecoder.serviceId());
+    }
+
+    @Test
+    void snapshotTimer()
+    {
+        final int offset = 18;
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + TimerEncoder.BLOCK_LENGTH;
+        final long correlationId = -901;
+        final long deadline = 12345678901L;
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
+            .thenAnswer(mockTryClaim(offset));
+
+        snapshotTaker.snapshotTimer(correlationId, deadline);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verifyNoMoreInteractions();
+
+        timerDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(correlationId, timerDecoder.correlationId());
+        assertEquals(deadline, timerDecoder.deadline());
+    }
+
+    @Test
+    void snapshotSessionShouldUseTryClaimIfDataFitsIntoMaxPayloadSize()
+    {
+        final int offset = 10;
+        final String responseChannel = "aeron:ipc";
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterSessionEncoder.BLOCK_LENGTH +
+            ClusterSessionEncoder.responseChannelHeaderLength() + responseChannel.length();
+        final ClusterSession clusterSession = new ClusterSession(
+            556, 13, 1024, 800, 42, responseChannel, CloseReason.CLIENT_ACTION);
+        when(publication.maxPayloadLength()).thenReturn(length);
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
+            .thenAnswer(mockTryClaim(offset));
+
+        snapshotTaker.snapshotSession(clusterSession);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verifyNoMoreInteractions();
+
+        clusterSessionDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(clusterSession.id(), clusterSessionDecoder.clusterSessionId());
+        assertEquals(clusterSession.correlationId(), clusterSessionDecoder.correlationId());
+        assertEquals(clusterSession.openedLogPosition(), clusterSessionDecoder.openedLogPosition());
+        assertEquals(clusterSession.timeOfLastActivityNs(), clusterSessionDecoder.timeOfLastActivity());
+        assertEquals(clusterSession.closeReason(), clusterSessionDecoder.closeReason());
+        assertEquals(clusterSession.responseStreamId(), clusterSessionDecoder.responseStreamId());
+        assertEquals(responseChannel, clusterSessionDecoder.responseChannel());
+    }
+
+    @Test
+    void snapshotSessionShouldUseOfferIfDataDoesNotFitIntoMaxPayloadSize()
+    {
+        final String responseChannel = "aeron:ipc?alias=very very very long string|mtu=4444";
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterSessionEncoder.BLOCK_LENGTH +
+            ClusterSessionEncoder.responseChannelHeaderLength() + responseChannel.length();
+        final ClusterSession clusterSession = new ClusterSession(
+            42, -1, 76, 98, 4, responseChannel, CloseReason.TIMEOUT);
+        when(publication.maxPayloadLength()).thenReturn(length - 1);
+        when(publication.offer(any(), anyInt(), anyInt()))
+            .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
+            .thenAnswer(mockOffer(length));
+
+        snapshotTaker.snapshotSession(clusterSession);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verifyNoMoreInteractions();
+
+        clusterSessionDecoder.wrapAndApplyHeader(buffer, 0, messageHeaderDecoder);
+        assertEquals(clusterSession.id(), clusterSessionDecoder.clusterSessionId());
+        assertEquals(clusterSession.correlationId(), clusterSessionDecoder.correlationId());
+        assertEquals(clusterSession.openedLogPosition(), clusterSessionDecoder.openedLogPosition());
+        assertEquals(clusterSession.timeOfLastActivityNs(), clusterSessionDecoder.timeOfLastActivity());
+        assertEquals(clusterSession.closeReason(), clusterSessionDecoder.closeReason());
+        assertEquals(clusterSession.responseStreamId(), clusterSessionDecoder.responseStreamId());
+        assertEquals(responseChannel, clusterSessionDecoder.responseChannel());
+    }
+
+    @Test
+    void snapshotClusterMembersShouldUseTryClaimIfDataFitsIntoMaxPayloadSize()
+    {
+        final int offset = 120;
+        final int memberId = 2;
+        final int highMemberId = 8;
+        final String clusterMembers = "0,ingress:port,consensus:port,log:port,catchup:port,archive:port|" +
+            "1,ingress:port,consensus:port,log:port,catchup:port,archive:port|" +
+            "2,ingress:port,consensus:port,log:port,catchup:port,archive:port";
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterMembersEncoder.BLOCK_LENGTH +
+            ClusterMembersEncoder.clusterMembersHeaderLength() + clusterMembers.length();
+        when(publication.maxPayloadLength()).thenReturn(length);
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(ADMIN_ACTION)
+            .thenAnswer(mockTryClaim(offset));
+
+        snapshotTaker.snapshotClusterMembers(memberId, highMemberId, clusterMembers);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verifyNoMoreInteractions();
+
+        clusterMembersDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(memberId, clusterMembersDecoder.memberId());
+        assertEquals(highMemberId, clusterMembersDecoder.highMemberId());
+        assertEquals(clusterMembers, clusterMembersDecoder.clusterMembers());
+    }
+
+    @Test
+    void snapshotClusterMembersShouldUseOfferIfDataDoesNotFitIntoMaxPayloadSize()
+    {
+        final int memberId = 2;
+        final int highMemberId = 8;
+        final String clusterMembers = "0,ingress:port,consensus:port,log:port,catchup:port,archive:port|" +
+            "1,ingress:port,consensus:port,log:port,catchup:port,archive:port|" +
+            "2,ingress:port,consensus:port,log:port,catchup:port,archive:port";
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterMembersEncoder.BLOCK_LENGTH +
+            ClusterMembersEncoder.clusterMembersHeaderLength() + clusterMembers.length();
+        when(publication.maxPayloadLength()).thenReturn(40);
+        when(publication.offer(any(), anyInt(), anyInt()))
+            .thenReturn(BACK_PRESSURED)
+            .thenAnswer(mockOffer(length));
+
+        snapshotTaker.snapshotClusterMembers(memberId, highMemberId, clusterMembers);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verifyNoMoreInteractions();
+
+        clusterMembersDecoder.wrapAndApplyHeader(buffer, 0, messageHeaderDecoder);
+        assertEquals(memberId, clusterMembersDecoder.memberId());
+        assertEquals(highMemberId, clusterMembersDecoder.highMemberId());
+        assertEquals(clusterMembers, clusterMembersDecoder.clusterMembers());
+    }
+
+    private Answer<Long> mockTryClaim(final int offset)
+    {
+        return (invocation) ->
+        {
+            final int length = invocation.getArgument(0);
+            final BufferClaim bufferClaim = invocation.getArgument(1);
+            final int frameLength = length + HEADER_LENGTH;
+            final int alignedFrameLength = align(frameLength, FRAME_ALIGNMENT);
+            bufferClaim.wrap(buffer, offset, alignedFrameLength);
+            return 1024L;
+        };
+    }
+
+    private Answer<Long> mockOffer(final int expectedLength)
+    {
+        return (invocation) ->
+        {
+            final DirectBuffer srcBuffer = invocation.getArgument(0);
+            final int srcOffset = invocation.getArgument(1);
+            assertEquals(0, srcOffset);
+            final int length = invocation.getArgument(2);
+            assertEquals(expectedLength, length);
+            buffer.putBytes(0, srcBuffer, srcOffset, length);
+            return 128L;
+        };
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
@@ -192,9 +192,9 @@ class ConsensusModuleSnapshotTakerTest
         final ClusterSession clusterSession = new ClusterSession(
             42, -1, 76, 98, 4, responseChannel, CloseReason.TIMEOUT);
         when(publication.maxPayloadLength()).thenReturn(length - 1);
-        when(publication.offer(any(), anyInt(), anyInt()))
+        when(publication.offer(any(), eq(0), eq(length)))
             .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
-            .thenAnswer(mockOffer(length));
+            .thenAnswer(mockOffer());
 
         snapshotTaker.snapshotSession(clusterSession);
 
@@ -261,9 +261,9 @@ class ConsensusModuleSnapshotTakerTest
         final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClusterMembersEncoder.BLOCK_LENGTH +
             ClusterMembersEncoder.clusterMembersHeaderLength() + clusterMembers.length();
         when(publication.maxPayloadLength()).thenReturn(40);
-        when(publication.offer(any(), anyInt(), anyInt()))
+        when(publication.offer(any(), eq(0), eq(length)))
             .thenReturn(BACK_PRESSURED)
-            .thenAnswer(mockOffer(length));
+            .thenAnswer(mockOffer());
 
         snapshotTaker.snapshotClusterMembers(memberId, highMemberId, clusterMembers);
 
@@ -294,15 +294,13 @@ class ConsensusModuleSnapshotTakerTest
         };
     }
 
-    private Answer<Long> mockOffer(final int expectedLength)
+    private Answer<Long> mockOffer()
     {
         return (invocation) ->
         {
             final DirectBuffer srcBuffer = invocation.getArgument(0);
             final int srcOffset = invocation.getArgument(1);
-            assertEquals(0, srcOffset);
             final int length = invocation.getArgument(2);
-            assertEquals(expectedLength, length);
             buffer.putBytes(0, srcBuffer, srcOffset, length);
             return 128L;
         };

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ServiceSnapshotTakerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ServiceSnapshotTakerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster.service;
+
+import io.aeron.ExclusivePublication;
+import io.aeron.cluster.codecs.ClientSessionDecoder;
+import io.aeron.cluster.codecs.ClientSessionEncoder;
+import io.aeron.cluster.codecs.MessageHeaderDecoder;
+import io.aeron.cluster.codecs.MessageHeaderEncoder;
+import io.aeron.logbuffer.BufferClaim;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdleStrategy;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static io.aeron.Publication.ADMIN_ACTION;
+import static io.aeron.Publication.BACK_PRESSURED;
+import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static org.agrona.BitUtil.align;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ServiceSnapshotTakerTest
+{
+    private final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+    private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
+    private final ClientSessionDecoder clientSessionDecoder = new ClientSessionDecoder();
+    private final ExclusivePublication publication = mock(ExclusivePublication.class);
+    private final IdleStrategy idleStrategy = mock(IdleStrategy.class);
+    private final ServiceSnapshotTaker serviceSnapshotTaker = new ServiceSnapshotTaker(publication, idleStrategy, null);
+
+    @Test
+    void snapshotSessionUsesTryClaimIfDataFitIntoMaxPayloadSize()
+    {
+        final int offset = 40;
+        final String responseChannel = "aeron:udp?endpoint=localhost:8080";
+        final byte[] encodedPrincipal = new byte[100];
+        ThreadLocalRandom.current().nextBytes(encodedPrincipal);
+        final ContainerClientSession session =
+            new ContainerClientSession(42, 8, responseChannel, encodedPrincipal, null);
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClientSessionEncoder.BLOCK_LENGTH +
+            ClientSessionEncoder.responseChannelHeaderLength() + responseChannel.length() +
+            ClientSessionEncoder.encodedPrincipalHeaderLength() + encodedPrincipal.length;
+        when(publication.maxPayloadLength()).thenReturn(length);
+        when(publication.tryClaim(eq(length), any()))
+            .thenReturn(BACK_PRESSURED)
+            .thenAnswer(mockTryClaim(offset));
+
+        serviceSnapshotTaker.snapshotSession(session);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).tryClaim(anyInt(), any());
+        inOrder.verifyNoMoreInteractions();
+
+        clientSessionDecoder.wrapAndApplyHeader(buffer, offset + HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(session.id(), clientSessionDecoder.clusterSessionId());
+        assertEquals(session.responseStreamId(), clientSessionDecoder.responseStreamId());
+        assertEquals(responseChannel, clientSessionDecoder.responseChannel());
+        assertEquals(encodedPrincipal.length, clientSessionDecoder.encodedPrincipalLength());
+        final byte[] snapshotPrincipal = new byte[encodedPrincipal.length];
+        clientSessionDecoder.getEncodedPrincipal(snapshotPrincipal, 0, snapshotPrincipal.length);
+        assertArrayEquals(encodedPrincipal, snapshotPrincipal);
+    }
+
+    @Test
+    void snapshotSessionUsesOfferIfDataDoesNotIntoMaxPayloadSize()
+    {
+        final String responseChannel = "aeron:udp?endpoint=localhost:8080|alias=long time ago";
+        final byte[] encodedPrincipal = new byte[1000];
+        ThreadLocalRandom.current().nextBytes(encodedPrincipal);
+        final ContainerClientSession session =
+            new ContainerClientSession(8, -3, responseChannel, encodedPrincipal, null);
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH + ClientSessionEncoder.BLOCK_LENGTH +
+            ClientSessionEncoder.responseChannelHeaderLength() + responseChannel.length() +
+            ClientSessionEncoder.encodedPrincipalHeaderLength() + encodedPrincipal.length;
+        when(publication.maxPayloadLength()).thenReturn(20);
+        when(publication.offer(any(), eq(0), eq(length)))
+            .thenReturn(BACK_PRESSURED, ADMIN_ACTION)
+            .thenAnswer(mockOffer());
+
+        serviceSnapshotTaker.snapshotSession(session);
+
+        final InOrder inOrder = inOrder(idleStrategy, publication);
+        inOrder.verify(publication).maxPayloadLength();
+        inOrder.verify(idleStrategy).reset();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verify(idleStrategy).idle();
+        inOrder.verify(publication).offer(any(), anyInt(), anyInt());
+        inOrder.verifyNoMoreInteractions();
+
+        clientSessionDecoder.wrapAndApplyHeader(buffer, 0, messageHeaderDecoder);
+        assertEquals(session.id(), clientSessionDecoder.clusterSessionId());
+        assertEquals(session.responseStreamId(), clientSessionDecoder.responseStreamId());
+        assertEquals(responseChannel, clientSessionDecoder.responseChannel());
+        assertEquals(encodedPrincipal.length, clientSessionDecoder.encodedPrincipalLength());
+        final byte[] snapshotPrincipal = new byte[encodedPrincipal.length];
+        clientSessionDecoder.getEncodedPrincipal(snapshotPrincipal, 0, snapshotPrincipal.length);
+        assertArrayEquals(encodedPrincipal, snapshotPrincipal);
+    }
+
+    private Answer<Long> mockTryClaim(final int offset)
+    {
+        return (invocation) ->
+        {
+            final int length = invocation.getArgument(0);
+            final BufferClaim bufferClaim = invocation.getArgument(1);
+            final int frameLength = length + HEADER_LENGTH;
+            final int alignedFrameLength = align(frameLength, FRAME_ALIGNMENT);
+            bufferClaim.wrap(buffer, offset, alignedFrameLength);
+            return 1024L;
+        };
+    }
+
+    private Answer<Long> mockOffer()
+    {
+        return (invocation) ->
+        {
+            final DirectBuffer srcBuffer = invocation.getArgument(0);
+            final int srcOffset = invocation.getArgument(1);
+            final int length = invocation.getArgument(2);
+            buffer.putBytes(0, srcBuffer, srcOffset, length);
+            return 128L;
+        };
+    }
+}


### PR DESCRIPTION
This PR updates `ConsensusModuleSnapshotTaker` and `ServiceSnapshotTaker` to use choose between `tryClaim` and `offer` into the snapshot publication depending on the size of the data.

_**Note:** The PR is intended for the `release/1.40.x` branch._