### PR TITLE
Authentication services

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Archive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Archive.java
@@ -3125,7 +3125,197 @@ public final class Archive implements AutoCloseable
         }
 
         /**
-         * Set the {@link AuthorisationServiceSupplier} that will be used for the Archive.
+         * <p>Set the {@link AuthorisationServiceSupplier} that will be used for the Archive.</p>
+         * <p>When using an authorisation service for the ConsensusModule, then the following values for protocolId,
+         * actionId, and type should be considered.</p>
+         *
+         * <table summary="Parameters for authorisation service queries from the Archive">
+         *     <thead>
+         *         <tr><td>Description</td><td>protocolId</td><td>actionId</td><td>type(s)</td></tr>
+         *     </thead>
+         *     <tbody>
+         *         <tr>
+         *             <td>Start the recording of a stream</td>
+         *             <td>{@link io.aeron.archive.codecs.MessageHeaderDecoder#SCHEMA_ID}</td>
+         *             <td>{@link io.aeron.archive.codecs.StartRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Start the recording of a stream (version 2)</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StartRecordingRequest2Decoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop the recording of a stream</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Replay a stream from the archive</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ReplayRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop a replay from the archive</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopReplayRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>List the recordings from the archive</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ListRecordingsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>List the recordings from the archive for a specific URI</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ListRecordingsForUriRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>List a specific recording from the archive</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ListRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Extend a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ExtendRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Extend a recording (version 2)</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ExtendRecordingRequest2Decoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Gets the position of a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.RecordingPositionRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Truncate a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.TruncateRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop a recording by subscription</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopRecordingSubscriptionRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Extend a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ExtendRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Get the stop position for a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopPositionRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Find the last recording for a given stream, session and channel fragment</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.FindLastMatchingRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>List subscriptions being used for recordings</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ListRecordingSubscriptionsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop all replays</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopAllReplaysRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Start replicating a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ReplicateRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Start replicating a recording (version 2)</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.ReplicateRequest2Decoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop replication a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopReplicationRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Get the start position of a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StartRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Detach segment files from a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.DetachSegmentsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Delete detached segments</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.DeleteDetachedSegmentsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Attach new segments for a recording</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.AttachSegmentsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Migrate segments from one recording to another</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.MigrateSegmentsRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Keep alive the archive connection</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.KeepAliveRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Replicate a recording with a tag</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.TaggedReplicateRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Stop recording by recording id</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.StopRecordingByIdentityRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Purge a recording by recording id</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.archive.codecs.PurgeRecordingRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *     </tbody>
+         * </table>
          *
          * @param authorisationServiceSupplier {@link AuthorisationServiceSupplier} to use for the Archive.
          * @return this for a fluent API.

--- a/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
+++ b/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
@@ -15,38 +15,157 @@
  */
 package io.aeron.security;
 
+import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.collections.Object2ObjectHashMap;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
 public class SimpleAuthenticator implements Authenticator
 {
+    private final Object2ObjectHashMap<Credentials, Principal> principalsByCredentialsMap =
+        new Object2ObjectHashMap<>();
+
+    private final Long2ObjectHashMap<Principal> authenticatedSessionIdToPrincipalMap = new Long2ObjectHashMap<>();
+
+    private SimpleAuthenticator(final Builder builder)
+    {
+        for (final Principal principal : builder.principals)
+        {
+            principalsByCredentialsMap.put(principal.credentials, principal);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void onConnectRequest(final long sessionId, final byte[] encodedCredentials, final long nowMs)
     {
-
+        final Principal principal = principalsByCredentialsMap.get(new Credentials(encodedCredentials));
+        if (null != principal && principal.credentialsMatch(encodedCredentials))
+        {
+            authenticatedSessionIdToPrincipalMap.put(sessionId, principal);
+        }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public void onChallengeResponse(final long sessionId, final byte[] encodedCredentials, final long nowMs)
     {
-
+        throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public void onConnectedSession(final SessionProxy sessionProxy, final long nowMs)
     {
-
+        final long sessionId = sessionProxy.sessionId();
+        final Principal principal = authenticatedSessionIdToPrincipalMap.get(sessionId);
+        if (null != principal)
+        {
+            if (sessionProxy.authenticate(principal.encodedPrincipal))
+            {
+                authenticatedSessionIdToPrincipalMap.remove(sessionId);
+            }
+        }
+        else
+        {
+            sessionProxy.reject();
+        }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public void onChallengedSession(final SessionProxy sessionProxy, final long nowMs)
     {
-
+        throw new UnsupportedOperationException();
     }
 
+    /**
+     * Builder to create instances of SimpleAuthenticator
+     */
     public static class Builder
     {
-        public Builder principal(final byte[] principal, final byte[] credentials)
+        private final ArrayList<Principal> principals = new ArrayList<>();
+
+        /**
+         * Add a principal/credentials pair to the list supported by this authenticator. Note that the
+         * {@link SimpleAuthenticator} keys the principals by the credentials, so the encoded credentials should
+         * include the encoded principal. The associated {@link CredentialsSupplier} used on the client should handle
+         * encoding these credentials correctly as well. E.g.
+         * <pre>
+         * final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+         *     .principal("user".getBytes(US_ASCII), "user:pass".getBytes(US_ASCII))
+         *     .newInstance();
+         * </pre>
+         *
+         * @param encodedPrincipal
+         * @param encodedCredentials
+         * @return
+         */
+        public Builder principal(final byte[] encodedPrincipal, final byte[] encodedCredentials)
         {
+            principals.add(new Principal(encodedPrincipal, encodedCredentials));
             return this;
         }
 
+        /**
+         * Construct a new instance of the SimpleAuthenticator.
+         *
+         * @return a new SimpleAuthenticator instance.
+         */
         public SimpleAuthenticator newInstance()
         {
-            return new SimpleAuthenticator();
+            return new SimpleAuthenticator(this);
+        }
+    }
+
+    private static final class Principal
+    {
+        private final byte[] encodedPrincipal;
+        private final Credentials credentials;
+
+        private Principal(final byte[] encodedPrincipal, final byte[] encodedCredentials)
+        {
+            this.encodedPrincipal = encodedPrincipal;
+            this.credentials = new Credentials(encodedCredentials);
+        }
+
+        public boolean credentialsMatch(final byte[] encodedCredentials)
+        {
+            return Arrays.equals(credentials.encodedCredentials, encodedCredentials);
+        }
+    }
+
+    private static final class Credentials
+    {
+        private final byte[] encodedCredentials;
+
+        private Credentials(final byte[] encodedCredentials)
+        {
+            this.encodedCredentials = encodedCredentials;
+        }
+
+        public boolean equals(final Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            final Credentials that = (Credentials)o;
+            return Arrays.equals(encodedCredentials, that.encodedCredentials);
+        }
+
+        public int hashCode()
+        {
+            return Arrays.hashCode(encodedCredentials);
         }
     }
 }

--- a/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
+++ b/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+public class SimpleAuthenticator implements Authenticator
+{
+    public void onConnectRequest(final long sessionId, final byte[] encodedCredentials, final long nowMs)
+    {
+
+    }
+
+    public void onChallengeResponse(final long sessionId, final byte[] encodedCredentials, final long nowMs)
+    {
+
+    }
+
+    public void onConnectedSession(final SessionProxy sessionProxy, final long nowMs)
+    {
+
+    }
+
+    public void onChallengedSession(final SessionProxy sessionProxy, final long nowMs)
+    {
+
+    }
+
+    public static class Builder
+    {
+        public Builder principal(final byte[] principal, final byte[] credentials)
+        {
+            return this;
+        }
+
+        public SimpleAuthenticator newInstance()
+        {
+            return new SimpleAuthenticator();
+        }
+    }
+}

--- a/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
+++ b/aeron-client/src/main/java/io/aeron/security/SimpleAuthenticator.java
@@ -21,7 +21,11 @@ import org.agrona.collections.Object2ObjectHashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class SimpleAuthenticator implements Authenticator
+/**
+ * An authenticator that works off a simple principal/credential pair constructed by a builder. It only supports simple
+ * authentication, but not challenge/response.
+ */
+public final class SimpleAuthenticator implements Authenticator
 {
     private final Object2ObjectHashMap<Credentials, Principal> principalsByCredentialsMap =
         new Object2ObjectHashMap<>();
@@ -102,9 +106,9 @@ public class SimpleAuthenticator implements Authenticator
          *     .newInstance();
          * </pre>
          *
-         * @param encodedPrincipal
-         * @param encodedCredentials
-         * @return
+         * @param encodedPrincipal      principal encoded as a byte array.
+         * @param encodedCredentials    credentials encoded as a byte array.
+         * @return this for a fluent API.
          */
         public Builder principal(final byte[] encodedPrincipal, final byte[] encodedCredentials)
         {

--- a/aeron-client/src/main/java/io/aeron/security/SimpleAuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/SimpleAuthorisationService.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * Authorisation service that supports setting general and per-principal rules as well as scoping to protocol, action
  * and type. Uses a fluent API to add authorisation rules.
  */
-public class SimpleAuthorisationService implements AuthorisationService
+public final class SimpleAuthorisationService implements AuthorisationService
 {
     private final AuthorisationService defaultAuthorisation;
     private final Object2ObjectHashMap<ByteArrayAsKey, Principal> principalByKeyMap = new Object2ObjectHashMap<>();
@@ -108,6 +108,17 @@ public class SimpleAuthorisationService implements AuthorisationService
             return this;
         }
 
+        /**
+         * Add rule for a specific principal that is scope to a protocolId, actionId, and type.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param type              a parameter of the message can be used to narrow the scope of the authorisation
+         *                          rule. This is message dependent.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
         public Builder addPrincipalRule(
             final int protocolId,
             final int actionId,
@@ -126,6 +137,15 @@ public class SimpleAuthorisationService implements AuthorisationService
             return this;
         }
 
+        /**
+         * Add rule for a specific principal that is scope to a protocolId and actionId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
         public Builder addPrincipalRule(
             final int protocolId,
             final int actionId,
@@ -139,6 +159,14 @@ public class SimpleAuthorisationService implements AuthorisationService
             return this;
         }
 
+        /**
+         * Add rule for a specific principal that is scope to a protocolId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
         public Builder addPrincipalRule(
             final int protocolId,
             final byte[] encodedPrincipal,
@@ -151,23 +179,16 @@ public class SimpleAuthorisationService implements AuthorisationService
             return this;
         }
 
-        public SimpleAuthorisationService newInstance()
-        {
-            return new SimpleAuthorisationService(this);
-        }
-
-        public Builder addGeneralRule(final int protocolId, final boolean isAllowed)
-        {
-            defaultPrincipal.byProtocol.put(protocolId, (Boolean)isAllowed);
-            return this;
-        }
-
-        public Builder addGeneralRule(final int protocolId, final int actionId, final boolean isAllowed)
-        {
-            defaultPrincipal.byProtocolAction.put(protocolId, actionId, isAllowed);
-            return this;
-        }
-
+        /**
+         * Add rule for all principals that is scoped to a protocolId, actionId and type.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param type              a parameter of the message can be used to narrow the scope of the authorisation
+         *                          rule. This is message dependent.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
         public Builder addGeneralRule(
             final int protocolId,
             final int actionId,
@@ -179,6 +200,43 @@ public class SimpleAuthorisationService implements AuthorisationService
             byTypeMap.computeIfAbsent(protocolId, actionId, (a, b) -> new HashSet<>()).add(type);
 
             return this;
+        }
+
+        /**
+         * Add rule for all principals that is scoped to a protocolId and actionId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+        * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addGeneralRule(final int protocolId, final int actionId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocolAction.put(protocolId, actionId, isAllowed);
+            return this;
+        }
+
+        /**
+         * Add rule for all principals that is scoped to a protocolId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addGeneralRule(final int protocolId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocol.put(protocolId, (Boolean)isAllowed);
+            return this;
+        }
+
+        /**
+         * Create and instance of the SimpleAuthorisationService.
+         *
+         * @return new SimpleAuthorisationService.
+         */
+        public SimpleAuthorisationService newInstance()
+        {
+            return new SimpleAuthorisationService(this);
         }
     }
 

--- a/aeron-client/src/main/java/io/aeron/security/SimpleAuthorisationService.java
+++ b/aeron-client/src/main/java/io/aeron/security/SimpleAuthorisationService.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+import org.agrona.collections.BiInt2ObjectMap;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.collections.Object2ObjectHashMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Authorisation service that supports setting general and per-principal rules as well as scoping to protocol, action
+ * and type. Uses a fluent API to add authorisation rules.
+ */
+public class SimpleAuthorisationService implements AuthorisationService
+{
+    private final AuthorisationService defaultAuthorisation;
+    private final Object2ObjectHashMap<ByteArrayAsKey, Principal> principalByKeyMap = new Object2ObjectHashMap<>();
+    private final Principal defaultPrincipal;
+
+    private SimpleAuthorisationService(final Builder builder)
+    {
+        defaultAuthorisation = builder.defaultAuthorisation;
+        principalByKeyMap.putAll(builder.principalByKeyMap);
+        defaultPrincipal = builder.defaultPrincipal;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isAuthorised(
+        final int protocolId,
+        final int actionId,
+        final Object type,
+        final byte[] encodedPrincipal)
+    {
+        Boolean authorised;
+
+        authorised = isAuthorised(
+            principalByKeyMap.get(new ByteArrayAsKey(encodedPrincipal)),
+            protocolId,
+            actionId,
+            type);
+        if (null != authorised)
+        {
+            return authorised;
+        }
+
+        authorised = isAuthorised(defaultPrincipal, protocolId, actionId, type);
+        if (null != authorised)
+        {
+            return authorised;
+        }
+
+        return defaultAuthorisation.isAuthorised(protocolId, actionId, type, encodedPrincipal);
+    }
+
+    private Boolean isAuthorised(
+        final Principal principal,
+        final int protocolId,
+        final int actionId,
+        final Object type)
+    {
+        if (null == principal)
+        {
+            return null;
+        }
+
+        return principal.isAuthorised(protocolId, actionId, type);
+    }
+
+    /**
+     * Builder to create the authorisation service.
+     */
+    public static class Builder
+    {
+        private AuthorisationService defaultAuthorisation = AuthorisationService.DENY_ALL;
+        private final Object2ObjectHashMap<ByteArrayAsKey, Principal> principalByKeyMap = new Object2ObjectHashMap<>();
+        private final Principal defaultPrincipal = new Principal(new byte[0]);
+
+        /**
+         * Set the default authorisation if the authorisation request does not match any of the supplied rules.
+         *
+         * @param defaultAuthorisation an authorisation service to fall back to.
+         * @return this for a fluent API
+         * @see AuthorisationService#ALLOW_ALL
+         * @see AuthorisationService#DENY_ALL
+         */
+        public Builder defaultAuthorisation(final AuthorisationService defaultAuthorisation)
+        {
+            this.defaultAuthorisation = defaultAuthorisation;
+            return this;
+        }
+
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final int actionId,
+            final Object type,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            final BiInt2ObjectMap<Set<Object>> byTypeMap = isAllowed ? principal.byProtocolActionTypeAllowed :
+                principal.byProtocolActionTypeDenied;
+
+            byTypeMap.computeIfAbsent(protocolId, actionId, (a, b) -> new HashSet<>()).add(type);
+
+            return this;
+        }
+
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final int actionId,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            principal.byProtocolAction.put(protocolId, actionId, isAllowed);
+            return this;
+        }
+
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            principal.byProtocol.put(protocolId, Boolean.valueOf(isAllowed));
+            return this;
+        }
+
+        public SimpleAuthorisationService newInstance()
+        {
+            return new SimpleAuthorisationService(this);
+        }
+
+        public Builder addGeneralRule(final int protocolId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocol.put(protocolId, (Boolean)isAllowed);
+            return this;
+        }
+
+        public Builder addGeneralRule(final int protocolId, final int actionId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocolAction.put(protocolId, actionId, isAllowed);
+            return this;
+        }
+
+        public Builder addGeneralRule(
+            final int protocolId,
+            final int actionId,
+            final Object type,
+            final boolean isAllowed)
+        {
+            final BiInt2ObjectMap<Set<Object>> byTypeMap = isAllowed ? defaultPrincipal.byProtocolActionTypeAllowed :
+                defaultPrincipal.byProtocolActionTypeDenied;
+            byTypeMap.computeIfAbsent(protocolId, actionId, (a, b) -> new HashSet<>()).add(type);
+
+            return this;
+        }
+    }
+
+    private static final class Principal
+    {
+        private final Int2ObjectHashMap<Boolean> byProtocol = new Int2ObjectHashMap<>();
+        private final BiInt2ObjectMap<Boolean> byProtocolAction = new BiInt2ObjectMap<>();
+        private final BiInt2ObjectMap<Set<Object>> byProtocolActionTypeAllowed = new BiInt2ObjectMap<>();
+        private final BiInt2ObjectMap<Set<Object>> byProtocolActionTypeDenied = new BiInt2ObjectMap<>();
+        private final byte[] encodedPrincipal;
+
+        private Principal(final byte[] encodedPrincipal)
+        {
+            this.encodedPrincipal = encodedPrincipal;
+        }
+
+        public Boolean isAuthorised(final int protocolId, final int actionId, final Object type)
+        {
+            final Set<Object> typesAllowed = byProtocolActionTypeAllowed.getOrDefault(
+                protocolId, actionId, Collections.emptySet());
+            if (typesAllowed.contains(type))
+            {
+                return Boolean.TRUE;
+            }
+
+            final Set<Object> typesDenied = byProtocolActionTypeDenied.getOrDefault(
+                protocolId, actionId, Collections.emptySet());
+            if (typesDenied.contains(type))
+            {
+                return Boolean.FALSE;
+            }
+
+            final Boolean authorised = byProtocolAction.get(protocolId, actionId);
+            if (null != authorised)
+            {
+                return authorised;
+            }
+
+            return byProtocol.get(protocolId);
+        }
+    }
+
+    private static final class ByteArrayAsKey
+    {
+        private final byte[] data;
+
+        private ByteArrayAsKey(final byte[] data)
+        {
+            this.data = data;
+        }
+
+        public boolean equals(final Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            final ByteArrayAsKey that = (ByteArrayAsKey)o;
+            return Arrays.equals(data, that.data);
+        }
+
+        public int hashCode()
+        {
+            return Arrays.hashCode(data);
+        }
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/security/SimpleAuthenticatorTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/SimpleAuthenticatorTest.java
@@ -1,13 +1,25 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.aeron.security;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.nio.charset.StandardCharsets;
-
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/aeron-client/src/test/java/io/aeron/security/SimpleAuthenticatorTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/SimpleAuthenticatorTest.java
@@ -1,0 +1,95 @@
+package io.aeron.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.nio.charset.StandardCharsets;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SimpleAuthenticatorTest
+{
+    @Test
+    void shouldAuthenticate()
+    {
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+        final long nowMs = 1_000_000L;
+        final long sessionId = 982374;
+
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] encodedCredentials = "user:pass".getBytes(US_ASCII);
+
+        when(mockSessionProxy.sessionId()).thenReturn(sessionId);
+
+        final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+            .principal(encodedPrincipal, encodedCredentials)
+            .newInstance();
+
+        simpleAuthenticator.onConnectRequest(sessionId, encodedCredentials, nowMs);
+        simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+
+        verify(mockSessionProxy).authenticate(encodedPrincipal);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"user:wrong", "wrong:pass"})
+    void shouldReject(final String incorrectCredentials)
+    {
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+        final long nowMs = 1_000_000L;
+        final long sessionId = 982374;
+
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] encodedCredentials = "user:pass".getBytes(US_ASCII);
+
+        when(mockSessionProxy.sessionId()).thenReturn(sessionId);
+
+        final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+            .principal(encodedPrincipal, encodedCredentials)
+            .newInstance();
+
+        simpleAuthenticator.onConnectRequest(sessionId, incorrectCredentials.getBytes(US_ASCII), nowMs);
+        simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+        verify(mockSessionProxy).reject();
+    }
+
+    @Test
+    void shouldHandleMultipleConcurrentAuthenticationRequests()
+    {
+        final long nowMs = 9283479L;
+        final String[][] users = {
+            { "user1", "user1:pass1" },
+            { "user2", "user2:pass2" },
+            { "user3", "user3:pass3" },
+            { "user4", "user4:pass4" },
+            { "user5", "user5:pass5" },
+        };
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+
+        final SimpleAuthenticator.Builder builder = new SimpleAuthenticator.Builder();
+
+        for (final String[] user : users)
+        {
+            builder.principal(user[0].getBytes(US_ASCII), user[1].getBytes(US_ASCII));
+        }
+
+        final SimpleAuthenticator simpleAuthenticator = builder.newInstance();
+
+        for (int i = 0; i < users.length; i++)
+        {
+            simpleAuthenticator.onConnectRequest(i + 1000, users[i][1].getBytes(US_ASCII), nowMs);
+        }
+
+        for (int i = 0; i < users.length; i++)
+        {
+            when(mockSessionProxy.sessionId()).thenReturn(i + 1000L);
+            simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+            verify(mockSessionProxy).authenticate(users[i][0].getBytes(US_ASCII));
+        }
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/security/SimpleAuthorisationServiceTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/SimpleAuthorisationServiceTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.security;
+
+import io.aeron.archive.codecs.MessageHeaderDecoder;
+import io.aeron.archive.codecs.ReplicateRequest2Decoder;
+import io.aeron.archive.codecs.StartPositionRequestDecoder;
+import io.aeron.archive.codecs.StartRecordingRequestDecoder;
+import io.aeron.archive.codecs.TruncateRecordingRequestDecoder;
+import io.aeron.cluster.codecs.BackupQueryDecoder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.aeron.security.AuthorisationService.ALLOW_ALL;
+import static io.aeron.security.AuthorisationService.DENY_ALL;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("checkstyle:Indentation")
+public class SimpleAuthorisationServiceTest
+{
+    public static final int ARCHIVE_PROTOCOL_ID = MessageHeaderDecoder.SCHEMA_ID;
+    public static final int CLUSTER_PROTOCOL_ID = io.aeron.cluster.codecs.MessageHeaderDecoder.SCHEMA_ID;
+    public static final int OTHER_PROTOCOL_ID = 873648576;
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocol(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, true)
+            .addGeneralRule(CLUSTER_PROTOCOL_ID, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocolAndMessage(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, true)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocolAndMessageAndType(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+        final String typeAllowed = "allowed";
+        final String typeDenied = "denied";
+        final String typeUnspecified = "unspecified";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, true)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeUnspecified, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocol(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, encodedPrincipal, true)
+            .addPrincipalRule(CLUSTER_PROTOCOL_ID, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocolAndMessage(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, true)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocolAndMessageAndType(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final String typeAllowed = "allowed";
+        final String typeDenied = "denied";
+        final String typeUnspecified = "unspecified";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal, true)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeUnspecified, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldPrioritisePrincipalOverGeneralRules(final boolean accept)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] unknownPrincipal = "unknownUser".getBytes(US_ASCII);
+        final String typeAllowed = "allowed";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(!accept ? ALLOW_ALL : DENY_ALL)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal, accept)
+            .addGeneralRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, !accept)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, accept)
+            .addGeneralRule(
+                ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, !accept)
+            .addPrincipalRule(
+                CLUSTER_PROTOCOL_ID, encodedPrincipal, accept)
+            .addGeneralRule(
+                CLUSTER_PROTOCOL_ID, !accept)
+            .newInstance();
+
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, unknownPrincipal));
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, unknownPrincipal));
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, unknownPrincipal));
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/security/SimpleAuthorisationServiceTest.java
+++ b/aeron-client/src/test/java/io/aeron/security/SimpleAuthorisationServiceTest.java
@@ -17,11 +17,9 @@ package io.aeron.security;
 
 import io.aeron.archive.codecs.MessageHeaderDecoder;
 import io.aeron.archive.codecs.ReplicateRequest2Decoder;
-import io.aeron.archive.codecs.StartPositionRequestDecoder;
 import io.aeron.archive.codecs.StartRecordingRequestDecoder;
 import io.aeron.archive.codecs.TruncateRecordingRequestDecoder;
 import io.aeron.cluster.codecs.BackupQueryDecoder;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -3549,7 +3549,41 @@ public final class ConsensusModule implements AutoCloseable
         }
 
         /**
-         * Set the {@link AuthorisationServiceSupplier} that will be used for the consensus module.
+         * <p>Set the {@link AuthorisationServiceSupplier} that will be used for the consensus module.</p>
+         *
+         * <p>When using an authorisation service for the ConsensusModule, then the following values for protocolId,
+         * actionId, and type should be considered.</p>
+         * <table summary="Parameters for authorisation service queries from the Consensus Module">
+         *     <thead>
+         *         <tr><td>Description</td><td>protocolId</td><td>actionId</td><td>type(s)</td></tr>
+         *     </thead>
+         *     <tbody>
+         *         <tr>
+         *             <td>Admin requests made through the client API</td>
+         *             <td>{@link MessageHeaderDecoder#SCHEMA_ID}</td>
+         *             <td>{@link io.aeron.cluster.codecs.AdminRequestDecoder#TEMPLATE_ID}</td>
+         *             <td>{@link io.aeron.cluster.codecs.AdminRequestType#SNAPSHOT}</td>
+         *         </tr>
+         *         <tr>
+         *             <td>Backup queries from Cluster Backup &amp; Standby</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.cluster.codecs.BackupQueryDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Heartbeat requests from Cluster Standby</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.cluster.codecs.HeartbeatRequestDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *         <tr>
+         *             <td>Standby snapshot notifications from Cluster Standby</td>
+         *             <td></td>
+         *             <td>{@link io.aeron.cluster.codecs.BackupQueryDecoder#TEMPLATE_ID}</td>
+         *             <td><code>(null)</code></td>
+         *         </tr>
+         *     </tbody>
+         * </table>
          *
          * @param authorisationServiceSupplier {@link AuthorisationServiceSupplier} to use for the consensus module.
          * @return this for a fluent API.

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/SampleAuthenticator.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/SampleAuthenticator.java
@@ -106,7 +106,8 @@ public final class SampleAuthenticator implements Authenticator
      */
     public void onConnectedSession(final SessionProxy sessionProxy, final long nowMs)
     {
-        final SessionState sessionState = sessionIdToStateMap.get(sessionProxy.sessionId());
+        final long sessionId = sessionProxy.sessionId();
+        final SessionState sessionState = sessionIdToStateMap.get(sessionId);
 
         if (null != sessionState)
         {
@@ -117,11 +118,15 @@ public final class SampleAuthenticator implements Authenticator
                     break;
 
                 case AUTHENTICATED:
-                    sessionProxy.authenticate(encodedPrincipal());
+                    if (sessionProxy.authenticate(encodedPrincipal()))
+                    {
+                        sessionIdToStateMap.remove(sessionId);
+                    }
                     break;
 
                 case REJECT:
                     sessionProxy.reject();
+                    sessionIdToStateMap.remove(sessionId);
                     break;
             }
         }
@@ -135,7 +140,8 @@ public final class SampleAuthenticator implements Authenticator
      */
     public void onChallengedSession(final SessionProxy sessionProxy, final long nowMs)
     {
-        final SessionState sessionState = sessionIdToStateMap.get(sessionProxy.sessionId());
+        final long sessionId = sessionProxy.sessionId();
+        final SessionState sessionState = sessionIdToStateMap.get(sessionId);
 
         if (null != sessionState)
         {
@@ -145,11 +151,15 @@ public final class SampleAuthenticator implements Authenticator
                     break;
 
                 case AUTHENTICATED:
-                    sessionProxy.authenticate(ArrayUtil.EMPTY_BYTE_ARRAY);
+                    if (sessionProxy.authenticate(ArrayUtil.EMPTY_BYTE_ARRAY))
+                    {
+                        sessionIdToStateMap.remove(sessionId);
+                    }
                     break;
 
                 case REJECT:
                     sessionProxy.reject();
+                    sessionIdToStateMap.remove(sessionId);
                     break;
             }
         }

--- a/aeron-samples/src/main/java/io/aeron/samples/security/SimpleAuthenticator.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/security/SimpleAuthenticator.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.samples.security;
+
+import io.aeron.security.Authenticator;
+import io.aeron.security.CredentialsSupplier;
+import io.aeron.security.SessionProxy;
+import org.agrona.collections.Long2ObjectHashMap;
+import org.agrona.collections.Object2ObjectHashMap;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * An authenticator that works off a simple principal/credential pair constructed by a builder. It only supports simple
+ * authentication, but not challenge/response.
+ */
+public final class SimpleAuthenticator implements Authenticator
+{
+    private final Object2ObjectHashMap<Credentials, Principal> principalsByCredentialsMap =
+        new Object2ObjectHashMap<>();
+
+    private final Long2ObjectHashMap<Principal> authenticatedSessionIdToPrincipalMap = new Long2ObjectHashMap<>();
+
+    private SimpleAuthenticator(final Builder builder)
+    {
+        for (final Principal principal : builder.principals)
+        {
+            principalsByCredentialsMap.put(principal.credentials, principal);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void onConnectRequest(final long sessionId, final byte[] encodedCredentials, final long nowMs)
+    {
+        final Principal principal = principalsByCredentialsMap.get(new Credentials(encodedCredentials));
+        if (null != principal && principal.credentialsMatch(encodedCredentials))
+        {
+            authenticatedSessionIdToPrincipalMap.put(sessionId, principal);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void onChallengeResponse(final long sessionId, final byte[] encodedCredentials, final long nowMs)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void onConnectedSession(final SessionProxy sessionProxy, final long nowMs)
+    {
+        final long sessionId = sessionProxy.sessionId();
+        final Principal principal = authenticatedSessionIdToPrincipalMap.get(sessionId);
+        if (null != principal)
+        {
+            if (sessionProxy.authenticate(principal.encodedPrincipal))
+            {
+                authenticatedSessionIdToPrincipalMap.remove(sessionId);
+            }
+        }
+        else
+        {
+            sessionProxy.reject();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void onChallengedSession(final SessionProxy sessionProxy, final long nowMs)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Builder to create instances of SimpleAuthenticator
+     */
+    public static class Builder
+    {
+        private final ArrayList<Principal> principals = new ArrayList<>();
+
+        /**
+         * Add a principal/credentials pair to the list supported by this authenticator. Note that the
+         * {@link SimpleAuthenticator} keys the principals by the credentials, so the encoded credentials should
+         * include the encoded principal. The associated {@link CredentialsSupplier} used on the client should handle
+         * encoding these credentials correctly as well. E.g.
+         * <pre>
+         * final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+         *     .principal("user".getBytes(US_ASCII), "user:pass".getBytes(US_ASCII))
+         *     .newInstance();
+         * </pre>
+         *
+         * @param encodedPrincipal      principal encoded as a byte array.
+         * @param encodedCredentials    credentials encoded as a byte array.
+         * @return this for a fluent API.
+         */
+        public Builder principal(final byte[] encodedPrincipal, final byte[] encodedCredentials)
+        {
+            principals.add(new Principal(encodedPrincipal, encodedCredentials));
+            return this;
+        }
+
+        /**
+         * Construct a new instance of the SimpleAuthenticator.
+         *
+         * @return a new SimpleAuthenticator instance.
+         */
+        public SimpleAuthenticator newInstance()
+        {
+            return new SimpleAuthenticator(this);
+        }
+    }
+
+    private static final class Principal
+    {
+        private final byte[] encodedPrincipal;
+        private final Credentials credentials;
+
+        private Principal(final byte[] encodedPrincipal, final byte[] encodedCredentials)
+        {
+            this.encodedPrincipal = encodedPrincipal;
+            this.credentials = new Credentials(encodedCredentials);
+        }
+
+        public boolean credentialsMatch(final byte[] encodedCredentials)
+        {
+            return Arrays.equals(credentials.encodedCredentials, encodedCredentials);
+        }
+    }
+
+    private static final class Credentials
+    {
+        private final byte[] encodedCredentials;
+
+        private Credentials(final byte[] encodedCredentials)
+        {
+            this.encodedCredentials = encodedCredentials;
+        }
+
+        public boolean equals(final Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            final Credentials that = (Credentials)o;
+            return Arrays.equals(encodedCredentials, that.encodedCredentials);
+        }
+
+        public int hashCode()
+        {
+            return Arrays.hashCode(encodedCredentials);
+        }
+    }
+}

--- a/aeron-samples/src/main/java/io/aeron/samples/security/SimpleAuthorisationService.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/security/SimpleAuthorisationService.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.samples.security;
+
+import io.aeron.security.AuthorisationService;
+import org.agrona.collections.BiInt2ObjectMap;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.collections.Object2ObjectHashMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Authorisation service that supports setting general and per-principal rules as well as scoping to protocol, action
+ * and type. Uses a fluent API to add authorisation rules.
+ */
+public final class SimpleAuthorisationService implements AuthorisationService
+{
+    private final AuthorisationService defaultAuthorisation;
+    private final Object2ObjectHashMap<ByteArrayAsKey, Principal> principalByKeyMap = new Object2ObjectHashMap<>();
+    private final Principal defaultPrincipal;
+
+    private SimpleAuthorisationService(final Builder builder)
+    {
+        defaultAuthorisation = builder.defaultAuthorisation;
+        principalByKeyMap.putAll(builder.principalByKeyMap);
+        defaultPrincipal = builder.defaultPrincipal;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isAuthorised(
+        final int protocolId,
+        final int actionId,
+        final Object type,
+        final byte[] encodedPrincipal)
+    {
+        Boolean authorised;
+
+        authorised = isAuthorised(
+            principalByKeyMap.get(new ByteArrayAsKey(encodedPrincipal)),
+            protocolId,
+            actionId,
+            type);
+        if (null != authorised)
+        {
+            return authorised;
+        }
+
+        authorised = isAuthorised(defaultPrincipal, protocolId, actionId, type);
+        if (null != authorised)
+        {
+            return authorised;
+        }
+
+        return defaultAuthorisation.isAuthorised(protocolId, actionId, type, encodedPrincipal);
+    }
+
+    private Boolean isAuthorised(
+        final Principal principal,
+        final int protocolId,
+        final int actionId,
+        final Object type)
+    {
+        if (null == principal)
+        {
+            return null;
+        }
+
+        return principal.isAuthorised(protocolId, actionId, type);
+    }
+
+    /**
+     * Builder to create the authorisation service.
+     */
+    public static class Builder
+    {
+        private AuthorisationService defaultAuthorisation = AuthorisationService.DENY_ALL;
+        private final Object2ObjectHashMap<ByteArrayAsKey, Principal> principalByKeyMap = new Object2ObjectHashMap<>();
+        private final Principal defaultPrincipal = new Principal(new byte[0]);
+
+        /**
+         * Set the default authorisation if the authorisation request does not match any of the supplied rules.
+         *
+         * @param defaultAuthorisation an authorisation service to fall back to.
+         * @return this for a fluent API
+         * @see AuthorisationService#ALLOW_ALL
+         * @see AuthorisationService#DENY_ALL
+         */
+        public Builder defaultAuthorisation(final AuthorisationService defaultAuthorisation)
+        {
+            this.defaultAuthorisation = defaultAuthorisation;
+            return this;
+        }
+
+        /**
+         * Add rule for a specific principal that is scope to a protocolId, actionId, and type.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param type              a parameter of the message can be used to narrow the scope of the authorisation
+         *                          rule. This is message dependent.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final int actionId,
+            final Object type,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            final BiInt2ObjectMap<Set<Object>> byTypeMap = isAllowed ? principal.byProtocolActionTypeAllowed :
+                principal.byProtocolActionTypeDenied;
+
+            byTypeMap.computeIfAbsent(protocolId, actionId, (a, b) -> new HashSet<>()).add(type);
+
+            return this;
+        }
+
+        /**
+         * Add rule for a specific principal that is scope to a protocolId and actionId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final int actionId,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            principal.byProtocolAction.put(protocolId, actionId, isAllowed);
+            return this;
+        }
+
+        /**
+         * Add rule for a specific principal that is scope to a protocolId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param encodedPrincipal  The principal encoded as byte array.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addPrincipalRule(
+            final int protocolId,
+            final byte[] encodedPrincipal,
+            final boolean isAllowed)
+        {
+            final Principal principal = principalByKeyMap.computeIfAbsent(
+                new ByteArrayAsKey(encodedPrincipal), (key) -> new Principal(key.data));
+
+            principal.byProtocol.put(protocolId, Boolean.valueOf(isAllowed));
+            return this;
+        }
+
+        /**
+         * Add rule for all principals that is scoped to a protocolId, actionId and type.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+         * @param type              a parameter of the message can be used to narrow the scope of the authorisation
+         *                          rule. This is message dependent.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addGeneralRule(
+            final int protocolId,
+            final int actionId,
+            final Object type,
+            final boolean isAllowed)
+        {
+            final BiInt2ObjectMap<Set<Object>> byTypeMap = isAllowed ? defaultPrincipal.byProtocolActionTypeAllowed :
+                defaultPrincipal.byProtocolActionTypeDenied;
+            byTypeMap.computeIfAbsent(protocolId, actionId, (a, b) -> new HashSet<>()).add(type);
+
+            return this;
+        }
+
+        /**
+         * Add rule for all principals that is scoped to a protocolId and actionId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param actionId          <code>sbe:message@id</code> value that the rule applies to.
+        * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addGeneralRule(final int protocolId, final int actionId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocolAction.put(protocolId, actionId, isAllowed);
+            return this;
+        }
+
+        /**
+         * Add rule for all principals that is scoped to a protocolId.
+         *
+         * @param protocolId        <code>sbe:messageSchema@id</code> value that the rule applies to.
+         * @param isAllowed         If the rule should allow or deny access.
+         * @return this for a fluent API.
+         */
+        public Builder addGeneralRule(final int protocolId, final boolean isAllowed)
+        {
+            defaultPrincipal.byProtocol.put(protocolId, (Boolean)isAllowed);
+            return this;
+        }
+
+        /**
+         * Create and instance of the SimpleAuthorisationService.
+         *
+         * @return new SimpleAuthorisationService.
+         */
+        public SimpleAuthorisationService newInstance()
+        {
+            return new SimpleAuthorisationService(this);
+        }
+    }
+
+    private static final class Principal
+    {
+        private final Int2ObjectHashMap<Boolean> byProtocol = new Int2ObjectHashMap<>();
+        private final BiInt2ObjectMap<Boolean> byProtocolAction = new BiInt2ObjectMap<>();
+        private final BiInt2ObjectMap<Set<Object>> byProtocolActionTypeAllowed = new BiInt2ObjectMap<>();
+        private final BiInt2ObjectMap<Set<Object>> byProtocolActionTypeDenied = new BiInt2ObjectMap<>();
+        private final byte[] encodedPrincipal;
+
+        private Principal(final byte[] encodedPrincipal)
+        {
+            this.encodedPrincipal = encodedPrincipal;
+        }
+
+        public Boolean isAuthorised(final int protocolId, final int actionId, final Object type)
+        {
+            final Set<Object> typesAllowed = byProtocolActionTypeAllowed.getOrDefault(
+                protocolId, actionId, Collections.emptySet());
+            if (typesAllowed.contains(type))
+            {
+                return Boolean.TRUE;
+            }
+
+            final Set<Object> typesDenied = byProtocolActionTypeDenied.getOrDefault(
+                protocolId, actionId, Collections.emptySet());
+            if (typesDenied.contains(type))
+            {
+                return Boolean.FALSE;
+            }
+
+            final Boolean authorised = byProtocolAction.get(protocolId, actionId);
+            if (null != authorised)
+            {
+                return authorised;
+            }
+
+            return byProtocol.get(protocolId);
+        }
+    }
+
+    private static final class ByteArrayAsKey
+    {
+        private final byte[] data;
+
+        private ByteArrayAsKey(final byte[] data)
+        {
+            this.data = data;
+        }
+
+        public boolean equals(final Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass())
+            {
+                return false;
+            }
+            final ByteArrayAsKey that = (ByteArrayAsKey)o;
+            return Arrays.equals(data, that.data);
+        }
+
+        public int hashCode()
+        {
+            return Arrays.hashCode(data);
+        }
+    }
+}

--- a/aeron-samples/src/test/java/io/aeron/samples/security/SimpleAuthenticatorTest.java
+++ b/aeron-samples/src/test/java/io/aeron/samples/security/SimpleAuthenticatorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.samples.security;
+
+import io.aeron.security.SessionProxy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SimpleAuthenticatorTest
+{
+    @Test
+    void shouldAuthenticate()
+    {
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+        final long nowMs = 1_000_000L;
+        final long sessionId = 982374;
+
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] encodedCredentials = "user:pass".getBytes(US_ASCII);
+
+        when(mockSessionProxy.sessionId()).thenReturn(sessionId);
+
+        final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+            .principal(encodedPrincipal, encodedCredentials)
+            .newInstance();
+
+        simpleAuthenticator.onConnectRequest(sessionId, encodedCredentials, nowMs);
+        simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+
+        verify(mockSessionProxy).authenticate(encodedPrincipal);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"user:wrong", "wrong:pass"})
+    void shouldReject(final String incorrectCredentials)
+    {
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+        final long nowMs = 1_000_000L;
+        final long sessionId = 982374;
+
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] encodedCredentials = "user:pass".getBytes(US_ASCII);
+
+        when(mockSessionProxy.sessionId()).thenReturn(sessionId);
+
+        final SimpleAuthenticator simpleAuthenticator = new SimpleAuthenticator.Builder()
+            .principal(encodedPrincipal, encodedCredentials)
+            .newInstance();
+
+        simpleAuthenticator.onConnectRequest(sessionId, incorrectCredentials.getBytes(US_ASCII), nowMs);
+        simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+        verify(mockSessionProxy).reject();
+    }
+
+    @Test
+    void shouldHandleMultipleConcurrentAuthenticationRequests()
+    {
+        final long nowMs = 9283479L;
+        final String[][] users = {
+            { "user1", "user1:pass1" },
+            { "user2", "user2:pass2" },
+            { "user3", "user3:pass3" },
+            { "user4", "user4:pass4" },
+            { "user5", "user5:pass5" },
+        };
+        final SessionProxy mockSessionProxy = mock(SessionProxy.class);
+
+        final SimpleAuthenticator.Builder builder = new SimpleAuthenticator.Builder();
+
+        for (final String[] user : users)
+        {
+            builder.principal(user[0].getBytes(US_ASCII), user[1].getBytes(US_ASCII));
+        }
+
+        final SimpleAuthenticator simpleAuthenticator = builder.newInstance();
+
+        for (int i = 0; i < users.length; i++)
+        {
+            simpleAuthenticator.onConnectRequest(i + 1000, users[i][1].getBytes(US_ASCII), nowMs);
+        }
+
+        for (int i = 0; i < users.length; i++)
+        {
+            when(mockSessionProxy.sessionId()).thenReturn(i + 1000L);
+            simpleAuthenticator.onConnectedSession(mockSessionProxy, nowMs);
+            verify(mockSessionProxy).authenticate(users[i][0].getBytes(US_ASCII));
+        }
+    }
+}

--- a/aeron-samples/src/test/java/io/aeron/samples/security/SimpleAuthorisationServiceTest.java
+++ b/aeron-samples/src/test/java/io/aeron/samples/security/SimpleAuthorisationServiceTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.samples.security;
+
+import io.aeron.archive.codecs.MessageHeaderDecoder;
+import io.aeron.archive.codecs.ReplicateRequest2Decoder;
+import io.aeron.archive.codecs.StartRecordingRequestDecoder;
+import io.aeron.archive.codecs.TruncateRecordingRequestDecoder;
+import io.aeron.cluster.codecs.BackupQueryDecoder;
+import io.aeron.security.AuthorisationService;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.aeron.security.AuthorisationService.ALLOW_ALL;
+import static io.aeron.security.AuthorisationService.DENY_ALL;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("checkstyle:Indentation")
+public class SimpleAuthorisationServiceTest
+{
+    public static final int ARCHIVE_PROTOCOL_ID = MessageHeaderDecoder.SCHEMA_ID;
+    public static final int CLUSTER_PROTOCOL_ID = io.aeron.cluster.codecs.MessageHeaderDecoder.SCHEMA_ID;
+    public static final int OTHER_PROTOCOL_ID = 873648576;
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocol(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, true)
+            .addGeneralRule(CLUSTER_PROTOCOL_ID, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocolAndMessage(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, true)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableGeneralAuthorisationForProtocolAndMessageAndType(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+        final String typeAllowed = "allowed";
+        final String typeDenied = "denied";
+        final String typeUnspecified = "unspecified";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, true)
+            .addGeneralRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeUnspecified, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocol(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, encodedPrincipal, true)
+            .addPrincipalRule(CLUSTER_PROTOCOL_ID, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            OTHER_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocolAndMessage(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, true)
+            .addPrincipalRule(ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, ReplicateRequest2Decoder.TEMPLATE_ID, "some resource", encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldEnableUserSpecificAuthorisationForProtocolAndMessageAndType(final boolean shouldAcceptByDefault)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final AuthorisationService defaultAuthorisation = shouldAcceptByDefault ? ALLOW_ALL : DENY_ALL;
+
+        final String typeAllowed = "allowed";
+        final String typeDenied = "denied";
+        final String typeUnspecified = "unspecified";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(defaultAuthorisation)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal, true)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal, false)
+            .newInstance();
+
+        assertTrue(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+
+        assertFalse(simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeDenied, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeUnspecified, encodedPrincipal));
+
+        assertEquals(shouldAcceptByDefault, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldPrioritisePrincipalOverGeneralRules(final boolean accept)
+    {
+        final byte[] encodedPrincipal = "user".getBytes(US_ASCII);
+        final byte[] unknownPrincipal = "unknownUser".getBytes(US_ASCII);
+        final String typeAllowed = "allowed";
+
+        final SimpleAuthorisationService simpleAuthorisationService = new SimpleAuthorisationService.Builder()
+            .defaultAuthorisation(!accept ? ALLOW_ALL : DENY_ALL)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal, accept)
+            .addGeneralRule(
+                ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, !accept)
+            .addPrincipalRule(
+                ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, encodedPrincipal, accept)
+            .addGeneralRule(
+                ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, !accept)
+            .addPrincipalRule(
+                CLUSTER_PROTOCOL_ID, encodedPrincipal, accept)
+            .addGeneralRule(
+                CLUSTER_PROTOCOL_ID, !accept)
+            .newInstance();
+
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, encodedPrincipal));
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, encodedPrincipal));
+        assertEquals(accept, simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, encodedPrincipal));
+
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, StartRecordingRequestDecoder.TEMPLATE_ID, typeAllowed, unknownPrincipal));
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            ARCHIVE_PROTOCOL_ID, TruncateRecordingRequestDecoder.TEMPLATE_ID, null, unknownPrincipal));
+        assertEquals(!accept, simpleAuthorisationService.isAuthorised(
+            CLUSTER_PROTOCOL_ID, BackupQueryDecoder.TEMPLATE_ID, null, unknownPrincipal));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def toolchainLauncher = javaToolchains.launcherFor {
 def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
-def agronaVersion = '1.19.0-SNAPSHOT'
+def agronaVersion = '1.19.0'
 def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.19.0 and < 2.0.0
 def sbeVersion = '1.28.3'
 def checkstyleVersion = '9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
 def agronaVersion = '1.19.0-SNAPSHOT'
-def agronaVersionRange = '[1.18.2,2.0[' // allow any release >= 1.18.2 and < 2.0.0
+def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.18.2 and < 2.0.0
 def sbeVersion = '1.28.3'
 def checkstyleVersion = '9.3'
 def hamcrestVersion = '2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
 def agronaVersion = '1.19.0-SNAPSHOT'
-def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.90.0 and < 2.0.0
+def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.19.0 and < 2.0.0
 def sbeVersion = '1.28.3'
 def checkstyleVersion = '9.3'
 def hamcrestVersion = '2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def toolchainLauncher = javaToolchains.launcherFor {
 def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
-def agronaVersion = '1.18.2'
+def agronaVersion = '1.19.0-SNAPSHOT'
 def agronaVersionRange = '[1.18.2,2.0[' // allow any release >= 1.18.2 and < 2.0.0
 def sbeVersion = '1.28.3'
 def checkstyleVersion = '9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ def aeronGroup = 'io.aeron'
 def aeronVersion = file('version.txt').text.trim()
 
 def agronaVersion = '1.19.0-SNAPSHOT'
-def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.18.2 and < 2.0.0
+def agronaVersionRange = '[1.19.0,2.0[' // allow any release >= 1.90.0 and < 2.0.0
 def sbeVersion = '1.28.3'
 def checkstyleVersion = '9.3'
 def hamcrestVersion = '2.2'


### PR DESCRIPTION
- Add Authentication and Authorisation services that allow for simple configuration of principals and roles.
- Add Javadoc that enumerates the protocol, action and types that are relevant to authorisation calls.
- Prevent memory leaks in the SampleAuthenticator.