### PR TITLE
Add ArchiveTool mark-valid, mark-invalid commands.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/Catalog.java
@@ -126,6 +126,7 @@ final class Catalog implements AutoCloseable
 
     private final boolean forceWrites;
     private final boolean forceMetadata;
+    private boolean indexInvalid;
     private boolean isClosed;
     private final File catalogFile;
     private final File archiveDir;
@@ -236,7 +237,7 @@ final class Catalog implements AutoCloseable
 
     Catalog(final File archiveDir, final EpochClock epochClock)
     {
-        this(archiveDir, epochClock, MIN_CAPACITY, false, null, null);
+        this(archiveDir, epochClock, MIN_CAPACITY, false, null, null, false);
     }
 
     Catalog(
@@ -245,11 +246,13 @@ final class Catalog implements AutoCloseable
         final long catalogCapacity,
         final boolean writable,
         final Checksum checksum,
-        final IntConsumer versionCheck)
+        final IntConsumer versionCheck,
+        final boolean indexInvalid)
     {
         this.archiveDir = archiveDir;
         this.forceWrites = false;
         this.forceMetadata = false;
+        this.indexInvalid = indexInvalid;
         this.epochClock = epochClock;
         this.catalogChannel = null;
         this.checksum = checksum;
@@ -954,7 +957,7 @@ final class Catalog implements AutoCloseable
             }
 
             recordingId = recordingId(catalogBuffer);
-            if (isValidDescriptor(catalogBuffer))
+            if (isValidDescriptor(catalogBuffer) || this.indexInvalid)
             {
                 catalogIndex.add(recordingId, offset);
             }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveMigrationUtils.java
@@ -165,7 +165,7 @@ final class ArchiveMigrationUtils
             LangUtil.rethrowUnchecked(ex);
         }
 
-        return new Catalog(archiveDir, epochClock, MIN_CAPACITY, true, null, (version) -> {});
+        return new Catalog(archiveDir, epochClock, MIN_CAPACITY, true, null, (version) -> {}, false);
     }
 
     private static int totalMarkFileLengthInVersion2(

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -721,7 +721,8 @@ class ArchiveTest
             MIN_CAPACITY,
             true,
             null,
-            intConsumer);
+            intConsumer,
+            false);
     }
 
     static final class SubscriptionDescriptor

--- a/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/CatalogTest.java
@@ -120,7 +120,7 @@ class CatalogTest
         IoUtil.deleteIfExists(catalogFile);
         Files.write(catalogFile.toPath(), new byte[oldRecordLength], CREATE_NEW);
 
-        try (Catalog catalog = new Catalog(archiveDir, clock, MIN_CAPACITY, true, null, (version) -> {}))
+        try (Catalog catalog = new Catalog(archiveDir, clock, MIN_CAPACITY, true, null, (version) -> {}, false))
         {
             assertEquals(oldRecordLength, catalog.alignment());
         }
@@ -156,7 +156,7 @@ class CatalogTest
         setNextRecordingId(-1);
 
         final ArchiveException exception = assertThrows(ArchiveException.class,
-            () -> new Catalog(archiveDir, clock, MIN_CAPACITY, true, null, null));
+            () -> new Catalog(archiveDir, clock, MIN_CAPACITY, true, null, null, false));
         assertEquals(
             "ERROR - invalid nextRecordingId: expected value greater or equal to " + (recordingThreeId + 1) +
             ", was -1",


### PR DESCRIPTION
These provide a way to patch the catalog in an emergency.

Added the following ArchiveTool commands:

```
mark-invalid <recordingId>: marks a recording as invalid.

mark-valid <recordingId>: marks a previously invalidated recording as valid.
```