### PR TITLE
Wait for counters to support memory santization

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -3210,6 +3210,14 @@ int aeron_driver_conductor_on_add_network_publication(
         return -1;
     }
 
+    if (aeron_publication_params_validate_mtu_for_sndbuf(
+        &params, udp_channel->socket_sndbuf_length, conductor->context->os_buffer_lengths.default_so_sndbuf) < 0)
+    {
+        AERON_APPEND_ERR("%s", "");
+        aeron_udp_channel_delete(udp_channel);
+        return -1;
+    }
+
     aeron_client_t *client = aeron_driver_conductor_get_or_add_client(conductor, command->correlated.client_id);
     if (NULL == client)
     {

--- a/aeron-driver/src/main/c/uri/aeron_driver_uri.h
+++ b/aeron-driver/src/main/c/uri/aeron_driver_uri.h
@@ -71,6 +71,8 @@ int aeron_driver_uri_subscription_params(
 int aeron_publication_params_validate_mtu_for_sndbuf(
     aeron_driver_uri_publication_params_t *params,
     size_t endpoint_socket_sndbuf,
+    size_t channel_socket_sndbuf,
+    size_t context_socket_sndbuf,
     size_t os_default_socket_sndbuf);
 
 int aeron_subscription_params_validate_initial_window_for_rcvbuf(

--- a/aeron-system-tests/src/test/java/io/aeron/test/driver/TestMediaDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/test/driver/TestMediaDriverTest.java
@@ -23,6 +23,7 @@ import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -34,8 +35,11 @@ class TestMediaDriverTest
     {
         final File aeronDirectory;
         final MediaDriver.Context context = new MediaDriver.Context().dirDeleteOnStart(true).dirDeleteOnShutdown(false);
-        try (TestMediaDriver driver = TestMediaDriver.launch(context, null))
+        try (TestMediaDriver driver = TestMediaDriver.launch(context, null);
+            Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
         {
+            Objects.requireNonNull(aeron);
+
             aeronDirectory = driver.context().aeronDirectory();
             assertNotNull(aeronDirectory);
 

--- a/aeron-test-support/src/main/java/io/aeron/test/InterruptingTestCallback.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/InterruptingTestCallback.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 public class InterruptingTestCallback implements BeforeEachCallback, AfterEachCallback
 {
@@ -68,7 +69,13 @@ public class InterruptingTestCallback implements BeforeEachCallback, AfterEachCa
         {
             final Thread testThread = Thread.currentThread();
 
-            timer = SCHEDULER.schedule(testThread::interrupt, annotation.value(), annotation.unit());
+            long delayMs = annotation.unit().toMillis(annotation.value());
+            if (SystemTestConfig.DRIVER_AWAIT_COUNTER_CLOSE)
+            {
+                delayMs = Math.max(delayMs, SystemTestConfig.MIN_COUNTER_CLOSE_INTERRUPT_TIMEOUT_MS);
+            }
+
+            timer = SCHEDULER.schedule(testThread::interrupt, delayMs, TimeUnit.MILLISECONDS);
         }
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/SystemTestConfig.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/SystemTestConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.test;
+
+public class SystemTestConfig
+{
+    public static final String DRIVER_AWAIT_COUNTER_CLOSE_PROP_NAME = "aeron.test.system.driver.await.counters";
+    public static final boolean DRIVER_AWAIT_COUNTER_CLOSE = Boolean.getBoolean(DRIVER_AWAIT_COUNTER_CLOSE_PROP_NAME);
+    public static final long MIN_COUNTER_CLOSE_INTERRUPT_TIMEOUT_MS = 20_000L;
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -15,13 +15,13 @@
  */
 package io.aeron.test.driver;
 
-import io.aeron.Aeron;
 import io.aeron.AeronCounters;
 import io.aeron.CommonContext;
 import io.aeron.driver.*;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.test.SystemTestConfig;
 import io.aeron.test.Tests;
+import org.agrona.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
 import org.agrona.LangUtil;
@@ -78,8 +78,8 @@ public final class CTestMediaDriver implements TestMediaDriver
     private final DriverOutputConsumer driverOutputConsumer;
     private final File stdoutFile;
     private final File stderrFile;
-    private Aeron.Context aeronContext;
-    private CountersReader countersReader;
+    private MappedByteBuffer cncByteBuffer = null;
+    private CountersReader countersReader = null;
     private boolean isClosed = false;
 
     private CTestMediaDriver(
@@ -110,9 +110,9 @@ public final class CTestMediaDriver implements TestMediaDriver
         Exception error = null;
         try
         {
-            if (null != aeronContext)
+            if (null == cncByteBuffer)
             {
-                aeronContext.close();
+                BufferUtil.free(cncByteBuffer);
             }
         }
         catch (final Exception ex)
@@ -194,7 +194,7 @@ public final class CTestMediaDriver implements TestMediaDriver
         if (null == countersReader)
         {
             final File cncFile = new File(context.aeronDirectoryName(), "cnc.dat");
-            final MappedByteBuffer cncByteBuffer = mapExistingFileReadOnly(cncFile);
+            cncByteBuffer = mapExistingFileReadOnly(cncFile);
             final DirectBuffer cncMetaData = createMetaDataBuffer(cncByteBuffer);
             final int cncVersion = cncMetaData.getInt(cncVersionOffset(0));
 

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -20,7 +20,6 @@ import io.aeron.AeronCounters;
 import io.aeron.CommonContext;
 import io.aeron.driver.*;
 import io.aeron.protocol.HeaderFlyweight;
-import io.aeron.samples.SamplesUtil;
 import io.aeron.test.SystemTestConfig;
 import io.aeron.test.Tests;
 import org.agrona.DirectBuffer;

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -159,7 +159,7 @@ public final class CTestMediaDriver implements TestMediaDriver
             }
         };
 
-        final long deadlineMs = System.currentTimeMillis() + 5_000;
+        final long deadlineMs = System.currentTimeMillis() + 10_000;
         do
         {
             counterCount.set(0);
@@ -169,6 +169,15 @@ public final class CTestMediaDriver implements TestMediaDriver
             Tests.yield();
         }
         while (0 != counterCount.get() && System.currentTimeMillis() < deadlineMs);
+
+//        if (0 != counterCount.get())
+//        {
+//            System.out.println("Counter did not reach 0 within timeout: " + counterCount);
+//        }
+//        else
+//        {
+//            System.out.println("Timeout remaining " + (deadlineMs - System.currentTimeMillis()));
+//        }
     }
 
     public void cleanup()

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -21,6 +21,7 @@ import io.aeron.CommonContext;
 import io.aeron.driver.*;
 import io.aeron.protocol.HeaderFlyweight;
 import io.aeron.samples.SamplesUtil;
+import io.aeron.test.SystemTestConfig;
 import io.aeron.test.Tests;
 import org.agrona.DirectBuffer;
 import org.agrona.IoUtil;
@@ -149,6 +150,11 @@ public final class CTestMediaDriver implements TestMediaDriver
 
     private void awaitSendersAndReceiversClosed()
     {
+        if (!SystemTestConfig.DRIVER_AWAIT_COUNTER_CLOSE)
+        {
+            return;
+        }
+
         final MutableInteger counterCount = new MutableInteger();
         final CountersReader.MetaData metaData = (counterId, typeId, keyBuffer, label) ->
         {
@@ -159,7 +165,7 @@ public final class CTestMediaDriver implements TestMediaDriver
             }
         };
 
-        final long deadlineMs = System.currentTimeMillis() + 10_000;
+        final long deadlineMs = System.currentTimeMillis() + 15_000;
         do
         {
             counterCount.set(0);
@@ -169,15 +175,6 @@ public final class CTestMediaDriver implements TestMediaDriver
             Tests.yield();
         }
         while (0 != counterCount.get() && System.currentTimeMillis() < deadlineMs);
-
-//        if (0 != counterCount.get())
-//        {
-//            System.out.println("Counter did not reach 0 within timeout: " + counterCount);
-//        }
-//        else
-//        {
-//            System.out.println("Timeout remaining " + (deadlineMs - System.currentTimeMillis()));
-//        }
     }
 
     public void cleanup()

--- a/build.gradle
+++ b/build.gradle
@@ -908,6 +908,7 @@ project(':aeron-system-tests') {
         systemProperty('aeron.test.system.ats.path', System.getProperty('aeron.test.system.ats.path'))
         systemProperty('aeron.test.system.ats.conf.dir', System.getProperty('aeron.test.system.ats.conf.dir'))
         systemProperty('aeron.test.system.ats.conf.file', System.getProperty('aeron.test.system.ats.conf.file'))
+        systemProperty('aeron.test.system.driver.await.counters', System.getProperty('aeron.test.system.driver.await.counters'))
     }
 
     shadowJar {


### PR DESCRIPTION
- Add a system property to specify that the system tests should wait for the send and receive endpoint counters to be removed before stopping the media driver.
- Add minimum timeout for InterruptingTestCallback if tests will wait for the counters to close before shutting down the media driver.
- Fix memory leak when creating endpoints with MTUs that are too large for the socket sndbuf.  