### PR TITLE
[Java] Make Archive counters unique.

### DIFF
--- a/aeron-archive/src/main/cpp/client/RecordingPos.h
+++ b/aeron-archive/src/main/cpp/client/RecordingPos.h
@@ -29,6 +29,9 @@ namespace aeron { namespace archive { namespace client
  *   0                   1                   2                   3
  *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                         Archive ID                            |
+ *  |                                                               |
+ *  +---------------------------------------------------------------+
  *  |                        Recording ID                           |
  *  |                                                               |
  *  +---------------------------------------------------------------+
@@ -52,6 +55,7 @@ constexpr const std::int64_t NULL_RECORDING_ID = aeron::NULL_VALUE;
 #pragma pack(4)
 struct RecordingPosKeyDefn
 {
+    std::int64_t archiveId;
     std::int64_t recordingId;
     std::int32_t sessionId;
     std::int32_t sourceIdentityLength;

--- a/aeron-archive/src/main/cpp/client/RecordingPos.h
+++ b/aeron-archive/src/main/cpp/client/RecordingPos.h
@@ -29,9 +29,6 @@ namespace aeron { namespace archive { namespace client
  *   0                   1                   2                   3
  *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |                         Archive ID                            |
- *  |                                                               |
- *  +---------------------------------------------------------------+
  *  |                        Recording ID                           |
  *  |                                                               |
  *  +---------------------------------------------------------------+
@@ -55,7 +52,6 @@ constexpr const std::int64_t NULL_RECORDING_ID = aeron::NULL_VALUE;
 #pragma pack(4)
 struct RecordingPosKeyDefn
 {
-    std::int64_t archiveId;
     std::int64_t recordingId;
     std::int32_t sessionId;
     std::int32_t sourceIdentityLength;

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -1633,7 +1633,14 @@ abstract class ArchiveConductor
             sourceIdentity);
 
         final Counter position = RecordingPos.allocate(
-            aeron, counterMetadataBuffer, recordingId, sessionId, streamId, strippedChannel, sourceIdentity);
+            aeron,
+            counterMetadataBuffer,
+            ctx.archiveId(),
+            recordingId,
+            sessionId,
+            streamId,
+            strippedChannel,
+            sourceIdentity);
         position.setOrdered(startPosition);
 
         final RecordingSession session = new RecordingSession(
@@ -1690,6 +1697,7 @@ abstract class ArchiveConductor
             final Counter position = RecordingPos.allocate(
                 aeron,
                 counterMetadataBuffer,
+                ctx.archiveId(),
                 recordingId,
                 image.sessionId(),
                 image.subscription().streamId(),

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveCounters.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveCounters.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.Aeron;
+import io.aeron.Counter;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.status.CountersReader;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.status.CountersReader.*;
+
+/**
+ * For allocating and finding Archive associated counters identified by the {@link Aeron#clientId()}.
+ */
+final class ArchiveCounters
+{
+    private ArchiveCounters()
+    {
+    }
+
+    /**
+     * Allocate a counter to represent state within an Archive. The {@code archiveId} is assumed to be
+     * {@link Aeron#clientId()}.
+     *
+     * @param aeron      from {@link Archive} instance to allocate the counter.
+     * @param tempBuffer temporary storage to create label and metadata.
+     * @param typeId     for the counter.
+     * @param name       of the counter for the label.
+     * @param archiveId  to which the allocated counter belongs.
+     * @return the {@link Counter} for the commit position.
+     */
+    public static Counter allocate(
+        final Aeron aeron,
+        final MutableDirectBuffer tempBuffer,
+        final int typeId,
+        final String name,
+        final long archiveId)
+    {
+        int index = 0;
+        tempBuffer.putLong(index, archiveId);
+        index += SIZE_OF_LONG;
+
+        index += tempBuffer.putStringWithoutLengthAscii(index, name);
+        index += tempBuffer.putStringWithoutLengthAscii(index, " - archiveId=");
+        index += tempBuffer.putLongAscii(index, archiveId);
+
+        return aeron.addCounter(typeId, tempBuffer, 0, SIZE_OF_LONG, tempBuffer, SIZE_OF_LONG, index - SIZE_OF_LONG);
+    }
+
+    /**
+     * Find the counter id for a type of counter in an Archive.
+     *
+     * @param counters  to search within.
+     * @param typeId    of the counter.
+     * @param archiveId to which the allocated counter belongs.
+     * @return the matching counter id or {@link Aeron#NULL_VALUE} if not found.
+     */
+    public static int find(final CountersReader counters, final int typeId, final long archiveId)
+    {
+        final AtomicBuffer buffer = counters.metaDataBuffer();
+
+        for (int i = 0, size = counters.maxCounterId(); i < size; i++)
+        {
+            final int counterState = counters.getCounterState(i);
+
+            if (RECORD_ALLOCATED == counterState)
+            {
+                if (counters.getCounterTypeId(i) == typeId &&
+                    buffer.getLong(CountersReader.metaDataOffset(i) + KEY_OFFSET) == archiveId)
+                {
+                    return i;
+                }
+            }
+            else if (RECORD_UNUSED == counterState)
+            {
+                break;
+            }
+        }
+
+        return NULL_VALUE;
+    }
+}

--- a/aeron-archive/src/main/java/io/aeron/archive/status/RecordingPos.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/status/RecordingPos.java
@@ -141,10 +141,10 @@ public final class RecordingPos
         for (int i = 0, size = countersReader.maxCounterId(); i < size; i++)
         {
             final int counterState = countersReader.getCounterState(i);
-            if (counterState == RECORD_ALLOCATED &&
-                countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID)
+            if (RECORD_ALLOCATED == counterState)
             {
-                if (buffer.getLong(CountersReader.metaDataOffset(i) + KEY_OFFSET + RECORDING_ID_OFFSET) == recordingId)
+                if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID &&
+                    buffer.getLong(CountersReader.metaDataOffset(i) + KEY_OFFSET + RECORDING_ID_OFFSET) == recordingId)
                 {
                     return i;
                 }
@@ -172,10 +172,10 @@ public final class RecordingPos
         for (int i = 0, size = countersReader.maxCounterId(); i < size; i++)
         {
             final int counterState = countersReader.getCounterState(i);
-            if (counterState == RECORD_ALLOCATED &&
-                countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID)
+            if (RECORD_ALLOCATED == counterState)
             {
-                if (buffer.getInt(CountersReader.metaDataOffset(i) + KEY_OFFSET + SESSION_ID_OFFSET) == sessionId)
+                if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID &&
+                    buffer.getInt(CountersReader.metaDataOffset(i) + KEY_OFFSET + SESSION_ID_OFFSET) == sessionId)
                 {
                     return i;
                 }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
@@ -23,6 +23,8 @@ import io.aeron.exceptions.ConfigurationException;
 import io.aeron.security.AuthorisationService;
 import io.aeron.security.AuthorisationServiceSupplier;
 import io.aeron.test.TestContexts;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.AfterEach;
@@ -31,15 +33,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.io.File;
 import java.nio.file.Path;
 
+import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.AeronCounters.ARCHIVE_CONTROL_SESSIONS_TYPE_ID;
 import static io.aeron.AeronCounters.*;
 import static io.aeron.archive.Archive.Configuration.*;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.status.CountersReader.RECORD_ALLOCATED;
+import static org.agrona.concurrent.status.CountersReader.RECORD_UNUSED;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ArchiveContextTest
 {
@@ -288,14 +297,18 @@ class ArchiveContextTest
     {
         context.totalWriteBytesCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_RECORDER_TOTAL_WRITE_BYTES_TYPE_ID, 42);
-        when(aeron.addCounter(ARCHIVE_RECORDER_TOTAL_WRITE_BYTES_TYPE_ID, "archive-recorder total write bytes"))
-            .thenReturn(counter);
+        final long archiveId = 555;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(
+            archiveId, ARCHIVE_RECORDER_TOTAL_WRITE_BYTES_TYPE_ID, 42, tempBuffer);
 
         context.conclude();
 
         assertSame(counter, context.totalWriteBytesCounter());
+        final DirectBuffer buffer = tempBuffer.getValue();
+        assertEquals(archiveId, buffer.getLong(0));
+        final String expectedLabel = "archive-recorder total write bytes - archiveId=" + archiveId;
+        assertEquals(expectedLabel, buffer.getStringWithoutLengthAscii(SIZE_OF_LONG, expectedLabel.length()));
     }
 
     @Test
@@ -313,14 +326,19 @@ class ArchiveContextTest
     {
         context.totalWriteTimeCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_RECORDER_TOTAL_WRITE_TIME_TYPE_ID, 42);
-        when(aeron.addCounter(ARCHIVE_RECORDER_TOTAL_WRITE_TIME_TYPE_ID, "archive-recorder total write time in ns"))
-            .thenReturn(counter);
+        final long archiveId = 89;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(
+            archiveId, ARCHIVE_RECORDER_TOTAL_WRITE_TIME_TYPE_ID, -666, tempBuffer);
+
 
         context.conclude();
 
         assertSame(counter, context.totalWriteTimeCounter());
+        final DirectBuffer buffer = tempBuffer.getValue();
+        assertEquals(archiveId, buffer.getLong(0));
+        final String expectedLabel = "archive-recorder total write time in ns - archiveId=" + archiveId;
+        assertEquals(expectedLabel, buffer.getStringWithoutLengthAscii(SIZE_OF_LONG, expectedLabel.length()));
     }
 
     @Test
@@ -338,14 +356,18 @@ class ArchiveContextTest
     {
         context.maxWriteTimeCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_RECORDER_MAX_WRITE_TIME_TYPE_ID, 142);
-        when(aeron.addCounter(ARCHIVE_RECORDER_MAX_WRITE_TIME_TYPE_ID, "archive-recorder max write time in ns"))
-            .thenReturn(counter);
+        final long archiveId = -76555;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(
+            archiveId, ARCHIVE_RECORDER_MAX_WRITE_TIME_TYPE_ID, 234126361, tempBuffer);
 
         context.conclude();
 
         assertSame(counter, context.maxWriteTimeCounter());
+        final DirectBuffer buffer = tempBuffer.getValue();
+        assertEquals(archiveId, buffer.getLong(0));
+        final String expectedLabel = "archive-recorder max write time in ns - archiveId=" + archiveId;
+        assertEquals(expectedLabel, buffer.getStringWithoutLengthAscii(SIZE_OF_LONG, expectedLabel.length()));
     }
 
     @Test
@@ -363,14 +385,18 @@ class ArchiveContextTest
     {
         context.totalReadBytesCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_REPLAYER_TOTAL_READ_BYTES_TYPE_ID, 999);
-        when(aeron.addCounter(ARCHIVE_REPLAYER_TOTAL_READ_BYTES_TYPE_ID, "archive-replayer total read bytes"))
-            .thenReturn(counter);
+        final long archiveId = 4234623784689L;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(
+            archiveId, ARCHIVE_REPLAYER_TOTAL_READ_BYTES_TYPE_ID, 999, tempBuffer);
 
         context.conclude();
 
         assertSame(counter, context.totalReadBytesCounter());
+        final DirectBuffer buffer = tempBuffer.getValue();
+        assertEquals(archiveId, buffer.getLong(0));
+        final String expectedLabel = "archive-replayer total read bytes - archiveId=" + archiveId;
+        assertEquals(expectedLabel, buffer.getStringWithoutLengthAscii(SIZE_OF_LONG, expectedLabel.length()));
     }
 
     @Test
@@ -388,14 +414,18 @@ class ArchiveContextTest
     {
         context.totalReadTimeCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_REPLAYER_TOTAL_READ_TIME_TYPE_ID, -8);
-        when(aeron.addCounter(ARCHIVE_REPLAYER_TOTAL_READ_TIME_TYPE_ID, "archive-replayer total read time in ns"))
-            .thenReturn(counter);
+        final long archiveId = 3;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(
+            archiveId, ARCHIVE_REPLAYER_TOTAL_READ_TIME_TYPE_ID, 0, tempBuffer);
 
         context.conclude();
 
         assertSame(counter, context.totalReadTimeCounter());
+        final DirectBuffer buffer = tempBuffer.getValue();
+        assertEquals(archiveId, buffer.getLong(0));
+        final String expectedLabel = "archive-replayer total read time in ns - archiveId=" + archiveId;
+        assertEquals(expectedLabel, buffer.getStringWithoutLengthAscii(SIZE_OF_LONG, expectedLabel.length()));
     }
 
     @Test
@@ -413,10 +443,9 @@ class ArchiveContextTest
     {
         context.maxReadTimeCounter(null);
 
-        final Aeron aeron = context.aeron();
-        final Counter counter = mockCounter(aeron.countersReader(), ARCHIVE_REPLAYER_MAX_READ_TIME_TYPE_ID, -76);
-        when(aeron.addCounter(ARCHIVE_REPLAYER_MAX_READ_TIME_TYPE_ID, "archive-replayer max read time in ns"))
-            .thenReturn(counter);
+        final long archiveId = 4321L;
+        final ArgumentCaptor<DirectBuffer> tempBuffer = ArgumentCaptor.forClass(DirectBuffer.class);
+        final Counter counter = mockArchiveCounter(archiveId, ARCHIVE_REPLAYER_MAX_READ_TIME_TYPE_ID, -76, tempBuffer);
 
         context.conclude();
 
@@ -431,6 +460,125 @@ class ArchiveContextTest
 
         final ConfigurationException exception = assertThrowsExactly(ConfigurationException.class, context::conclude);
         assertTrue(exception.getMessage().endsWith("expected=" + ARCHIVE_REPLAYER_MAX_READ_TIME_TYPE_ID));
+    }
+
+    @Test
+    void concludeThrowsConfigurationExceptionIfMaxWriteCounterAlreadyExistsForTheCurrentArchive()
+    {
+        context.maxWriteTimeCounter(null);
+
+        final long archiveId = 42;
+        final int id = 2;
+        context.archiveId(archiveId);
+        final AtomicBuffer metadataBuffer = mock(AtomicBuffer.class);
+        final CountersReader countersReader = context.aeron().countersReader();
+        when(countersReader.metaDataBuffer()).thenReturn(metadataBuffer);
+        when(countersReader.maxCounterId()).thenReturn(id + 1);
+        when(countersReader.getCounterState(anyInt())).thenReturn(
+            RECORD_ALLOCATED, RECORD_ALLOCATED, RECORD_ALLOCATED, RECORD_UNUSED);
+        when(countersReader.getCounterTypeId(anyInt())).thenReturn(
+            ARCHIVE_CONTROL_SESSIONS_TYPE_ID, ARCHIVE_RECORDER_MAX_WRITE_TIME_TYPE_ID);
+        when(metadataBuffer.getLong(anyInt())).thenReturn(archiveId, Long.MAX_VALUE, archiveId);
+
+        final ConfigurationException exception = assertThrowsExactly(ConfigurationException.class, context::conclude);
+        assertEquals(
+            "ERROR - existing max write time counter detected for archiveId=" + archiveId,
+            exception.getMessage());
+    }
+
+    @Test
+    void archiveIdIsNullValueByDefault()
+    {
+        assertEquals(NULL_VALUE, context.archiveId());
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = { Long.MIN_VALUE, Long.MAX_VALUE, 0, 5, 28, -17 })
+    void archiveIdReturnsAssignedValue(final long archiveId)
+    {
+        context.archiveId(archiveId);
+        assertEquals(archiveId, context.archiveId());
+
+        context.conclude();
+        assertEquals(archiveId, context.archiveId());
+    }
+
+    @Test
+    void concludeUsesSystemPropertyToAssignArchiveId()
+    {
+        final long archiveId = 53110011;
+        System.setProperty(ARCHIVE_ID_PROP_NAME, Long.toString(archiveId));
+        try
+        {
+            context.conclude();
+
+            assertEquals(archiveId, context.archiveId());
+        }
+        finally
+        {
+            System.clearProperty(ARCHIVE_ID_PROP_NAME);
+        }
+    }
+
+    @Test
+    void concludeUsesAeronClientIdIfSystemPropertyIsNotSet()
+    {
+        final long archiveId = -236462348238L;
+        when(context.aeron().clientId()).thenReturn(archiveId);
+
+        context.conclude();
+
+        assertEquals(archiveId, context.archiveId());
+    }
+
+    @Test
+    void concludeUsesAeronClientIdIfSystemPropertyIsEmpty()
+    {
+        System.setProperty(ARCHIVE_ID_PROP_NAME, "");
+        try
+        {
+            final long archiveId = 42;
+            when(context.aeron().clientId()).thenReturn(archiveId);
+
+            context.conclude();
+
+            assertEquals(archiveId, context.archiveId());
+        }
+        finally
+        {
+            System.clearProperty(ARCHIVE_ID_PROP_NAME);
+        }
+    }
+
+    @Test
+    void concludeUsesAeronClientIdIfSystemPropertyIsSetToNullValue()
+    {
+        System.setProperty(ARCHIVE_ID_PROP_NAME, "-1");
+        try
+        {
+            final long archiveId = 888;
+            when(context.aeron().clientId()).thenReturn(archiveId);
+
+            context.conclude();
+
+            assertEquals(archiveId, context.archiveId());
+        }
+        finally
+        {
+            System.clearProperty(ARCHIVE_ID_PROP_NAME);
+        }
+    }
+
+    private Counter mockArchiveCounter(
+        final long archiveId, final int typeId, final int id, final ArgumentCaptor<DirectBuffer> tempBuffer)
+    {
+        context.archiveId(archiveId);
+        final Aeron aeron = context.aeron();
+        final Counter counter = mockCounter(aeron.countersReader(), typeId, id);
+        when(aeron.addCounter(
+            eq(typeId), tempBuffer.capture(), eq(0), eq(SIZE_OF_LONG), any(), eq(SIZE_OF_LONG), anyInt()))
+            .thenReturn(counter);
+        return counter;
     }
 
     private static Counter mockCounter(final CountersReader countersReader, final int typeId, final int id)

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveCountersTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveCountersTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive;
+
+import io.aeron.Aeron;
+import io.aeron.Counter;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.concurrent.status.CountersManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InOrder;
+
+import static io.aeron.Aeron.NULL_VALUE;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.status.CountersReader.COUNTER_LENGTH;
+import static org.agrona.concurrent.status.CountersReader.METADATA_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+class ArchiveCountersTest
+{
+    @Test
+    void allocateCounterUsingAeronClientIdAsArchiveIdentifier()
+    {
+        final int typeId = 999;
+        final String name = "<test counter>";
+        final long archiveId = -1832178932131546L;
+        final String expectedLabel = name + " - archiveId=" + archiveId;
+        final Aeron aeron = mock(Aeron.class);
+        final MutableDirectBuffer tempBuffer = new UnsafeBuffer(new byte[SIZE_OF_LONG + expectedLabel.length()]);
+        final Counter counter = mock(Counter.class);
+        when(aeron.clientId()).thenReturn(archiveId);
+        when(aeron.addCounter(typeId, tempBuffer, 0, SIZE_OF_LONG, tempBuffer, SIZE_OF_LONG, expectedLabel.length()))
+            .thenReturn(counter);
+
+        final Counter result = ArchiveCounters.allocate(aeron, tempBuffer, typeId, name, aeron.clientId());
+
+        assertSame(counter, result);
+        final InOrder inOrder = inOrder(aeron);
+        inOrder.verify(aeron).clientId();
+        inOrder.verify(aeron).addCounter(anyInt(), any(), anyInt(), anyInt(), any(), anyInt(), anyInt());
+        inOrder.verifyNoMoreInteractions();
+        assertEquals(archiveId, tempBuffer.getLong(0));
+        assertEquals(expectedLabel,
+            tempBuffer.getStringWithoutLengthAscii(SIZE_OF_LONG, tempBuffer.capacity() - SIZE_OF_LONG));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "5,8", "42,-10", "-19, 61312936129398123" })
+    void findReturnsNullValueIfCounterNotFound(final int typeId, final long archiveId)
+    {
+        final CountersManager countersManager = new CountersManager(
+            new UnsafeBuffer(new byte[2 * METADATA_LENGTH]), new UnsafeBuffer(new byte[2 * COUNTER_LENGTH]));
+        assertEquals(1, countersManager.maxCounterId());
+        countersManager.allocate(
+            "test",
+            42,
+            (keyBuffer) ->
+            {
+                keyBuffer.putLong(0, 61312936129398123L);
+            });
+
+        assertEquals(NULL_VALUE, ArchiveCounters.find(countersManager, typeId, archiveId));
+    }
+
+    @Test
+    void findReturnsFirstMatchingCounter()
+    {
+        final CountersManager countersManager = new CountersManager(
+            new UnsafeBuffer(new byte[8 * METADATA_LENGTH]), new UnsafeBuffer(new byte[8 * COUNTER_LENGTH]));
+        final int typeId = 7;
+        final long archiveId = Long.MIN_VALUE / 13;
+        countersManager.allocate(
+            "test 1",
+            typeId,
+            (keyBuffer) -> {});
+        countersManager.allocate(
+            "test 2",
+            typeId,
+            (keyBuffer) -> keyBuffer.putLong(0, 42));
+        countersManager.allocate(
+            "test 3",
+            21,
+            (keyBuffer) -> keyBuffer.putLong(0, archiveId));
+        final int counter4 = countersManager.allocate(
+            "test 4",
+            typeId,
+            (keyBuffer) -> keyBuffer.putLong(0, archiveId));
+        countersManager.allocate(
+            "test 5",
+            typeId,
+            (keyBuffer) -> keyBuffer.putLong(0, archiveId));
+
+        assertEquals(counter4, ArchiveCounters.find(countersManager, typeId, archiveId));
+    }
+}

--- a/aeron-archive/src/test/java/io/aeron/archive/status/RecordingPosTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/status/RecordingPosTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2022 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.archive.status;
+
+import io.aeron.Aeron;
+import io.aeron.Counter;
+import org.agrona.BitUtil;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+import static io.aeron.archive.status.RecordingPos.RECORDING_POSITION_TYPE_ID;
+import static io.aeron.test.Tests.generateStringWithSuffix;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.concurrent.status.CountersReader.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RecordingPosTest
+{
+    @Test
+    void allocateMaxKeyAndLabel()
+    {
+        final long archiveId = Long.MIN_VALUE;
+        final long recordingId = 54311;
+        final int sessionId = 42;
+        final int streamId = -13;
+        final String strippedChannel = generateStringWithSuffix("stripped channel", ".", 1000);
+        final String sourceIdentity = generateStringWithSuffix("source identity", "X", 5000);
+        final UnsafeBuffer tempBuffer = new UnsafeBuffer(new byte[METADATA_LENGTH]);
+        final Counter counter = mock(Counter.class);
+        final Aeron aeron = mock(Aeron.class);
+        when(aeron.addCounter(
+            eq(RECORDING_POSITION_TYPE_ID),
+            eq(tempBuffer),
+            eq(0),
+            eq(MAX_KEY_LENGTH),
+            eq(tempBuffer),
+            eq(MAX_KEY_LENGTH),
+            eq(MAX_LABEL_LENGTH)))
+            .thenReturn(counter);
+
+        final Counter result = RecordingPos.allocate(
+            aeron,
+            tempBuffer,
+            archiveId,
+            recordingId,
+            sessionId,
+            streamId,
+            strippedChannel,
+            sourceIdentity);
+
+        assertSame(counter, result);
+        int offset = 0;
+        assertEquals(archiveId, tempBuffer.getLong(offset));
+        offset += SIZE_OF_LONG;
+        assertEquals(recordingId, tempBuffer.getLong(offset));
+        offset += SIZE_OF_LONG;
+        assertEquals(sessionId, tempBuffer.getInt(offset));
+        offset += SIZE_OF_INT;
+        final int expectedSourceIdentityLength = MAX_KEY_LENGTH - offset - SIZE_OF_INT;
+        assertEquals(expectedSourceIdentityLength, tempBuffer.getInt(offset));
+        assertTrue(expectedSourceIdentityLength < sourceIdentity.length());
+        offset += SIZE_OF_INT;
+        assertEquals(
+            sourceIdentity.substring(0, expectedSourceIdentityLength),
+            tempBuffer.getStringWithoutLengthAscii(offset, expectedSourceIdentityLength));
+
+        offset = BitUtil.align(offset + expectedSourceIdentityLength, SIZE_OF_INT);
+        assertEquals("rec-pos: -9223372036854775808 54311 42 -13 ", tempBuffer.getStringWithoutLengthAscii(offset, 43));
+        offset += 43;
+        final int expectedStrippedChannelLength = MAX_LABEL_LENGTH - offset;
+        assertTrue(expectedStrippedChannelLength < strippedChannel.length());
+        assertEquals(
+            strippedChannel.substring(0, expectedStrippedChannelLength),
+            tempBuffer.getStringWithoutLengthAscii(offset, expectedStrippedChannelLength));
+    }
+
+    @Test
+    void allocateShouldAlignLabelByFourBytes()
+    {
+        final long archiveId = 888;
+        final long recordingId = 1;
+        final int sessionId = 30;
+        final int streamId = 222;
+        final String strippedChannel = "channel";
+        final String sourceIdentity = "source";
+        final UnsafeBuffer tempBuffer = new UnsafeBuffer(new byte[METADATA_LENGTH]);
+        final Counter counter = mock(Counter.class);
+        final Aeron aeron = mock(Aeron.class);
+        when(aeron.addCounter(
+            eq(RECORDING_POSITION_TYPE_ID),
+            eq(tempBuffer),
+            eq(0),
+            eq(30),
+            eq(tempBuffer),
+            eq(32),
+            eq(29)))
+            .thenReturn(counter);
+
+        final Counter result = RecordingPos.allocate(
+            aeron,
+            tempBuffer,
+            archiveId,
+            recordingId,
+            sessionId,
+            streamId,
+            strippedChannel,
+            sourceIdentity);
+
+        assertSame(counter, result);
+        int offset = 0;
+        assertEquals(archiveId, tempBuffer.getLong(offset));
+        offset += SIZE_OF_LONG;
+        assertEquals(recordingId, tempBuffer.getLong(offset));
+        offset += SIZE_OF_LONG;
+        assertEquals(sessionId, tempBuffer.getInt(offset));
+        offset += SIZE_OF_INT;
+        assertEquals(sourceIdentity.length(), tempBuffer.getInt(offset));
+        offset += SIZE_OF_INT;
+        assertEquals(sourceIdentity, tempBuffer.getStringWithoutLengthAscii(offset, sourceIdentity.length()));
+
+        offset = 32;
+        assertEquals("rec-pos: 888 1 30 222 ", tempBuffer.getStringWithoutLengthAscii(offset, 22));
+        offset += 22;
+        assertEquals(strippedChannel, tempBuffer.getStringWithoutLengthAscii(offset, strippedChannel.length()));
+    }
+}

--- a/aeron-client/src/main/cpp/concurrent/CountersReader.h
+++ b/aeron-client/src/main/cpp/concurrent/CountersReader.h
@@ -206,7 +206,7 @@ public:
     inline std::int32_t getCounterTypeId(std::int32_t id) const
     {
         validateCounterId(id);
-        return m_metadataBuffer.getInt32Volatile(metadataOffset(id) + TYPE_ID_OFFSET);
+        return m_metadataBuffer.getInt32(metadataOffset(id) + TYPE_ID_OFFSET);
     }
 
     inline std::int64_t getFreeForReuseDeadline(std::int32_t id) const


### PR DESCRIPTION
This PR contains the following changes:
- Adds a notion of `archiveId` (`long`) which can be set on the `Archive.Context` programmatically or via the system property `aeron.archive.id`.
  If not set then it defaults to `Aeron.clientId()` of the corresponding `Aeron` instance.
- Uses `archiveId` to make Archive-specific counters unique, i.e. adds `archiveId` to the key and label (i.e. `` similar to what `ClusterCounters` does.
- Changes `RecordingPos` to include `archiveId` in the key and label.

Here a sample of how the counters look like after the change:
```java
...
 33:           21,365,164 - archive-conductor max cycle time in ns - archiveId=1
 34:                    0 - archive-conductor work cycle time exceeded count: threshold=1000000000ns - archiveId=1
 35:            2,268,616 - archive-recorder max cycle time in ns - archiveId=1
 36:                    0 - archive-recorder work cycle time exceeded count: threshold=1000000000ns - archiveId=1
 37:            1,476,860 - archive-replayer max cycle time in ns - archiveId=1
 38:                    0 - archive-replayer work cycle time exceeded count: threshold=1000000000ns - archiveId=1
 39:                    1 - Archive Control Sessions - archiveId=1
 40:            1,832,163 - archive-recorder max write time in ns - archiveId=1
 41:       10,716,987,392 - archive-recorder total write bytes - archiveId=1
 42:        2,977,878,326 - archive-recorder total write time in ns - archiveId=1
 43:                    0 - archive-replayer max read time in ns - archiveId=1
 44:                    0 - archive-replayer total read bytes - archiveId=1
 45:                    0 - archive-replayer total read time in ns - archiveId=1
...
 73:        4,327,473,152 - rec-pos: 1 994977179 1001 aeron:ipc - archiveId=1
```