### PR TITLE
[C] Set URI for receiver counters based on matching subscription

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -4536,6 +4536,15 @@ void aeron_driver_conductor_on_create_publication_image(void *clientd, void *ite
     }
 
     aeron_subscription_link_t subscription_link = conductor->network_subscriptions.array[0];
+    for (size_t i = 0; i < conductor->network_subscriptions.length; i++)
+    {
+        if (aeron_subscription_link_matches_allowing_wildcard(&conductor->network_subscriptions.array[i], endpoint, command->stream_id, command->session_id))
+        {
+            subscription_link = conductor->network_subscriptions.array[i];
+            break;
+        }
+    }
+
     const char *uri = subscription_link.channel;
     size_t uri_length = subscription_link.channel_length;
 


### PR DESCRIPTION
Currently the URI of the first subscription is used for all other subscriptions.
If you create two subscriptions, one on channel A and the next on channel B the receiver counters (rcv-pos and rcv-hwm) will both report their channel as A for both subscriptions.

I think this fixes that.