### PR TITLE
[Java/C] CnC file length validation.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -933,7 +933,7 @@ public final class Archive implements AutoCloseable
         private AuthorisationServiceSupplier authorisationServiceSupplier;
         private Counter controlSessionsCounter;
 
-        private int errorBufferLength;
+        private int errorBufferLength = Configuration.errorBufferLength();
         private ErrorHandler errorHandler;
         private AtomicCounter errorCounter;
         private CountedErrorHandler countedErrorHandler;
@@ -1085,11 +1085,6 @@ public final class Archive implements AutoCloseable
 
             if (null == markFile)
             {
-                if (0 == errorBufferLength)
-                {
-                    errorBufferLength = Configuration.errorBufferLength();
-                }
-
                 if (errorBufferLength < ERROR_BUFFER_LENGTH_DEFAULT ||
                     errorBufferLength > Integer.MAX_VALUE - ArchiveMarkFile.HEADER_LENGTH)
                 {

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
@@ -613,8 +613,9 @@ class ArchiveContextTest
         System.setProperty(ERROR_BUFFER_LENGTH_PROP_NAME, String.valueOf(errorBufferLength));
         try
         {
+            final Archive.Context ctx = TestContexts.localhostArchive();
             final ConfigurationException exception =
-                assertThrowsExactly(ConfigurationException.class, context::conclude);
+                assertThrowsExactly(ConfigurationException.class, ctx::conclude);
             assertEquals("ERROR - invalid errorBufferLength=" + errorBufferLength, exception.getMessage());
         }
         finally

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
@@ -42,6 +42,10 @@ import static io.aeron.Aeron.NULL_VALUE;
 import static io.aeron.AeronCounters.ARCHIVE_CONTROL_SESSIONS_TYPE_ID;
 import static io.aeron.AeronCounters.*;
 import static io.aeron.archive.Archive.Configuration.*;
+import static io.aeron.driver.Configuration.MAX_UDP_PAYLOAD_LENGTH;
+import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MAX_LENGTH;
+import static io.aeron.logbuffer.LogBufferDescriptor.TERM_MIN_LENGTH;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.agrona.concurrent.status.CountersReader.RECORD_ALLOCATED;
 import static org.agrona.concurrent.status.CountersReader.RECORD_UNUSED;
@@ -566,6 +570,56 @@ class ArchiveContextTest
         finally
         {
             System.clearProperty(ARCHIVE_ID_PROP_NAME);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -31, HEADER_LENGTH, MAX_UDP_PAYLOAD_LENGTH + 1, 69 })
+    void shouldValidateControlMtuLength(final int controlMtuLength)
+    {
+        context.controlMtuLength(controlMtuLength);
+
+        final ConfigurationException exception =
+            assertThrowsExactly(ConfigurationException.class, context::conclude);
+        assertTrue(exception.getMessage().contains("mtuLength=" + controlMtuLength));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -100, 0, TERM_MIN_LENGTH - 1, TERM_MAX_LENGTH + 64, 100000 })
+    void shouldValidateControlTermBufferLength(final int controlTermBufferLength)
+    {
+        context.controlTermBufferLength(controlTermBufferLength);
+
+        final IllegalStateException exception =
+            assertThrowsExactly(IllegalStateException.class, context::conclude);
+        assertTrue(exception.getMessage().contains(": length=" + controlTermBufferLength));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -3, ERROR_BUFFER_LENGTH_DEFAULT - 1, Integer.MAX_VALUE })
+    void shouldValidateErrorBufferLengthSetExplicitly(final int errorBufferLength)
+    {
+        context.errorBufferLength(errorBufferLength);
+
+        final ConfigurationException exception =
+            assertThrowsExactly(ConfigurationException.class, context::conclude);
+        assertEquals("ERROR - invalid errorBufferLength=" + errorBufferLength, exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, ERROR_BUFFER_LENGTH_DEFAULT - 1, Integer.MAX_VALUE })
+    void shouldValidateErrorBufferLengthSetViaSystemProperty(final int errorBufferLength)
+    {
+        System.setProperty(ERROR_BUFFER_LENGTH_PROP_NAME, String.valueOf(errorBufferLength));
+        try
+        {
+            final ConfigurationException exception =
+                assertThrowsExactly(ConfigurationException.class, context::conclude);
+            assertEquals("ERROR - invalid errorBufferLength=" + errorBufferLength, exception.getMessage());
+        }
+        finally
+        {
+            System.clearProperty(ERROR_BUFFER_LENGTH_PROP_NAME);
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -708,7 +708,7 @@ public final class ConsensusModule implements AutoCloseable
         /**
          * Size in bytes of the error buffer for the cluster.
          */
-        public static final int ERROR_BUFFER_LENGTH_DEFAULT = 1024 * 1024;
+        public static final int ERROR_BUFFER_LENGTH_DEFAULT = ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
 
         /**
          * Timeout a leader will wait on getting termination ACKs from followers.

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -51,6 +51,8 @@ public final class ClusterMarkFile implements AutoCloseable
 
     public static final int HEADER_LENGTH = 8 * 1024;
     public static final int VERSION_FAILED = -1;
+    public static final int ERROR_BUFFER_MIN_LENGTH = 1024 * 1024;
+    public static final int ERROR_BUFFER_MAX_LENGTH = Integer.MAX_VALUE - HEADER_LENGTH;
 
     public static final String FILE_EXTENSION = ".dat";
     public static final String FILENAME = "cluster-mark" + FILE_EXTENSION;
@@ -78,6 +80,11 @@ public final class ClusterMarkFile implements AutoCloseable
         final EpochClock epochClock,
         final long timeoutMs)
     {
+        if (errorBufferLength < ERROR_BUFFER_MIN_LENGTH || errorBufferLength > ERROR_BUFFER_MAX_LENGTH)
+        {
+            throw new IllegalArgumentException("Invalid errorBufferLength: " + errorBufferLength);
+        }
+
         final boolean markFileExists = file.exists();
         final int totalFileLength = HEADER_LENGTH + errorBufferLength;
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusterMarkFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusterMarkFileTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster.service;
+
+import io.aeron.cluster.codecs.mark.ClusterComponentType;
+import org.agrona.concurrent.SystemEpochClock;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.file.Path;
+
+import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MAX_LENGTH;
+import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+class ClusterMarkFileTest
+{
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MIN_VALUE, -100, ERROR_BUFFER_MIN_LENGTH - 1, ERROR_BUFFER_MAX_LENGTH + 1 })
+    void throwsExceptionIfErrorBufferLengthIsInvalid(final int errorBufferLength, final @TempDir Path dir)
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> new ClusterMarkFile(
+            dir.resolve("test.cfg").toFile(),
+            ClusterComponentType.CONSENSUS_MODULE,
+            errorBufferLength,
+            SystemEpochClock.INSTANCE,
+            10));
+        assertEquals("Invalid errorBufferLength: " + errorBufferLength, exception.getMessage());
+    }
+}

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -272,10 +272,6 @@ static void aeron_driver_conductor_on_endpoint_change_null(const void *channel)
 #define AERON_THREADING_MODE_DEFAULT AERON_THREADING_MODE_DEDICATED
 #define AERON_DIR_DELETE_ON_START_DEFAULT false
 #define AERON_DIR_DELETE_ON_SHUTDOWN_DEFAULT false
-#define AERON_TO_CONDUCTOR_BUFFER_LENGTH_DEFAULT (1024 * 1024 + AERON_RB_TRAILER_LENGTH)
-#define AERON_TO_CLIENTS_BUFFER_LENGTH_DEFAULT (1024 * 1024 + AERON_BROADCAST_BUFFER_TRAILER_LENGTH)
-#define AERON_COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT (1024 * 1024)
-#define AERON_ERROR_BUFFER_LENGTH_DEFAULT (1024 * 1024)
 #define AERON_CLIENT_LIVENESS_TIMEOUT_NS_DEFAULT (10 * 1000 * 1000 * 1000LL)
 #define AERON_TERM_BUFFER_LENGTH_DEFAULT (16 * 1024 * 1024)
 #define AERON_IPC_TERM_BUFFER_LENGTH_DEFAULT (64 * 1024 * 1024)
@@ -631,28 +627,28 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         AERON_TO_CONDUCTOR_BUFFER_LENGTH_ENV_VAR,
         getenv(AERON_TO_CONDUCTOR_BUFFER_LENGTH_ENV_VAR),
         _context->to_driver_buffer_length,
-        1024 + AERON_RB_TRAILER_LENGTH,
+        AERON_TO_CONDUCTOR_BUFFER_LENGTH_DEFAULT,
         INT32_MAX);
 
     _context->to_clients_buffer_length = aeron_config_parse_size64(
         AERON_TO_CLIENTS_BUFFER_LENGTH_ENV_VAR,
         getenv(AERON_TO_CLIENTS_BUFFER_LENGTH_ENV_VAR),
         _context->to_clients_buffer_length,
-        1024 + AERON_BROADCAST_BUFFER_TRAILER_LENGTH,
+        AERON_TO_CLIENTS_BUFFER_LENGTH_DEFAULT,
         INT32_MAX);
 
     _context->counters_values_buffer_length = aeron_config_parse_size64(
         AERON_COUNTERS_VALUES_BUFFER_LENGTH_ENV_VAR,
         getenv(AERON_COUNTERS_VALUES_BUFFER_LENGTH_ENV_VAR),
         _context->counters_values_buffer_length,
-        1024,
-        INT32_MAX);
+        AERON_COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT,
+        AERON_COUNTERS_VALUES_BUFFER_LENGTH_MAX);
 
     _context->error_buffer_length = aeron_config_parse_size64(
         AERON_ERROR_BUFFER_LENGTH_ENV_VAR,
         getenv(AERON_ERROR_BUFFER_LENGTH_ENV_VAR),
         _context->error_buffer_length,
-        1024,
+        AERON_ERROR_BUFFER_LENGTH_DEFAULT,
         INT32_MAX);
 
     _context->client_liveness_timeout_ns = aeron_config_parse_duration_ns(
@@ -702,14 +698,14 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         getenv(AERON_IPC_PUBLICATION_TERM_WINDOW_LENGTH_ENV_VAR),
         _context->ipc_publication_window_length,
         0,
-        INT32_MAX);
+        AERON_LOGBUFFER_TERM_MAX_LENGTH);
 
     _context->publication_window_length = aeron_config_parse_size64(
         AERON_PUBLICATION_TERM_WINDOW_LENGTH_ENV_VAR,
         getenv(AERON_PUBLICATION_TERM_WINDOW_LENGTH_ENV_VAR),
         _context->publication_window_length,
         0,
-        INT32_MAX);
+        AERON_LOGBUFFER_TERM_MAX_LENGTH);
 
     _context->socket_rcvbuf = aeron_config_parse_size64(
         AERON_SOCKET_SO_RCVBUF_ENV_VAR,

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -25,6 +25,7 @@
 #include "concurrent/aeron_spsc_concurrent_array_queue.h"
 #include "concurrent/aeron_mpsc_concurrent_array_queue.h"
 #include "concurrent/aeron_mpsc_rb.h"
+#include "concurrent/aeron_broadcast_descriptor.h"
 #include "aeron_flow_control.h"
 #include "aeron_congestion_control.h"
 #include "aeron_agent.h"
@@ -42,6 +43,12 @@
 
 #define AERON_DRIVER_RECEIVER_IO_VECTOR_LENGTH_MAX (16)
 #define AERON_DRIVER_RECEIVER_MAX_UDP_PACKET_LENGTH (64 * 1024)
+
+#define AERON_TO_CONDUCTOR_BUFFER_LENGTH_DEFAULT (1024 * 1024 + AERON_RB_TRAILER_LENGTH)
+#define AERON_TO_CLIENTS_BUFFER_LENGTH_DEFAULT (1024 * 1024 + AERON_BROADCAST_BUFFER_TRAILER_LENGTH)
+#define AERON_COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT (1024 * 1024)
+#define AERON_COUNTERS_VALUES_BUFFER_LENGTH_MAX (500 * 1024 * 1024)
+#define AERON_ERROR_BUFFER_LENGTH_DEFAULT (1024 * 1024)
 
 typedef struct aeron_driver_conductor_stct aeron_driver_conductor_t;
 

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -177,6 +177,11 @@ public final class Configuration
     public static final int COUNTERS_VALUES_BUFFER_LENGTH_DEFAULT = 1024 * 1024;
 
     /**
+     * Maximum length of the buffer for the counters file.
+     */
+    public static final int COUNTERS_VALUES_BUFFER_LENGTH_MAX = 500 * 1024 * 1024;
+
+    /**
      * Property name for length of the memory mapped buffer for the distinct error log.
      */
     public static final String ERROR_BUFFER_LENGTH_PROP_NAME = "aeron.error.buffer.length";
@@ -682,6 +687,7 @@ public final class Configuration
 
     /**
      * Property name for resolver interface to which network connections are made.
+     *
      * @see #RESOLVER_BOOTSTRAP_NEIGHBOR_PROP_NAME
      */
     public static final String RESOLVER_INTERFACE_PROP_NAME = "aeron.driver.resolver.interface";
@@ -689,6 +695,7 @@ public final class Configuration
     /**
      * Property name for resolver bootstrap neighbors for which it can bootstrap naming, format is comma separated list
      * of {@code hostname:port} pairs.
+     *
      * @see #RESOLVER_INTERFACE_PROP_NAME
      */
     public static final String RESOLVER_BOOTSTRAP_NEIGHBOR_PROP_NAME = "aeron.driver.resolver.bootstrap.neighbor";
@@ -837,6 +844,7 @@ public final class Configuration
      * Should spy subscriptions simulate a connection to a network publication.
      * <p>
      * If true then this will override the min group size of the min and tagged flow control strategies.
+     *
      * @return true if spy subscriptions should simulate a connection to a network publication.
      * @see #SPIES_SIMULATE_CONNECTION_PROP_NAME
      */
@@ -1852,21 +1860,11 @@ public final class Configuration
      */
     public static void validatePageSize(final int pageSize)
     {
-        if (pageSize < PAGE_MIN_SIZE)
-        {
-            throw new ConfigurationException(
-                "page size less than min size of " + PAGE_MIN_SIZE + ": " + pageSize);
-        }
-
-        if (pageSize > PAGE_MAX_SIZE)
-        {
-            throw new ConfigurationException(
-                "page size greater than max size of " + PAGE_MAX_SIZE + ": " + pageSize);
-        }
+        validateValueRange(pageSize, PAGE_MIN_SIZE, PAGE_MAX_SIZE, "filePageSize");
 
         if (!BitUtil.isPowerOfTwo(pageSize))
         {
-            throw new ConfigurationException("page size not a power of 2: " + pageSize);
+            throw new ConfigurationException("filePageSize not a power of 2: " + pageSize);
         }
     }
 
@@ -1886,7 +1884,7 @@ public final class Configuration
 
         if (Math.abs((long)high - low) > Integer.MAX_VALUE)
         {
-            throw new ConfigurationException("reserved range too large");
+            throw new ConfigurationException("reserved session range too large");
         }
     }
 
@@ -1964,4 +1962,20 @@ public final class Configuration
     {
         return srcAddress.getHostString() + ':' + srcAddress.getPort();
     }
+
+    static void validateValueRange(final long value, final long minValue, final long maxValue, final String name)
+    {
+        if (value < minValue)
+        {
+            throw new ConfigurationException(
+                name + " less than min size of " + minValue + ": " + value);
+        }
+
+        if (value > maxValue)
+        {
+            throw new ConfigurationException(
+                name + " greater than max size of " + maxValue + ": " + value);
+        }
+    }
+
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -570,9 +570,13 @@ public final class MediaDriver implements AutoCloseable
             {
                 CloseHelper.close(errorHandler, logFactory);
 
-                final AtomicCounter errorCounter = systemCounters.get(ERRORS);
-                errorCounter.disconnectCountersManager();
-                errorCounter.close();
+                if (null != systemCounters)
+                {
+                    final AtomicCounter errorCounter = systemCounters.get(ERRORS);
+                    errorCounter.disconnectCountersManager();
+                    errorCounter.close();
+                }
+
                 if (errorHandler instanceof AutoCloseable)
                 {
                     CloseHelper.quietClose((AutoCloseable)errorHandler);

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
@@ -17,6 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.driver.MediaDriver.Context;
 import io.aeron.exceptions.ConfigurationException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,10 +33,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class MediaDriverContextTest
 {
+    private final Context context = new Context();
+
+    @AfterEach
+    void afterEach()
+    {
+        context.close();
+    }
+
     @Test
     void nakMulticastMaxBackoffNsDefaultValue()
     {
-        final Context context = new Context();
         assertEquals(NAK_MAX_BACKOFF_DEFAULT_NS, context.nakMulticastMaxBackoffNs());
     }
 
@@ -57,7 +65,6 @@ class MediaDriverContextTest
     @Test
     void nakMulticastMaxBackoffNsExplicitValue()
     {
-        final Context context = new Context();
         context.nakMulticastMaxBackoffNs(Long.MIN_VALUE);
         assertEquals(Long.MIN_VALUE, context.nakMulticastMaxBackoffNs());
     }
@@ -66,7 +73,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { Integer.MIN_VALUE, -5, 0, 1024 * 1024, 1024 * 1024 + 64 * 12 - 1 })
     void conductorBufferLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.conductorBufferLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);
@@ -77,7 +83,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { Integer.MIN_VALUE, -5, 0, 1024 * 1024, 1024 * 1024 + 64 * 2 - 1 })
     void toClientsBufferLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.toClientsBufferLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);
@@ -88,7 +93,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { -76, 0, 1024 * 1024 - 1, 1024 * 1024 * 1024 })
     void counterValuesBufferLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.counterValuesBufferLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);
@@ -99,7 +103,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { -76, 0, ERROR_BUFFER_LENGTH_DEFAULT - 1 })
     void errorBufferLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.errorBufferLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);
@@ -113,7 +116,6 @@ class MediaDriverContextTest
         final Path aeronDir = temp.resolve("aeron");
         Files.createDirectories(aeronDir);
 
-        final Context context = new Context();
         context.aeronDirectoryName(aeronDir.toString());
         context.lossReportBufferLength(length);
 
@@ -125,7 +127,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { -76, -3, TERM_MAX_LENGTH + 1 })
     void publicationTermWindowLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.publicationTermWindowLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);
@@ -136,7 +137,6 @@ class MediaDriverContextTest
     @ValueSource(ints = { -76, -3, TERM_MAX_LENGTH + 1 })
     void ipcPublicationTermWindowLengthMustBeWithinRange(final int length)
     {
-        final Context context = new Context();
         context.ipcPublicationTermWindowLength(length);
 
         final ConfigurationException exception = assertThrows(ConfigurationException.class, context::conclude);


### PR DESCRIPTION
This PR contains the following changes:
- Adds validation for the CnC file length and the length of the components.
- Sets the upper limit for the `counterValuesBufferLength` to **500MB**.
- Adds length validations to the Archive and the Cluster.