### PR TITLE
Node State File with persistent candidateTermId.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveMigration_0_1.java
@@ -59,7 +59,7 @@ class ArchiveMigration_0_1 implements ArchiveMigrationStep
         final File archiveDir)
     {
         try (FileChannel ignore = MigrationUtils.createMigrationTimestampFile(
-            archiveDir, markFile.decoder().version(), minimumVersion()))
+            archiveDir, catalog.version(), minimumVersion()))
         {
             catalog.forEach(
                 (recordingDescriptorOffset, headerEncoder, headerDecoder, encoder, decoder) ->

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -3660,6 +3660,7 @@ public final class ConsensusModule implements AutoCloseable
         public void close()
         {
             CloseHelper.close(countedErrorHandler, recordingLog);
+            CloseHelper.close(countedErrorHandler, nodeStateFile);
             CloseHelper.close(countedErrorHandler, markFile);
             if (errorHandler instanceof AutoCloseable)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -66,7 +66,6 @@ import java.nio.MappedByteBuffer;
  *     &lt;Node State Header&gt;
  *     &lt;Candidate Term Id&gt;
  * </pre>
- * </p>
  */
 public class NodeStateFile implements AutoCloseable
 {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An extensible list of information relating to a specific cluster node.  Used to track persistent state that is node
+ * specific and shouldn't be present in the snapshot.  E.g. candidateTermId.
+ * <p>
+ *     The structure consists of a node header at the beginning of the file followed by n entries that use the
+ *     standard open framing header, followed by the message header, and finally the body.
+ * </p>
+ * <pre>
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                     Node State Header                         |
+ *  +---------------------------------------------------------------+
+ *  </pre>
+ *  <p>
+ *      Entry
+ *  </p>
+ *  <pre>
+ *   0                   1                   2                   3
+ *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ *  |                Standard Open Framing Header                   |
+ *  |                                                               |
+ *  +---------------------------------------------------------------+
+ *  |                       Message Header                          |
+ *  |                                                               |
+ *  +---------------------------------------------------------------+
+ *  |                       Message Body (Variable                ...
+ *  ...                                                             |
+ *  +---------------------------------------------------------------+
+ * </pre>
+ * <p>
+ *     The current structure contains:
+ * <pre>
+ *     &lt;Node State Header&gt;
+ *     &lt;Candidate Term Id&gt;
+ * </pre>
+ * </p>
+ */
+public class NodeStateFile
+{
+    public static final String FILENAME = "node-state.dat";
+
+    private File archiveDir;
+
+    public NodeStateFile(final File archiveDir, final boolean createNew) throws IOException
+    {
+        this.archiveDir = archiveDir;
+        final File nodeStateFile = new File(archiveDir, NodeStateFile.FILENAME);
+        if (!createNew && !nodeStateFile.exists())
+        {
+            throw new IOException("NodeStateFile does not existing and createNew=false");
+        }
+    }
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -226,7 +226,7 @@ public class NodeStateFile implements AutoCloseable
                 SimpleOpenFramingHeaderDecoder.BLOCK_LENGTH,
                 SimpleOpenFramingHeaderDecoder.SCHEMA_VERSION);
 
-            final long messageLength = simpleOpenFramingHeaderDecoder.messageLength();
+            final int messageLength = (int)simpleOpenFramingHeaderDecoder.messageLength();
             final int messagePosition = position + simpleOpenFramingHeaderDecoder.sbeBlockLength();
 
             messageHeaderDecoder.wrap(buffer, messagePosition);

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -72,7 +72,7 @@ public class NodeStateFile implements AutoCloseable
     public static final String FILENAME = "node-state.dat";
     private static final int MINIMUM_FILE_LENGTH =
         NodeStateHeaderDecoder.BLOCK_LENGTH +
-        SimpleOpenFramingHeaderDecoder.BLOCK_LENGTH +
+        FramingHeaderDecoder.BLOCK_LENGTH +
         MessageHeaderDecoder.ENCODED_LENGTH +
         CandidateTermDecoder.BLOCK_LENGTH;
     private final CandidateTerm candidateTerm = new CandidateTerm();
@@ -81,8 +81,8 @@ public class NodeStateFile implements AutoCloseable
     private int fileSyncLevel;
     private final NodeStateHeaderDecoder nodeStateHeaderDecoder = new NodeStateHeaderDecoder();
     private final NodeStateHeaderEncoder nodeStateHeaderEncoder = new NodeStateHeaderEncoder();
-    private final SimpleOpenFramingHeaderDecoder simpleOpenFramingHeaderDecoder = new SimpleOpenFramingHeaderDecoder();
-    private final SimpleOpenFramingHeaderEncoder simpleOpenFramingHeaderEncoder = new SimpleOpenFramingHeaderEncoder();
+    private final FramingHeaderDecoder simpleOpenFramingHeaderDecoder = new FramingHeaderDecoder();
+    private final FramingHeaderEncoder simpleOpenFramingHeaderEncoder = new FramingHeaderEncoder();
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
     private final MessageHeaderEncoder messageHeaderEncoder = new MessageHeaderEncoder();
     private final CandidateTermDecoder candidateTermDecoder = new CandidateTermDecoder();
@@ -178,7 +178,7 @@ public class NodeStateFile implements AutoCloseable
         final NodeStateHeaderEncoder nodeStateHeaderEncoder,
         final CandidateTermDecoder candidateTermDecoder,
         final CandidateTermEncoder candidateTermEncoder,
-        final SimpleOpenFramingHeaderDecoder simpleOpenFramingHeaderDecoder,
+        final FramingHeaderDecoder simpleOpenFramingHeaderDecoder,
         final MessageHeaderDecoder messageHeaderDecoder)
     {
         nodeStateHeaderDecoder.wrap(
@@ -212,7 +212,7 @@ public class NodeStateFile implements AutoCloseable
         final int startPosition,
         final int templateId,
         final DirectBuffer buffer,
-        final SimpleOpenFramingHeaderDecoder simpleOpenFramingHeaderDecoder,
+        final FramingHeaderDecoder simpleOpenFramingHeaderDecoder,
         final MessageHeaderDecoder messageHeaderDecoder)
     {
         int position = startPosition;
@@ -222,8 +222,8 @@ public class NodeStateFile implements AutoCloseable
             simpleOpenFramingHeaderDecoder.wrap(
                 buffer,
                 position,
-                SimpleOpenFramingHeaderDecoder.BLOCK_LENGTH,
-                SimpleOpenFramingHeaderDecoder.SCHEMA_VERSION);
+                FramingHeaderDecoder.BLOCK_LENGTH,
+                FramingHeaderDecoder.SCHEMA_VERSION);
 
             final int messageLength = (int)simpleOpenFramingHeaderDecoder.messageLength();
             final int messagePosition = position + simpleOpenFramingHeaderDecoder.sbeBlockLength();
@@ -244,8 +244,8 @@ public class NodeStateFile implements AutoCloseable
         final MutableDirectBuffer buffer,
         final NodeStateHeaderDecoder nodeStateHeaderDecoder,
         final NodeStateHeaderEncoder nodeStateHeaderEncoder,
-        final SimpleOpenFramingHeaderDecoder simpleOpenFramingHeaderDecoder,
-        final SimpleOpenFramingHeaderEncoder simpleOpenFramingHeaderEncoder,
+        final FramingHeaderDecoder simpleOpenFramingHeaderDecoder,
+        final FramingHeaderEncoder simpleOpenFramingHeaderEncoder,
         final MessageHeaderDecoder messageHeaderDecoder,
         final MessageHeaderEncoder messageHeaderEncoder,
         final CandidateTermDecoder candidateTermDecoder,
@@ -263,8 +263,8 @@ public class NodeStateFile implements AutoCloseable
         simpleOpenFramingHeaderDecoder.wrap(
             buffer,
             firstFramingHeaderOffset,
-            SimpleOpenFramingHeaderDecoder.BLOCK_LENGTH,
-            SimpleOpenFramingHeaderDecoder.SCHEMA_VERSION);
+            FramingHeaderDecoder.BLOCK_LENGTH,
+            FramingHeaderDecoder.SCHEMA_VERSION);
 
         simpleOpenFramingHeaderEncoder.encodingType(CandidateTermDecoder.SCHEMA_ID);
 
@@ -274,7 +274,7 @@ public class NodeStateFile implements AutoCloseable
             buffer, firstFramingHeaderOffset + simpleOpenFramingHeaderEncoder.sbeBlockLength(), messageHeaderDecoder);
 
         simpleOpenFramingHeaderEncoder.messageLength(
-            SimpleOpenFramingHeaderEncoder.BLOCK_LENGTH +
+            FramingHeaderEncoder.BLOCK_LENGTH +
             MessageHeaderEncoder.ENCODED_LENGTH +
             candidateTermEncoder.encodedLength());
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.cluster.service;
 
-import io.aeron.Aeron;
 import io.aeron.CommonContext;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
@@ -245,42 +244,6 @@ public final class ClusterMarkFile implements AutoCloseable
     public long candidateTermId()
     {
         return buffer.getLongVolatile(MarkFileHeaderDecoder.candidateTermIdEncodingOffset());
-    }
-
-    /**
-     * Record the fact that a node is aware of an election, so it can survive a restart.
-     *
-     * @param candidateTermId to record that a vote has taken place.
-     * @param fileSyncLevel   as defined by cluster file sync level.
-     */
-    public void candidateTermId(final long candidateTermId, final int fileSyncLevel)
-    {
-        buffer.putLongVolatile(MarkFileHeaderEncoder.candidateTermIdEncodingOffset(), candidateTermId);
-        if (fileSyncLevel > 0)
-        {
-            markFile.mappedByteBuffer().force();
-        }
-    }
-
-    /**
-     * Record the fact that a node is aware of an election, so it can survive a restart.
-     *
-     * @param candidateTermId to record that a vote has taken place.
-     * @param fileSyncLevel   as defined by cluster file sync level.
-     * @return the max of the existing and proposed candidateTermId.
-     */
-    public long proposeMaxCandidateTermId(final long candidateTermId, final int fileSyncLevel)
-    {
-        final long existingCandidateTermId = buffer.getLongVolatile(
-            MarkFileHeaderEncoder.candidateTermIdEncodingOffset());
-
-        if (candidateTermId > existingCandidateTermId)
-        {
-            candidateTermId(candidateTermId, fileSyncLevel);
-            return candidateTermId;
-        }
-
-        return existingCandidateTermId;
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -181,7 +181,8 @@ public final class ClusterMarkFile implements AutoCloseable
             {
                 if (SemanticVersion.major(version) != MAJOR_VERSION)
                 {
-                    throw new ClusterException("mark file major version " + SemanticVersion.major(version) +
+                    throw new ClusterException(
+                        "mark file major version " + SemanticVersion.major(version) +
                         " does not match software: " + MAJOR_VERSION);
                 }
             },

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.cluster.service;
 
+import io.aeron.Aeron;
 import io.aeron.CommonContext;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -4,12 +4,11 @@
 Codec for the persistent local state of a cluster node.
 -->
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
-                   package="io.aeron.cluster.codecs"
+                   package="io.aeron.cluster.codecs.node"
                    id="112"
                    version="10"
                    semanticVersion="5.3"
-                   description="Message Codecs for communicating with, and within, an Aeron Cluster."
-                   byteOrder="littleEndian">
+                   description="Message Codecs for communicating with, and within, an Aeron Cluster.">
     <types>
         <composite name="messageHeader" description="Message identifiers and length of message root.">
             <type name="blockLength"    primitiveType="uint16"/>
@@ -40,10 +39,15 @@ Codec for the persistent local state of a cluster node.
         <field name="version" id="1" type="int32"/>
     </sbe:message>
 
-    <sbe:message name="candidateTermId" id="301">
+    <sbe:message name="candidateTerm" id="301">
         <field name="candidateTermId"   id="1" type="int64"/>
         <field name="timestamp"         id="2" type="time_t"/>
         <field name="logPosition"       id="3" type="int64"/>
+    </sbe:message>
+
+    <sbe:message name="SimpleOpenFramingHeader" id="302">
+        <field name="messageLength" id="1" type="uint32"/>
+        <field name="encodingType"  id="2" type="uint32"/>
     </sbe:message>
 
 </sbe:messageSchema>

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<!--
+Codec for the persistent local state of a cluster node.
+-->
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="io.aeron.cluster.codecs"
+                   id="112"
+                   version="10"
+                   semanticVersion="5.3"
+                   description="Message Codecs for communicating with, and within, an Aeron Cluster."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root.">
+            <type name="blockLength"    primitiveType="uint16"/>
+            <type name="templateId"     primitiveType="uint16"/>
+            <type name="schemaId"       primitiveType="uint16"/>
+            <type name="version"        primitiveType="uint16"/>
+        </composite>
+        <composite name="groupSizeEncoding" description="Repeating group dimensions.">
+            <type name="blockLength"    primitiveType="uint16"/>
+            <type name="numInGroup"     primitiveType="uint16"/>
+        </composite>
+        <composite name="varAsciiEncoding" description="Variable length ASCII string header.">
+            <type name="length"         primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData"        primitiveType="uint8" length="0" characterEncoding="US-ASCII"/>
+        </composite>
+        <composite name="varDataEncoding" description="Variable length data blob header.">
+            <type name="length"         primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData"        primitiveType="uint8" length="0"/>
+        </composite>
+        <composite name="sofh">
+            <type name="messageLength" primitiveType="uint32"/>
+            <type name="encodingType" primitiveType="uint32"/>
+        </composite>
+        <type name="time_t" primitiveType="int64" description="Epoch time in milliseconds since 1 Jan 1970 UTC."/>
+    </types>
+
+    <sbe:message name="nodeStateHeader" id="300">
+        <field name="version" id="1" type="int32"/>
+    </sbe:message>
+
+    <sbe:message name="candidateTermId" id="301">
+        <field name="candidateTermId"   id="1" type="int64"/>
+        <field name="timestamp"         id="2" type="time_t"/>
+        <field name="logPosition"       id="3" type="int64"/>
+    </sbe:message>
+
+</sbe:messageSchema>

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -41,7 +41,7 @@ Codec for the persistent local state of a cluster node.
         <field name="logPosition"       id="3" type="int64"/>
     </sbe:message>
 
-    <sbe:message name="SimpleOpenFramingHeader" id="302">
+    <sbe:message name="FramingHeader" id="302">
         <field name="messageLength" id="1" type="uint32"/>
         <field name="encodingType"  id="2" type="uint32"/>
     </sbe:message>

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -28,10 +28,6 @@ Codec for the persistent local state of a cluster node.
             <type name="length"         primitiveType="uint32" maxValue="1073741824"/>
             <type name="varData"        primitiveType="uint8" length="0"/>
         </composite>
-        <composite name="sofh">
-            <type name="messageLength" primitiveType="uint32"/>
-            <type name="encodingType" primitiveType="uint32"/>
-        </composite>
         <type name="time_t" primitiveType="int64" description="Epoch time in milliseconds since 1 Jan 1970 UTC."/>
     </types>
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -52,6 +52,8 @@ public class ElectionTest
     private final Image logImage = mock(Image.class);
     private final RecordingLog recordingLog = mock(RecordingLog.class);
     private final ClusterMarkFile clusterMarkFile = mock(ClusterMarkFile.class);
+    private final NodeStateFile nodeStateFile = mock(NodeStateFile.class);
+    private final NodeStateFile.CandidateTerm candidateTerm = mock(NodeStateFile.CandidateTerm.class);
     private final ConsensusPublisher consensusPublisher = mock(ConsensusPublisher.class);
     private final ConsensusModuleAgent consensusModuleAgent = mock(ConsensusModuleAgent.class);
     private final CountedErrorHandler countedErrorHandler = mock(CountedErrorHandler.class);
@@ -62,10 +64,12 @@ public class ElectionTest
         .aeron(aeron)
         .recordingLog(recordingLog)
         .clusterClock(clock)
+        .epochClock(clock)
         .random(new Random())
         .electionStateCounter(electionStateCounter)
         .commitPositionCounter(commitPositionCounter)
         .clusterMarkFile(clusterMarkFile)
+        .nodeStateFile(nodeStateFile)
         .countedErrorHandler(countedErrorHandler);
 
     @BeforeEach
@@ -76,9 +80,10 @@ public class ElectionTest
         when(consensusModuleAgent.logRecordingId()).thenReturn(RECORDING_ID);
         when(consensusModuleAgent.addLogPublication(anyLong())).thenReturn(LOG_SESSION_ID);
         when(subscription.imageBySessionId(anyInt())).thenReturn(logImage);
+        when(nodeStateFile.candidateTerm()).thenReturn(candidateTerm);
 
-        when(clusterMarkFile.candidateTermId()).thenAnswer((invocation) -> markFileCandidateTermId.get());
-        when(clusterMarkFile.proposeMaxCandidateTermId(anyLong(), anyInt())).thenAnswer(
+        when(candidateTerm.candidateTermId()).thenAnswer((invocation) -> markFileCandidateTermId.get());
+        when(nodeStateFile.proposeMaxCandidateTermId(anyLong(), anyLong(), anyLong())).thenAnswer(
             (invocation) ->
             {
                 final long candidateTermId = invocation.getArgument(0);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -46,15 +46,20 @@ class NodeStateFileTest
     void shouldCreateIfCreateNewTrueAndFileDoesNotExist(@TempDir final File clusterDir) throws IOException
     {
         assertEquals(0, Objects.requireNonNull(clusterDir.list()).length);
-        new NodeStateFile(clusterDir, true, syncLevel);
-        assertTrue(new File(clusterDir, NodeStateFile.FILENAME).exists());
+        try (NodeStateFile ignore = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            Objects.requireNonNull(ignore);
+            assertTrue(new File(clusterDir, NodeStateFile.FILENAME).exists());
+        }
     }
 
     @Test
     void shouldHaveNullCandidateTermIdOnInitialCreation(@TempDir final File clusterDir) throws IOException
     {
-        final NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel);
-        assertEquals(Aeron.NULL_VALUE, nodeStateFile.candidateTerm().candidateTermId());
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertEquals(Aeron.NULL_VALUE, nodeStateFile.candidateTerm().candidateTermId());
+        }
     }
 
     @Test

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -1,0 +1,27 @@
+package io.aeron.cluster;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NodeStateFileTest
+{
+    @Test
+    void shouldFailIfCreateNewFalseAndFileDoesNotExist(@TempDir final File archiveDir)
+    {
+        assertThrows(IOException.class, () -> new NodeStateFile(archiveDir, false));
+    }
+
+    @Test
+    void shouldCreateIfCreateNewTrueAndFileDoesNotExist(@TempDir final File archiveDir) throws IOException
+    {
+        assertEquals(0, Objects.requireNonNull(archiveDir.list()).length);
+        final NodeStateFile nodeStateFile = new NodeStateFile(archiveDir, true);
+        assertTrue(new File(archiveDir, NodeStateFile.FILENAME).exists());
+    }
+}

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.cluster;
 
 import org.junit.jupiter.api.Test;
@@ -21,7 +36,26 @@ class NodeStateFileTest
     void shouldCreateIfCreateNewTrueAndFileDoesNotExist(@TempDir final File archiveDir) throws IOException
     {
         assertEquals(0, Objects.requireNonNull(archiveDir.list()).length);
-        final NodeStateFile nodeStateFile = new NodeStateFile(archiveDir, true);
+        new NodeStateFile(archiveDir, true);
         assertTrue(new File(archiveDir, NodeStateFile.FILENAME).exists());
+    }
+
+    @Test
+    void shouldPersistCandidateTermId(@TempDir final File archiveDir) throws Exception
+    {
+        final long candidateTermId = 832234;
+        final long timestampMs = 324234;
+        final long logPosition = 8923423;
+        try (NodeStateFile nodeStateFile = new NodeStateFile(archiveDir, true))
+        {
+            nodeStateFile.updateCandidateTermId(candidateTermId, logPosition, timestampMs);
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(archiveDir, false))
+        {
+            assertEquals(candidateTermId, nodeStateFile.candidateTerm().candidateTermId());
+            assertEquals(timestampMs, nodeStateFile.candidateTerm().timestamp());
+            assertEquals(logPosition, nodeStateFile.candidateTerm().logPosition());
+        }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
@@ -18,6 +18,7 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FragmentHandler;
+import io.aeron.logbuffer.Header;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SystemTestWatcher;
@@ -377,4 +378,38 @@ class TimestampingSystemTest
             assertNotEquals(SENTINEL_VALUE, sendTimestamp.longValue());
         }
     }
+
+final class Poller implements FragmentHandler
+{
+    private long lastMediaRcvTimestamp = 0;
+    private long lastChannelRcvTimestamp = 0;
+    private long lastChannelSndTimestamp = 0;
+
+    public void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
+    {
+
+        long mediaRcvTimestamp = lastChannelRcvTimestamp;
+        if (0 != header.reservedValue())
+        {
+            mediaRcvTimestamp = header.reservedValue();
+            lastMediaRcvTimestamp = mediaRcvTimestamp;
+        }
+
+        long channelRcvTimestamp = buffer.getLong(offset);
+        if (0 != header.reservedValue())
+        {
+            channelRcvTimestamp = header.reservedValue();
+            lastChannelRcvTimestamp = channelRcvTimestamp;
+        }
+
+        long channelSndTimestamp = buffer.getLong(offset + 8);
+        if (0 != header.reservedValue())
+        {
+            channelSndTimestamp = header.reservedValue();
+            lastChannelSndTimestamp = channelSndTimestamp;
+        }
+
+        // Do something with timestamps
+    }
+}
 }

--- a/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/TimestampingSystemTest.java
@@ -18,7 +18,6 @@ package io.aeron;
 import io.aeron.driver.MediaDriver;
 import io.aeron.exceptions.RegistrationException;
 import io.aeron.logbuffer.FragmentHandler;
-import io.aeron.logbuffer.Header;
 import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import io.aeron.test.SystemTestWatcher;
@@ -378,38 +377,4 @@ class TimestampingSystemTest
             assertNotEquals(SENTINEL_VALUE, sendTimestamp.longValue());
         }
     }
-
-final class Poller implements FragmentHandler
-{
-    private long lastMediaRcvTimestamp = 0;
-    private long lastChannelRcvTimestamp = 0;
-    private long lastChannelSndTimestamp = 0;
-
-    public void onFragment(final DirectBuffer buffer, final int offset, final int length, final Header header)
-    {
-
-        long mediaRcvTimestamp = lastChannelRcvTimestamp;
-        if (0 != header.reservedValue())
-        {
-            mediaRcvTimestamp = header.reservedValue();
-            lastMediaRcvTimestamp = mediaRcvTimestamp;
-        }
-
-        long channelRcvTimestamp = buffer.getLong(offset);
-        if (0 != header.reservedValue())
-        {
-            channelRcvTimestamp = header.reservedValue();
-            lastChannelRcvTimestamp = channelRcvTimestamp;
-        }
-
-        long channelSndTimestamp = buffer.getLong(offset + 8);
-        if (0 != header.reservedValue())
-        {
-            channelSndTimestamp = header.reservedValue();
-            lastChannelSndTimestamp = channelSndTimestamp;
-        }
-
-        // Do something with timestamps
-    }
-}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -622,6 +622,7 @@ project(':aeron-cluster') {
     tasks.register('generateCodecs', JavaExec) {
         def codecsFile = 'src/main/resources/cluster/aeron-cluster-codecs.xml'
         def markCodecsFile = 'src/main/resources/cluster/aeron-cluster-mark-codecs.xml'
+        def nodeStateCodecsFile = 'src/main/resources/cluster/aeron-cluster-node-state-codecs.xml'
         def sbeFile = 'src/main/resources/cluster/fpl/sbe.xsd'
 
         inputs.files(codecsFile, markCodecsFile, sbeFile)
@@ -634,7 +635,7 @@ project(':aeron-cluster') {
             'sbe.target.language': 'Java',
             'sbe.validation.xsd': sbeFile,
             'sbe.validation.stop.on.error': 'true')
-        args = [codecsFile, markCodecsFile]
+        args = [codecsFile, markCodecsFile, nodeStateCodecsFile]
     }
 
     compileJava.dependsOn compileGeneratedJava


### PR DESCRIPTION
- Introduce NodeStateFile.
- Add support for storing candidateTermId NodeStateFile.
- Migrate candidateTermId from the cluster mark file
- Use NodeStateFile in Election to trace candidateTermId.