### PR TITLE
[C] Dont clean beyond rcv_position, when all subscribers are resting

### DIFF
--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -385,7 +385,7 @@ void aeron_publication_image_track_rebuild(aeron_publication_image_t *image, int
         }
 
         const int64_t rcv_position = *image->rcv_pos_position.value_addr;
-        const int64_t consumed_position = rcv_position < min_sub_pos ? rcv_position : min_sub_pos;
+        const int64_t consumed_position = INT64_MAX == min_sub_pos ? rcv_position : min_sub_pos;
         const int64_t rebuild_position = rcv_position > max_sub_pos ? rcv_position : max_sub_pos;
 
         bool loss_found = false;


### PR DESCRIPTION
Admittedly I'm not 100% sure about this change, but it seems like with the existing code the following situation can occur.

All subscribers are resting, this leads min_sub_pos = INT64_MAX, and ends up calling aeron_publication_image_clean_buffer_to with INT64_MAX - term length.
We wipe out the rest of the term, this could wipe out frames above the rcv position.
If we then had an active subscriber join again whilst rcv position is still on the same term, I think one of the two will happen (unsure which):
- end up sending unnecessary NAKs, repopulating the frames. And then as the clean position is already set to the end of the term, we wont reclean this section?
- client will get stuck waiting for frame data to be populated?