### PR TITLE
Only try unblocking if producer is ahead for liveness_timeout

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2776,10 +2776,10 @@ void aeron_driver_conductor_on_check_for_blocked_driver_commands(aeron_driver_co
 {
     int64_t consumer_position = aeron_mpsc_rb_consumer_position(&conductor->to_driver_commands);
 
-    if (consumer_position == conductor->last_consumer_command_position)
+    if (consumer_position == conductor->last_consumer_command_position &&
+        aeron_mpsc_rb_producer_position(&conductor->to_driver_commands) > consumer_position)
     {
-        if (aeron_mpsc_rb_producer_position(&conductor->to_driver_commands) > consumer_position &&
-            now_ns > (conductor->time_of_last_to_driver_position_change_ns +
+        if (now_ns > (conductor->time_of_last_to_driver_position_change_ns +
                 (int64_t)conductor->context->client_liveness_timeout_ns))
         {
             if (aeron_mpsc_rb_unblock(&conductor->to_driver_commands))

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1180,10 +1180,10 @@ public final class DriverConductor implements Agent
     {
         final long consumerPosition = toDriverCommands.consumerPosition();
 
-        if (consumerPosition == lastConsumerCommandPosition)
+        if (consumerPosition == lastConsumerCommandPosition &&
+            toDriverCommands.producerPosition() > consumerPosition)
         {
-            if (toDriverCommands.producerPosition() > consumerPosition &&
-                ((timeOfLastToDriverPositionChangeNs + clientLivenessTimeoutNs) - nowNs < 0))
+            if ((timeOfLastToDriverPositionChangeNs + clientLivenessTimeoutNs) - nowNs < 0)
             {
                 if (toDriverCommands.unblock())
                 {


### PR DESCRIPTION
I think it's more consistent with the [Java driver implementation](https://github.com/real-logic/aeron/blob/f63401abf37c6fff3fea6b4af45a540c13e03bb7/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java#L487) and should fix the issue #1393 1393.