### PR TITLE
[Java] Name resolution execution time tracking.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
@@ -250,7 +250,7 @@ public class DriverComponentLogger implements ComponentLogger
             NAME_RESOLUTION_RESOLVE,
             "DefaultNameResolver",
             DriverInterceptor.NameResolution.Resolve.class,
-            "resolveHook");
+            "logResolve");
 
         return tempBuilder;
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
@@ -248,9 +248,16 @@ public class DriverComponentLogger implements ComponentLogger
         tempBuilder = addEventInstrumentation(
             tempBuilder,
             NAME_RESOLUTION_RESOLVE,
-            "DefaultNameResolver",
+            "TimeTrackingNameResolver",
             DriverInterceptor.NameResolution.Resolve.class,
             "logResolve");
+
+        tempBuilder = addEventInstrumentation(
+            tempBuilder,
+            NAME_RESOLUTION_LOOKUP,
+            "TimeTrackingNameResolver",
+            DriverInterceptor.NameResolution.Lookup.class,
+            "logLookup");
 
         return tempBuilder;
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -82,9 +82,13 @@ public enum DriverEventCode implements EventCode
     FLOW_CONTROL_RECEIVER_ADDED(48, DriverEventDissector::dissectFlowControlReceiver),
     FLOW_CONTROL_RECEIVER_REMOVED(49, DriverEventDissector::dissectFlowControlReceiver),
 
-    NAME_RESOLUTION_RESOLVE(50, DriverEventDissector::dissectResolve),
+    NAME_RESOLUTION_RESOLVE(50,
+        (code, buffer, offset, builder) -> DriverEventDissector.dissectResolve(buffer, offset, builder)),
 
-    GENERIC_MESSAGE(51, DriverEventDissector::dissectString);
+    GENERIC_MESSAGE(51, DriverEventDissector::dissectString),
+
+    NAME_RESOLUTION_LOOKUP(52,
+        (code, buffer, offset, builder) -> DriverEventDissector.dissectLookup(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.DRIVER.getTypeCode();
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -330,16 +330,23 @@ final class DriverEventDissector
         int absoluteOffset = offset;
         absoluteOffset += dissectLogHeader(CONTEXT, NAME_RESOLUTION_RESOLVE, buffer, absoluteOffset, builder);
 
+        final boolean isReResolution = 1 == buffer.getByte(absoluteOffset);
+        absoluteOffset += SIZE_OF_BYTE;
+
+        final long durationNs = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+
         builder.append(": resolver=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
-        absoluteOffset += SIZE_OF_INT; // String length
+        absoluteOffset += SIZE_OF_INT;
 
-        builder.append(" durationNs=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
-        absoluteOffset += SIZE_OF_LONG;
+        builder.append(" durationNs=").append(durationNs);
 
         builder.append(" hostname=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
-        absoluteOffset += SIZE_OF_INT; // String length
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" isReResolution=").append(isReResolution);
 
         builder.append(" address=");
         dissectInetAddress(buffer, absoluteOffset, builder);
@@ -351,19 +358,23 @@ final class DriverEventDissector
         int absoluteOffset = offset;
         absoluteOffset += dissectLogHeader(CONTEXT, NAME_RESOLUTION_LOOKUP, buffer, absoluteOffset, builder);
 
+        final boolean isReLookup = 1 == buffer.getByte(absoluteOffset);
+        absoluteOffset += SIZE_OF_BYTE;
+
+        final long durationNs = buffer.getLong(absoluteOffset, LITTLE_ENDIAN);
+        absoluteOffset += SIZE_OF_LONG;
+
         builder.append(": resolver=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(" durationNs=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
-        absoluteOffset += SIZE_OF_LONG;
+        builder.append(" durationNs=").append(durationNs);
 
         builder.append(" name=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
         absoluteOffset += SIZE_OF_INT;
 
-        builder.append(" isRelookup=").append(1 == buffer.getByte(absoluteOffset));
-        absoluteOffset += SIZE_OF_BOOLEAN;
+        builder.append(" isReLookup=").append(isReLookup);
 
         builder.append(" resolvedName=");
         buffer.getStringAscii(absoluteOffset, builder);

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -342,7 +342,7 @@ final class DriverEventDissector
 
         builder.append(" durationNs=").append(durationNs);
 
-        builder.append(" hostname=");
+        builder.append(" name=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
         absoluteOffset += SIZE_OF_INT;
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -335,6 +335,9 @@ final class DriverEventDissector
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
         absoluteOffset += SIZE_OF_INT; // String length
 
+        builder.append(" durationNs=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_LONG;
+
         builder.append(" hostname=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
         absoluteOffset += SIZE_OF_INT; // String length

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -23,8 +23,7 @@ import org.agrona.MutableDirectBuffer;
 import static io.aeron.agent.CommonEventDissector.*;
 import static io.aeron.agent.DriverEventCode.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
-import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.agrona.BitUtil.*;
 
 /**
  * Dissect encoded log events and append them to a provided {@link StringBuilder}.
@@ -326,10 +325,10 @@ final class DriverEventDissector
     }
 
     static void dissectResolve(
-        final DriverEventCode code, final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+        final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
     {
         int absoluteOffset = offset;
-        absoluteOffset += dissectLogHeader(CONTEXT, code, buffer, absoluteOffset, builder);
+        absoluteOffset += dissectLogHeader(CONTEXT, NAME_RESOLUTION_RESOLVE, buffer, absoluteOffset, builder);
 
         builder.append(": resolver=");
         absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
@@ -344,6 +343,30 @@ final class DriverEventDissector
 
         builder.append(" address=");
         dissectInetAddress(buffer, absoluteOffset, builder);
+    }
+
+    static void dissectLookup(
+        final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, NAME_RESOLUTION_LOOKUP, buffer, absoluteOffset, builder);
+
+        builder.append(": resolver=");
+        absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" durationNs=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_LONG;
+
+        builder.append(" name=");
+        absoluteOffset += buffer.getStringAscii(absoluteOffset, builder);
+        absoluteOffset += SIZE_OF_INT;
+
+        builder.append(" isRelookup=").append(1 == buffer.getByte(absoluteOffset));
+        absoluteOffset += SIZE_OF_BOOLEAN;
+
+        builder.append(" resolvedName=");
+        buffer.getStringAscii(absoluteOffset, builder);
     }
 
     static int frameType(final MutableDirectBuffer buffer, final int termOffset)

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -244,14 +244,21 @@ final class DriverEventEncoder
         final int length,
         final int captureLength,
         final String resolverName,
+        final long durationNs,
         final String hostName,
         final InetAddress inetAddress)
     {
         int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+
         encodedLength += encodeTrailingString(
             encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolverName);
+
+        encodingBuffer.putLong(offset + encodedLength, durationNs, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
+
         encodedLength += encodeTrailingString(
             encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, hostName);
+
         encodeInetAddress(encodingBuffer, offset + encodedLength, inetAddress);
     }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -246,15 +246,19 @@ final class DriverEventEncoder
         final String resolverName,
         final long durationNs,
         final String hostName,
+        final boolean isReResolution,
         final InetAddress inetAddress)
     {
         int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodedLength += encodeTrailingString(
-            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolverName);
+        encodingBuffer.putByte(offset + encodedLength, (byte)(isReResolution ? 1 : 0));
+        encodedLength += SIZE_OF_BOOLEAN;
 
         encodingBuffer.putLong(offset + encodedLength, durationNs, LITTLE_ENDIAN);
         encodedLength += SIZE_OF_LONG;
+
+        encodedLength += encodeTrailingString(
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolverName);
 
         encodedLength += encodeTrailingString(
             encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, hostName);
@@ -270,22 +274,22 @@ final class DriverEventEncoder
         final String resolverName,
         final long durationNs,
         final String name,
-        final boolean isRelookup,
+        final boolean isReLookup,
         final String resolvedName)
     {
         int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
 
-        encodedLength += encodeTrailingString(
-            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_WITH_PORT_LENGTH, resolverName);
+        encodingBuffer.putByte(offset + encodedLength, (byte)(isReLookup ? 1 : 0));
+        encodedLength += SIZE_OF_BOOLEAN;
 
         encodingBuffer.putLong(offset + encodedLength, durationNs, LITTLE_ENDIAN);
         encodedLength += SIZE_OF_LONG;
 
         encodedLength += encodeTrailingString(
-            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_WITH_PORT_LENGTH, name);
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_WITH_PORT_LENGTH, resolverName);
 
-        encodingBuffer.putByte(offset + encodedLength, (byte)(isRelookup ? 1 : 0));
-        encodedLength += SIZE_OF_BOOLEAN;
+        encodedLength += encodeTrailingString(
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_WITH_PORT_LENGTH, name);
 
         encodeTrailingString(
             encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_WITH_PORT_LENGTH, resolvedName);

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -337,18 +337,20 @@ public final class DriverEventLogger
     /**
      * Log a resolution for a resolver and the associated result.
      *
-     * @param code          representing the event type
-     * @param resolverName  simple class name of the resolver
-     * @param name          host name being resolved
-     * @param address       address that was resolved to, can be null
+     * @param code         representing the event type
+     * @param resolverName simple class name of the resolver
+     * @param durationNs   of the call in nanoseconds.
+     * @param name         host name being resolved
+     * @param address      address that was resolved to, can be null
      */
     public void logResolve(
         final DriverEventCode code,
         final String resolverName,
+        final long durationNs,
         final String name,
         final InetAddress address)
     {
-        final int length = trailingStringLength(resolverName, MAX_HOST_NAME_LENGTH) +
+        final int length = SIZE_OF_LONG + trailingStringLength(resolverName, MAX_HOST_NAME_LENGTH) +
             trailingStringLength(name, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
@@ -360,7 +362,8 @@ public final class DriverEventLogger
         {
             try
             {
-                encodeResolve((UnsafeBuffer)ringBuffer.buffer(), index, length, length, resolverName, name, address);
+                encodeResolve(
+                    (UnsafeBuffer)ringBuffer.buffer(), index, length, length, resolverName, durationNs, name, address);
             }
             finally
             {

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -341,18 +341,21 @@ public final class DriverEventLogger
     /**
      * Log a resolution for a resolver and the associated result.
      *
-     * @param resolverName simple class name of the resolver
-     * @param durationNs   of the call in nanoseconds.
-     * @param name         host name being resolved
-     * @param address      address that was resolved to, can be null
+     * @param resolverName   simple class name of the resolver.
+     * @param durationNs     of the call in nanoseconds.
+     * @param name           host name being resolved.
+     * @param isReResolution {@code true} if this is a re-resolution or {@code false} if initial resolution.
+     * @param address        address that was resolved to, can be {@code null}.
      */
     public void logResolve(
         final String resolverName,
         final long durationNs,
         final String name,
+        final boolean isReResolution,
         final InetAddress address)
     {
-        final int length = SIZE_OF_LONG + trailingStringLength(resolverName, MAX_HOST_NAME_LENGTH) +
+        final int length = SIZE_OF_BOOLEAN + SIZE_OF_LONG +
+            trailingStringLength(resolverName, MAX_HOST_NAME_LENGTH) +
             trailingStringLength(name, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
@@ -365,7 +368,15 @@ public final class DriverEventLogger
             try
             {
                 encodeResolve(
-                    (UnsafeBuffer)ringBuffer.buffer(), index, length, length, resolverName, durationNs, name, address);
+                    (UnsafeBuffer)ringBuffer.buffer(),
+                    index,
+                    length,
+                    length,
+                    resolverName,
+                    durationNs,
+                    name,
+                    isReResolution,
+                    address);
             }
             finally
             {
@@ -380,14 +391,14 @@ public final class DriverEventLogger
      * @param resolverName simple class name of the resolver
      * @param durationNs   of the call in nanoseconds.
      * @param name         host name being resolved
-     * @param isRelookup      address that was resolved to, can be null
+     * @param isReLookup      address that was resolved to, can be null
      * @param resolvedName      address that was resolved to, can be null
      */
     public void logLookup(
         final String resolverName,
         final long durationNs,
         final String name,
-        final boolean isRelookup,
+        final boolean isReLookup,
         final String resolvedName)
     {
         final int length = SIZE_OF_LONG + trailingStringLength(resolverName, MAX_HOST_NAME_WITH_PORT_LENGTH) +
@@ -410,7 +421,7 @@ public final class DriverEventLogger
                     resolverName,
                     durationNs,
                     name,
-                    isRelookup,
+                    isReLookup,
                     resolvedName);
             }
             finally

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -62,9 +62,10 @@ class DriverInterceptor
                 final String resolverName,
                 final long durationNs,
                 final String name,
+                final boolean isReResolution,
                 final InetAddress address)
             {
-                LOGGER.logResolve(resolverName, durationNs, name, address);
+                LOGGER.logResolve(resolverName, durationNs, name, isReResolution, address);
             }
         }
 
@@ -75,10 +76,10 @@ class DriverInterceptor
                 final String resolverName,
                 final long durationNs,
                 final String name,
-                final boolean isRelookup,
+                final boolean isReLookup,
                 final String resolvedName)
             {
-                LOGGER.logLookup(resolverName, durationNs, name, isRelookup, resolvedName);
+                LOGGER.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
             }
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -58,12 +58,13 @@ class DriverInterceptor
         static class Resolve
         {
             @Advice.OnMethodEnter
-            static void resolveHook(
+            static void logResolve(
                 final String resolverName,
+                final long durationNs,
                 final String name,
                 final InetAddress address)
             {
-                LOGGER.logResolve(DriverEventCode.NAME_RESOLUTION_RESOLVE, resolverName, name, address);
+                LOGGER.logResolve(NAME_RESOLUTION_RESOLVE, resolverName, durationNs, name, address);
             }
         }
     }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -64,7 +64,21 @@ class DriverInterceptor
                 final String name,
                 final InetAddress address)
             {
-                LOGGER.logResolve(NAME_RESOLUTION_RESOLVE, resolverName, durationNs, name, address);
+                LOGGER.logResolve(resolverName, durationNs, name, address);
+            }
+        }
+
+        static class Lookup
+        {
+            @Advice.OnMethodEnter
+            static void logLookup(
+                final String resolverName,
+                final long durationNs,
+                final String name,
+                final boolean isRelookup,
+                final String resolvedName)
+            {
+                LOGGER.logLookup(resolverName, durationNs, name, isRelookup, resolvedName);
             }
         }
     }

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -637,19 +637,21 @@ class DriverEventDissectorTest
         final String resolver = "testResolver";
         final long durationNs = 32167;
         final String hostname = "localhost";
+        final boolean isReResolution = false;
         final InetAddress address = InetAddress.getByName("127.0.0.1");
 
-        final int length = trailingStringLength(resolver, MAX_HOST_NAME_LENGTH) +
+        final int length = SIZE_OF_BOOLEAN + SIZE_OF_LONG + trailingStringLength(resolver, MAX_HOST_NAME_LENGTH) +
             trailingStringLength(hostname, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, durationNs, hostname, address);
+        DriverEventEncoder.encodeResolve(
+            buffer, 0, length, length, resolver, durationNs, hostname, isReResolution, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(buffer, 0, builder);
 
         assertThat(builder.toString(), endsWith(
-            "DRIVER: NAME_RESOLUTION_RESOLVE [37/37]: " +
-            "resolver=testResolver durationNs=32167 hostname=localhost address=127.0.0.1"));
+            "DRIVER: NAME_RESOLUTION_RESOLVE [46/46]: " +
+            "resolver=testResolver durationNs=32167 hostname=localhost isReResolution=false address=127.0.0.1"));
     }
 
     @Test
@@ -658,19 +660,21 @@ class DriverEventDissectorTest
         final String resolver = "myResolver";
         final long durationNs = -1;
         final String hostname = "some-host";
+        final boolean isReResolution = true;
         final InetAddress address = null;
 
-        final int length = trailingStringLength(resolver, MAX_HOST_NAME_LENGTH) +
+        final int length = SIZE_OF_BOOLEAN + SIZE_OF_LONG + trailingStringLength(resolver, MAX_HOST_NAME_LENGTH) +
             trailingStringLength(hostname, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, durationNs, hostname, address);
+        DriverEventEncoder.encodeResolve(
+            buffer, 0, length, length, resolver, durationNs, hostname, isReResolution, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(buffer, 0, builder);
 
         assertThat(builder.toString(), endsWith(
-            "DRIVER: NAME_RESOLUTION_RESOLVE [31/31]: " +
-            "resolver=myResolver durationNs=-1 hostname=some-host address=unknown-address"));
+            "DRIVER: NAME_RESOLUTION_RESOLVE [40/40]: " +
+            "resolver=myResolver durationNs=-1 hostname=some-host isReResolution=true address=unknown-address"));
     }
 
     @Test
@@ -680,22 +684,22 @@ class DriverEventDissectorTest
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
-        final String expected = "DRIVER: NAME_RESOLUTION_RESOLVE [522/522]: resolver=testResolver." +
+        final String expected = "DRIVER: NAME_RESOLUTION_RESOLVE [531/531]: resolver=testResolver." +
             "this.is.a.really.long.string.to.force.truncation.000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000... durationNs=555 " +
             "hostname=testResolver.this.is.a.really.long.string.to.force.truncati" +
             "on.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
-            "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000... address=127" +
-            ".0.0.1";
+            "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000... " +
+            "isReResolution=false address=127.0.0.1";
 
         final InetAddress address = InetAddress.getByName("127.0.0.1");
 
-        final int length = trailingStringLength(longString, MAX_HOST_NAME_LENGTH) +
+        final int length = SIZE_OF_BOOLEAN + SIZE_OF_LONG + trailingStringLength(longString, MAX_HOST_NAME_LENGTH) +
             trailingStringLength(longString, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, longString, 555, longString, address);
+        DriverEventEncoder.encodeResolve(buffer, 0, length, length, longString, 555, longString, false, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(buffer, 0, builder);
 
@@ -709,21 +713,22 @@ class DriverEventDissectorTest
         final String resolver = "xyz";
         final long durationNs = 32167;
         final String name = "localhost:7777";
-        final boolean isRelookup = false;
+        final boolean isReLookup = false;
         final String resolvedName = "test:1234";
 
-        final int length = trailingStringLength(resolver, MAX_HOST_NAME_WITH_PORT_LENGTH) + SIZE_OF_LONG +
-            trailingStringLength(name, MAX_HOST_NAME_WITH_PORT_LENGTH) + SIZE_OF_BOOLEAN +
+        final int length = SIZE_OF_BOOLEAN + SIZE_OF_LONG +
+            trailingStringLength(resolver, MAX_HOST_NAME_WITH_PORT_LENGTH) +
+            trailingStringLength(name, MAX_HOST_NAME_WITH_PORT_LENGTH) +
             trailingStringLength(resolvedName, MAX_HOST_NAME_WITH_PORT_LENGTH);
 
         DriverEventEncoder.encodeLookup(
-            buffer, offset, length, length, resolver, durationNs, name, isRelookup, resolvedName);
+            buffer, offset, length, length, resolver, durationNs, name, isReLookup, resolvedName);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectLookup(buffer, offset, builder);
 
         assertThat(builder.toString(), endsWith(
             "DRIVER: NAME_RESOLUTION_LOOKUP [47/47]: " +
-            "resolver=xyz durationNs=32167 name=localhost:7777 isRelookup=false resolvedName=test:1234"));
+            "resolver=xyz durationNs=32167 name=localhost:7777 isReLookup=false resolvedName=test:1234"));
     }
 
     private DirectBuffer newBuffer(final byte[] bytes)

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -635,6 +635,7 @@ class DriverEventDissectorTest
     void dissectResolve() throws UnknownHostException
     {
         final String resolver = "testResolver";
+        final long durationNs = 32167;
         final String hostname = "localhost";
         final InetAddress address = InetAddress.getByName("127.0.0.1");
 
@@ -642,18 +643,20 @@ class DriverEventDissectorTest
             trailingStringLength(hostname, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, hostname, address);
+        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, durationNs, hostname, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(NAME_RESOLUTION_RESOLVE, buffer, 0, builder);
 
         assertThat(builder.toString(), endsWith(
-            "DRIVER: NAME_RESOLUTION_RESOLVE [37/37]: resolver=testResolver hostname=localhost address=127.0.0.1"));
+            "DRIVER: NAME_RESOLUTION_RESOLVE [37/37]: " +
+            "resolver=testResolver durationNs=32167 hostname=localhost address=127.0.0.1"));
     }
 
     @Test
     void dissectResolveNullAddress()
     {
         final String resolver = "myResolver";
+        final long durationNs = -1;
         final String hostname = "some-host";
         final InetAddress address = null;
 
@@ -661,12 +664,13 @@ class DriverEventDissectorTest
             trailingStringLength(hostname, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, hostname, address);
+        DriverEventEncoder.encodeResolve(buffer, 0, length, length, resolver, durationNs, hostname, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(NAME_RESOLUTION_RESOLVE, buffer, 0, builder);
 
         assertThat(builder.toString(), endsWith(
-            "DRIVER: NAME_RESOLUTION_RESOLVE [31/31]: resolver=myResolver hostname=some-host address=unknown-address"));
+            "DRIVER: NAME_RESOLUTION_RESOLVE [31/31]: " +
+            "resolver=myResolver durationNs=-1 hostname=some-host address=unknown-address"));
     }
 
     @Test
@@ -679,7 +683,8 @@ class DriverEventDissectorTest
         final String expected = "DRIVER: NAME_RESOLUTION_RESOLVE [522/522]: resolver=testResolver." +
             "this.is.a.really.long.string.to.force.truncation.000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
-            "0000000000000000000000000000000... hostname=testResolver.this.is.a.really.long.string.to.force.truncati" +
+            "0000000000000000000000000000000... durationNs=555 " +
+            "hostname=testResolver.this.is.a.really.long.string.to.force.truncati" +
             "on.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000... address=127" +
             ".0.0.1";
@@ -690,7 +695,7 @@ class DriverEventDissectorTest
             trailingStringLength(longString, MAX_HOST_NAME_LENGTH) +
             inetAddressLength(address);
 
-        DriverEventEncoder.encodeResolve(buffer, 0, length, length, longString, longString, address);
+        DriverEventEncoder.encodeResolve(buffer, 0, length, length, longString, 555, longString, address);
         final StringBuilder builder = new StringBuilder();
         DriverEventDissector.dissectResolve(NAME_RESOLUTION_RESOLVE, buffer, 0, builder);
 

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -651,7 +651,7 @@ class DriverEventDissectorTest
 
         assertThat(builder.toString(), endsWith(
             "DRIVER: NAME_RESOLUTION_RESOLVE [46/46]: " +
-            "resolver=testResolver durationNs=32167 hostname=localhost isReResolution=false address=127.0.0.1"));
+            "resolver=testResolver durationNs=32167 name=localhost isReResolution=false address=127.0.0.1"));
     }
 
     @Test
@@ -674,7 +674,7 @@ class DriverEventDissectorTest
 
         assertThat(builder.toString(), endsWith(
             "DRIVER: NAME_RESOLUTION_RESOLVE [40/40]: " +
-            "resolver=myResolver durationNs=-1 hostname=some-host isReResolution=true address=unknown-address"));
+            "resolver=myResolver durationNs=-1 name=some-host isReResolution=true address=unknown-address"));
     }
 
     @Test
@@ -688,7 +688,7 @@ class DriverEventDissectorTest
             "this.is.a.really.long.string.to.force.truncation.000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000... durationNs=555 " +
-            "hostname=testResolver.this.is.a.really.long.string.to.force.truncati" +
+            "name=testResolver.this.is.a.really.long.string.to.force.truncati" +
             "on.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
             "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000... " +
             "isReResolution=false address=127.0.0.1";

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventLoggerTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventLoggerTest.java
@@ -285,7 +285,6 @@ class DriverEventLoggerTest
         logBuffer.putLong(CAPACITY + TAIL_POSITION_OFFSET, recordOffset);
         final DriverEventCode eventCode = NAME_RESOLUTION_RESOLVE;
 
-        final int offset = 10;
         final String resolverName = "test";
         final long durationNs = TimeUnit.DAYS.toNanos(1);
         final String hostName = generateStringWithSuffix("very-l", "0", 1000);

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveContextTest.java
@@ -67,6 +67,9 @@ class ArchiveContextTest
     void beforeEach(final @TempDir Path tempDir)
     {
         final Aeron aeron = mock(Aeron.class);
+        when(aeron.addCounter(
+            anyInt(), any(DirectBuffer.class), anyInt(), anyInt(), any(DirectBuffer.class), anyInt(), anyInt()))
+            .thenAnswer(invocation -> mock(Counter.class));
         final CountersReader countersReader = mock(CountersReader.class);
         final Aeron.Context aeronContext = new Aeron.Context();
         aeronContext.subscriberErrorHandler(RethrowingErrorHandler.INSTANCE);

--- a/aeron-client/src/main/java/io/aeron/CounterProvider.java
+++ b/aeron-client/src/main/java/io/aeron/CounterProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.status.AtomicCounter;
+
+/**
+ * Functional interface that abstracts creation of the counters.
+ */
+@FunctionalInterface
+public interface CounterProvider
+{
+    /**
+     * Allocate a counter record and wrap it with a new {@link AtomicCounter} for use.
+     * <p>
+     * If the keyBuffer is null then a copy of the key is not attempted.
+     *
+     * @param typeId      for the counter.
+     * @param keyBuffer   containing the optional key for the counter.
+     * @param keyOffset   within the keyBuffer at which the key begins.
+     * @param keyLength   of the key in the keyBuffer.
+     * @param labelBuffer containing the mandatory label for the counter.
+     * @param labelOffset within the labelBuffer at which the label begins.
+     * @param labelLength of the label in the labelBuffer.
+     * @return the counter object.
+     */
+    AtomicCounter newCounter(
+        int typeId,
+        DirectBuffer keyBuffer,
+        int keyOffset,
+        int keyLength,
+        DirectBuffer labelBuffer,
+        int labelOffset,
+        int labelLength);
+}

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1731,6 +1731,7 @@ public final class ConsensusModule implements AutoCloseable
             {
                 nameResolver = DefaultNameResolver.INSTANCE;
             }
+            nameResolver.init(aeron::addCounter);
 
             final ChannelUri channelUri = ChannelUri.parse(logChannel());
             isLogMdc = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -18,6 +18,7 @@ package io.aeron.cluster;
 import io.aeron.Aeron;
 import io.aeron.CommonContext;
 import io.aeron.Counter;
+import io.aeron.CounterProvider;
 import io.aeron.RethrowingErrorHandler;
 import io.aeron.cluster.client.ClusterException;
 import io.aeron.cluster.codecs.mark.MarkFileHeaderDecoder;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -57,8 +59,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ConsensusModuleContextTest
 {
@@ -475,6 +476,20 @@ class ConsensusModuleContextTest
         context.conclude();
 
         assertEquals(existingCandidateTermId, context.nodeStateFile().candidateTerm().candidateTermId());
+    }
+
+    @Test
+    void shouldInitializeNameResolver()
+    {
+        final NameResolver nameResolver = mock(NameResolver.class);
+        context.nameResolver(nameResolver);
+
+        context.conclude();
+
+        final ArgumentCaptor<CounterProvider> argumentCaptor = ArgumentCaptor.forClass(CounterProvider.class);
+        verify(nameResolver).init(argumentCaptor.capture());
+        assertNotNull(argumentCaptor.getValue());
+        verifyNoMoreInteractions(nameResolver);
     }
 
     public static class TestAuthorisationSupplier implements AuthorisationServiceSupplier

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -34,6 +34,7 @@ import io.aeron.security.SessionProxy;
 import io.aeron.test.TestContexts;
 import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestClusterClock;
+import org.agrona.DirectBuffer;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.AgentInvoker;
 import org.agrona.concurrent.status.AtomicCounter;
@@ -54,6 +55,8 @@ import static io.aeron.cluster.codecs.mark.ClusterComponentType.CONSENSUS_MODULE
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,6 +78,9 @@ class ConsensusModuleContextTest
         when(aeronContext.useConductorAgentInvoker()).thenReturn(true);
         final AgentInvoker conductorInvoker = mock(AgentInvoker.class);
         final Aeron aeron = mock(Aeron.class);
+        when(aeron.addCounter(
+            anyInt(), any(DirectBuffer.class), anyInt(), anyInt(), any(DirectBuffer.class), anyInt(), anyInt()))
+            .thenAnswer(invocation -> mock(Counter.class));
         when(aeron.context()).thenReturn(aeronContext);
         when(aeron.conductorAgentInvoker()).thenReturn(conductorInvoker);
         when(aeron.countersReader()).thenReturn(countersManager);

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -16,6 +16,7 @@
 package io.aeron.cluster.service;
 
 import io.aeron.Aeron;
+import io.aeron.Counter;
 import io.aeron.RethrowingErrorHandler;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +43,7 @@ class ClusteredServiceContainerContextTest
         when(aeronContext.aeronDirectoryName()).thenReturn("funny");
         when(aeronContext.subscriberErrorHandler()).thenReturn(errorHandler);
         final Aeron aeron = mock(Aeron.class);
+        when(aeron.addCounter(anyInt(), any(String.class))).thenAnswer(invocation -> mock(Counter.class));
         when(aeron.context()).thenReturn(aeronContext);
         final AtomicCounter errorCounter = mock(AtomicCounter.class);
         final ClusteredService clusteredService = mock(ClusteredService.class);

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -751,6 +751,16 @@ public final class Configuration
     public static final long RECEIVER_CYCLE_THRESHOLD_DEFAULT_NS = TimeUnit.MILLISECONDS.toNanos(1000);
 
     /**
+     * Property name for threshold value for the name resolution threshold to track for being exceeded.
+     */
+    public static final String NAME_RESOLVER_THRESHOLD_PROP_NAME = "aeron.name.resolver.threshold";
+
+    /**
+     * Default threshold value for the name resolution threshold to track for being exceeded.
+     */
+    public static final long NAME_RESOLVER_THRESHOLD_DEFAULT_NS = TimeUnit.SECONDS.toNanos(5);
+
+    /**
      * Should the driver configuration be printed on start.
      *
      * @return true if the driver configuration be printed on start.
@@ -1472,6 +1482,16 @@ public final class Configuration
     public static long receiverCycleThresholdNs()
     {
         return getDurationInNanos(RECEIVER_CYCLE_THRESHOLD_PROP_NAME, RECEIVER_CYCLE_THRESHOLD_DEFAULT_NS);
+    }
+
+    /**
+     * Get threshold value for the name resolution time threshold to track for being exceeded.
+     *
+     * @return threshold value in nanoseconds.
+     */
+    public static long nameResolverThresholdNs()
+    {
+        return getDurationInNanos(NAME_RESOLVER_THRESHOLD_PROP_NAME, NAME_RESOLVER_THRESHOLD_DEFAULT_NS);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
@@ -42,8 +42,6 @@ public class DefaultNameResolver implements NameResolver
         {
         }
 
-        resolveHook(this.getClass().getSimpleName(), name, resolvedAddress);
-
         return resolvedAddress;
     }
 
@@ -53,8 +51,24 @@ public class DefaultNameResolver implements NameResolver
      * @param resolverName      used to handle the resolution.
      * @param hostname          that was resolved.
      * @param resolvedAddress   the resulting address or null if it can't be resolved.
+     * @deprecated Replaced with {@link DefaultNameResolver#logResolve(String, long, String, InetAddress)}.
+     * @see #logResolve(String, long, String, InetAddress)
      */
+    @Deprecated
     public void resolveHook(final String resolverName, final String hostname, final InetAddress resolvedAddress)
+    {
+    }
+
+    /**
+     * Name resolution hook, useful for logging.
+     *
+     * @param resolverName    used to handle the resolution.
+     * @param durationNs      of the resolution query in nanoseconds.
+     * @param hostname        that was resolved.
+     * @param resolvedAddress the resulting address or null if it can't be resolved.
+     */
+    public static void logResolve(
+        final String resolverName, final long durationNs, final String hostname, final InetAddress resolvedAddress)
     {
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
@@ -48,27 +48,13 @@ public class DefaultNameResolver implements NameResolver
     /**
      * Name resolution hook, useful for logging.
      *
-     * @param resolverName      used to handle the resolution.
-     * @param hostname          that was resolved.
-     * @param resolvedAddress   the resulting address or null if it can't be resolved.
-     * @deprecated Replaced with {@link DefaultNameResolver#logResolve(String, long, String, InetAddress)}.
-     * @see #logResolve(String, long, String, InetAddress)
+     * @param resolverName    used to handle the resolution.
+     * @param hostname        that was resolved.
+     * @param resolvedAddress the resulting address or null if it can't be resolved.
+     * @deprecated No longer used for logging.
      */
     @Deprecated
     public void resolveHook(final String resolverName, final String hostname, final InetAddress resolvedAddress)
-    {
-    }
-
-    /**
-     * Name resolution hook, useful for logging.
-     *
-     * @param resolverName    used to handle the resolution.
-     * @param durationNs      of the resolution query in nanoseconds.
-     * @param hostname        that was resolved.
-     * @param resolvedAddress the resulting address or null if it can't be resolved.
-     */
-    static void logResolve(
-        final String resolverName, final long durationNs, final String hostname, final InetAddress resolvedAddress)
     {
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DefaultNameResolver.java
@@ -67,7 +67,7 @@ public class DefaultNameResolver implements NameResolver
      * @param hostname        that was resolved.
      * @param resolvedAddress the resulting address or null if it can't be resolved.
      */
-    public static void logResolve(
+    static void logResolve(
         final String resolverName, final long durationNs, final String hostname, final InetAddress resolvedAddress)
     {
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -119,7 +119,8 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
 
         cache = new DriverNameResolverCache(TIMEOUT_MS);
 
-        final UdpChannel placeholderChannel = UdpChannel.parse("aeron:udp?endpoint=localhost:8050");
+        final UdpChannel placeholderChannel =
+            UdpChannel.parse("aeron:udp?endpoint=localhost:8050", delegateResolver);
         transport = new UdpNameResolutionTransport(placeholderChannel, localSocketAddress, unsafeBuffer, ctx);
 
         neighborsCounter = ctx.countersManager().newCounter(
@@ -205,8 +206,6 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         catch (final UnknownHostException ignore)
         {
         }
-
-        DefaultNameResolver.INSTANCE.resolveHook(this.getClass().getSimpleName(), name, resolvedAddress);
 
         return resolvedAddress;
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3747,7 +3747,7 @@ public final class MediaDriver implements AutoCloseable
                     nameResolverThresholdNs);
             }
 
-            nameResolver.init(this);
+            nameResolver.init(countersManager::newCounter);
         }
 
         private void concludeCounters()

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -453,6 +453,7 @@ public final class MediaDriver implements AutoCloseable
         private long conductorCycleThresholdNs = Configuration.conductorCycleThresholdNs();
         private long senderCycleThresholdNs = Configuration.senderCycleThresholdNs();
         private long receiverCycleThresholdNs = Configuration.receiverCycleThresholdNs();
+        private long nameResolverThresholdNs = Configuration.nameResolverThresholdNs();
 
         private int conductorBufferLength = Configuration.conductorBufferLength();
         private int toClientsBufferLength = Configuration.toClientsBufferLength();
@@ -550,6 +551,7 @@ public final class MediaDriver implements AutoCloseable
         private DutyCycleTracker conductorDutyCycleTracker;
         private DutyCycleTracker senderDutyCycleTracker;
         private DutyCycleTracker receiverDutyCycleTracker;
+        private DutyCycleTracker nameResolverTimeTracker;
 
         /**
          * Perform a shallow copy of the object.
@@ -3168,6 +3170,32 @@ public final class MediaDriver implements AutoCloseable
         }
 
         /**
+         * Set a threshold for the {@link NameResolver} which when exceed it will increment the
+         * {@link io.aeron.driver.status.SystemCounterDescriptor#NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED} counter.
+         *
+         * @param thresholdNs value in nanoseconds
+         * @return this for fluent API.
+         * @see Configuration#NAME_RESOLVER_THRESHOLD_PROP_NAME
+         * @see Configuration#NAME_RESOLVER_THRESHOLD_DEFAULT_NS
+         */
+        public Context nameResolverThresholdNs(final long thresholdNs)
+        {
+            this.nameResolverThresholdNs = thresholdNs;
+            return this;
+        }
+
+        /**
+         * Threshold for the {@link NameResolver} which when exceed it will increment the
+         * {@link io.aeron.driver.status.SystemCounterDescriptor#NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED} counter.
+         *
+         * @return threshold to track for the name resolution.
+         */
+        public long nameResolverThresholdNs()
+        {
+            return nameResolverThresholdNs;
+        }
+
+        /**
          * Maximum number of {@link DriverManagedResource}s to free within a single duty cycle within the conductor.
          *
          * @param resourceFreeLimit number of resources to limit to.
@@ -3279,6 +3307,28 @@ public final class MediaDriver implements AutoCloseable
         public Context receiverDutyCycleTracker(final DutyCycleTracker dutyCycleTracker)
         {
             this.receiverDutyCycleTracker = dutyCycleTracker;
+            return this;
+        }
+
+        /**
+         * Duty cycle tracker used for the {@link NameResolver}.
+         *
+         * @return {@link NameResolver} duty cycle tracker.
+         */
+        public DutyCycleTracker nameResolverTimeTracker()
+        {
+            return nameResolverTimeTracker;
+        }
+
+        /**
+         * Set the duty cycle tracker used for the {@link NameResolver}.
+         *
+         * @param dutyCycleTracker for the {@link NameResolver}.
+         * @return this for a fluent API.
+         */
+        public Context nameResolverTimeTracker(final DutyCycleTracker dutyCycleTracker)
+        {
+            this.nameResolverTimeTracker = dutyCycleTracker;
             return this;
         }
 
@@ -3688,6 +3738,16 @@ public final class MediaDriver implements AutoCloseable
                     systemCounters.get(RECEIVER_CYCLE_TIME_THRESHOLD_EXCEEDED),
                     receiverCycleThresholdNs);
             }
+
+            if (null == nameResolverTimeTracker)
+            {
+                nameResolverTimeTracker = new DutyCycleStallTracker(
+                    systemCounters.get(NAME_RESOLVER_MAX_TIME),
+                    systemCounters.get(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED),
+                    nameResolverThresholdNs);
+            }
+
+            nameResolver.init(this);
         }
 
         private void concludeCounters()

--- a/aeron-driver/src/main/java/io/aeron/driver/NameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NameResolver.java
@@ -29,7 +29,7 @@ public interface NameResolver
      *
      * @param name           to resolve.
      * @param uriParamName   that the resolution is for.
-     * @param isReResolution true if this is a re-resolution or false if initial resolution.
+     * @param isReResolution {@code true} if this is a re-resolution or {@code false} if initial resolution.
      * @return address for the name that most recently represents the name or null if not resolvable currently.
      * @see io.aeron.CommonContext#ENDPOINT_PARAM_NAME
      * @see io.aeron.CommonContext#MDC_CONTROL_PARAM_NAME
@@ -42,7 +42,7 @@ public interface NameResolver
      *
      * @param name         to lookup
      * @param uriParamName that the lookup is for.
-     * @param isReLookup   true if this is a re-lookup or false if initial lookup.
+     * @param isReLookup   {@code true} if this is a re-lookup or {@code true} if initial lookup.
      * @return string in name:port form.
      */
     default String lookup(String name, String uriParamName, boolean isReLookup)

--- a/aeron-driver/src/main/java/io/aeron/driver/NameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NameResolver.java
@@ -15,6 +15,8 @@
  */
 package io.aeron.driver;
 
+import io.aeron.CounterProvider;
+
 import java.net.InetAddress;
 
 /**
@@ -53,8 +55,21 @@ public interface NameResolver
      * used for actions like adding counters.
      *
      * @param context for the media driver that the name resolver is running in.
+     * @deprecated Use {@link #init(CounterProvider)} instead.
+     * @see #init(CounterProvider)
      */
+    @Deprecated
     default void init(MediaDriver.Context context)
+    {
+        throw new UnsupportedOperationException("deprecated: use NameResolver.init(io.aeron.CounterFactory) instead");
+    }
+
+    /**
+     * Do post construction initialisation of the name resolver.
+     *
+     * @param counterProvider for adding counters.
+     */
+    default void init(CounterProvider counterProvider)
     {
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import org.agrona.CloseHelper;
+import org.agrona.concurrent.NanoClock;
+
+import java.net.InetAddress;
+
+import static java.util.Objects.requireNonNull;
+
+final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
+{
+    private final NameResolver delegateResolver;
+    private final NanoClock clock;
+    private final DutyCycleTracker maxTimeTracker;
+
+    TimeTrackingNameResolver(
+        final NameResolver delegateResolver,
+        final NanoClock clock,
+        final DutyCycleTracker maxTimeTracker)
+    {
+        this.delegateResolver = requireNonNull(delegateResolver);
+        this.clock = requireNonNull(clock);
+        this.maxTimeTracker = requireNonNull(maxTimeTracker);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public InetAddress resolve(final String name, final String uriParamName, final boolean isReResolution)
+    {
+        final long beginNs = clock.nanoTime();
+        maxTimeTracker.update(beginNs);
+        InetAddress address = null;
+        try
+        {
+            address = delegateResolver.resolve(name, uriParamName, isReResolution);
+            return address;
+        }
+        finally
+        {
+            final long endNs = clock.nanoTime();
+            maxTimeTracker.measureAndUpdate(endNs);
+            DefaultNameResolver.logResolve(delegateResolver.getClass().getSimpleName(), endNs - beginNs, name, address);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String lookup(final String name, final String uriParamName, final boolean isReLookup)
+    {
+        return delegateResolver.lookup(name, uriParamName, isReLookup);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void init(final MediaDriver.Context context)
+    {
+        delegateResolver.init(context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int doWork(final long nowMs)
+    {
+        return delegateResolver.doWork(nowMs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void close()
+    {
+        if (delegateResolver instanceof AutoCloseable)
+        {
+            CloseHelper.close((AutoCloseable)delegateResolver);
+        }
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
@@ -56,7 +56,7 @@ final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
         {
             final long endNs = clock.nanoTime();
             maxTimeTracker.measureAndUpdate(endNs);
-            logResolve(delegateResolver.getClass().getSimpleName(), endNs - beginNs, name, address);
+            logResolve(delegateResolver.getClass().getSimpleName(), endNs - beginNs, name, isReResolution, address);
         }
     }
 
@@ -77,12 +77,7 @@ final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
         {
             final long endNs = clock.nanoTime();
             maxTimeTracker.measureAndUpdate(endNs);
-            logLookup(
-                delegateResolver.getClass().getSimpleName(),
-                endNs - beginNs,
-                name,
-                isReLookup,
-                resolvedName);
+            logLookup(delegateResolver.getClass().getSimpleName(), endNs - beginNs, name, isReLookup, resolvedName);
         }
     }
 
@@ -114,7 +109,11 @@ final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
     }
 
     private static void logResolve(
-        final String resolverName, final long durationNs, final String name, final InetAddress resolvedAddress)
+        final String resolverName,
+        final long durationNs,
+        final String name,
+        final boolean isReResolution,
+        final InetAddress resolvedAddress)
     {
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.driver;
 
+import io.aeron.CounterProvider;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.NanoClock;
 
@@ -70,9 +71,9 @@ final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
     /**
      * {@inheritDoc}
      */
-    public void init(final MediaDriver.Context context)
+    public void init(final CounterProvider counterProvider)
     {
-        delegateResolver.init(context);
+        delegateResolver.init(counterProvider);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
@@ -182,7 +182,17 @@ public enum SystemCounterDescriptor
     /**
      * Count of the number of times the cycle time threshold has been exceeded by the receiver in its work cycle.
      */
-    RECEIVER_CYCLE_TIME_THRESHOLD_EXCEEDED(31, "Receiver work cycle exceeded threshold count");
+    RECEIVER_CYCLE_TIME_THRESHOLD_EXCEEDED(31, "Receiver work cycle exceeded threshold count"),
+
+    /**
+     * The maximum time spent by the NameResolver in one of its operations.
+     */
+    NAME_RESOLVER_MAX_TIME(32, "NameResolver max time in ns"),
+
+    /**
+     * Count of the number of times the time threshold has been exceeded by the NameResolver.
+     */
+    NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED(33, "NameResolver exceeded threshold count");
 
     /**
      * All system counters have the same type id, i.e. system counters are the same type. Other types can exist.

--- a/aeron-driver/src/test/java/io/aeron/driver/DefaultNameResolverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DefaultNameResolverTest.java
@@ -18,10 +18,10 @@ package io.aeron.driver;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class DefaultNameResolverTest
 {
@@ -38,7 +38,7 @@ class DefaultNameResolverTest
     }
 
     @Test
-    void resolveResolvesLocalhostAddress() throws UnknownHostException
+    void resolveResolvesLocalhostAddress()
     {
         final String hostName = "localhost";
         final String uriParamName = "control";
@@ -46,6 +46,6 @@ class DefaultNameResolverTest
 
         final InetAddress address = nameResolver.resolve(hostName, uriParamName, isReResolution);
 
-        assertSame(InetAddress.getLocalHost(), address);
+        assertEquals(InetAddress.getLoopbackAddress(), address);
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/DefaultNameResolverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DefaultNameResolverTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultNameResolverTest
+{
+    private final DefaultNameResolver nameResolver = new DefaultNameResolver();
+
+    @Test
+    void resolveReturnsNullForUnknownHost()
+    {
+        final String hostName = UUID.randomUUID().toString();
+        final String uriParamName = "endpoint";
+        final boolean isReResolution = false;
+
+        assertNull(nameResolver.resolve(hostName, uriParamName, isReResolution));
+    }
+
+    @Test
+    void resolveResolvesLocalhostAddress() throws UnknownHostException
+    {
+        final String hostName = "localhost";
+        final String uriParamName = "control";
+        final boolean isReResolution = true;
+
+        final InetAddress address = nameResolver.resolve(hostName, uriParamName, isReResolution);
+
+        assertSame(InetAddress.getLocalHost(), address);
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -59,8 +59,7 @@ import java.util.function.LongConsumer;
 import static io.aeron.ErrorCode.*;
 import static io.aeron.driver.Configuration.*;
 import static io.aeron.driver.status.ClientHeartbeatTimestamp.HEARTBEAT_TYPE_ID;
-import static io.aeron.driver.status.SystemCounterDescriptor.CONDUCTOR_CYCLE_TIME_THRESHOLD_EXCEEDED;
-import static io.aeron.driver.status.SystemCounterDescriptor.CONDUCTOR_MAX_CYCLE_TIME;
+import static io.aeron.driver.status.SystemCounterDescriptor.*;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static io.aeron.logbuffer.FrameDescriptor.frameLengthOrdered;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
@@ -155,6 +154,11 @@ class DriverConductorTest
             spySystemCounters.get(CONDUCTOR_CYCLE_TIME_THRESHOLD_EXCEEDED),
             600_000_000);
 
+        final DutyCycleStallTracker nameResolverTimeTracker = new DutyCycleStallTracker(
+            spySystemCounters.get(NAME_RESOLVER_MAX_TIME),
+            spySystemCounters.get(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED),
+            1_000_000_000);
+
         final MediaDriver.Context ctx = new MediaDriver.Context()
             .tempBuffer(new UnsafeBuffer(new byte[METADATA_LENGTH]))
             .timerIntervalNs(DEFAULT_TIMER_INTERVAL_NS)
@@ -185,7 +189,8 @@ class DriverConductorTest
             .conductorCycleThresholdNs(600_000_000)
             .nameResolver(DefaultNameResolver.INSTANCE)
             .threadingMode(ThreadingMode.DEDICATED)
-            .conductorDutyCycleTracker(conductorDutyCycleTracker);
+            .conductorDutyCycleTracker(conductorDutyCycleTracker)
+            .nameResolverTimeTracker(nameResolverTimeTracker);
 
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
         driverConductor = new DriverConductor(ctx);

--- a/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
@@ -80,7 +80,8 @@ class IpcPublicationTest
             .nameResolver(DefaultNameResolver.INSTANCE)
             .nanoClock(new CachedNanoClock())
             .threadingMode(ThreadingMode.DEDICATED)
-            .conductorDutyCycleTracker(new DutyCycleTracker());
+            .conductorDutyCycleTracker(new DutyCycleTracker())
+            .nameResolverTimeTracker(new DutyCycleTracker());
 
         driverProxy = new DriverProxy(toDriverCommands, CLIENT_ID);
         driverConductor = new DriverConductor(ctx);

--- a/aeron-driver/src/test/java/io/aeron/driver/TimeTrackingNameResolverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TimeTrackingNameResolverTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import org.agrona.concurrent.NanoClock;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.stubbing.Answer;
+
+import java.net.InetAddress;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TimeTrackingNameResolverTest
+{
+    @Test
+    void throwsNullPointerExceptionIfDelegateResolverIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new TimeTrackingNameResolver(null, mock(NanoClock.class), mock(DutyCycleTracker.class)));
+    }
+
+    @Test
+    void throwsNullPointerExceptionIfNanoClockIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new TimeTrackingNameResolver(mock(NameResolver.class), null, mock(DutyCycleTracker.class)));
+    }
+
+    @Test
+    void throwsNullPointerExceptionIfDutyCycleTrackerIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new TimeTrackingNameResolver(mock(NameResolver.class), mock(NanoClock.class), null));
+    }
+
+    @Test
+    void closeIsANoOpIfDelegateResolverIsNotCloseable()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        final NanoClock clock = mock(NanoClock.class);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        resolver.close();
+
+        verifyNoInteractions(delegateResolver, clock, maxTime);
+    }
+
+    @Test
+    void closeIShouldCloseDelegateResolver() throws Exception
+    {
+        final NameResolver delegateResolver = mock(
+            NameResolver.class, withSettings().extraInterfaces(AutoCloseable.class));
+        final NanoClock clock = mock(NanoClock.class);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        resolver.close();
+
+        verify((AutoCloseable)delegateResolver).close();
+        verifyNoMoreInteractions(delegateResolver);
+        verifyNoInteractions(clock, maxTime);
+    }
+
+    @Test
+    void doWorkShouldCallActualMethod()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        final NanoClock clock = mock(NanoClock.class);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        final long nowMs = 1111;
+        resolver.doWork(nowMs);
+
+        verify(delegateResolver).doWork(nowMs);
+        verifyNoMoreInteractions(delegateResolver);
+        verifyNoInteractions(clock, maxTime);
+    }
+
+    @Test
+    void initShouldCallActualMethod()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        final NanoClock clock = mock(NanoClock.class);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        final MediaDriver.Context ctx = mock(MediaDriver.Context.class);
+        resolver.init(ctx);
+
+        verify(delegateResolver).init(ctx);
+        verifyNoMoreInteractions(delegateResolver);
+        verifyNoInteractions(clock, maxTime);
+    }
+
+    @Test
+    void lookupShouldCallActualMethod()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        when(delegateResolver.lookup(anyString(), anyString(), anyBoolean()))
+            .thenAnswer((Answer<String>)invocation -> invocation.getArgument(0) + "!");
+        final NanoClock clock = mock(NanoClock.class);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        final String name = "my-host";
+        final String endpoint = "endpoint";
+        final boolean isReLookup = false;
+        assertEquals(name + "!", resolver.lookup(name, endpoint, isReLookup));
+
+        verify(delegateResolver).lookup(name, endpoint, isReLookup);
+        verifyNoMoreInteractions(delegateResolver);
+        verifyNoInteractions(clock, maxTime);
+    }
+
+    @Test
+    void resolveShouldMeasureExecutionTime()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        when(delegateResolver.resolve(anyString(), anyString(), anyBoolean()))
+            .thenAnswer((Answer<InetAddress>)invocation -> InetAddress.getByName(invocation.getArgument(0)));
+        final NanoClock clock = mock(NanoClock.class);
+        final long beginNs = SECONDS.toNanos(1);
+        final long endNs = SECONDS.toNanos(9);
+        when(clock.nanoTime()).thenReturn(beginNs, endNs);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        final String name = "localhost";
+        final String endpoint = "endpoint";
+        final boolean isReLookup = true;
+        assertEquals(InetAddress.getLoopbackAddress(), resolver.resolve(name, endpoint, isReLookup));
+
+        final InOrder inOrder = inOrder(delegateResolver, clock, maxTime);
+        inOrder.verify(clock).nanoTime();
+        inOrder.verify(maxTime).update(beginNs);
+        inOrder.verify(delegateResolver).resolve(name, endpoint, isReLookup);
+        inOrder.verify(clock).nanoTime();
+        inOrder.verify(maxTime).measureAndUpdate(endNs);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void resolveShouldMeasureExecutionTimeEvenWhenExceptionIsThrown()
+    {
+        final NameResolver delegateResolver = mock(NameResolver.class);
+        final IllegalStateException exception = new IllegalStateException("error");
+        when(delegateResolver.resolve(anyString(), anyString(), anyBoolean()))
+            .thenThrow(exception);
+        final NanoClock clock = mock(NanoClock.class);
+        final long beginNs = SECONDS.toNanos(0);
+        final long endNs = SECONDS.toNanos(3);
+        when(clock.nanoTime()).thenReturn(beginNs, endNs);
+        final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
+        final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
+
+        final String name = "localhost";
+        final String endpoint = "endpoint";
+        final boolean isReLookup = true;
+        final IllegalStateException error =
+            assertThrowsExactly(IllegalStateException.class, () -> resolver.resolve(name, endpoint, isReLookup));
+        assertSame(exception, error);
+
+        final InOrder inOrder = inOrder(delegateResolver, clock, maxTime);
+        inOrder.verify(clock).nanoTime();
+        inOrder.verify(maxTime).update(beginNs);
+        inOrder.verify(delegateResolver).resolve(name, endpoint, isReLookup);
+        inOrder.verify(clock).nanoTime();
+        inOrder.verify(maxTime).measureAndUpdate(endNs);
+        inOrder.verifyNoMoreInteractions();
+    }
+}

--- a/aeron-driver/src/test/java/io/aeron/driver/TimeTrackingNameResolverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/TimeTrackingNameResolverTest.java
@@ -15,6 +15,7 @@
  */
 package io.aeron.driver;
 
+import io.aeron.CounterProvider;
 import org.agrona.concurrent.NanoClock;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
@@ -105,10 +106,10 @@ class TimeTrackingNameResolverTest
         final DutyCycleTracker maxTime = mock(DutyCycleTracker.class);
         final TimeTrackingNameResolver resolver = new TimeTrackingNameResolver(delegateResolver, clock, maxTime);
 
-        final MediaDriver.Context ctx = mock(MediaDriver.Context.class);
-        resolver.init(ctx);
+        final CounterProvider factory = mock(CounterProvider.class);
+        resolver.init(factory);
 
-        verify(delegateResolver).init(ctx);
+        verify(delegateResolver).init(factory);
         verifyNoMoreInteractions(delegateResolver);
         verifyNoInteractions(clock, maxTime);
     }

--- a/aeron-driver/src/test/java/io/aeron/driver/status/DutyCycleStallTrackerTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/status/DutyCycleStallTrackerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver.status;
+
+import org.agrona.concurrent.status.AtomicCounter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.mockito.Mockito.*;
+
+class DutyCycleStallTrackerTest
+{
+    @Test
+    void throwsNullPointerExceptionIfMaxTimeCounterIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new DutyCycleStallTracker(null, mock(AtomicCounter.class), 1));
+    }
+
+    @Test
+    void throwsNullPointerExceptionIfThresholdCounterIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class,
+            () -> new DutyCycleStallTracker(mock(AtomicCounter.class), null, 1));
+    }
+
+    @Test
+    void reportMeasurementIsANoOpIfMaxCounterIsClosed()
+    {
+        final AtomicCounter maxCycleTime = mock(AtomicCounter.class);
+        when(maxCycleTime.isClosed()).thenReturn(true);
+        final AtomicCounter cycleTimeThresholdExceededCount = mock(AtomicCounter.class);
+        final DutyCycleStallTracker dutyCycleStallTracker =
+            new DutyCycleStallTracker(maxCycleTime, cycleTimeThresholdExceededCount, 1);
+
+        dutyCycleStallTracker.reportMeasurement(555);
+
+        verify(maxCycleTime).isClosed();
+        verifyNoMoreInteractions(maxCycleTime);
+        verifyNoInteractions(cycleTimeThresholdExceededCount);
+    }
+
+    @Test
+    void reportMeasurementOnlyUpdatesThresholdCounterWhenExceeded()
+    {
+        final AtomicCounter maxCycleTime = mock(AtomicCounter.class);
+        when(maxCycleTime.isClosed()).thenReturn(false);
+        final AtomicCounter cycleTimeThresholdExceededCount = mock(AtomicCounter.class);
+        final int cycleTimeThresholdNs = 1000;
+        final DutyCycleStallTracker dutyCycleStallTracker =
+            new DutyCycleStallTracker(maxCycleTime, cycleTimeThresholdExceededCount, cycleTimeThresholdNs);
+
+        dutyCycleStallTracker.reportMeasurement(555);
+        dutyCycleStallTracker.reportMeasurement(1000);
+        dutyCycleStallTracker.reportMeasurement(1001);
+
+        verify(maxCycleTime, times(3)).isClosed();
+        verify(maxCycleTime).proposeMaxOrdered(555L);
+        verify(maxCycleTime).proposeMaxOrdered(1000L);
+        verify(maxCycleTime).proposeMaxOrdered(1001L);
+        verify(cycleTimeThresholdExceededCount).incrementOrdered();
+        verifyNoMoreInteractions(maxCycleTime, cycleTimeThresholdExceededCount);
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/RedirectingNameResolver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/RedirectingNameResolver.java
@@ -80,6 +80,7 @@ public class RedirectingNameResolver implements NameResolver
 
     public InetAddress resolve(final String name, final String uriParamName, final boolean isReResolution)
     {
+        final long beginNs = System.nanoTime();
         final NameEntry nameEntry = nameToEntryMap.get(name);
         final String hostname = null != nameEntry ? nameEntry.redirectHost(name) : name;
 
@@ -88,8 +89,9 @@ public class RedirectingNameResolver implements NameResolver
         {
             resolvedAddress = DefaultNameResolver.INSTANCE.resolve(hostname, uriParamName, isReResolution);
         }
+        final long durationNs = System.nanoTime() - beginNs;
 
-        DefaultNameResolver.INSTANCE.resolveHook(this.getClass().getSimpleName(), hostname, resolvedAddress);
+        DefaultNameResolver.logResolve(this.getClass().getSimpleName(), durationNs, hostname, resolvedAddress);
 
         return resolvedAddress;
     }

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/RedirectingNameResolver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/RedirectingNameResolver.java
@@ -80,7 +80,6 @@ public class RedirectingNameResolver implements NameResolver
 
     public InetAddress resolve(final String name, final String uriParamName, final boolean isReResolution)
     {
-        final long beginNs = System.nanoTime();
         final NameEntry nameEntry = nameToEntryMap.get(name);
         final String hostname = null != nameEntry ? nameEntry.redirectHost(name) : name;
 
@@ -89,9 +88,6 @@ public class RedirectingNameResolver implements NameResolver
         {
             resolvedAddress = DefaultNameResolver.INSTANCE.resolve(hostname, uriParamName, isReResolution);
         }
-        final long durationNs = System.nanoTime() - beginNs;
-
-        DefaultNameResolver.logResolve(this.getClass().getSimpleName(), durationNs, hostname, resolvedAddress);
 
         return resolvedAddress;
     }


### PR DESCRIPTION
This PR adds a capability to track the execution of the `NameResolver#resolve` and `NameResolver#lookup` methods via a new set of counters. It also extends the existing logging events with the `durationNs` field and adds logging for the lookup method, e.g.:
```bash
[43598.051268] DRIVER: NAME_RESOLUTION_LOOKUP [74/74]: resolver=RedirectingNameResolver durationNs=6430 name=127.0.0.1:24326 isReLookup=false resolvedName=127.0.0.1:24326
[43598.051826] DRIVER: NAME_RESOLUTION_RESOLVE [57/57]: resolver=RedirectingNameResolver durationNs=21460 name=127.0.0.1 isReResolution=false address=127.0.0.1
```
There is also a new method `NameResolver#init(CounterProvider)` which was added to replace the `NameResolver#init(MediaDriver.Context)`. The latter could only be used in the driver while the former can be used in other places.