### PR TITLE
Reset eos_flagged when adding receiver

### DIFF
--- a/aeron-driver/src/main/c/aeron_min_flow_control.c
+++ b/aeron-driver/src/main/c/aeron_min_flow_control.c
@@ -200,6 +200,7 @@ int64_t aeron_min_flow_control_strategy_process_sm(
             receiver->receiver_id = receiver_id;
             receiver->session_id = status_message_header->session_id;
             receiver->stream_id = status_message_header->stream_id;
+            receiver->eos_flagged = false;
 
             min_position = (position + window_length) < min_position ? (position + window_length) : min_position;
 


### PR DESCRIPTION
I think if this is reusing the index of a previously removed receiver eos_flagged can be left as true. This leads to immediate removal of the new receiver if `aeron_min_flow_control_strategy_on_idle` is called prior to receiving a second SM for this receiver.