### PR TITLE
[C] Populate client image subscriber_position_id.

### DIFF
--- a/aeron-client/src/main/c/aeron_image.c
+++ b/aeron-client/src/main/c/aeron_image.c
@@ -87,6 +87,7 @@ int aeron_image_create(
     _image->log_buffer = log_buffer;
 
     _image->subscriber_position = subscriber_position;
+    _image->subscriber_position_id = subscriber_position_id;
 
     _image->conductor = conductor;
     _image->correlation_id = correlation_id;

--- a/aeron-client/src/test/c/aeron_image_test.cpp
+++ b/aeron-client/src/test/c/aeron_image_test.cpp
@@ -508,6 +508,8 @@ TEST_F(ImageTest, shouldPollOneFragmentToControlledFragmentHandlerOnBreak)
     aeron_image_constants_t image_constants;
     aeron_image_constants(m_image, &image_constants);
 
+    EXPECT_EQ(image_constants.subscriber_position_id, SUBSCRIBER_POSITION_ID);
+
     auto handler = [&](const uint8_t *buffer, size_t length, aeron_header_t *header)
         -> aeron_controlled_fragment_handler_action_t
     {


### PR DESCRIPTION
subscriber_position_id was passed to aeron_image_create(), but never used.