### PR TITLE
[C] Introduce a parameters structure for aeron_udp_channel_transport_init

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2114,7 +2114,7 @@ aeron_send_channel_endpoint_t *aeron_driver_conductor_get_or_add_send_channel_en
         }
 
         if (aeron_send_channel_endpoint_create(
-            &endpoint, channel, conductor->context, &conductor->counters_manager, registration_id) < 0)
+            &endpoint, channel, params, conductor->context, &conductor->counters_manager, registration_id) < 0)
         {
             // the `channel` is now owned by the endpoint
             return NULL;

--- a/aeron-driver/src/main/c/aeron_driver_name_resolver.c
+++ b/aeron-driver/src/main/c/aeron_driver_name_resolver.c
@@ -270,16 +270,22 @@ int aeron_driver_name_resolver_init(
         goto error_cleanup;
     }
 
+
+    aeron_udp_channel_transport_params_t transport_params = {
+        context->socket_rcvbuf,
+        context->socket_sndbuf,
+        context->mtu_length,
+        _driver_resolver->interface_index,
+        0,
+        false,
+    };
+
     if (_driver_resolver->transport_bindings->init_func(
         &_driver_resolver->transport,
         &_driver_resolver->local_socket_addr,
         NULL, // Unicast only.
         NULL, // No connected
-        _driver_resolver->interface_index,
-        0,
-        context->socket_rcvbuf,
-        context->socket_sndbuf,
-        false,
+        &transport_params,
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_CONDUCTOR) < 0)
     {

--- a/aeron-driver/src/main/c/media/aeron_receive_destination.c
+++ b/aeron-driver/src/main/c/media/aeron_receive_destination.c
@@ -57,16 +57,21 @@ int aeron_receive_destination_create(
 
     _destination->port_manager = context->receiver_port_manager;
 
+    aeron_udp_channel_transport_params_t transport_params = {
+        socket_rcvbuf,
+        socket_sndbuf,
+        context->mtu_length,
+        destination_channel->interface_index,
+        0 != destination_channel->multicast_ttl ? destination_channel->multicast_ttl : context->multicast_ttl,
+        is_media_timestamping,
+    };
+
     if (context->udp_channel_transport_bindings->init_func(
         &_destination->transport,
         &_destination->bind_addr,
         &destination_channel->local_data,
         NULL,
-        destination_channel->interface_index,
-        0 != destination_channel->multicast_ttl ? destination_channel->multicast_ttl : context->multicast_ttl,
-        socket_rcvbuf,
-        socket_sndbuf,
-        is_media_timestamping,
+        &transport_params,
         context,
         AERON_UDP_CHANNEL_TRANSPORT_AFFINITY_RECEIVER) < 0)
     {

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.h
@@ -72,6 +72,7 @@ aeron_send_channel_endpoint_t;
 int aeron_send_channel_endpoint_create(
     aeron_send_channel_endpoint_t **endpoint,
     aeron_udp_channel_t *channel,
+    aeron_driver_uri_publication_params_t *params,
     aeron_driver_context_t *context,
     aeron_counters_manager_t *counters_manager,
     int64_t registration_id);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.h
@@ -28,6 +28,17 @@
 #define AERON_UDP_CHANNEL_TRANSPORT_CHANNEL_RCV_TIMESTAMP (0x4)
 #define AERON_UDP_CHANNEL_TRANSPORT_CHANNEL_SND_TIMESTAMP (0x8)
 
+struct aeron_udp_channel_transport_params_stct
+{
+    size_t socket_rcvbuf;
+    size_t socket_sndbuf;
+    size_t mtu_length;
+    unsigned int multicast_if_index;
+    uint8_t ttl;
+    bool is_media_timestamping;
+};
+typedef struct aeron_udp_channel_transport_params_stct aeron_udp_channel_transport_params_t;
+
 typedef struct aeron_udp_channel_transport_stct
 {
     aeron_socket_t fd;
@@ -49,11 +60,7 @@ int aeron_udp_channel_transport_init(
     struct sockaddr_storage *bind_addr,
     struct sockaddr_storage *multicast_if_addr,
     struct sockaddr_storage *connect_addr,
-    unsigned int multicast_if_index,
-    uint8_t ttl,
-    size_t socket_rcvbuf,
-    size_t socket_sndbuf,
-    bool is_media_timestamping,
+    aeron_udp_channel_transport_params_t *params,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity);
 

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport_bindings.h
@@ -32,6 +32,7 @@ typedef enum aeron_udp_channel_transport_affinity_en
 aeron_udp_channel_transport_affinity_t;
 
 struct mmsghdr;
+typedef struct aeron_udp_channel_transport_params_stct aeron_udp_channel_transport_params_t;
 typedef struct aeron_udp_channel_transport_stct aeron_udp_channel_transport_t;
 typedef struct aeron_network_publication_stct aeron_network_publication_t;
 typedef struct aeron_publication_image_stct aeron_publication_image_t;
@@ -44,11 +45,7 @@ typedef int (*aeron_udp_channel_transport_init_func_t)(
     struct sockaddr_storage *bind_addr,
     struct sockaddr_storage *multicast_if_addr,
     struct sockaddr_storage *connect_addr,
-    unsigned int multicast_if_index,
-    uint8_t ttl,
-    size_t socket_rcvbuf,
-    size_t socket_sndbuf,
-    bool is_media_timestamping,
+    aeron_udp_channel_transport_params_t *params,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity);
 

--- a/aeron-driver/src/test/c/aeron_network_publication_test.cpp
+++ b/aeron-driver/src/test/c/aeron_network_publication_test.cpp
@@ -92,8 +92,10 @@ protected:
             return nullptr;
         }
 
+        aeron_driver_uri_publication_params_t params = {};
+        params.mtu_length = 1408;
         aeron_send_channel_endpoint_t *endpoint = nullptr;
-        if (aeron_send_channel_endpoint_create(&endpoint, channel, m_context, &m_counters_manager, 1) < 0)
+        if (aeron_send_channel_endpoint_create(&endpoint, channel, &params, m_context, &m_counters_manager, 1) < 0)
         {
             return nullptr;
         }

--- a/aeron-driver/src/test/c/aeron_test_udp_bindings.h
+++ b/aeron-driver/src/test/c/aeron_test_udp_bindings.h
@@ -37,11 +37,7 @@ int aeron_test_udp_channel_transport_init(
     struct sockaddr_storage *bind_addr,
     struct sockaddr_storage *multicast_if_addr,
     struct sockaddr_storage *connect_addr,
-    unsigned int multicast_if_index,
-    uint8_t ttl,
-    size_t socket_rcvbuf,
-    size_t socket_sndbuf,
-    bool is_media_timestamping,
+    aeron_udp_channel_transport_params_t *params,
     aeron_driver_context_t *context,
     aeron_udp_channel_transport_affinity_t affinity)
 {


### PR DESCRIPTION
Add mtu_length as a parameter to be passed to UDP bindings. This makes it easier for bindings to validate the MTU length in use by Aeron.