### PR TITLE
[C] Fix rejoin logic by swapping cool down map insertion and removal.

### DIFF
--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -921,10 +921,9 @@ void aeron_publication_image_on_time_event(
                 image->conductor_fields.state = AERON_PUBLICATION_IMAGE_STATE_LINGER;
                 image->conductor_fields.time_of_last_state_change_ns = now_ns;
 
-                aeron_driver_conductor_image_transition_to_linger(conductor, image);
-
                 aeron_receive_channel_endpoint_dec_image_ref_count(image->endpoint);
                 aeron_driver_receiver_proxy_on_remove_publication_image(conductor->context->receiver_proxy, image);
+                aeron_driver_conductor_image_transition_to_linger(conductor, image);
 
                 aeron_receive_channel_endpoint_try_remove_endpoint(image->endpoint);
             }


### PR DESCRIPTION
Seems to have been broken by this commit: https://github.com/reissGRVS/aeron/commit/605a71feac0d101fb5006c52aea48e6ea1a844ec#r104348901

The cool down entry was being inserted after the remove attempt.

Remove attempt via aeron_driver_conductor_image_transition_to_linger https://github.com/real-logic/aeron/blob/f94e8e899ff5900556d7e6c5bab65fcd18784f89/aeron-driver/src/main/c/aeron_driver_conductor.c#L1351

Insert via aeron_driver_receiver_proxy_on_remove_publication_image->aeron_driver_receiver_on_remove_publication_image->aeron_receive_channel_endpoint_on_remove_publication_image->aeron_data_packet_dispatcher_remove_publication_image
https://github.com/real-logic/aeron/blob/f94e8e899ff5900556d7e6c5bab65fcd18784f89/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c#L262