### PR TITLE
[C] Fix aeron_err_clear().

### DIFF
--- a/aeron-client/src/main/c/util/aeron_error.c
+++ b/aeron-client/src/main/c/util/aeron_error.c
@@ -318,6 +318,7 @@ void aeron_err_clear(void)
 
     aeron_set_errno(0);
     error_state->errcode = 0;
+    error_state->offset = 0;
     strcpy(error_state->errmsg, "no error");
 }
 

--- a/aeron-client/src/test/c/util/aeron_error_test.cpp
+++ b/aeron-client/src/test/c/util/aeron_error_test.cpp
@@ -17,9 +17,9 @@
 #include <array>
 #include <atomic>
 #include <thread>
-#include <cstdint>
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 extern "C"
 {
@@ -120,6 +120,19 @@ TEST_F(ErrorTest, shouldReportZeroAsErrorForBackwardCompatibility)
     index = assert_substring(err_msg, "] this is the root error", index);
 
     EXPECT_LT(index, err_msg.length());
+}
+
+TEST_F(ErrorTest, shouldAllowToAppendAfterClearing)
+{
+    AERON_APPEND_ERR("%s", "first error");
+    aeron_err_clear();
+    AERON_APPEND_ERR("%s", "second error");
+
+    std::string err_msg = std::string(aeron_errmsg());
+
+    EXPECT_THAT(err_msg, testing::Not(testing::HasSubstr("no error")));
+    EXPECT_THAT(err_msg, testing::Not(testing::HasSubstr("first error")));
+    EXPECT_THAT(err_msg, testing::HasSubstr("second error"));
 }
 
 #define CALLS_PER_THREAD (1000)


### PR DESCRIPTION
Noticed that sometimes "no error" is reported instead of the actual error. If you clear and then append without setting first, then modifications will be done at previous offset and will be invisible.