### PR TITLE
Stricter validation on control addresses

### DIFF
--- a/aeron-driver/src/main/c/aeron_driver_conductor.c
+++ b/aeron-driver/src/main/c/aeron_driver_conductor.c
@@ -2069,14 +2069,14 @@ static int aeron_driver_conductor_tagged_channels_match(aeron_udp_channel_t *exi
         return -1;
     }
 
-    bool endpoints_match = false;
-    if (aeron_udp_channel_endpoints_match(existing, other, &endpoints_match) < 0)
+    bool has_matching_endpoints = false;
+    if (aeron_udp_channel_endpoints_match(existing, other, &has_matching_endpoints) < 0)
     {
         AERON_APPEND_ERR("%s", "");
         return -1;
     }
 
-    if (!endpoints_match)
+    if (!has_matching_endpoints)
     {
         AERON_SET_ERR(
             EINVAL,

--- a/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
+++ b/aeron-driver/src/main/c/media/aeron_send_channel_endpoint.c
@@ -58,7 +58,7 @@ int aeron_send_channel_endpoint_create(
     _endpoint->data_paths = &context->sender_proxy->sender->data_paths;
 
     struct sockaddr_storage *connect_addr = NULL;
-    if (channel->has_explicit_control || channel->is_dynamic_control_mode || channel->is_manual_control_mode)
+    if (channel->is_dynamic_control_mode || channel->is_manual_control_mode)
     {
         if (aeron_alloc((void **)&_endpoint->destination_tracker, sizeof(aeron_udp_destination_tracker_t)) < 0 ||
             aeron_udp_destination_tracker_init(

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.c
@@ -471,6 +471,8 @@ extern bool aeron_udp_channel_is_wildcard(aeron_udp_channel_t *channel);
 
 extern int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other, bool *result);
 
+extern bool aeron_udp_channel_control_modes_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other);
+
 extern bool aeron_udp_channel_equals(aeron_udp_channel_t *a, aeron_udp_channel_t *b);
 
 extern size_t aeron_udp_channel_socket_so_sndbuf(aeron_udp_channel_t *channel, size_t default_so_sndbuf);

--- a/aeron-driver/src/main/c/media/aeron_udp_channel.h
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel.h
@@ -74,6 +74,12 @@ inline int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron
     bool cmp = false;
     int rc = 0;
 
+    if (aeron_udp_channel_is_wildcard(other))
+    {
+        *result = true;
+        return rc;
+    }
+
     rc = aeron_sockaddr_storage_cmp(&channel->remote_data, &other->remote_data, &cmp);
     if (rc < 0)
     {
@@ -96,6 +102,13 @@ inline int aeron_udp_channel_endpoints_match(aeron_udp_channel_t *channel, aeron
 
     *result = cmp;
     return 0;
+}
+
+inline bool aeron_udp_channel_control_modes_match(aeron_udp_channel_t *channel, aeron_udp_channel_t *other)
+{
+    return (!other->is_dynamic_control_mode && !other->is_manual_control_mode) ||
+        (channel->is_manual_control_mode == other->is_manual_control_mode &&
+        channel->is_dynamic_control_mode == other->is_dynamic_control_mode);
 }
 
 inline bool aeron_udp_channel_equals(aeron_udp_channel_t *a, aeron_udp_channel_t *b)

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -462,6 +462,7 @@ public final class DriverConductor implements Agent
         final ChannelUri channelUri = udpChannel.channelUri();
         final PublicationParams params = getPublicationParams(channelUri, ctx, this, false);
         validateEndpointForPublication(udpChannel);
+        validateControlForPublication(udpChannel);
         validateMtuForMaxMessage(params, channel);
 
         final SendChannelEndpoint channelEndpoint = getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
@@ -2122,6 +2123,25 @@ public final class DriverConductor implements Agent
             0 == udpChannel.remoteData().getPort())
         {
             throw new IllegalArgumentException(ENDPOINT_PARAM_NAME + " has port=0 for publication: channel=" +
+                udpChannel.originalUriString());
+        }
+    }
+
+    private static void validateControlForPublication(final UdpChannel udpChannel)
+    {
+        if (udpChannel.isDynamicControlMode() && null == udpChannel.channelUri().get(MDC_CONTROL_PARAM_NAME))
+        {
+            throw new IllegalArgumentException(
+                "'control-mode=dynamic' requires that 'control' parameter is set, channel=" +
+                udpChannel.originalUriString());
+        }
+
+        if (null != udpChannel.channelUri().get(MDC_CONTROL_PARAM_NAME) &&
+            null == udpChannel.channelUri().get(ENDPOINT_PARAM_NAME) &&
+            null == udpChannel.channelUri().get(MDC_CONTROL_MODE_PARAM_NAME))
+        {
+            throw new IllegalArgumentException(
+                "'control' parameter requires that either 'endpoint' or 'control-mode' is specified, channel=" +
                 udpChannel.originalUriString());
         }
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -94,7 +94,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
             udpChannel,
             udpChannel.remoteControl(),
             udpChannel.localControl(),
-            udpChannel.hasExplicitControl() || udpChannel.isManualControlMode() ? null : udpChannel.remoteData(),
+            udpChannel.isDynamicControlMode() || udpChannel.isManualControlMode() ? null : udpChannel.remoteData(),
             context.senderPortManager(),
             context);
 
@@ -107,8 +107,9 @@ public class SendChannelEndpoint extends UdpChannelTransport
         {
             multiSndDestination = new ManualSndMultiDestination(context.senderCachedNanoClock());
         }
-        else if (udpChannel.isDynamicControlMode() || udpChannel.hasExplicitControl())
+        else if (udpChannel.isDynamicControlMode())
         {
+            assert udpChannel.hasExplicitControl();
             multiSndDestination = new DynamicSndMultiDestination(context.senderCachedNanoClock());
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -699,24 +699,41 @@ public final class UdpChannel
             return false;
         }
 
-        if (udpChannel.remoteData().getAddress().isAnyLocalAddress() &&
+        if (!hasMatchingAddress(udpChannel))
+        {
+            throw new IllegalArgumentException(
+                "matching tag=" + tag + " has mismatched endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
+        }
+
+        if (!matchesControlMode(udpChannel))
+        {
+            throw new IllegalArgumentException(
+                "matching tag=" + tag + " has mismatched control-mode: " + uriStr + " <> " + udpChannel.uriStr);
+        }
+
+        return true;
+    }
+
+    private boolean hasMatchingAddress(final UdpChannel udpChannel)
+    {
+        final boolean otherChannelIsWildcard = udpChannel.remoteData().getAddress().isAnyLocalAddress() &&
             udpChannel.remoteData().getPort() == 0 &&
             udpChannel.localData().getAddress().isAnyLocalAddress() &&
-            udpChannel.localData().getPort() == 0)
-        {
-            return true;
-        }
+            udpChannel.localData().getPort() == 0;
 
-        if (udpChannel.remoteData().getAddress().equals(remoteData.getAddress()) &&
+        final boolean otherChannelMatches = udpChannel.remoteData().getAddress().equals(remoteData.getAddress()) &&
             udpChannel.remoteData().getPort() == remoteData.getPort() &&
             udpChannel.localData().getAddress().equals(localData.getAddress()) &&
-            udpChannel.localData().getPort() == localData.getPort())
-        {
-            return true;
-        }
+            udpChannel.localData().getPort() == localData.getPort();
 
-        throw new IllegalArgumentException(
-            "matching tag=" + tag + " has explicit endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
+        return otherChannelIsWildcard || otherChannelMatches;
+    }
+
+    private boolean matchesControlMode(final UdpChannel udpChannel)
+    {
+        return null == udpChannel.channelUri().get(MDC_CONTROL_MODE_PARAM_NAME) ||
+            (isDynamicControlMode() == udpChannel.isDynamicControlMode() &&
+                isManualControlMode() == udpChannel.isManualControlMode());
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -699,16 +699,16 @@ public final class UdpChannel
             return false;
         }
 
-        if (!hasMatchingAddress(udpChannel))
-        {
-            throw new IllegalArgumentException(
-                "matching tag=" + tag + " has mismatched endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
-        }
-
         if (!matchesControlMode(udpChannel))
         {
             throw new IllegalArgumentException(
                 "matching tag=" + tag + " has mismatched control-mode: " + uriStr + " <> " + udpChannel.uriStr);
+        }
+
+        if (!hasMatchingAddress(udpChannel))
+        {
+            throw new IllegalArgumentException(
+                "matching tag=" + tag + " has mismatched endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
         }
 
         return true;

--- a/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
+++ b/aeron-driver/src/test/c/aeron_c_multi_destination_test.cpp
@@ -29,8 +29,9 @@ extern "C"
 
 #define PUB_URI_1 "aeron:udp?endpoint=localhost:24324"
 #define PUB_URI_2 "aeron:udp?endpoint=localhost:24325"
-#define MDC_URI "aeron:udp?control=localhost:24326"
-#define MDC_DEST_URI (MDC_URI "|endpoint=localhost:24327")
+#define CONTROL_URI "aeron:udp?control=localhost:24326"
+#define MDC_URI (CONTROL_URI "|control-mode=dynamic")
+#define MDC_DEST_URI (CONTROL_URI "|endpoint=localhost:24327")
 #define MDS_URI "aeron:udp?control-mode=manual"
 #define STREAM_ID (117)
 
@@ -159,4 +160,25 @@ TEST_F(CMultiDestinationTest, shouldAddPublicationAndMdcPublicationForMds)
     EXPECT_EQ(aeron_exclusive_publication_close(pub1, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_exclusive_publication_close(pub2, nullptr, nullptr), 0);
     EXPECT_EQ(aeron_subscription_close(subscription, nullptr, nullptr), 0);
+}
+
+TEST_F(CMultiDestinationTest, shouldNotAllowChannelsWithControlButWithoutEndpointOrControlMode)
+{
+    ASSERT_TRUE(connect());
+
+    aeron_async_add_exclusive_publication_t *async_pub1 = nullptr;
+    ASSERT_EQ(aeron_async_add_exclusive_publication(&async_pub1, m_aeron, CONTROL_URI, STREAM_ID), 0);
+    aeron_exclusive_publication_t *pub1 = awaitExclusivePublicationOrError(async_pub1);
+    ASSERT_EQ(nullptr, pub1);
+}
+
+TEST_F(CMultiDestinationTest, shouldNotAllowChannelsWithControlModeDynamicButWithoutControl)
+{
+    ASSERT_TRUE(connect());
+
+    aeron_async_add_exclusive_publication_t *async_pub1 = nullptr;
+    ASSERT_EQ(aeron_async_add_exclusive_publication(
+        &async_pub1, m_aeron, "aeron:udp?control-mode=dynamic", STREAM_ID), 0);
+    aeron_exclusive_publication_t *pub1 = awaitExclusivePublicationOrError(async_pub1);
+    ASSERT_EQ(nullptr, pub1);
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/UdpChannelTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/UdpChannelTest.java
@@ -585,6 +585,12 @@ class UdpChannelTest
         assertEquals(1234L, channel.groupTag());
     }
 
+    @Test
+    void shouldSpecifyControlIfDynamicControlModeSpecified()
+    {
+        assertThrows(InvalidChannelException.class, () -> UdpChannel.parse("aeron:udp?control-mode=dynamic"));
+    }
+
     private static Matcher<NetworkInterface> supportsMulticastOrIsLoopback()
     {
         return new NetworkInterfaceTypeSafeMatcher();

--- a/aeron-driver/src/test/java/io/aeron/driver/media/WildcardPortManagerTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/WildcardPortManagerTest.java
@@ -28,7 +28,7 @@ class WildcardPortManagerTest
 {
     final int[] portRange = new int[]{ 20000, 20003};
     final UdpChannel udpChannelPort0 = UdpChannel.parse("aeron:udp?endpoint=localhost:0");
-    final UdpChannel udpChannelPubControl = UdpChannel.parse("aeron:udp?control=localhost:0");
+    final UdpChannel udpChannelPubControl = UdpChannel.parse("aeron:udp?control=localhost:0|endpoint=localhost:9999");
 
     @Test
     void shouldAllocateConsecutivePortsInRange() throws BindException

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(InterruptingTestCallback.class)
-class ChannelValidationTests
+class ChannelValidationTest
 {
     @RegisterExtension
     final SystemTestWatcher watcher = new SystemTestWatcher();
@@ -438,6 +438,26 @@ class ChannelValidationTests
         assertThrows(
             RegistrationException.class,
             () -> addSubscription("aeron:udp?control=localhost:0|endpoint=localhost:20000", 10001));
+    }
+
+    @Test
+    void shouldDisallowControlEndpointWithoutControlModeOrEndpoint()
+    {
+        launch();
+
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control=localhost:9999", 10001));
+    }
+
+    @Test
+    void shouldDisallowControlModeDynamicWithoutControl()
+    {
+        launch();
+
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=dynamic", 10001));
     }
 
     private Publication addPublication(final String channel, final int streamId)

--- a/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ChannelValidationTest.java
@@ -460,6 +460,82 @@ class ChannelValidationTest
             () -> addPublication("aeron:udp?control-mode=dynamic", 10001));
     }
 
+    @Test
+    void shouldAllowDynamicControlModeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001);
+        addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001);
+        addPublication("aeron:udp?tags=200", 10001);
+    }
+
+    @Test
+    void shouldNotAllowNormalToControlModeDynamicChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?control=localhost:23454|endpoint=localhost:23455|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001));
+    }
+
+    @Test
+    void shouldNotAllowDynamicToControlModelNormalChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control=localhost:23454|endpoint=localhost:23455|tags=200", 10001));
+    }
+
+    @Test
+    void shouldNotAllowDynamicToControlModelManualChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=manual|control=localhost:23454|tags=200", 10001));
+    }
+
+    @Test
+    void shouldNotAllowManualToControlModelDynamicChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?control-mode=manual|control=localhost:23454|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001));
+    }
+
+    @Test
+    void shouldNotAllowNormalToControlModelDynamicChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?endpoint=localhost:23455|control=localhost:23454|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=dynamic|control=localhost:23454|tags=200", 10001));
+    }
+
+    @Test
+    void shouldNotAllowNormalToControlModelManualChangeWithTags()
+    {
+        launch();
+
+        addPublication("aeron:udp?endpoint=localhost:23455|control=localhost:23454|tags=200", 10001);
+        assertThrows(
+            RegistrationException.class,
+            () -> addPublication("aeron:udp?control-mode=manual|control=localhost:23454|tags=200", 10001));
+    }
+
     private Publication addPublication(final String channel, final int streamId)
     {
         final Publication pub = aeron.addPublication(channel, streamId);

--- a/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/MultiDestinationCastTest.java
@@ -510,7 +510,7 @@ class MultiDestinationCastTest
     }
 
     @Test
-//    @SlowTest
+    @SlowTest
     @InterruptAfter(5)
     void shouldNotAllowMdcSubscriptionsWhenChannelHasControlButNotSpecifiedAsMdc()
     {

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -693,7 +693,7 @@ class PubAndSubTest
     @Test
     void shouldRejectSubscriptionsIfUsingTagsAndParametersAndEndpointDoesNotMatchEndpointWithExplicitControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(
@@ -714,7 +714,7 @@ class PubAndSubTest
     @Test
     void shouldRejectSubscriptionsIfUsingTagsAndParametersAndEndpointDoesNotMatchEndpointWithoutControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(
@@ -735,7 +735,7 @@ class PubAndSubTest
     @Test
     void shouldRejectSubscriptionsIfUsingTagsAndParametersAndEndpointDoesNotMatchControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(
@@ -789,7 +789,7 @@ class PubAndSubTest
     @Test
     void shouldRejectPublicationsIfUsingTagsAndParametersAndEndpointDoesNotMatchEndpointWithExplicitControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(
@@ -810,7 +810,7 @@ class PubAndSubTest
     @Test
     void shouldRejectPublicationsIfUsingTagsAndParametersAndEndpointDoesNotMatchEndpointWithoutControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(
@@ -831,7 +831,7 @@ class PubAndSubTest
     @Test
     void shouldRejectPublicationsIfUsingTagsAndParametersAndEndpointDoesNotMatchControl()
     {
-        watcher.ignoreErrorsMatching((s) -> s.contains("has explicit endpoint or control"));
+        watcher.ignoreErrorsMatching((s) -> s.contains("has mismatched endpoint or control"));
         launch("aeron:ipc");
 
         final ChannelUriStringBuilder builder = new ChannelUriStringBuilder(

--- a/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResolvedEndpointSystemTest.java
@@ -265,7 +265,7 @@ class ResolvedEndpointSystemTest
     @InterruptAfter(5)
     void shouldAllowSystemAssignedPortOnDynamicMultiDestinationPublication()
     {
-        final String mdcUri = "aeron:udp?control=localhost:0";
+        final String mdcUri = "aeron:udp?control=localhost:0|control-mode=dynamic";
 
         try (Publication pub = client.addPublication(mdcUri, STREAM_ID))
         {

--- a/aeron-system-tests/src/test/java/io/aeron/WildcardPortManagerSystemTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/WildcardPortManagerSystemTest.java
@@ -95,7 +95,7 @@ public class WildcardPortManagerSystemTest
         final String endpoint3 = awaitResolvedEndpoint(subscription3);
         assertEquals("127.0.0.1:20701", endpoint3);
 
-        final String publicationChannel = "aeron:udp?control=127.0.0.1:0|linger=0";
+        final String publicationChannel = "aeron:udp?control=127.0.0.1:0|control-mode=dynamic|linger=0";
 
         final Publication publication1 = aeron.addPublication(publicationChannel, 5);
         final String controlEndpoint1 = awaitResolvedEndpoint(publication1);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -81,6 +81,7 @@ class ReplicateRecordingTest
     private static final int LIVE_STREAM_ID = 1033;
     private static final String LIVE_CHANNEL = new ChannelUriStringBuilder()
         .media("udp")
+        .controlMode("dynamic")
         .controlEndpoint("localhost:8100")
         .termLength(TERM_LENGTH)
         .build();


### PR DESCRIPTION
This tidies up some of the validation around control-mode and control address.  It now requires that `control-mode=dynamic` have a control address and also be explicitly stated.  Just specifying a control address does not imply `control-mode=dynamic`.  Now specifying a `control` address requires a `control-mode` or an `endpoint`.  If an endpoint is specified then this is a plain channel with an explicit control address (i.e. not a wildcard).

It also validates how control-mode can be specified with respect to the use of tags.  I.e. the control-mode can be omitted or must match the control-mode of any existing channel with the same tag.