### PR TITLE
[C] Handle failed create_publication_image

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_receiver.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.c
@@ -527,13 +527,13 @@ void aeron_driver_receiver_on_remove_publication_image(void *clientd, void *item
     aeron_publication_image_receiver_release(image);
 }
 
-void aeron_driver_receiver_on_remove_cool_down(void *clientd, void *item)
+void aeron_driver_receiver_on_remove_with_state(void *clientd, void *item)
 {
     aeron_driver_receiver_t *receiver = (aeron_driver_receiver_t *)clientd;
-    aeron_command_remove_cool_down_t *cmd = (aeron_command_remove_cool_down_t *)item;
+    aeron_command_on_remove_with_state_t *cmd = (aeron_command_on_remove_with_state_t *)item;
     aeron_receive_channel_endpoint_t *endpoint = (aeron_receive_channel_endpoint_t *)cmd->endpoint;
 
-    if (aeron_receive_channel_endpoint_on_remove_cool_down(endpoint, cmd->session_id, cmd->stream_id) < 0)
+    if (aeron_receive_channel_endpoint_on_remove_with_state(endpoint, cmd->session_id, cmd->stream_id, cmd->state) < 0)
     {
         AERON_APPEND_ERR("%s", "receiver on_remove_cool_down");
         aeron_driver_receiver_log_error(receiver);

--- a/aeron-driver/src/main/c/aeron_driver_receiver.h
+++ b/aeron-driver/src/main/c/aeron_driver_receiver.h
@@ -118,7 +118,7 @@ void aeron_driver_receiver_on_remove_destination(void *clientd, void *item);
 void aeron_driver_receiver_on_add_publication_image(void *clientd, void *item);
 void aeron_driver_receiver_on_remove_publication_image(void *clientd, void *item);
 
-void aeron_driver_receiver_on_remove_cool_down(void *clientd, void *item);
+void aeron_driver_receiver_on_remove_with_state(void *clientd, void *item);
 
 void aeron_driver_receiver_on_resolution_change(void *clientd, void *item);
 

--- a/aeron-driver/src/main/c/aeron_driver_receiver_proxy.c
+++ b/aeron-driver/src/main/c/aeron_driver_receiver_proxy.c
@@ -258,17 +258,43 @@ void aeron_driver_receiver_proxy_on_remove_cool_down(
     int32_t session_id,
     int32_t stream_id)
 {
-    aeron_command_remove_cool_down_t cmd =
+    aeron_command_on_remove_with_state_t cmd =
         {
-            .base = { .func = aeron_driver_receiver_on_remove_cool_down, .item = NULL },
+            .base = { .func = aeron_driver_receiver_on_remove_with_state, .item = NULL },
             .endpoint = endpoint,
             .session_id = session_id,
-            .stream_id = stream_id
+            .stream_id = stream_id,
+            .state = AERON_DATA_PACKET_DISPATCHER_IMAGE_COOL_DOWN
         };
 
     if (AERON_THREADING_MODE_IS_SHARED_OR_INVOKER(receiver_proxy->threading_mode))
     {
-        aeron_driver_receiver_on_remove_cool_down(receiver_proxy->receiver, &cmd);
+        aeron_driver_receiver_on_remove_with_state(receiver_proxy->receiver, &cmd);
+    }
+    else
+    {
+        aeron_driver_receiver_proxy_offer(receiver_proxy, &cmd, sizeof(cmd));
+    }
+}
+
+void aeron_driver_receiver_proxy_on_remove_init_in_progress(
+    aeron_driver_receiver_proxy_t *receiver_proxy,
+    aeron_receive_channel_endpoint_t *endpoint,
+    int32_t session_id,
+    int32_t stream_id)
+{
+    aeron_command_on_remove_with_state_t cmd =
+        {
+            .base = { .func = aeron_driver_receiver_on_remove_with_state, .item = NULL },
+            .endpoint = endpoint,
+            .session_id = session_id,
+            .stream_id = stream_id,
+            .state = AERON_DATA_PACKET_DISPATCHER_IMAGE_INIT_IN_PROGRESS
+        };
+
+    if (AERON_THREADING_MODE_IS_SHARED_OR_INVOKER(receiver_proxy->threading_mode))
+    {
+        aeron_driver_receiver_on_remove_with_state(receiver_proxy->receiver, &cmd);
     }
     else
     {

--- a/aeron-driver/src/main/c/aeron_driver_receiver_proxy.h
+++ b/aeron-driver/src/main/c/aeron_driver_receiver_proxy.h
@@ -104,14 +104,15 @@ typedef struct aeron_command_publication_image_stct
 }
 aeron_command_publication_image_t;
 
-typedef struct aeron_command_remove_cool_down_stct
+typedef struct aeron_command_on_remove_with_state_stct
 {
     aeron_command_base_t base;
     void *endpoint;
     int32_t session_id;
     int32_t stream_id;
+    uint32_t state;
 }
-aeron_command_remove_cool_down_t;
+aeron_command_on_remove_with_state_t;
 
 void aeron_driver_receiver_proxy_on_add_publication_image(
     aeron_driver_receiver_proxy_t *receiver_proxy,
@@ -121,6 +122,11 @@ void aeron_driver_receiver_proxy_on_remove_publication_image(
     aeron_driver_receiver_proxy_t *receiver_proxy,
     aeron_publication_image_t *image);
 void aeron_driver_receiver_proxy_on_remove_cool_down(
+    aeron_driver_receiver_proxy_t *receiver_proxy,
+    aeron_receive_channel_endpoint_t *endpoint,
+    int32_t session_id,
+    int32_t stream_id);
+void aeron_driver_receiver_proxy_on_remove_init_in_progress(
     aeron_driver_receiver_proxy_t *receiver_proxy,
     aeron_receive_channel_endpoint_t *endpoint,
     int32_t session_id,

--- a/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_receive_channel_endpoint.h
@@ -236,10 +236,10 @@ inline int aeron_receive_channel_endpoint_on_remove_pending_setup(
     return aeron_data_packet_dispatcher_remove_pending_setup(&endpoint->dispatcher, session_id, stream_id);
 }
 
-inline int aeron_receive_channel_endpoint_on_remove_cool_down(
-    aeron_receive_channel_endpoint_t *endpoint, int32_t session_id, int32_t stream_id)
+static inline int aeron_receive_channel_endpoint_on_remove_with_state(
+    aeron_receive_channel_endpoint_t *endpoint, int32_t session_id, int32_t stream_id, uint32_t image_state)
 {
-    return aeron_data_packet_dispatcher_remove_cool_down(&endpoint->dispatcher, session_id, stream_id);
+    return aeron_data_packet_dispatcher_remove_with_state(&endpoint->dispatcher, session_id, stream_id, image_state);
 }
 
 inline void aeron_receive_channel_endpoint_receiver_release(aeron_receive_channel_endpoint_t *endpoint)


### PR DESCRIPTION
Currently if create_publication_image fails:
1. It can fail silently without actually committing errors.
2. It will leave an entry in the data_packet_dispatcher for that session/stream in INIT_IN_PROGRESS state, for as long as there is a subscriber. This stops any potential for this stream/session to be subscribed to, even if the error was temporary.

This change removes the dead entry from the image_by_session_id_map in the packet_dispatcher, and ensures errors are logged if a failure is hit.