### PR TITLE
[Java] Allow running Archive in IPC-only mode.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -504,14 +504,12 @@ public final class Archive implements AutoCloseable
         public static final String ARCHIVE_ID_PROP_NAME = "aeron.archive.id";
 
         /**
-         * Is control channel enabled.
+         * Is control channel enabled. Defaults to {@code true}.
+         * <p>
+         * If set to anything other than {@code true} then control channel is disabled, i.e. the Archive will run in
+         * IPC-only mode.
          */
         public static final String CONTROL_CHANNEL_ENABLED_PROP_NAME = "aeron.archive.control.channel.enabled";
-
-        /**
-         * Control channel enabled for an archive which defaults to {@code true}.
-         */
-        public static final boolean CONTROL_CHANNEL_ENABLED_DEFAULT = true;
 
         /**
          * Update interval in ms for archive mark file.
@@ -881,8 +879,7 @@ public final class Archive implements AutoCloseable
          */
         public static boolean controlChannelEnabled()
         {
-            final String propValue = System.getProperty(
-                CONTROL_CHANNEL_ENABLED_PROP_NAME, Boolean.toString(CONTROL_CHANNEL_ENABLED_DEFAULT));
+            final String propValue = System.getProperty(CONTROL_CHANNEL_ENABLED_PROP_NAME, "true");
             return "true".equals(propValue);
         }
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -504,6 +504,16 @@ public final class Archive implements AutoCloseable
         public static final String ARCHIVE_ID_PROP_NAME = "aeron.archive.id";
 
         /**
+         * Is control channel enabled.
+         */
+        public static final String CONTROL_CHANNEL_ENABLED_PROP_NAME = "aeron.archive.control.channel.enabled";
+
+        /**
+         * Control channel enabled for an archive which defaults to {@code true}.
+         */
+        public static final boolean CONTROL_CHANNEL_ENABLED_DEFAULT = true;
+
+        /**
          * Update interval in ms for archive mark file.
          */
         static final long MARK_FILE_UPDATE_INTERVAL_MS = TimeUnit.SECONDS.toMillis(1);
@@ -763,7 +773,7 @@ public final class Archive implements AutoCloseable
          */
         public static boolean deleteArchiveOnStart()
         {
-            return "true".equalsIgnoreCase(getProperty(ARCHIVE_DIR_DELETE_ON_START_PROP_NAME, "false"));
+            return "true".equals(getProperty(ARCHIVE_DIR_DELETE_ON_START_PROP_NAME, "false"));
         }
 
         /**
@@ -862,6 +872,19 @@ public final class Archive implements AutoCloseable
         {
             return getProperty(REPLAY_CHECKSUM_PROP_NAME);
         }
+
+        /**
+         * Should the control channel be enabled.
+         *
+         * @return {@code true} if the control channel to be enabled.
+         * @see #CONTROL_CHANNEL_ENABLED_PROP_NAME
+         */
+        public static boolean controlChannelEnabled()
+        {
+            final String propValue = System.getProperty(
+                CONTROL_CHANNEL_ENABLED_PROP_NAME, Boolean.toString(CONTROL_CHANNEL_ENABLED_DEFAULT));
+            return "true".equals(propValue);
+        }
     }
 
     /**
@@ -893,6 +916,7 @@ public final class Archive implements AutoCloseable
         private AeronArchive.Context archiveClientContext;
         private AgentInvoker mediaDriverAgentInvoker;
 
+        private boolean controlChannelEnabled = Configuration.controlChannelEnabled();
         private String controlChannel = AeronArchive.Configuration.controlChannel();
         private int controlStreamId = AeronArchive.Configuration.controlStreamId();
         private String localControlChannel = AeronArchive.Configuration.localControlChannel();
@@ -999,15 +1023,18 @@ public final class Archive implements AutoCloseable
             io.aeron.driver.Configuration.validateMtuLength(controlMtuLength);
             checkTermLength(controlTermBufferLength);
 
-            if (null == controlChannel)
+            if (controlChannelEnabled)
             {
-                throw new ConfigurationException("Archive.Context.controlChannel must be set");
-            }
+                if (null == controlChannel)
+                {
+                    throw new ConfigurationException("Archive.Context.controlChannel must be set");
+                }
 
-            if (!controlChannel.startsWith(CommonContext.UDP_CHANNEL))
-            {
-                throw new ConfigurationException(
-                    "Archive.Context.controlChannel must be UDP media: uri=" + controlChannel);
+                if (!controlChannel.startsWith(CommonContext.UDP_CHANNEL))
+                {
+                    throw new ConfigurationException(
+                        "Archive.Context.controlChannel must be UDP media: uri=" + controlChannel);
+                }
             }
 
             if (!localControlChannel.startsWith(CommonContext.IPC_CHANNEL))
@@ -1288,26 +1315,33 @@ public final class Archive implements AutoCloseable
 
             if (null == archiveClientContext.controlResponseChannel())
             {
-                final ChannelUri controlChannelUri = ChannelUri.parse(controlChannel);
-                final String endpoint = controlChannelUri.get(ENDPOINT_PARAM_NAME);
-                int separatorIndex = -1;
-
-                if (null == endpoint || -1 == (separatorIndex = endpoint.lastIndexOf(':')))
+                if (controlChannelEnabled)
                 {
-                    throw new ConfigurationException(
-                        "Unable to derive Archive.Context.archiveClientContext.controlResponseChannel as " +
-                        "Archive.Context.controlChannel.endpoint=" + endpoint +
-                        " and is not in the <host>:<port> format");
+                    final ChannelUri controlChannelUri = ChannelUri.parse(controlChannel);
+                    final String endpoint = controlChannelUri.get(ENDPOINT_PARAM_NAME);
+                    int separatorIndex = -1;
 
+                    if (null == endpoint || -1 == (separatorIndex = endpoint.lastIndexOf(':')))
+                    {
+                        throw new ConfigurationException(
+                            "Unable to derive Archive.Context.archiveClientContext.controlResponseChannel as " +
+                                "Archive.Context.controlChannel.endpoint=" + endpoint +
+                                " and is not in the <host>:<port> format");
+                    }
+
+                    final String responseEndpoint = endpoint.substring(0, separatorIndex) + ":0";
+                    final String responseChannel = new ChannelUriStringBuilder()
+                        .media("udp")
+                        .endpoint(responseEndpoint)
+                        .build();
+
+                    archiveClientContext.controlResponseChannel(responseChannel);
                 }
-
-                final String responseEndpoint = endpoint.substring(0, separatorIndex) + ":0";
-                final String responseChannel = new ChannelUriStringBuilder()
-                    .media("udp")
-                    .endpoint(responseEndpoint)
-                    .build();
-
-                archiveClientContext.controlResponseChannel(responseChannel);
+                else
+                {
+                    throw new ConfigurationException("Archive.Context.archiveClientContext.controlResponseChannel " +
+                        "must be set if Archive.Context.controlChannelEnabled is false");
+                }
             }
 
             archiveClientContext.aeron(aeron).lock(NoOpLock.INSTANCE).errorHandler(errorHandler);
@@ -1415,7 +1449,7 @@ public final class Archive implements AutoCloseable
         /**
          * Should an existing archive be deleted on start. Useful only for testing.
          *
-         * @return true if an existing archive should be deleted on start up.
+         * @return {@code true} if an existing archive should be deleted on start up.
          */
         public boolean deleteArchiveOnStart()
         {
@@ -1553,6 +1587,30 @@ public final class Archive implements AutoCloseable
         }
 
         /**
+         * Should the UDP control channel be enabled.
+         *
+         * @return {@code true} if the UDP control channel should be enabled.
+         * @see Configuration#CONTROL_CHANNEL_ENABLED_PROP_NAME
+         */
+        public boolean controlChannelEnabled()
+        {
+            return controlChannelEnabled;
+        }
+
+        /**
+         * Set if the UDP control channel should be enabled.
+         *
+         * @param controlChannelEnabled indication of if the recording events channel should be enabled.
+         * @return this for a fluent API.
+         * @see Configuration#CONTROL_CHANNEL_ENABLED_PROP_NAME
+         */
+        public Context controlChannelEnabled(final boolean controlChannelEnabled)
+        {
+            this.controlChannelEnabled = controlChannelEnabled;
+            return this;
+        }
+
+        /**
          * Get the channel URI on which the control request subscription will listen.
          *
          * @return the channel URI on which the control request subscription will listen.
@@ -1651,7 +1709,7 @@ public final class Archive implements AutoCloseable
         /**
          * Should the control streams use sparse file term buffers.
          *
-         * @return true if the control stream should use sparse file term buffers.
+         * @return {@code true} if the control stream should use sparse file term buffers.
          * @see io.aeron.archive.client.AeronArchive.Configuration#CONTROL_TERM_BUFFER_SPARSE_PROP_NAME
          */
         public boolean controlTermBufferSparse()
@@ -1775,7 +1833,7 @@ public final class Archive implements AutoCloseable
         /**
          * Should the recording events channel be enabled.
          *
-         * @return true if the recording events channel should be enabled.
+         * @return {@code true} if the recording events channel should be enabled.
          * @see io.aeron.archive.client.AeronArchive.Configuration#RECORDING_EVENTS_ENABLED_PROP_NAME
          */
         public boolean recordingEventsEnabled()

--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -879,8 +879,7 @@ public final class Archive implements AutoCloseable
          */
         public static boolean controlChannelEnabled()
         {
-            final String propValue = System.getProperty(CONTROL_CHANNEL_ENABLED_PROP_NAME, "true");
-            return "true".equals(propValue);
+            return "true".equals(System.getProperty(CONTROL_CHANNEL_ENABLED_PROP_NAME, "true"));
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -151,9 +151,17 @@ abstract class ArchiveConductor
         recordingEventsProxy = ctx.recordingEventsEnabled() ? new RecordingEventsProxy(
             aeron.addExclusivePublication(ctx.recordingEventsChannel(), ctx.recordingEventsStreamId())) : null;
 
-        final ChannelUri controlChannelUri = ChannelUri.parse(ctx.controlChannel());
-        controlChannelUri.put(CommonContext.SPARSE_PARAM_NAME, Boolean.toString(ctx.controlTermBufferSparse()));
-        controlSubscription = aeron.addSubscription(controlChannelUri.toString(), ctx.controlStreamId(), this, null);
+        if (ctx.controlChannelEnabled())
+        {
+            final ChannelUri controlChannelUri = ChannelUri.parse(ctx.controlChannel());
+            controlChannelUri.put(CommonContext.SPARSE_PARAM_NAME, Boolean.toString(ctx.controlTermBufferSparse()));
+            controlSubscription = aeron.addSubscription(
+                controlChannelUri.toString(), ctx.controlStreamId(), this, null);
+        }
+        else
+        {
+            controlSubscription = null;
+        }
         localControlSubscription = aeron.addSubscription(
             ctx.localControlChannel(), ctx.localControlStreamId(), this, null);
     }

--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMarkFile.java
@@ -319,7 +319,7 @@ public class ArchiveMarkFile implements AutoCloseable
         final int headerLength =
             MarkFileHeaderEncoder.BLOCK_LENGTH +
             (4 * VarAsciiEncodingEncoder.lengthEncodingLength()) +
-            ctx.controlChannel().length() +
+            (null != ctx.controlChannel() ? ctx.controlChannel().length() : 0) +
             ctx.localControlChannel().length() +
             (null != ctx.recordingEventsChannel() ? ctx.recordingEventsChannel().length() : 0) +
             ctx.aeronDirectoryName().length();

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -849,7 +849,7 @@ public final class AeronArchive implements AutoCloseable
      *
      * @param channel  to stop recording for.
      * @param streamId to stop recording for.
-     * @return true if the recording was stopped or false if the subscription is not currently active.
+     * @return {@code true} if the recording was stopped or false if the subscription is not currently active.
      */
     public boolean tryStopRecording(final String channel, final int streamId)
     {
@@ -910,7 +910,7 @@ public final class AeronArchive implements AutoCloseable
      * {@link #extendRecording(long, String, int, SourceLocation)}.
      *
      * @param subscriptionId is the {@link Subscription#registrationId()} for the recording in the archive.
-     * @return true if the recording was stopped or false if the subscription is not currently active.
+     * @return {@code true} if the recording was stopped or false if the subscription is not currently active.
      */
     public boolean tryStopRecording(final long subscriptionId)
     {
@@ -939,7 +939,7 @@ public final class AeronArchive implements AutoCloseable
      * Try stop an active recording by its recording id.
      *
      * @param recordingId for which active recording should be stopped.
-     * @return true if the recording was stopped or false if the recording is not currently active.
+     * @return {@code true} if the recording was stopped or false if the recording is not currently active.
      */
     public boolean tryStopRecordingByIdentity(final long recordingId)
     {
@@ -2026,7 +2026,7 @@ public final class AeronArchive implements AutoCloseable
      * Attempt to stop a replication session by id returned from {@link #replicate(long, long, int, String, String)}.
      *
      * @param replicationId to stop replication for.
-     * @return true if the replication was stopped, false if the replication is not active.
+     * @return {@code true} if the replication was stopped, false if the replication is not active.
      * @see #replicate(long, long, int, String, String)
      */
     public boolean tryStopReplication(final long replicationId)
@@ -2677,13 +2677,14 @@ public final class AeronArchive implements AutoCloseable
         /**
          * Should term buffer files be sparse for control request and response streams.
          *
-         * @return true if term buffer files should be sparse for control request and response streams.
+         * @return {@code true} if term buffer files should be sparse for control request and response streams.
          * @see #CONTROL_TERM_BUFFER_SPARSE_PROP_NAME
          */
         public static boolean controlTermBufferSparse()
         {
-            final String propValue = System.getProperty(CONTROL_TERM_BUFFER_SPARSE_PROP_NAME);
-            return null != propValue ? "true".equals(propValue) : CONTROL_TERM_BUFFER_SPARSE_DEFAULT;
+            final String propValue = System.getProperty(
+                CONTROL_TERM_BUFFER_SPARSE_PROP_NAME, Boolean.toString(CONTROL_TERM_BUFFER_SPARSE_DEFAULT));
+            return "true".equals(propValue);
         }
 
         /**
@@ -2801,13 +2802,14 @@ public final class AeronArchive implements AutoCloseable
         /**
          * Should the recording events stream be enabled.
          *
-         * @return true if the recording events stream be enabled.
+         * @return {@code true} if the recording events stream be enabled.
          * @see #RECORDING_EVENTS_ENABLED_PROP_NAME
          */
         public static boolean recordingEventsEnabled()
         {
-            final String propValue = System.getProperty(RECORDING_EVENTS_ENABLED_PROP_NAME);
-            return null != propValue ? Boolean.parseBoolean(propValue) : RECORDING_EVENTS_ENABLED_DEFAULT;
+            final String propValue = System.getProperty(
+                RECORDING_EVENTS_ENABLED_PROP_NAME, Boolean.toString(RECORDING_EVENTS_ENABLED_DEFAULT));
+            return "true".equals(propValue);
         }
     }
 
@@ -3096,7 +3098,7 @@ public final class AeronArchive implements AutoCloseable
         /**
          * Should the control streams use sparse file term buffers.
          *
-         * @return true if the control stream should use sparse file term buffers.
+         * @return {@code true} if the control stream should use sparse file term buffers.
          * @see Configuration#CONTROL_TERM_BUFFER_SPARSE_PROP_NAME
          */
         public boolean controlTermBufferSparse()


### PR DESCRIPTION
This PR adds a new configuration property `aeron.archive.control.channel.enabled` which allows disabling control channel (UDP) when set to `false`. In which case the Archive only listens to the IPC requests.
Setting this property to `false` also requires that the `Archive.Context.archiveClientContext.controlResponseChannel` is set as it won't be derived from the `Archive.Context.controlChannel`.

Fixes #1416. 