### PR TITLE
[C] Ignore resting subscribers when calculating publication image join position

### DIFF
--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -313,7 +313,11 @@ inline int64_t aeron_publication_image_join_position(aeron_publication_image_t *
 
     for (size_t i = 0, length = image->conductor_fields.subscribable.length; i < length; i++)
     {
-        int64_t sub_pos = aeron_counter_get_volatile(image->conductor_fields.subscribable.array[i].value_addr);
+        aeron_tetherable_position_t *tetherable_position = &image->conductor_fields.subscribable.array[i];
+        if (tetherable_position->state == AERON_SUBSCRIPTION_TETHER_RESTING)
+            continue;
+
+        int64_t sub_pos = aeron_counter_get_volatile(tetherable_position->value_addr);
 
         if (sub_pos < position)
         {

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -314,8 +314,10 @@ inline int64_t aeron_publication_image_join_position(aeron_publication_image_t *
     for (size_t i = 0, length = image->conductor_fields.subscribable.length; i < length; i++)
     {
         aeron_tetherable_position_t *tetherable_position = &image->conductor_fields.subscribable.array[i];
-        if (tetherable_position->state == AERON_SUBSCRIPTION_TETHER_RESTING)
+        if (AERON_SUBSCRIPTION_TETHER_RESTING == tetherable_position->state)
+        {
             continue;
+        }
 
         int64_t sub_pos = aeron_counter_get_volatile(tetherable_position->value_addr);
 

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -314,7 +314,7 @@ inline int64_t aeron_publication_image_join_position(aeron_publication_image_t *
     for (size_t i = 0, length = image->conductor_fields.subscribable.length; i < length; i++)
     {
         aeron_tetherable_position_t *tetherable_position = &image->conductor_fields.subscribable.array[i];
-        if (AERON_SUBSCRIPTION_TETHER_RESTING == tetherable_position->state)
+        if (AERON_SUBSCRIPTION_TETHER_ACTIVE != tetherable_position->state)
         {
             continue;
         }


### PR DESCRIPTION
If resting subscribers aren't ignored a new subscription can end up joining at a position in an invalid term, leading to bogus data and potential corruption of the rcv_position.