### PR TITLE
Cluster relocatable mark files

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -1907,7 +1907,7 @@ public final class ConsensusModule implements AutoCloseable
          * defaults to {@link #clusterDir()} if it is not set explicitly via the
          * {@link ClusteredServiceContainer.Configuration#MARK_FILE_DIR_PROP_NAME}.
          *
-         * @return the directory in which the Archive will store mark file (i.e. {@code cluster-mark.dat}).
+         * @return the directory in which the ConsensusModule will store mark file (i.e. {@code cluster-mark.dat}).
          * @see ClusteredServiceContainer.Configuration#MARK_FILE_DIR_PROP_NAME
          * @see #clusterDir()
          */
@@ -1917,7 +1917,7 @@ public final class ConsensusModule implements AutoCloseable
         }
 
         /**
-         * Set the directory in which the Archive will store mark file (i.e. {@code cluster-mark.dat}).
+         * Set the directory in which the ConsensusModule will store mark file (i.e. {@code cluster-mark.dat}).
          *
          * @param markFileDir the directory in which the Archive will store mark file (i.e. {@code cluster-mark.dat}).
          * @return this for a fluent API.

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -431,6 +431,17 @@ public final class ClusterMarkFile implements AutoCloseable
     }
 
     /**
+     * The filename to be used for the link file given a service id.
+     *
+     * @param serviceId of the service the {@link ClusterMarkFile} represents.
+     * @return the filename to be used for the link file given a service id.
+     */
+    public static String linkFilenameForService(final int serviceId)
+    {
+        return SERVICE_FILENAME_PREFIX + serviceId + LINK_FILE_EXTENSION;
+    }
+
+    /**
      * The control properties for communicating between the consensus module and the services.
      *
      * @return the control properties for communicating between the consensus module and the services.

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusterMarkFile.java
@@ -55,7 +55,9 @@ public final class ClusterMarkFile implements AutoCloseable
     public static final int ERROR_BUFFER_MAX_LENGTH = Integer.MAX_VALUE - HEADER_LENGTH;
 
     public static final String FILE_EXTENSION = ".dat";
+    public static final String LINK_FILE_EXTENSION = ".lnk";
     public static final String FILENAME = "cluster-mark" + FILE_EXTENSION;
+    public static final String LINK_FILENAME = "cluster-mark" + LINK_FILE_EXTENSION;
     public static final String SERVICE_FILENAME_PREFIX = "cluster-mark-service-";
 
     private final MarkFileHeaderDecoder headerDecoder = new MarkFileHeaderDecoder();
@@ -191,6 +193,18 @@ public final class ClusterMarkFile implements AutoCloseable
         buffer = markFile.buffer();
         headerDecoder.wrap(buffer, 0, MarkFileHeaderDecoder.BLOCK_LENGTH, MarkFileHeaderDecoder.SCHEMA_VERSION);
         errorBuffer = new UnsafeBuffer(buffer, headerDecoder.headerLength(), headerDecoder.errorBufferLength());
+    }
+
+
+    /**
+     * Get the parent directory containing the mark file.
+     *
+     * @return parent directory of the mark file.
+     * @see MarkFile#parentDirectory()
+     */
+    public File parentDirectory()
+    {
+        return markFile.parentDirectory();
     }
 
     /**

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -744,8 +744,8 @@ public final class ClusteredServiceContainer implements AutoCloseable
 
             MarkFile.ensureMarkFileLink(
                 clusterDir,
-                new File(markFileDir, ClusterMarkFile.FILENAME),
-                ClusterMarkFile.LINK_FILENAME);
+                new File(markFileDir, ClusterMarkFile.markFilenameForService(serviceId)),
+                ClusterMarkFile.linkFilenameForService(serviceId));
 
             if (null == errorLog)
             {
@@ -1518,11 +1518,12 @@ public final class ClusteredServiceContainer implements AutoCloseable
         }
 
         /**
-         * Get the directory in which the ConsensusModule will store mark file (i.e. {@code
+         * Get the directory in which the ClusteredServiceContainer will store mark file (i.e. {@code
          * cluster-mark-service-0.dat}). It defaults to {@link #clusterDir()} if it is not set explicitly via the {@link
          * ClusteredServiceContainer.Configuration#MARK_FILE_DIR_PROP_NAME}.
          *
-         * @return the directory in which the Archive will store mark file (i.e. {@code cluster-mark-service-0.dat}).
+         * @return the directory in which the ClusteredServiceContainer will store mark file (i.e. {@code
+         *         cluster-mark-service-0.dat}).
          * @see ClusteredServiceContainer.Configuration#MARK_FILE_DIR_PROP_NAME
          * @see #clusterDir()
          */
@@ -1532,9 +1533,10 @@ public final class ClusteredServiceContainer implements AutoCloseable
         }
 
         /**
-         * Set the directory in which the Archive will store mark file (i.e. {@code cluster-mark-service-0.dat}).
+         * Set the directory in which the ClusteredServiceContainer will store mark file (i.e. {@code
+         * cluster-mark-service-0.dat}).
          *
-         * @param markFileDir the directory in which the Archive will store mark file (i.e. {@code
+         * @param markFileDir the directory in which the ClusteredServiceContainer will store mark file (i.e. {@code
          *                    cluster-mark-service-0.dat}).
          * @return this for a fluent API.
          */

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -536,6 +536,7 @@ class ConsensusModuleContextTest
 
             assertEquals(markFileDir, context.markFileDir());
             assertTrue(markFileDir.exists());
+            assertTrue(new File(context.clusterDir(), ClusterMarkFile.LINK_FILENAME).exists());
         }
         finally
         {
@@ -555,6 +556,7 @@ class ConsensusModuleContextTest
 
         assertEquals(markFileDir, context.markFileDir());
         assertTrue(markFileDir.exists());
+        assertTrue(new File(context.clusterDir(), ClusterMarkFile.LINK_FILENAME).exists());
     }
 
     @ParameterizedTest

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ConsensusModuleContextTest.java
@@ -58,6 +58,7 @@ import static io.aeron.AeronCounters.NODE_CONTROL_TOGGLE_TYPE_ID;
 import static io.aeron.cluster.ConsensusModule.Configuration.*;
 import static io.aeron.cluster.codecs.mark.ClusterComponentType.CONSENSUS_MODULE;
 import static io.aeron.cluster.service.ClusterMarkFile.ERROR_BUFFER_MIN_LENGTH;
+import static io.aeron.cluster.service.ClusteredServiceContainer.Configuration.MARK_FILE_DIR_PROP_NAME;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -517,6 +518,59 @@ class ConsensusModuleContextTest
 
         assertEquals(
             new File(context.clusterDirectoryName()).getCanonicalPath(), context.clusterDir().getCanonicalPath());
+    }
+
+    @Test
+    void concludeShouldCreateMarkFileDirSetViaSystemProperty(final @TempDir File tempDir)
+    {
+        final File rootDir = new File(tempDir, "root");
+        final File markFileDir = new File(rootDir, "mark-file-dir");
+        assertFalse(markFileDir.exists());
+
+        System.setProperty(MARK_FILE_DIR_PROP_NAME, markFileDir.getAbsolutePath());
+        try
+        {
+            assertSame(null, context.markFileDir());
+
+            context.conclude();
+
+            assertEquals(markFileDir, context.markFileDir());
+            assertTrue(markFileDir.exists());
+        }
+        finally
+        {
+            System.clearProperty(MARK_FILE_DIR_PROP_NAME);
+        }
+    }
+
+    @Test
+    void concludeShouldCreateMarkFileDirSetDirectly(final @TempDir File tempDir)
+    {
+        final File rootDir = new File(tempDir, "root");
+        final File markFileDir = new File(rootDir, "mark-file-dir");
+        assertFalse(markFileDir.exists());
+        context.markFileDir(markFileDir);
+
+        context.conclude();
+
+        assertEquals(markFileDir, context.markFileDir());
+        assertTrue(markFileDir.exists());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldRemoveLinkIfMarkFileIsInClusterDir(final boolean isSet) throws IOException
+    {
+        final File markFileDir = isSet ? context.clusterDir() : null;
+
+        context.markFileDir(markFileDir);
+        final File oldLinkFile = new File(context.clusterDir(), ClusterMarkFile.LINK_FILENAME);
+        assertTrue(oldLinkFile.createNewFile());
+        assertTrue(oldLinkFile.exists());
+
+        context.conclude();
+
+        assertFalse(oldLinkFile.exists());
     }
 
     public static class TestAuthorisationSupplier implements AuthorisationServiceSupplier

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -99,6 +99,8 @@ class ClusteredServiceContainerContextTest
 
             assertEquals(markFileDir, context.markFileDir());
             assertTrue(markFileDir.exists());
+            assertTrue(
+                new File(context.clusterDir(), ClusterMarkFile.linkFilenameForService(context.serviceId())).exists());
         }
         finally
         {
@@ -118,6 +120,8 @@ class ClusteredServiceContainerContextTest
 
         assertEquals(markFileDir, context.markFileDir());
         assertTrue(markFileDir.exists());
+        assertTrue(
+            new File(context.clusterDir(), ClusterMarkFile.linkFilenameForService(context.serviceId())).exists());
     }
 
     @ParameterizedTest
@@ -127,7 +131,7 @@ class ClusteredServiceContainerContextTest
         final File markFileDir = isSet ? context.clusterDir() : null;
 
         context.serviceId(serviceId).markFileDir(markFileDir);
-        final File oldLinkFile = new File(context.clusterDir(), ClusterMarkFile.markFilenameForService(serviceId));
+        final File oldLinkFile = new File(context.clusterDir(), ClusterMarkFile.linkFilenameForService(serviceId));
         assertTrue(oldLinkFile.createNewFile());
         assertTrue(oldLinkFile.exists());
 

--- a/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/service/ClusteredServiceContainerContextTest.java
@@ -18,6 +18,7 @@ package io.aeron.cluster.service;
 import io.aeron.Aeron;
 import io.aeron.Counter;
 import io.aeron.RethrowingErrorHandler;
+import org.agrona.CloseHelper;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,6 +106,7 @@ class ClusteredServiceContainerContextTest
         finally
         {
             System.clearProperty(MARK_FILE_DIR_PROP_NAME);
+            CloseHelper.quietClose(context::close);
         }
     }
 
@@ -116,12 +118,19 @@ class ClusteredServiceContainerContextTest
         assertFalse(markFileDir.exists());
         context.serviceId(serviceId).markFileDir(markFileDir);
 
-        context.conclude();
+        try
+        {
+            context.conclude();
 
-        assertEquals(markFileDir, context.markFileDir());
-        assertTrue(markFileDir.exists());
-        assertTrue(
-            new File(context.clusterDir(), ClusterMarkFile.linkFilenameForService(context.serviceId())).exists());
+            assertEquals(markFileDir, context.markFileDir());
+            assertTrue(markFileDir.exists());
+            assertTrue(
+                new File(context.clusterDir(), ClusterMarkFile.linkFilenameForService(context.serviceId())).exists());
+        }
+        finally
+        {
+            CloseHelper.quietClose(context::close);
+        }
     }
 
     @ParameterizedTest
@@ -135,8 +144,15 @@ class ClusteredServiceContainerContextTest
         assertTrue(oldLinkFile.createNewFile());
         assertTrue(oldLinkFile.exists());
 
-        context.conclude();
+        try
+        {
+            context.conclude();
 
-        assertFalse(oldLinkFile.exists());
+            assertFalse(oldLinkFile.exists());
+        }
+        finally
+        {
+            CloseHelper.quietClose(context::close);
+        }
     }
 }

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -156,6 +156,7 @@ public final class TestCluster implements AutoCloseable
     private IntHashSet byHostInvalidInitialResolutions;
     private IntHashSet byMemberInvalidInitialResolutions;
     private boolean acceptStandbySnapshots;
+    private File markFileBaseDir;
 
     private TestCluster(
         final int staticMemberCount,
@@ -276,6 +277,7 @@ public final class TestCluster implements AutoCloseable
     {
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestNode.Context context = new TestNode.Context(serviceSupplier.apply(index), nodeNameMappings());
 
         context.aeronArchiveContext
@@ -322,6 +324,7 @@ public final class TestCluster implements AutoCloseable
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
             .acceptStandbySnapshots(acceptStandbySnapshots)
+            .markFileDir(markFileDir)
             .deleteDirOnStart(cleanStart);
 
         nodes[index] = new TestNode(context, dataCollector);
@@ -340,6 +343,7 @@ public final class TestCluster implements AutoCloseable
     {
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestNode.Context context = new TestNode.Context(serviceSupplier.apply(index), nodeNameMappings());
 
         context.aeronArchiveContext
@@ -385,6 +389,7 @@ public final class TestCluster implements AutoCloseable
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
             .acceptStandbySnapshots(acceptStandbySnapshots)
+            .markFileDir(markFileDir)
             .deleteDirOnStart(cleanStart);
 
         nodes[index] = new TestNode(context, dataCollector);
@@ -403,6 +408,7 @@ public final class TestCluster implements AutoCloseable
     {
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestNode.Context context = new TestNode.Context(serviceSupplier.apply(index), nodeNameMappings());
 
         context.aeronArchiveContext
@@ -450,6 +456,7 @@ public final class TestCluster implements AutoCloseable
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
             .acceptStandbySnapshots(acceptStandbySnapshots)
+            .markFileDir(markFileDir)
             .deleteDirOnStart(cleanStart);
 
         nodes[index] = new TestNode(context, dataCollector);
@@ -467,6 +474,7 @@ public final class TestCluster implements AutoCloseable
     {
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestNode.Context context = new TestNode.Context(serviceSupplier.apply(index), nodeNameMappings());
 
         context.aeronArchiveContext
@@ -513,6 +521,7 @@ public final class TestCluster implements AutoCloseable
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
             .acceptStandbySnapshots(acceptStandbySnapshots)
+            .markFileDir(markFileDir)
             .deleteDirOnStart(false);
 
         nodes[index] = new TestNode(context, dataCollector);
@@ -545,6 +554,7 @@ public final class TestCluster implements AutoCloseable
         final int index = staticMemberCount + dynamicMemberCount;
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + index;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + index + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + index) : null;
         final TestBackupNode.Context context = new TestBackupNode.Context();
 
         context.aeronArchiveContext
@@ -588,6 +598,7 @@ public final class TestCluster implements AutoCloseable
             .credentialsSupplier(credentialsSupplier)
             .sourceType(sourceType)
             .deleteDirOnStart(cleanStart)
+            .markFileDir(markFileDir)
             .eventsListener(new BackupListener());
 
         backupNode = new TestBackupNode(index, context, dataCollector);
@@ -604,6 +615,7 @@ public final class TestCluster implements AutoCloseable
     {
         final String baseDirName = CommonContext.getAeronDirectoryName() + "-" + backupNodeIndex;
         final String aeronDirName = CommonContext.getAeronDirectoryName() + "-" + backupNodeIndex + "-driver";
+        final File markFileDir = null != markFileBaseDir ? new File(markFileBaseDir, "mark-" + backupNodeIndex) : null;
         final TestNode.Context context = new TestNode.Context(
             serviceSupplier.apply(backupNodeIndex),
             nodeNameMappings());
@@ -651,6 +663,7 @@ public final class TestCluster implements AutoCloseable
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)
             .acceptStandbySnapshots(acceptStandbySnapshots)
+            .markFileDir(markFileDir)
             .deleteDirOnStart(false);
 
         backupNode = null;
@@ -2064,6 +2077,7 @@ public final class TestCluster implements AutoCloseable
         private final IntHashSet byMemberInvalidInitialResolutions = new IntHashSet();
         private int archiveSegmentFileLength = TestCluster.SEGMENT_FILE_LENGTH;
         private boolean acceptStandbySnapshots = false;
+        private File markFileBaseDir = null;
 
         public Builder withStaticNodes(final int nodeCount)
         {
@@ -2148,6 +2162,18 @@ public final class TestCluster implements AutoCloseable
             return this;
         }
 
+        public Builder withSegmentFileLength(final int archiveSegmentFileLength)
+        {
+            this.archiveSegmentFileLength = archiveSegmentFileLength;
+            return this;
+        }
+
+        public Builder markFileBaseDir(final File markFileBaseDir)
+        {
+            this.markFileBaseDir = markFileBaseDir;
+            return this;
+        }
+
         public TestCluster start()
         {
             return start(nodeCount);
@@ -2176,6 +2202,7 @@ public final class TestCluster implements AutoCloseable
             testCluster.segmentFileLength(archiveSegmentFileLength);
             testCluster.invalidInitialResolutions(byHostInvalidInitialResolutions, byMemberInvalidInitialResolutions);
             testCluster.acceptStandbySnapshots(acceptStandbySnapshots);
+            testCluster.markFileBaseDir(markFileBaseDir);
 
             try
             {
@@ -2202,12 +2229,11 @@ public final class TestCluster implements AutoCloseable
 
             return testCluster;
         }
+    }
 
-        public Builder withSegmentFileLength(final int archiveSegmentFileLength)
-        {
-            this.archiveSegmentFileLength = archiveSegmentFileLength;
-            return this;
-        }
+    private void markFileBaseDir(final File markFileBaseDir)
+    {
+        this.markFileBaseDir = markFileBaseDir;
     }
 
     private void invalidInitialResolutions(

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -103,7 +103,6 @@ public final class TestNode implements AutoCloseable
             dataCollector.addForCleanup(baseDir);
 
             containers = new ClusteredServiceContainer[services.length];
-            final File servicesDir = new File(baseDir, "services");
             for (int i = 0; i < services.length; i++)
             {
                 final ClusteredServiceContainer.Context ctx = context.serviceContainerContext.clone();
@@ -113,13 +112,13 @@ public final class TestNode implements AutoCloseable
                         .controlResponseChannel("aeron:ipc"))
                     .terminationHook(ClusterTests.terminationHook(
                         context.isTerminationExpected, context.hasServiceTerminated[i]))
-                    .clusterDir(servicesDir)
+                    .clusterDir(context.consensusModuleContext.clusterDir())
+                    .markFileDir(context.consensusModuleContext.markFileDir())
                     .clusteredService(services[i])
                     .serviceId(i);
                 containers[i] = ClusteredServiceContainer.launch(ctx);
             }
 
-            dataCollector.add(servicesDir.toPath());
             dataCollector.add(consensusModule.context().clusterDir().toPath());
             dataCollector.add(archive.context().archiveDir().toPath());
             dataCollector.add(mediaDriver.context().aeronDirectory().toPath());


### PR DESCRIPTION
Allows for the consensus module, clustered service container and cluster backup to store their mark files in a location other than in the cluster directory (e.g. on a in-memory file system).  This allows for improved performance due to reducing I/O for writing the timestamp into the mark file.