### PR TITLE
[C] Only count active subscriptions in is drained check

### DIFF
--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -260,7 +260,7 @@ inline bool aeron_publication_image_is_drained(aeron_publication_image_t *image)
     {
         aeron_tetherable_position_t *tetherable_position = &image->conductor_fields.subscribable.array[i];
 
-        if (AERON_SUBSCRIPTION_TETHER_RESTING != tetherable_position->state)
+        if (AERON_SUBSCRIPTION_TETHER_ACTIVE = tetherable_position->state)
         {
             const int64_t sub_pos = aeron_counter_get_volatile(tetherable_position->value_addr);
 

--- a/aeron-driver/src/main/c/aeron_publication_image.h
+++ b/aeron-driver/src/main/c/aeron_publication_image.h
@@ -260,7 +260,7 @@ inline bool aeron_publication_image_is_drained(aeron_publication_image_t *image)
     {
         aeron_tetherable_position_t *tetherable_position = &image->conductor_fields.subscribable.array[i];
 
-        if (AERON_SUBSCRIPTION_TETHER_ACTIVE = tetherable_position->state)
+        if (AERON_SUBSCRIPTION_TETHER_ACTIVE == tetherable_position->state)
         {
             const int64_t sub_pos = aeron_counter_get_volatile(tetherable_position->value_addr);
 


### PR DESCRIPTION
If an image is in the draining state it does not call aeron_publication_image_check_untethered_subscriptions, so all subscriptions maintain their state forever.
If one of the subscriptions is in the linger state it will never progress to resting if it is completely blocked.
Therefore the aeron_publication_image_is_drained here https://github.com/real-logic/aeron/blob/master/aeron-driver/src/main/c/aeron_publication_image.c#L917 will never return true, and the image will never progress to linger or done.