### PR TITLE
Fix comment for startReplay from "matching channel and stream id" to "matching session id".

### DIFF
--- a/aeron-archive/src/main/cpp/client/AeronArchive.h
+++ b/aeron-archive/src/main/cpp/client/AeronArchive.h
@@ -801,7 +801,7 @@ public:
      * @param replayParams   to control the behaviour of the replay.
      * @tparam IdleStrategy  to use for polling operations.
      * @return the id of the replay session which will be the same as the Image#sessionId of the received
-     *         replay for correlation with the matching channel and stream id in the lower 32 bits.
+     *         replay for correlation with the matching session id in the lower 32 bits.
      */
     template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>
     inline std::int64_t startReplay(
@@ -841,7 +841,7 @@ public:
      * @param replayStreamId to which the replay should be sent.
      * @tparam IdleStrategy  to use for polling operations.
      * @return the id of the replay session which will be the same as the Image#sessionId of the received
-     *         replay for correlation with the matching channel and stream id in the lower 32 bits.
+     *         replay for correlation with the matching session id in the lower 32 bits.
      */
     template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>
     inline std::int64_t startReplay(
@@ -883,7 +883,7 @@ public:
      * @param replayStreamId to which the replay should be sent.
      * @tparam IdleStrategy  to use for polling operations.
      * @return the id of the replay session which will be the same as the Image#sessionId of the received
-     *         replay for correlation with the matching channel and stream id in the lower 32 bits.
+     *         replay for correlation with the matching session id in the lower 32 bits.
      */
     template<typename IdleStrategy = aeron::concurrent::BackoffIdleStrategy>
     inline std::int64_t startBoundedReplay(

--- a/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/AeronArchive.java
@@ -989,7 +989,7 @@ public final class AeronArchive implements AutoCloseable
      * @param replayChannel  to which the replay should be sent.
      * @param replayStreamId to which the replay should be sent.
      * @return the id of the replay session which will be the same as the {@link Image#sessionId()} of the received
-     * replay for correlation with the matching channel and stream id in the lower 32 bits.
+     * replay for correlation with the matching session id in the lower 32 bits.
      */
     public long startReplay(
         final long recordingId,
@@ -1042,7 +1042,7 @@ public final class AeronArchive implements AutoCloseable
      * @param replayChannel  to which the replay should be sent.
      * @param replayStreamId to which the replay should be sent.
      * @return the id of the replay session which will be the same as the {@link Image#sessionId()} of the received
-     * replay for correlation with the matching channel and stream id in the lower 32 bits.
+     * replay for correlation with the matching session id in the lower 32 bits.
      */
     public long startBoundedReplay(
         final long recordingId,
@@ -1090,7 +1090,7 @@ public final class AeronArchive implements AutoCloseable
      * @param replayStreamId to which the replay should be sent.
      * @param replayParams   optional parameters for the replay
      * @return the id of the replay session which will be the same as the {@link Image#sessionId()} of the received
-     * replay for correlation with the matching channel and stream id in the lower 32 bits.
+     * replay for correlation with the matching session id in the lower 32 bits.
      * @see ReplayParams
      */
     public long startReplay(


### PR DESCRIPTION
This changes the comments to match the documentation in the [wiki](https://github.com/real-logic/aeron/wiki/Aeron-Archive#replaying-streams).