### PR TITLE
Store cluster membership changes in node state file

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1568,6 +1568,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 {
                     clusterMemberJoined(memberId, newMembers);
                 }
+
+                ctx.nodeStateFile().updateClusterMembers(leadershipTermId, memberId, highMemberId, clusterMembers);
             }
             else if (ChangeType.QUIT == changeType)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -448,40 +448,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         pendingServiceMessageTrackers[0].loadState(nextServiceSessionId, logServiceSessionId, pendingMessageCapacity);
     }
 
-    public void onLoadClusterMembers(
-        final int memberId,
-        final int highMemberId,
-        final String members,
-        final DirectBuffer buffer,
-        final int offset,
-        final int length)
-    {
-        if (null == dynamicJoin && !ctx.clusterMembersIgnoreSnapshot())
-        {
-            if (NULL_VALUE == this.memberId)
-            {
-                this.memberId = memberId;
-                ctx.clusterMarkFile().memberId(memberId);
-            }
-
-            if (ClusterMember.EMPTY_MEMBERS == activeMembers)
-            {
-                activeMembers = ClusterMember.parse(members);
-                this.highMemberId = Math.max(ClusterMember.highMemberId(activeMembers), highMemberId);
-                rankedPositions = new long[ClusterMember.quorumThreshold(activeMembers.length)];
-                thisMember = clusterMemberByIdMap.get(memberId);
-
-                ClusterMember.addConsensusPublications(
-                    activeMembers,
-                    thisMember,
-                    ctx.consensusChannel(),
-                    ctx.consensusStreamId(),
-                    aeron,
-                    ctx.countedErrorHandler());
-            }
-        }
-    }
-
     public void onLoadPendingMessageTracker(
         final long nextServiceSessionId,
         final long logServiceSessionId,
@@ -3379,7 +3345,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         final PendingServiceMessageTracker trackerOne = pendingServiceMessageTrackers[0];
         snapshotTaker.snapshotConsensusModuleState(
             nextSessionId, trackerOne.nextServiceSessionId(), trackerOne.logServiceSessionId(), trackerOne.size());
-        snapshotTaker.snapshotClusterMembers(memberId, highMemberId, ClusterMember.encodeAsString(activeMembers));
 
         for (int i = 0, size = sessions.size(); i < size; i++)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1568,8 +1568,6 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 {
                     clusterMemberJoined(memberId, newMembers);
                 }
-
-                ctx.nodeStateFile().updateClusterMembers(leadershipTermId, memberId, highMemberId, clusterMembers);
             }
             else if (ChangeType.QUIT == changeType)
             {
@@ -1592,6 +1590,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
             {
                 election.onMembershipChange(activeMembers, changeType, memberId, logPosition);
             }
+
+            ctx.nodeStateFile().updateClusterMembers(leadershipTermId, memberId, highMemberId, clusterMembers);
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotAdapter.java
@@ -177,19 +177,7 @@ class ConsensusModuleSnapshotAdapter implements ControlledFragmentHandler
                 break;
 
             case ClusterMembersDecoder.TEMPLATE_ID:
-                clusterMembersDecoder.wrap(
-                    buffer,
-                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
-                    messageHeaderDecoder.blockLength(),
-                    messageHeaderDecoder.version());
-
-                listener.onLoadClusterMembers(
-                    clusterMembersDecoder.memberId(),
-                    clusterMembersDecoder.highMemberId(),
-                    clusterMembersDecoder.clusterMembers(),
-                    buffer,
-                    offset,
-                    length);
+                // Ignored
                 break;
 
             case PendingMessageTrackerDecoder.TEMPLATE_ID:

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotListener.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotListener.java
@@ -33,9 +33,6 @@ interface ConsensusModuleSnapshotListener
         int offset,
         int length);
 
-    void onLoadClusterMembers(
-        int memberId, int highMemberId, String clusterMembers, DirectBuffer buffer, int offset, int length);
-
     void onLoadPendingMessage(long clusterSessionId, DirectBuffer buffer, int offset, int length);
 
     void onLoadClusterSession(

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPrinter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPrinter.java
@@ -58,20 +58,6 @@ class ConsensusModuleSnapshotPrinter implements ConsensusModuleSnapshotListener
             " pendingMessageCapacity=" + pendingMessageCapacity);
     }
 
-    public void onLoadClusterMembers(
-        final int memberId,
-        final int highMemberId,
-        final String clusterMembers,
-        final DirectBuffer buffer,
-        final int offset,
-        final int length)
-    {
-        out.println("Cluster Members:" +
-            " memberId=" + memberId +
-            " highMemberId=" + highMemberId +
-            " clusterMembers=" + clusterMembers);
-    }
-
     public void onLoadPendingMessage(
         final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
     {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -52,14 +52,11 @@ import static org.agrona.concurrent.UnsafeBuffer.ALIGNMENT;
  *  <pre>
  *   0                   1                   2                   3
  *   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- *  |                       Framing Header                          |
- *  |                                                               |
  *  +---------------------------------------------------------------+
  *  |                       Message Header                          |
  *  |                                                               |
  *  +---------------------------------------------------------------+
- *  |                       Message Body (Variable                ...
+ *  |                       Message Body (Variable)               ...
  *  ...                                                             |
  *  +---------------------------------------------------------------+
  * </pre>
@@ -67,7 +64,9 @@ import static org.agrona.concurrent.UnsafeBuffer.ALIGNMENT;
  *     The current structure contains:
  * <pre>
  *     &lt;Node State Header&gt;
- *     &lt;Candidate Term Id&gt;
+ *     &lt;Candidate Term&gt;
+ *     &lt;Cluster Members&gt;
+ *     &lt;Node State Footer&gt;
  * </pre>
  */
 public class NodeStateFile implements AutoCloseable

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -44,9 +44,9 @@ import static org.agrona.concurrent.UnsafeBuffer.ALIGNMENT;
  *  +---------------------------------------------------------------+
  *  </pre>
  *  <p>
- *      Entry.  All messages must be laid so that the message body has an 8-byte alignment.  Fields with the message
- *      body that required volatile accesses must be aligned to an 8 byte boundary.  The framing header and message
- *      header are 8-bytes long to aid with this.
+ *      Entry.  All records must be laid so that the body has an 8-byte alignment.  Fields with the that requires
+ *      volatile accesses must be aligned to an 8 byte boundary.  The message header is 8-bytes long to aid with this.
+ *      Records are padded to an 8-byte boundary before the next record.
  *  </p>
  *  <pre>
  *   0                   1                   2                   3

--- a/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/NodeStateFile.java
@@ -17,6 +17,8 @@ package io.aeron.cluster;
 
 import io.aeron.Aeron;
 import io.aeron.cluster.client.ClusterException;
+import io.aeron.cluster.codecs.ClusterMembersDecoder;
+import io.aeron.cluster.codecs.ClusterMembersEncoder;
 import io.aeron.cluster.codecs.node.*;
 import io.aeron.cluster.service.ClusterMarkFile;
 import org.agrona.DirectBuffer;
@@ -81,6 +83,8 @@ public class NodeStateFile implements AutoCloseable
     private final int fileSyncLevel;
     private final NodeStateHeaderDecoder nodeStateHeaderDecoder = new NodeStateHeaderDecoder();
     private final NodeStateHeaderEncoder nodeStateHeaderEncoder = new NodeStateHeaderEncoder();
+    private final ClusterMembersEncoder clusterMembersEncoder = new ClusterMembersEncoder();
+    private final ClusterMembersDecoder clusterMembersDecoder = new ClusterMembersDecoder();
     private final FramingHeaderDecoder simpleOpenFramingHeaderDecoder = new FramingHeaderDecoder();
     private final FramingHeaderEncoder simpleOpenFramingHeaderEncoder = new FramingHeaderEncoder();
     private final MessageHeaderDecoder messageHeaderDecoder = new MessageHeaderDecoder();
@@ -333,6 +337,19 @@ public class NodeStateFile implements AutoCloseable
         return candidateTerm;
     }
 
+    public ClusterMembers clusterMembers()
+    {
+        return null;
+    }
+
+    public void updateClusterMembers(
+        final int clusterMemberId,
+        final long highClusterMemberId,
+        final String clusterMembers)
+    {
+
+    }
+
     /**
      * Wrapper class for the candidate term.
      */
@@ -370,6 +387,11 @@ public class NodeStateFile implements AutoCloseable
         {
             return candidateTermDecoder.logPosition();
         }
+    }
+
+    public final class ClusterMembers
+    {
+
     }
 
     private void syncFile(final MappedByteBuffer mappedFile)

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -33,6 +33,7 @@ Codec for the persistent local state of a cluster node.
 
     <sbe:message name="nodeStateHeader" id="300">
         <field name="version" id="1" type="int32"/>
+        <field name="padding" id="2" type="int32"/>
     </sbe:message>
 
     <sbe:message name="candidateTerm" id="301">
@@ -42,8 +43,19 @@ Codec for the persistent local state of a cluster node.
     </sbe:message>
 
     <sbe:message name="FramingHeader" id="302">
-        <field name="messageLength" id="1" type="uint32"/>
-        <field name="encodingType"  id="2" type="uint32"/>
+        <field name="messageLength" id="1" type="int32"/>
+        <field name="encodingType"  id="2" type="int32"/>
     </sbe:message>
+
+    <sbe:message name="ClusterMembers"
+                 id="303"
+                 description="Serialised state of Cluster Members.">
+        <field name="leadershipTermId"         id="1" type="int64"/>
+        <field name="memberId"                 id="2" type="int32"/>
+        <field name="highMemberId"             id="3" type="int32"/>
+        <data  name="clusterMembers"           id="4" type="varAsciiEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="nodeStateFooter" id="304"/>
 
 </sbe:messageSchema>

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-node-state-codecs.xml
@@ -15,6 +15,8 @@ Codec for the persistent local state of a cluster node.
             <type name="templateId"     primitiveType="uint16"/>
             <type name="schemaId"       primitiveType="uint16"/>
             <type name="version"        primitiveType="uint16"/>
+            <type name="frameLength"    primitiveType="int32"/>
+            <type name="padding"   primitiveType="int32"/>
         </composite>
         <composite name="groupSizeEncoding" description="Repeating group dimensions.">
             <type name="blockLength"    primitiveType="uint16"/>
@@ -40,11 +42,6 @@ Codec for the persistent local state of a cluster node.
         <field name="candidateTermId"   id="1" type="int64"/>
         <field name="timestamp"         id="2" type="time_t"/>
         <field name="logPosition"       id="3" type="int64"/>
-    </sbe:message>
-
-    <sbe:message name="FramingHeader" id="302">
-        <field name="messageLength" id="1" type="int32"/>
-        <field name="encodingType"  id="2" type="int32"/>
     </sbe:message>
 
     <sbe:message name="ClusterMembers"

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -176,7 +176,7 @@ class NodeStateFileTest
 
             assertNotNull(nodeStateFile.clusterMembers());
             assertEquals(memberId, nodeStateFile.clusterMembers().memberId());
-            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highClusterMemberId());
+            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highMemberId());
             assertEquals(longClusterMembers, nodeStateFile.clusterMembers().clusterMembers());
         }
 
@@ -189,7 +189,7 @@ class NodeStateFileTest
         {
             assertNotNull(nodeStateFile.clusterMembers());
             assertEquals(memberId, nodeStateFile.clusterMembers().memberId());
-            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highClusterMemberId());
+            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highMemberId());
             assertEquals(shortClusterMembers, nodeStateFile.clusterMembers().clusterMembers());
         }
     }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -123,6 +123,54 @@ class NodeStateFileTest
         }
     }
 
+    @Test
+    void shouldHaveNullClusterMembersOnCreation(@TempDir final File clusterDir) throws IOException
+    {
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertNull(nodeStateFile.clusterMembers());
+        }
+    }
+
+    @Test
+    void shouldHaveNullClusterMembersIfNotSet(@TempDir final File clusterDir) throws IOException
+    {
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            nodeStateFile.updateCandidateTermId(1, 2, 3);
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertNull(nodeStateFile.clusterMembers());
+        }
+    }
+
+    @Test
+    void shouldShouldPersistClusterMembers(@TempDir final File clusterDir) throws IOException
+    {
+        final long candidateTermId = 832234;
+        final long timestampMs = 324234;
+        final long logPosition = 8923423;
+        final int clusterMemberId = 32;
+        final long highClusterMemberId = 65;
+        final String clusterMembers =
+            "0,host0:20000,host0:20001,host0:20002,host0:220003,host0:20004|" +
+            "1,host1:20000,host1:20001,host1:20002,host1:220003,host1:20004|" +
+            "2,host2:20000,host2:20001,host2:20002,host2:220003,host2:20004|";
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            nodeStateFile.updateCandidateTermId(1, 2, 3);
+            nodeStateFile.updateClusterMembers(clusterMemberId, highClusterMemberId, clusterMembers);
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertNull(nodeStateFile.clusterMembers());
+        }
+    }
+
     private void forceVersion(final File clusterDir, final int semanticVersion)
     {
         MappedByteBuffer buffer = null;

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -152,22 +152,45 @@ class NodeStateFileTest
         final long candidateTermId = 832234;
         final long timestampMs = 324234;
         final long logPosition = 8923423;
-        final int clusterMemberId = 32;
-        final long highClusterMemberId = 65;
-        final String clusterMembers =
+        final long leadershipTermId = 82734982734L;
+        final int memberId = 32;
+        final int highClusterMemberId = 65;
+        final String longClusterMembers =
             "0,host0:20000,host0:20001,host0:20002,host0:220003,host0:20004|" +
             "1,host1:20000,host1:20001,host1:20002,host1:220003,host1:20004|" +
             "2,host2:20000,host2:20001,host2:20002,host2:220003,host2:20004|";
+        final String shortClusterMembers =
+            "0,host0:20000,host0:20001,host0:20002,host0:220003,host0:20004|";
 
         try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
         {
-            nodeStateFile.updateCandidateTermId(1, 2, 3);
-            nodeStateFile.updateClusterMembers(clusterMemberId, highClusterMemberId, clusterMembers);
+            nodeStateFile.updateCandidateTermId(candidateTermId, logPosition, timestampMs);
+            nodeStateFile.updateClusterMembers(leadershipTermId, memberId, highClusterMemberId, longClusterMembers);
         }
 
         try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
         {
-            assertNull(nodeStateFile.clusterMembers());
+            assertEquals(candidateTermId, nodeStateFile.candidateTerm().candidateTermId());
+            assertEquals(timestampMs, nodeStateFile.candidateTerm().timestamp());
+            assertEquals(logPosition, nodeStateFile.candidateTerm().logPosition());
+
+            assertNotNull(nodeStateFile.clusterMembers());
+            assertEquals(memberId, nodeStateFile.clusterMembers().memberId());
+            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highClusterMemberId());
+            assertEquals(longClusterMembers, nodeStateFile.clusterMembers().clusterMembers());
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            nodeStateFile.updateClusterMembers(leadershipTermId, memberId, highClusterMemberId, shortClusterMembers);
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertNotNull(nodeStateFile.clusterMembers());
+            assertEquals(memberId, nodeStateFile.clusterMembers().memberId());
+            assertEquals(highClusterMemberId, nodeStateFile.clusterMembers().highClusterMemberId());
+            assertEquals(shortClusterMembers, nodeStateFile.clusterMembers().clusterMembers());
         }
     }
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/NodeStateFileTest.java
@@ -147,6 +147,21 @@ class NodeStateFileTest
     }
 
     @Test
+    void shouldHandleReloadOfEmptyFile(@TempDir final File clusterDir) throws IOException
+    {
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            Objects.requireNonNull(nodeStateFile);
+        }
+
+        try (NodeStateFile nodeStateFile = new NodeStateFile(clusterDir, true, syncLevel))
+        {
+            assertEquals(Aeron.NULL_VALUE, nodeStateFile.candidateTerm().candidateTermId());
+            assertNull(nodeStateFile.clusterMembers());
+        }
+    }
+
+    @Test
     void shouldShouldPersistClusterMembers(@TempDir final File clusterDir) throws IOException
     {
         final long candidateTermId = 832234;

--- a/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
+++ b/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
@@ -324,16 +324,6 @@ public class ConsensusModuleSnapshotPendingServiceMessagesPatch
             maxClusterSessionId = max(maxClusterSessionId, clusterSessionId);
         }
 
-        public void onLoadClusterMembers(
-            final int memberId,
-            final int highMemberId,
-            final String clusterMembers,
-            final DirectBuffer buffer,
-            final int offset,
-            final int length)
-        {
-        }
-
         public void onLoadClusterSession(
             final long clusterSessionId,
             final long correlationId,
@@ -421,17 +411,6 @@ public class ConsensusModuleSnapshotPendingServiceMessagesPatch
                 .nextServiceSessionId(targetNextServiceSessionId);
 
             writeToSnapshot(tempBuffer, 0, length);
-        }
-
-        public void onLoadClusterMembers(
-            final int memberId,
-            final int highMemberId,
-            final String clusterMembers,
-            final DirectBuffer buffer,
-            final int offset,
-            final int length)
-        {
-            writeToSnapshot(buffer, offset, length);
         }
 
         public void onLoadPendingMessage(

--- a/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
+++ b/aeron-samples/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatchTest.java
@@ -601,16 +601,6 @@ class ConsensusModuleSnapshotPendingServiceMessagesPatchTest
         {
         }
 
-        public void onLoadClusterMembers(
-            final int memberId,
-            final int highMemberId,
-            final String clusterMembers,
-            final DirectBuffer buffer,
-            final int offset,
-            final int length)
-        {
-        }
-
         public void onLoadPendingMessage(
             final long clusterSessionId, final DirectBuffer buffer, final int offset, final int length)
         {


### PR DESCRIPTION
- Support dynamically sized records in the node state file.  Handle this by moving trailing records up/down the file as required.
- Add a footer record for tracking the end of the file.
- Add cluster members record.
- Remove cluster member state from the consensus module snapshot.