### PR TITLE
[C] Fix spy subscription channel.

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -3633,11 +3633,11 @@ int aeron_driver_conductor_on_add_spy_subscription(
     aeron_driver_conductor_t *conductor, aeron_subscription_command_t *command)
 {
     aeron_udp_channel_t *udp_channel = NULL;
-    const char *uri = (const char *)command + sizeof(aeron_subscription_command_t) + strlen(AERON_SPY_PREFIX);
+    const char *uri = (const char *)command + sizeof(aeron_subscription_command_t);
     aeron_driver_uri_subscription_params_t params;
 
     if (aeron_udp_channel_parse(
-        command->channel_length - strlen(AERON_SPY_PREFIX), uri, &conductor->name_resolver, &udp_channel, false) < 0 ||
+        command->channel_length - strlen(AERON_SPY_PREFIX), uri + strlen(AERON_SPY_PREFIX), &conductor->name_resolver, &udp_channel, false) < 0 ||
         aeron_driver_uri_subscription_params(&udp_channel->uri, &params, conductor) < 0)
     {
         AERON_APPEND_ERR("%s", "");


### PR DESCRIPTION
When looking at AeronStat of a C media driver, noticed that a spy subscription doesn't have the aeron-spy: prefix like in the Java driver. Turns out we incorrectly copy the channel into the link - starting after the prefix. Also, the copy uses the full length potentially trying to access data out of bound. This was inconsistent with MDS code which is using the full channel for spies.

Image unavailability callbacks now get the full channel with prefix.