### PR TITLE
Support specifying endpoints and tags in the same URI

### DIFF
--- a/aeron-client/src/main/c/util/aeron_netutil.c
+++ b/aeron-client/src/main/c/util/aeron_netutil.c
@@ -722,3 +722,34 @@ done:
 
     return result;
 }
+
+int aeron_sockaddr_storage_cmp(struct sockaddr_storage *a, struct sockaddr_storage *b, bool *result)
+{
+    if (a->ss_family != b->ss_family)
+    {
+        *result = false;
+    }
+    else if (AF_INET == a->ss_family)
+    {
+        struct sockaddr_in *a_in = (struct sockaddr_in *)a;
+        struct sockaddr_in *b_in = (struct sockaddr_in *)b;
+
+        *result = (a_in->sin_addr.s_addr == b_in->sin_addr.s_addr) && (a_in->sin_port == b_in->sin_port);
+    }
+    else if (AF_INET6 == a->ss_family)
+    {
+        struct sockaddr_in6 *a_in6 = (struct sockaddr_in6 *)a;
+        struct sockaddr_in6 *b_in6 = (struct sockaddr_in6 *)b;
+
+        *result = 0 == memcmp(&a_in6->sin6_addr, &b_in6->sin6_addr, sizeof(struct sockaddr_in6)) &&
+            (a_in6->sin6_port == b_in6->sin6_port);
+    }
+    else
+    {
+        *result = false;
+        AERON_SET_ERR(EINVAL, "%s", "Unsupported address family");
+        return -1;
+    }
+
+    return 0;
+}

--- a/aeron-client/src/main/c/util/aeron_netutil.h
+++ b/aeron-client/src/main/c/util/aeron_netutil.h
@@ -88,4 +88,6 @@ int aeron_format_source_identity(char *buffer, size_t length, struct sockaddr_st
 
 int aeron_netutil_get_so_buf_lengths(size_t *default_so_rcvbuf, size_t *default_so_sndbuf);
 
+int aeron_sockaddr_storage_cmp(struct sockaddr_storage *a, struct sockaddr_storage *b, bool *result);
+
 #endif //AERON_NETUTIL_H

--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2038,11 +2038,18 @@ aeron_send_channel_endpoint_t *aeron_driver_conductor_get_or_add_send_channel_en
 
     if (NULL != endpoint)
     {
-        if (!aeron_udp_channel_is_wildcard(channel))
+        bool endpoints_match = false;
+        if (aeron_udp_channel_endpoints_match(channel, endpoint->conductor_fields.udp_channel, &endpoints_match) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            goto error_cleanup;
+        }
+
+        if (!aeron_udp_channel_is_wildcard(channel) && !endpoints_match)
         {
             AERON_SET_ERR(
                 EINVAL,
-                "matching tag %" PRId64 "  has explicit endpoint or control: %.*s <> %.*s",
+                "matching tag %" PRId64 " has explicit endpoint or control: %.*s <> %.*s",
                 channel->tag_id,
                 (int)endpoint->conductor_fields.udp_channel->uri_length,
                 endpoint->conductor_fields.udp_channel->original_uri,
@@ -2179,7 +2186,14 @@ aeron_receive_channel_endpoint_t *aeron_driver_conductor_get_or_add_receive_chan
 
     if (NULL != endpoint)
     {
-        if (!aeron_udp_channel_is_wildcard(channel))
+        bool endpoints_match = false;
+        if (aeron_udp_channel_endpoints_match(channel, endpoint->conductor_fields.udp_channel, &endpoints_match) < 0)
+        {
+            AERON_APPEND_ERR("%s", "");
+            goto error_cleanup;
+        }
+
+        if (!aeron_udp_channel_is_wildcard(channel) && !endpoints_match)
         {
             AERON_SET_ERR(
                 EINVAL,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -469,6 +469,8 @@ void aeron_udp_channel_delete(aeron_udp_channel_t *channel)
 
 extern bool aeron_udp_channel_is_wildcard(aeron_udp_channel_t *channel);
 
+extern int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other, bool *result);
+
 extern bool aeron_udp_channel_equals(aeron_udp_channel_t *a, aeron_udp_channel_t *b);
 
 extern size_t aeron_udp_channel_socket_so_sndbuf(aeron_udp_channel_t *channel, size_t default_so_sndbuf);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.h
@@ -71,8 +71,8 @@ inline bool aeron_udp_channel_is_wildcard(aeron_udp_channel_t *channel)
 
 inline int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other, bool *result)
 {
-    bool cmp;
-    int rc;
+    bool cmp = false;
+    int rc = 0;
 
     rc = aeron_sockaddr_storage_cmp(&channel->remote_data, &other->remote_data, &cmp);
     if (rc < 0)

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.h
@@ -21,6 +21,7 @@
 #include "uri/aeron_uri.h"
 #include "util/aeron_netutil.h"
 #include "aeron_name_resolver.h"
+#include "util/aeron_error.h"
 
 #define AERON_UDP_CHANNEL_RESERVED_VALUE_OFFSET (-8)
 
@@ -66,6 +67,35 @@ inline bool aeron_udp_channel_is_wildcard(aeron_udp_channel_t *channel)
 {
     return aeron_is_wildcard_addr(&channel->remote_data) && aeron_is_wildcard_port(&channel->remote_data) &&
         aeron_is_wildcard_addr(&channel->local_data) && aeron_is_wildcard_port(&channel->local_data);
+}
+
+inline int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other, bool *result)
+{
+    bool cmp;
+    int rc;
+
+    rc = aeron_sockaddr_storage_cmp(&channel->remote_data, &other->remote_data, &cmp);
+    if (rc < 0)
+    {
+        AERON_APPEND_ERR("%s", "remote_data");
+        return rc;
+    }
+
+    if (!cmp)
+    {
+        *result = cmp;
+        return 0;
+    }
+
+    rc = aeron_sockaddr_storage_cmp(&channel->local_data, &other->local_data, &cmp);
+    if (rc < 0)
+    {
+        AERON_APPEND_ERR("%s", "local_data");
+        return rc;
+    }
+
+    *result = cmp;
+    return 0;
 }
 
 inline bool aeron_udp_channel_equals(aeron_udp_channel_t *a, aeron_udp_channel_t *b)

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -707,11 +707,10 @@ public final class UdpChannel
             return true;
         }
 
-        // TODO: Should we do this????
         if (udpChannel.remoteData().getAddress().equals(remoteData.getAddress()) &&
             udpChannel.remoteData().getPort() == remoteData.getPort() &&
-            udpChannel.localData.getAddress().equals(localData.getAddress()) &&
-            udpChannel.localData.getPort() == localData.getPort())
+            udpChannel.localData().getAddress().equals(localData.getAddress()) &&
+            udpChannel.localData().getPort() == localData.getPort())
         {
             return true;
         }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -707,6 +707,15 @@ public final class UdpChannel
             return true;
         }
 
+        // TODO: Should we do this????
+        if (udpChannel.remoteData().getAddress().equals(remoteData.getAddress()) &&
+            udpChannel.remoteData().getPort() == remoteData.getPort() &&
+            udpChannel.localData.getAddress().equals(localData.getAddress()) &&
+            udpChannel.localData.getPort() == localData.getPort())
+        {
+            return true;
+        }
+
         throw new IllegalArgumentException(
             "matching tag=" + tag + " has explicit endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
     }

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;

--- a/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiSubscriberTest.java
@@ -40,7 +40,6 @@ import static io.aeron.AeronCounters.DRIVER_RECEIVER_HWM_TYPE_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(InterruptingTestCallback.class)
@@ -153,14 +152,20 @@ class MultiSubscriberTest
                 Tests.yield();
             }
 
-            final int counterIdA = aeron.countersReader()
-                .findByTypeIdAndRegistrationId(DRIVER_RECEIVER_HWM_TYPE_ID, subAImageCorrelationId.get());
-            assertNotEquals(-1, counterIdA);
+            int counterIdA;
+            while (-1 == (counterIdA = aeron.countersReader()
+                .findByTypeIdAndRegistrationId(DRIVER_RECEIVER_HWM_TYPE_ID, subAImageCorrelationId.get())))
+            {
+                Tests.yield();
+            }
             assertThat(aeron.countersReader().getCounterLabel(counterIdA), containsString(channelA));
 
-            final int counterIdB = aeron.countersReader()
-                .findByTypeIdAndRegistrationId(DRIVER_RECEIVER_HWM_TYPE_ID, subBImageCorrelationId.get());
-            assertNotEquals(-1, counterIdB);
+            int counterIdB;
+            while (-1 == (counterIdB = aeron.countersReader()
+                .findByTypeIdAndRegistrationId(DRIVER_RECEIVER_HWM_TYPE_ID, subBImageCorrelationId.get())))
+            {
+                Tests.yield();
+            }
             assertThat(aeron.countersReader().getCounterLabel(counterIdB), containsString(channelB));
         }
     }

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -58,7 +58,6 @@ import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -35,6 +35,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,6 +46,7 @@ import org.mockito.InOrder;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.SystemTests.verifyLossOccurredForStream;
@@ -668,6 +670,24 @@ class PubAndSubTest
             Tests.yield();
         }
     }
+
+
+    @Test
+    void shouldHandleTagsAndParametersIfParametersMatch()
+    {
+        launch("aeron:ipc");
+
+        try (
+            Subscription ignore1 = subscribingClient.addSubscription("aeron:udp?endpoint=127.0.0.1:0|tags=1001", 1000);
+            Subscription ignore2 = subscribingClient.addSubscription("aeron:udp?endpoint=127.0.0.1:0|tags=1001", 1000))
+        {
+            Objects.requireNonNull(ignore1);
+            Objects.requireNonNull(ignore2);
+
+
+        }
+    }
+
 
     private void publishMessage()
     {


### PR DESCRIPTION
- Allow a channel URI to contain both tags and endpoint parameters even if there is already a send or receive channel endpoint for the tag.
- For existing endpoints, check that the control and endpoint values are the same and reject if they do not match.
- Potential Fix for #1498.