### PR TITLE
Fix C client when one image matches multiple subscriptions

### DIFF
--- a/aeron-client/src/main/c/aeron_client_conductor.h
+++ b/aeron-client/src/main/c/aeron_client_conductor.h
@@ -23,6 +23,7 @@
 #include "command/aeron_control_protocol.h"
 #include "aeronc.h"
 #include "concurrent/aeron_counters_manager.h"
+#include "collections/aeron_array_to_ptr_hash_map.h"
 #include "collections/aeron_int64_to_ptr_hash_map.h"
 
 #define AERON_CLIENT_COMMAND_QUEUE_FAIL_THRESHOLD (10)
@@ -158,7 +159,7 @@ typedef struct aeron_client_conductor_stct
 
     aeron_int64_to_ptr_hash_map_t log_buffer_by_id_map;
     aeron_int64_to_ptr_hash_map_t resource_by_id_map;
-    aeron_int64_to_ptr_hash_map_t image_by_id_map;
+    aeron_array_to_ptr_hash_map_t image_by_key_map;
 
     struct available_counter_handlers_stct
     {

--- a/aeron-client/src/main/c/aeron_image.c
+++ b/aeron-client/src/main/c/aeron_image.c
@@ -90,7 +90,8 @@ int aeron_image_create(
     _image->subscriber_position_id = subscriber_position_id;
 
     _image->conductor = conductor;
-    _image->correlation_id = correlation_id;
+    _image->key.correlation_id = correlation_id;
+    _image->key.subscription_registration_id = subscription->registration_id;
     _image->session_id = session_id;
     _image->removal_change_number = INT64_MAX;
     _image->final_position = 0;
@@ -143,7 +144,7 @@ int aeron_image_constants(aeron_image_t *image, aeron_image_constants_t *constan
 
     constants->subscription = image->subscription;
     constants->source_identity = image->source_identity;
-    constants->correlation_id = image->correlation_id;
+    constants->correlation_id = image->key.correlation_id;
     constants->join_position = image->join_position;
     constants->position_bits_to_shift = image->position_bits_to_shift;
     constants->term_buffer_length = (size_t)image->term_length_mask + 1;

--- a/aeron-client/src/main/c/aeron_image.h
+++ b/aeron-client/src/main/c/aeron_image.h
@@ -23,6 +23,13 @@
 #include "aeron_context.h"
 #include "aeron_client_conductor.h"
 
+typedef struct aeron_image_key_stct
+{
+    int64_t correlation_id;
+    int64_t subscription_registration_id;
+}
+aeron_image_key_t;
+
 typedef struct aeron_image_stct
 {
     aeron_client_command_base_t command_base;
@@ -35,7 +42,7 @@ typedef struct aeron_image_stct
 
     volatile int64_t *subscriber_position;
 
-    int64_t correlation_id;
+    aeron_image_key_t key;
     int64_t removal_change_number;
     int64_t join_position;
     int64_t final_position;

--- a/aeron-client/src/main/c/collections/aeron_array_to_ptr_hash_map.h
+++ b/aeron-client/src/main/c/collections/aeron_array_to_ptr_hash_map.h
@@ -197,11 +197,11 @@ inline int aeron_array_to_ptr_hash_map_put(
     if (NULL == old_value)
     {
         ++map->size;
-        map->keys[index].arr = key;
         map->keys[index].hash_code = hash_code;
         map->keys[index].arr_length = key_len;
     }
 
+    map->keys[index].arr = key;
     map->values[index] = value;
 
     if (map->size > map->resize_threshold)

--- a/aeron-client/src/test/c/aeron_subscription_test.cpp
+++ b/aeron-client/src/test/c/aeron_subscription_test.cpp
@@ -99,7 +99,7 @@ public:
 
         if (aeron_image_create(
             &image,
-            nullptr,
+            m_subscription,
             m_conductor,
             log_buffer,
             SUBSCRIBER_POSITION_ID,

--- a/aeron-client/src/test/c/collections/aeron_array_to_ptr_hash_map_test.cpp
+++ b/aeron-client/src/test/c/collections/aeron_array_to_ptr_hash_map_test.cpp
@@ -74,6 +74,18 @@ TEST_F(ArrToPtrHashMapTest, shouldReplaceExistingValueForTheSameKey)
     EXPECT_EQ(m_map.size, 1u);
 }
 
+TEST_F(ArrToPtrHashMapTest, shouldReplaceKeyWhenReplacingValue)
+{
+    int key1 = 100, key2 = 100;
+    int value = 42, new_value = 43;
+    ASSERT_EQ(aeron_array_to_ptr_hash_map_init(&m_map, 8, AERON_MAP_DEFAULT_LOAD_FACTOR), 0);
+
+    EXPECT_EQ(aeron_array_to_ptr_hash_map_put(&m_map, (uint8_t *)&key1, 4, (void *)&value), 0);
+    EXPECT_EQ(aeron_array_to_ptr_hash_map_put(&m_map, (uint8_t *)&key2, 4, (void *)&new_value), 0);
+    key1 = 200;
+    EXPECT_EQ(aeron_array_to_ptr_hash_map_get(&m_map, (uint8_t *)&key2, 4), &new_value);
+}
+
 TEST_F(ArrToPtrHashMapTest, shouldGrowWhenThresholdExceeded)
 {
     int value = 42, value_at_16 = 43;


### PR DESCRIPTION
On the client side, aeron_image_t represents a link between a subscription and an image. There can be multiple subscriptions using a single image, which means there can be multiple aeron_image_t objects with the same correlation_id. Using the correlation_id as the map key means only the last object is kept, leading to a potential memory leak and invalid image unavailability notifications. This change makes the map keyed on both correlation_id and subscription_registration_id which uniquely identify aeron_image_t objects.

Changed aeron_int64_to_ptr_hash_map_put to replace the key as well, which makes more sense, especially when using keys embedded in values.