### PR TITLE
Let Archive take care of handling Aeron exceptions when client is embedded.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -1415,6 +1415,8 @@ final class ClientConductor implements Agent
         return workCount;
     }
 
+    private long forceErrorNs = -1;
+
     private void checkServiceInterval(final long nowNs)
     {
         if ((timeOfLastServiceNs + interServiceTimeoutNs) - nowNs < 0)
@@ -1425,6 +1427,16 @@ final class ClientConductor implements Agent
             throw new ConductorServiceTimeoutException(
                 "service interval exceeded: timeout=" + interServiceTimeoutNs +
                 "ns, interval=" + (nowNs - timeOfLastServiceNs) + "ns");
+        }
+
+        if (-1 == forceErrorNs)
+        {
+            forceErrorNs = nowNs;
+        }
+
+        if ((forceErrorNs + TimeUnit.SECONDS.toNanos(5)) < nowNs)
+        {
+            throw new ConductorServiceTimeoutException("forced");
         }
     }
 

--- a/aeron-client/src/main/java/io/aeron/exceptions/AeronException.java
+++ b/aeron-client/src/main/java/io/aeron/exceptions/AeronException.java
@@ -185,4 +185,15 @@ public class AeronException extends RuntimeException
     {
         return category;
     }
+
+    /**
+     * Determines if a throwable is a FATAL AeronException.
+     *
+     * @param t throwable to check
+     * @return true if this is an AeronException with a category set to FATAL, false otherwise.
+     */
+    public static boolean isFatal(final Throwable t)
+    {
+        return t instanceof AeronException && Category.FATAL == ((AeronException)t).category;
+    }
 }


### PR DESCRIPTION
- Allow AgentTerminationExceptions and FATAL AeronException to shutdown the Archive.main method.