### PR TITLE
Correct nextServiceSessionId on snapshot

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3391,7 +3391,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
 
         for (final PendingServiceMessageTracker tracker : pendingServiceMessageTrackers)
         {
-            snapshotTaker.snapshot(tracker);
+            snapshotTaker.snapshot(tracker, ctx.errorHandler());
         }
 
         snapshotTaker.markEnd(SNAPSHOT_TYPE_ID, logPosition, leadershipTermId, 0, clusterTimeUnit, ctx.appVersion());

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleSnapshotTakerTest.java
@@ -21,6 +21,8 @@ import io.aeron.cluster.codecs.*;
 import io.aeron.cluster.service.ClusterClock;
 import io.aeron.logbuffer.BufferClaim;
 import org.agrona.DirectBuffer;
+import org.agrona.ErrorHandler;
+import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
@@ -97,7 +99,7 @@ class ConsensusModuleSnapshotTakerTest
         when(publication.offer(any(), anyInt(), anyInt()))
             .thenReturn(BACK_PRESSURED, 9L);
 
-        snapshotTaker.snapshot(pendingServiceMessageTracker);
+        snapshotTaker.snapshot(pendingServiceMessageTracker, mock(ErrorHandler.class));
 
         final InOrder inOrder = inOrder(idleStrategy, publication);
         inOrder.verify(idleStrategy).reset();
@@ -115,6 +117,35 @@ class ConsensusModuleSnapshotTakerTest
         assertEquals(-8791026472627208192L, pendingMessageTrackerDecoder.logServiceSessionId());
         assertEquals(capacity, pendingMessageTrackerDecoder.pendingMessageCapacity());
         assertEquals(serviceId, pendingMessageTrackerDecoder.serviceId());
+    }
+
+    @Test
+    void snapshotPendingServiceMessageTrackerWithServiceMessagesMissedByFollower()
+    {
+        final int serviceId = 6;
+        final PendingServiceMessageTracker pendingServiceMessageTracker = new PendingServiceMessageTracker(
+            serviceId, mock(Counter.class), mock(LogPublisher.class), mock(ClusterClock.class));
+        final AtomicBuffer headerMessageBuffer = new UnsafeBuffer(new byte[1024]);
+
+        final long expectedLogServiceSessionId = pendingServiceMessageTracker.logServiceSessionId() + 1;
+        final long expectedNextServiceSessionId = expectedLogServiceSessionId + 1;
+        when(publication.tryClaim(anyInt(), any())).thenAnswer(
+            (Answer<Long>)invocation ->
+            {
+                final int length = invocation.getArgument(0, Integer.class);
+                final BufferClaim bufferClaim = invocation.getArgument(1, BufferClaim.class);
+
+                bufferClaim.wrap(headerMessageBuffer, 0, length + 32);
+                return (long)length;
+            });
+
+        pendingServiceMessageTracker.sweepFollowerMessages(expectedLogServiceSessionId);
+
+        snapshotTaker.snapshot(pendingServiceMessageTracker, mock(ErrorHandler.class));
+
+        pendingMessageTrackerDecoder.wrapAndApplyHeader(headerMessageBuffer, HEADER_LENGTH, messageHeaderDecoder);
+        assertEquals(expectedNextServiceSessionId, pendingMessageTrackerDecoder.nextServiceSessionId());
+        assertEquals(expectedLogServiceSessionId, pendingMessageTrackerDecoder.logServiceSessionId());
     }
 
     @Test

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/ClusterTests.java
@@ -39,6 +39,8 @@ public class ClusterTests
     public static final String NO_OP_MSG = "No op!           ";
     public static final String REGISTER_TIMER_MSG = "Register a timer!";
     public static final String ECHO_SERVICE_IPC_INGRESS_MSG = "Echo as Service IPC ingress";
+    public static final String ECHO_SERVICE_IPC_INGRESS_MSG_SKIP_FOLLOWER =
+        "Echo as Service IPC ingress (skip follower)";
     public static final String UNEXPECTED_MSG =
         "Should never get this message because it is not going to be committed!";
     public static final String LARGE_MSG;


### PR DESCRIPTION
When the `PendingServiceMessageTracker` buffer is empty, but the `nextServiceSessionId` is lower that what it should be, this indicates that the follower may not have queued a service IPC message correctly.  This corrects the value at the point of snapshot and logs an error to alert the user to the potential non-determinism.  This avoids a fatal exception on startup.