### PR TITLE
[C/Java] Changes to host name resolution upon media driver startup.

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverComponentLogger.java
@@ -255,6 +255,13 @@ public class DriverComponentLogger implements ComponentLogger
             DriverInterceptor.NameResolution.Lookup.class,
             "logLookup");
 
+        tempBuilder = addEventInstrumentation(
+            tempBuilder,
+            NAME_RESOLUTION_HOST_NAME,
+            "TimeTrackingNameResolver",
+            DriverInterceptor.NameResolution.HostName.class,
+            "logHostName");
+
         return tempBuilder;
     }
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventCode.java
@@ -88,7 +88,10 @@ public enum DriverEventCode implements EventCode
     TEXT_DATA(51, DriverEventDissector::dissectString),
 
     NAME_RESOLUTION_LOOKUP(52,
-        (code, buffer, offset, builder) -> DriverEventDissector.dissectLookup(buffer, offset, builder));
+        (code, buffer, offset, builder) -> DriverEventDissector.dissectLookup(buffer, offset, builder)),
+
+    NAME_RESOLUTION_HOST_NAME(53,
+        (code, buffer, offset, builder) -> DriverEventDissector.dissectHostName(buffer, offset, builder));
 
     static final int EVENT_CODE_TYPE = EventCodeType.DRIVER.getTypeCode();
 

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventDissector.java
@@ -380,6 +380,19 @@ final class DriverEventDissector
         buffer.getStringAscii(absoluteOffset, builder);
     }
 
+    static void dissectHostName(
+        final MutableDirectBuffer buffer, final int offset, final StringBuilder builder)
+    {
+        int absoluteOffset = offset;
+        absoluteOffset += dissectLogHeader(CONTEXT, NAME_RESOLUTION_HOST_NAME, buffer, absoluteOffset, builder);
+
+        builder.append(": durationNs=").append(buffer.getLong(absoluteOffset, LITTLE_ENDIAN));
+        absoluteOffset += SIZE_OF_LONG;
+
+        builder.append(" hostName=");
+        buffer.getStringAscii(absoluteOffset, builder);
+    }
+
     static int frameType(final MutableDirectBuffer buffer, final int termOffset)
     {
         return buffer.getShort(FrameDescriptor.typeOffset(termOffset), LITTLE_ENDIAN) & 0xFFFF;

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventEncoder.java
@@ -293,4 +293,21 @@ final class DriverEventEncoder
         encodeTrailingString(
             encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, resolvedName);
     }
+
+    static void encodeHostName(
+        final UnsafeBuffer encodingBuffer,
+        final int offset,
+        final int length,
+        final int captureLength,
+        final long durationNs,
+        final String hostName)
+    {
+        int encodedLength = encodeLogHeader(encodingBuffer, offset, captureLength, length);
+
+        encodingBuffer.putLong(offset + encodedLength, durationNs, LITTLE_ENDIAN);
+        encodedLength += SIZE_OF_LONG;
+
+        encodedLength += encodeTrailingString(
+            encodingBuffer, offset + encodedLength, SIZE_OF_INT + MAX_HOST_NAME_LENGTH, hostName);
+    }
 }

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverEventLogger.java
@@ -386,8 +386,8 @@ public final class DriverEventLogger
      * @param resolverName simple class name of the resolver
      * @param durationNs   of the call in nanoseconds.
      * @param name         host name being resolved
-     * @param isReLookup      address that was resolved to, can be null
-     * @param resolvedName      address that was resolved to, can be null
+     * @param isReLookup   address that was resolved to, can be null
+     * @param resolvedName address that was resolved to, can be null
      */
     public void logLookup(
         final String resolverName,
@@ -418,6 +418,39 @@ public final class DriverEventLogger
                     name,
                     isReLookup,
                     resolvedName);
+            }
+            finally
+            {
+                ringBuffer.commit(index);
+            }
+        }
+    }
+
+    /**
+     * Log a host name resolution duration.
+     *
+     * @param durationNs of the call in nanoseconds.
+     * @param hostName   host name being resolved.
+     */
+    public void logHostName(final long durationNs, final String hostName)
+    {
+        final int length = SIZE_OF_LONG + trailingStringLength(hostName, MAX_HOST_NAME_LENGTH);
+
+        final int encodedLength = encodedLength(length);
+
+        final ManyToOneRingBuffer ringBuffer = this.ringBuffer;
+        final int index = ringBuffer.tryClaim(toEventCodeId(NAME_RESOLUTION_HOST_NAME), encodedLength);
+        if (index > 0)
+        {
+            try
+            {
+                encodeHostName(
+                    (UnsafeBuffer)ringBuffer.buffer(),
+                    index,
+                    length,
+                    length,
+                    durationNs,
+                    hostName);
             }
             finally
             {

--- a/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/DriverInterceptor.java
@@ -82,6 +82,17 @@ class DriverInterceptor
                 LOGGER.logLookup(resolverName, durationNs, name, isReLookup, resolvedName);
             }
         }
+
+        static class HostName
+        {
+            @Advice.OnMethodEnter
+            static void logHostName(
+                final long durationNs,
+                final String hostName)
+            {
+                LOGGER.logHostName(durationNs, hostName);
+            }
+        }
     }
 
     static class FlowControl

--- a/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/DriverEventDissectorTest.java
@@ -732,6 +732,23 @@ class DriverEventDissectorTest
             "resolver=xyz durationNs=32167 name=localhost:7777 isReLookup=false resolvedName=test:1234"));
     }
 
+    @Test
+    void dissectHostName()
+    {
+        final int offset = 8;
+        final long durationNs = 32167;
+        final String hostName = "some.funky.host.name";
+
+        final int length = SIZE_OF_LONG + trailingStringLength(hostName, MAX_HOST_NAME_LENGTH);
+
+        DriverEventEncoder.encodeHostName(buffer, offset, length, length, durationNs, hostName);
+        final StringBuilder builder = new StringBuilder();
+        DriverEventDissector.dissectHostName(buffer, offset, builder);
+
+        assertThat(builder.toString(), endsWith(
+            "DRIVER: NAME_RESOLUTION_HOST_NAME [32/32]: durationNs=32167 hostName=some.funky.host.name"));
+    }
+
     private DirectBuffer newBuffer(final byte[] bytes)
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(allocate(bytes.length));

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -658,10 +658,7 @@ int aeron_driver_conductor_init(aeron_driver_conductor_t *conductor, aeron_drive
     char host_name[AERON_MAX_HOSTNAME_LEN];
     if (gethostname(host_name, AERON_MAX_HOSTNAME_LEN) < 0)
     {
-        char *fallback_host_name = "<unresolved>";
-        size_t fallback_host_name_length = strlen(fallback_host_name);
-        strncpy(host_name, fallback_host_name, fallback_host_name_length);
-        host_name[fallback_host_name_length] = '\0';
+        strcpy(host_name, "<unresolved>");
     }
 
     int64_t end_ns = context->nano_clock();

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -94,6 +94,10 @@ typedef void (*aeron_driver_name_resolver_on_lookup_t)(
     bool is_re_lookup,
     const char *resolved_name);
 
+typedef void (*aeron_driver_name_resolver_on_host_name_t)(
+    int64_t duration_ns,
+    const char *host_name);
+
 typedef struct aeron_driver_context_stct
 {
     char *aeron_dir;                                        /* aeron.dir */
@@ -274,11 +278,13 @@ typedef struct aeron_driver_context_stct
     const char *resolver_name;
     const char *resolver_interface;
     const char *resolver_bootstrap_neighbor;
+    const char *name_resolver_init_args;
+    const char *name_resolver_host_name;
     aeron_name_resolver_supplier_func_t name_resolver_supplier_func;
     aeron_name_resolver_supplier_func_t driver_name_resolver_bootstrap_resolver_supplier_func;
-    const char *name_resolver_init_args;
     aeron_driver_name_resolver_on_resolve_t on_name_resolve_func;
     aeron_driver_name_resolver_on_lookup_t on_name_lookup_func;
+    aeron_driver_name_resolver_on_host_name_t on_host_name_func;
 
     aeron_duty_cycle_tracker_t *conductor_duty_cycle_tracker;
     aeron_duty_cycle_tracker_t *sender_duty_cycle_tracker;

--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.h
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.h
@@ -74,6 +74,7 @@ typedef enum aeron_driver_agent_event_enum
     AERON_DRIVER_EVENT_NAME_RESOLUTION_RESOLVE = 50,
     AERON_DRIVER_EVENT_NAME_TEXT_DATA = 51,
     AERON_DRIVER_EVENT_NAME_RESOLUTION_LOOKUP = 52,
+    AERON_DRIVER_EVENT_NAME_RESOLUTION_HOST_NAME = 53,
 
     // C-specific events. Note: event IDs are dynamic to avoid gaps in the sparse arrays.
     AERON_DRIVER_EVENT_ADD_DYNAMIC_DISSECTOR,
@@ -186,6 +187,14 @@ typedef struct aeron_driver_agent_name_resolver_lookup_log_header_stct
     bool is_re_lookup;
 }
 aeron_driver_agent_name_resolver_lookup_log_header_t;
+
+typedef struct aeron_driver_agent_name_resolver_host_name_log_header_stct
+{
+    int64_t time_ns;
+    int64_t duration_ns;
+    int32_t host_name_length;
+}
+aeron_driver_agent_name_resolver_host_name_log_header_t;
 
 typedef struct aeron_driver_agent_text_data_log_header_stct
 {

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -177,7 +177,7 @@ public final class DriverConductor implements Agent
 
         ctx.systemCounters().get(RESOLUTION_CHANGES).appendToLabel(
             ": driverName=" + ctx.resolverName() +
-            " hostname=" + (null != hostName ? hostName : "<unresolved>"));
+            " hostname=" + hostName);
 
         ctx.systemCounters().get(CONDUCTOR_MAX_CYCLE_TIME).appendToLabel(": " + ctx.threadingMode().name());
         ctx.systemCounters().get(CONDUCTOR_CYCLE_TIME_THRESHOLD_EXCEEDED).appendToLabel(

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -258,7 +258,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         }
         catch (final UnknownHostException ignore)
         {
-            return null;
+            return "<unresolved>";
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverNameResolver.java
@@ -92,7 +92,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
     private long selfResolutionDeadlineMs;
     private long neighborResolutionDeadlineMs;
 
-    DriverNameResolver(final MediaDriver.Context ctx)
+    DriverNameResolver(final MediaDriver.Context ctx, final String hostName)
     {
         mtuLength = ctx.mtuLength();
         invalidPackets = ctx.systemCounters().get(SystemCounterDescriptor.INVALID_PACKETS);
@@ -110,7 +110,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
             UdpNameResolutionTransport.getInterfaceAddress(ctx.resolverInterface()) :
             new InetSocketAddress("0.0.0.0", 0);
 
-        localDriverName = null != ctx.resolverName() ? ctx.resolverName() : getCanonicalName();
+        localDriverName = null != ctx.resolverName() ? ctx.resolverName() : hostName;
         localName = localDriverName.getBytes(StandardCharsets.US_ASCII);
         localAddress = localSocketAddress.getAddress().getAddress();
 
@@ -250,23 +250,7 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         return 0;
     }
 
-    static String getCanonicalName()
-    {
-        String canonicalName = null;
-
-        try
-        {
-            canonicalName = InetAddress.getLocalHost().getHostName();
-        }
-        catch (final UnknownHostException ex)
-        {
-            LangUtil.rethrowUnchecked(ex);
-        }
-
-        return canonicalName;
-    }
-
-    static String getCanonicalName(final String fallback)
+    static String getHostName()
     {
         try
         {
@@ -274,10 +258,9 @@ final class DriverNameResolver implements AutoCloseable, UdpNameResolutionTransp
         }
         catch (final UnknownHostException ignore)
         {
-            return fallback;
+            return null;
         }
     }
-
 
     private void openDatagramChannel()
     {

--- a/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/TimeTrackingNameResolver.java
@@ -109,6 +109,10 @@ final class TimeTrackingNameResolver implements NameResolver, AutoCloseable
         }
     }
 
+    static void logHostName(final long durationNs, final String hostName)
+    {
+    }
+
     private static void logResolve(
         final String resolverName,
         final long durationNs,

--- a/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
+++ b/aeron-driver/src/test/c/agent/aeron_driver_agent_test.cpp
@@ -1519,18 +1519,25 @@ TEST_F(DriverAgentTest, dissecLogHeaderShouldFormatNanoTimeWithMicrosecondPrecis
     ASSERT_EQ("[333000555.000999] DRIVER: CMD_IN_CLIENT_CLOSE [100/200]", result);
 }
 
-TEST_F(DriverAgentTest, shouldNotAssignFlowControlOnNameResolveFunctionWhenNotConfigured)
+TEST_F(DriverAgentTest, shouldNotAssignOnNameResolveFunctionWhenNotConfigured)
 {
     aeron_driver_agent_init_logging_events_interceptors(m_context);
 
     EXPECT_EQ(nullptr, m_context->on_name_resolve_func);
 }
 
-TEST_F(DriverAgentTest, shouldNotAssignFlowControlOnNameLookupFunctionWhenNotConfigured)
+TEST_F(DriverAgentTest, shouldNotAssignOnNameLookupFunctionWhenNotConfigured)
 {
     aeron_driver_agent_init_logging_events_interceptors(m_context);
 
     EXPECT_EQ(nullptr, m_context->on_name_lookup_func);
+}
+
+TEST_F(DriverAgentTest, shouldNotHostNameFunctionWhenNotConfigured)
+{
+    aeron_driver_agent_init_logging_events_interceptors(m_context);
+
+    EXPECT_EQ(nullptr, m_context->on_host_name_func);
 }
 
 TEST_F(DriverAgentTest, shouldInitializeOnNameResolveFunction)
@@ -1555,10 +1562,11 @@ TEST_F(DriverAgentTest, shouldInitializeOnNameLookupFunction)
 
 TEST_F(DriverAgentTest, shouldInitializeNameResolverFunctions)
 {
-    EXPECT_TRUE(aeron_driver_agent_logging_events_init("NAME_RESOLUTION_LOOKUP,NAME_RESOLUTION_RESOLVE", nullptr));
+    EXPECT_TRUE(aeron_driver_agent_logging_events_init("NAME_RESOLUTION_LOOKUP,NAME_RESOLUTION_RESOLVE,NAME_RESOLUTION_HOST_NAME", nullptr));
     aeron_driver_agent_init_logging_events_interceptors(m_context);
 
     EXPECT_NE(nullptr, m_context->on_name_resolve_func);
     EXPECT_NE(nullptr, m_context->on_name_lookup_func);
+    EXPECT_NE(nullptr, m_context->on_host_name_func);
     EXPECT_NE((void *)m_context->on_name_resolve_func, (void *)m_context->on_name_lookup_func);
 }

--- a/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
@@ -466,14 +466,16 @@ class NameReResolutionTest
     @Test
     void shouldTrackNameResolutionTime()
     {
-        assertEquals(0, countersReader.getCounterValue(NAME_RESOLVER_MAX_TIME.id()));
-        assertEquals(0, countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id()));
+        final long maxTimeNs = countersReader.getCounterValue(NAME_RESOLVER_MAX_TIME.id());
+        final long thresholdCounter = countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id());
+        assertNotEquals(0, maxTimeNs);
+        assertNotEquals(0, thresholdCounter);
 
         publication = client.addPublication(PUBLICATION_URI, STREAM_ID);
         publication.close();
 
         assertNotEquals(0, countersReader.getCounterValue(NAME_RESOLVER_MAX_TIME.id()));
-        assertNotEquals(0, countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id()));
+        assertNotEquals(thresholdCounter, countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id()));
     }
 
     private static void assumeBindAddressAvailable(final String address)

--- a/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
@@ -466,10 +466,12 @@ class NameReResolutionTest
     @Test
     void shouldTrackNameResolutionTime()
     {
+        Tests.awaitCounterDelta(countersReader, NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id(), 0, 1);
+
         final long maxTimeNs = countersReader.getCounterValue(NAME_RESOLVER_MAX_TIME.id());
-        final long thresholdCounter = countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id());
         assertNotEquals(0, maxTimeNs);
-        assertNotEquals(0, thresholdCounter);
+        final long thresholdCounter = countersReader.getCounterValue(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED.id());
+        assertEquals(1, thresholdCounter);
 
         publication = client.addPublication(PUBLICATION_URI, STREAM_ID);
         publication.close();


### PR DESCRIPTION
This PR contains the following changes:
* Host name is resolved only once.
* Host name resolution time is tracked via name resolution duty cycle tracker.
* Agent logging was added around host name resolution.
* For Java the name resolution happens after the time was initialized, i.e. the pause will be reflected in a DriveConductor's duty cycle counter.
* C driver name resolution logging fixes.