### PR TITLE
[Java] Add client version info to the `client-heartbeat` counter.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -18,7 +18,10 @@ package io.aeron;
 import io.aeron.exceptions.ConfigurationException;
 import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.status.CountersReader;
+
+import static org.agrona.BitUtil.SIZE_OF_INT;
 
 /**
  * This class serves as a registry for all counter type IDs used by Aeron.
@@ -425,7 +428,7 @@ public final class AeronCounters
     }
 
     /**
-     * Append {@code archiveId} at the end of the counter label.
+     * Append version information at the end of the counter's label.
      *
      * @param tempBuffer     to append label to.
      * @param offset         at which current label data ends.
@@ -443,10 +446,59 @@ public final class AeronCounters
     }
 
     /**
+     * Append specified {@code value} at the end of the counter's label as ASCII encoded value up to the
+     * {@link CountersReader#MAX_LABEL_LENGTH}.
+     *
+     * @param metaDataBuffer containing the counter metadata.
+     * @param counterId      to append version info to.
+     * @param value          to be appended to the label.
+     * @return number of bytes that got appended.
+     * @throws IllegalArgumentException if {@code counterId} is invalid or points to non-allocated counter.
+     */
+    public static int appendToLabel(
+        final AtomicBuffer metaDataBuffer, final int counterId, final String value)
+    {
+        if (counterId < 0)
+        {
+            throw new IllegalArgumentException("counter id " + counterId + " is negative");
+        }
+
+        final int maxCounterId = (metaDataBuffer.capacity() / CountersReader.METADATA_LENGTH) - 1;
+        if (counterId > maxCounterId)
+        {
+            throw new IllegalArgumentException(
+                "counter id " + counterId + " out of range: 0 - maxCounterId=" + maxCounterId);
+        }
+
+        final int counterMetaDataOffset = CountersReader.metaDataOffset(counterId);
+        final int state = metaDataBuffer.getIntVolatile(counterMetaDataOffset);
+        if (CountersReader.RECORD_ALLOCATED != state)
+        {
+            throw new IllegalArgumentException("counter id " + counterId + " state != RECORD_ALLOCATED");
+        }
+
+        final int existingLabelLength = metaDataBuffer.getInt(counterMetaDataOffset + CountersReader.LABEL_OFFSET);
+        final int remainingLabelLength = CountersReader.MAX_LABEL_LENGTH - existingLabelLength;
+
+        final int writtenLength = metaDataBuffer.putStringWithoutLengthAscii(
+            counterMetaDataOffset + CountersReader.LABEL_OFFSET + SIZE_OF_INT + existingLabelLength,
+            value,
+            0,
+            remainingLabelLength);
+        if (writtenLength > 0)
+        {
+            metaDataBuffer.putIntOrdered(
+                counterMetaDataOffset + CountersReader.LABEL_OFFSET, existingLabelLength + writtenLength);
+        }
+
+        return writtenLength;
+    }
+
+    /**
      * Format version information to dislay purposes.
      *
      * @param fullVersion of the component.
-     * @param commitHash Git commit SHA.
+     * @param commitHash  Git commit SHA.
      * @return formatted String.
      */
     public static String formatVersionInfo(final String fullVersion, final String commitHash)

--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -21,6 +21,8 @@ import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.status.CountersReader;
 
+import java.util.Objects;
+
 import static org.agrona.BitUtil.SIZE_OF_INT;
 
 /**
@@ -458,6 +460,7 @@ public final class AeronCounters
     public static int appendToLabel(
         final AtomicBuffer metaDataBuffer, final int counterId, final String value)
     {
+        Objects.requireNonNull(metaDataBuffer);
         if (counterId < 0)
         {
             throw new IllegalArgumentException("counter id " + counterId + " is negative");

--- a/aeron-client/src/main/java/io/aeron/ClientConductor.java
+++ b/aeron-client/src/main/java/io/aeron/ClientConductor.java
@@ -1446,10 +1446,14 @@ final class ClientConductor implements Agent
                 final int counterId = HeartbeatTimestamp.findCounterIdByRegistrationId(
                     countersReader, HEARTBEAT_TYPE_ID, ctx.clientId());
 
-                if (counterId != CountersReader.NULL_COUNTER_ID)
+                if (CountersReader.NULL_COUNTER_ID != counterId)
                 {
                     heartbeatTimestamp = new AtomicCounter(counterValuesBuffer, counterId);
                     heartbeatTimestamp.setOrdered(nowMs);
+                    AeronCounters.appendToLabel(
+                        countersReader.metaDataBuffer(),
+                        counterId,
+                        " " + AeronCounters.formatVersionInfo(AeronVersion.VERSION, AeronVersion.GIT_SHA));
                     timeOfLastKeepAliveNs = nowNs;
                 }
             }

--- a/aeron-client/src/test/java/io/aeron/AeronCountersTest.java
+++ b/aeron-client/src/test/java/io/aeron/AeronCountersTest.java
@@ -142,8 +142,15 @@ class AeronCountersTest
     void appendToLabelThrowsIllegalArgumentExceptionIfCounterIsNegative(final int counterId)
     {
         final IllegalArgumentException exception = assertThrowsExactly(
-            IllegalArgumentException.class, () -> AeronCounters.appendToLabel(null, counterId, "test"));
+            IllegalArgumentException.class, () -> AeronCounters.appendToLabel(new UnsafeBuffer(), counterId, "test"));
         assertEquals("counter id " + counterId + " is negative", exception.getMessage());
+    }
+
+    @Test
+    void appendToLabelThrowsNullPointerExceptionIfBufferIsNull()
+    {
+        assertThrowsExactly(
+            NullPointerException.class, () -> AeronCounters.appendToLabel(null, 5, "test"));
     }
 
     @ParameterizedTest

--- a/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/CncFileReader.java
@@ -27,6 +27,7 @@ import org.agrona.concurrent.status.CountersReader;
 
 import java.io.File;
 import java.nio.MappedByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static io.aeron.CncFileDescriptor.*;
 import static io.aeron.samples.SamplesUtil.mapExistingFileReadOnly;
@@ -67,7 +68,8 @@ public final class CncFileReader implements AutoCloseable
 
         this.countersReader = new CountersReader(
             createCountersMetaDataBuffer(cncByteBuffer, cncMetaDataBuffer),
-            createCountersValuesBuffer(cncByteBuffer, cncMetaDataBuffer));
+            createCountersValuesBuffer(cncByteBuffer, cncMetaDataBuffer),
+            StandardCharsets.US_ASCII);
     }
 
     /**

--- a/aeron-samples/src/main/java/io/aeron/samples/SamplesUtil.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/SamplesUtil.java
@@ -15,7 +15,10 @@
  */
 package io.aeron.samples;
 
-import io.aeron.*;
+import io.aeron.CommonContext;
+import io.aeron.FragmentAssembler;
+import io.aeron.Image;
+import io.aeron.Subscription;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.protocol.HeaderFlyweight;
 import org.agrona.DirectBuffer;
@@ -34,6 +37,7 @@ import java.util.function.Consumer;
 
 import static io.aeron.CncFileDescriptor.*;
 import static java.nio.channels.FileChannel.MapMode.READ_ONLY;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Utility functions for the samples.
@@ -222,7 +226,8 @@ public class SamplesUtil
 
         return new CountersReader(
             createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
-            createCountersValuesBuffer(cncByteBuffer, cncMetaData));
+            createCountersValuesBuffer(cncByteBuffer, cncMetaData),
+            US_ASCII);
     }
 
     /**
@@ -245,6 +250,7 @@ public class SamplesUtil
 
         return new CountersReader(
             createCountersMetaDataBuffer(cncByteBuffer, cncMetaData),
-            createCountersValuesBuffer(cncByteBuffer, cncMetaData));
+            createCountersValuesBuffer(cncByteBuffer, cncMetaData),
+            US_ASCII);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
@@ -19,8 +19,10 @@ import io.aeron.Aeron;
 import io.aeron.driver.status.SystemCounterDescriptor;
 import io.aeron.test.SystemTestWatcher;
 import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,11 +42,18 @@ public class SystemCountersTest
     {
         final MediaDriver.Context context = new MediaDriver.Context()
             .dirDeleteOnStart(true)
-            .dirDeleteOnShutdown(true);
+            .dirDeleteOnShutdown(true)
+            .threadingMode(ThreadingMode.SHARED);
         driver = TestMediaDriver.launch(context, systemTestWatcher);
         systemTestWatcher.dataCollector().add(driver.context().aeronDirectory());
 
         aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+    }
+
+    @AfterEach
+    void after()
+    {
+        CloseHelper.closeAll(aeron, driver);
     }
 
     @Test

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SystemCountersTest
 {
@@ -71,20 +70,10 @@ public class SystemCountersTest
             }
         });
 
-        boolean result = true;
         for (final SystemCounterDescriptor counter : SystemCounterDescriptor.values())
         {
             final String counterLabel = idToLabel.get(counter.id());
-            if (!counterLabel.startsWith(counter.label()))
-            {
-                result = false;
-                System.out.println(counter.name() + ": expected=" + counter.label() + ", got=" + counterLabel);
-            }
-            else
-            {
-                assertThat(counterLabel, startsWith(counter.label()));
-            }
+            assertThat(counterLabel, startsWith(counter.label()));
         }
-        assertTrue(result);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SystemCountersTest
@@ -69,10 +71,20 @@ public class SystemCountersTest
             }
         });
 
+        boolean result = true;
         for (final SystemCounterDescriptor counter : SystemCounterDescriptor.values())
         {
             final String counterLabel = idToLabel.get(counter.id());
-            assertTrue(counterLabel.startsWith(counter.label()), counter.name());
+            if (!counterLabel.startsWith(counter.label()))
+            {
+                result = false;
+                System.out.println(counter.name() + ": expected=" + counter.label() + ", got=" + counterLabel);
+            }
+            else
+            {
+                assertThat(counterLabel, startsWith(counter.label()));
+            }
         }
+        assertTrue(result);
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/SystemCountersTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.Aeron;
+import io.aeron.driver.status.SystemCounterDescriptor;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.collections.Int2ObjectHashMap;
+import org.agrona.concurrent.status.CountersReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SystemCountersTest
+{
+    @RegisterExtension
+    final SystemTestWatcher systemTestWatcher = new SystemTestWatcher();
+
+    private TestMediaDriver driver;
+    private Aeron aeron;
+
+    @BeforeEach
+    void before()
+    {
+        final MediaDriver.Context context = new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .dirDeleteOnShutdown(true);
+        driver = TestMediaDriver.launch(context, systemTestWatcher);
+        systemTestWatcher.dataCollector().add(driver.context().aeronDirectory());
+
+        aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+    }
+
+    @Test
+    void shouldCreatePublicationUsingSparseFiles()
+    {
+        final CountersReader countersReader = aeron.countersReader();
+        final Int2ObjectHashMap<String> idToLabel = new Int2ObjectHashMap<>();
+        countersReader.forEach((counterId, typeId, keyBuffer, label) ->
+        {
+            if (SystemCounterDescriptor.SYSTEM_COUNTER_TYPE_ID == typeId)
+            {
+                idToLabel.put(keyBuffer.getInt(0), label);
+            }
+        });
+
+        for (final SystemCounterDescriptor counter : SystemCounterDescriptor.values())
+        {
+            final String counterLabel = idToLabel.get(counter.id());
+            assertTrue(counterLabel.startsWith(counter.label()), counter.name());
+        }
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/SystemTestWatcher.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/SystemTestWatcher.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.net.UnknownHostException;
 import java.nio.MappedByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -472,7 +473,8 @@ public class SystemTestWatcher implements DriverOutputConsumer, AfterTestExecuti
                 {
                     final CountersReader countersReader = new CountersReader(
                         createCountersMetaDataBuffer(mappedByteBuffer, metaDataBuffer),
-                        createCountersValuesBuffer(mappedByteBuffer, metaDataBuffer));
+                        createCountersValuesBuffer(mappedByteBuffer, metaDataBuffer),
+                        StandardCharsets.US_ASCII);
                     countersReader.forEach(
                         (counterId, label) ->
                         {

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -32,6 +32,7 @@ import org.agrona.concurrent.status.CountersReader;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -190,7 +191,7 @@ public final class CTestMediaDriver implements TestMediaDriver
                 .keepAliveIntervalNs(TimeUnit.MILLISECONDS.toNanos(100))
                 .conclude();
             countersReader = new CountersReader(
-                aeronContext.countersMetaDataBuffer(), aeronContext.countersValuesBuffer());
+                aeronContext.countersMetaDataBuffer(), aeronContext.countersValuesBuffer(), StandardCharsets.US_ASCII);
         }
 
         return countersReader;

--- a/buildSrc/src/main/java/io/aeron/build/GithubUtil.java
+++ b/buildSrc/src/main/java/io/aeron/build/GithubUtil.java
@@ -46,7 +46,7 @@ final class GithubUtil
             final String commitSha = reader.abbreviate(commitId, 10).name();
             final Status status = git.status().call();
 
-            return status.isClean() ? commitSha : commitSha + "+guilty";
+            return status.hasUncommittedChanges() ? commitSha + "+guilty" : commitSha;
         }
     }
 

--- a/cppbuild/centos/Dockerfile
+++ b/cppbuild/centos/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser --uid $USER_ID --system --gid $GROUP_ID athena
 
 # Install dev tools
 RUN yum install -y centos-release-scl && \
-    yum install -y "devtoolset-${GCC_VERSION}-gcc" "devtoolset-${GCC_VERSION}-gcc-c++" make
+    yum install -y "devtoolset-${GCC_VERSION}-gcc" "devtoolset-${GCC_VERSION}-gcc-c++" make git
 
 # Install Java
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \

--- a/cppbuild/rocky/Dockerfile
+++ b/cppbuild/rocky/Dockerfile
@@ -10,7 +10,7 @@ RUN adduser --uid $USER_ID --system --gid $GROUP_ID athena
 
 # Install dev tools
 RUN yum install -y scl-utils && \
-    yum install -y "gcc-toolset-${GCC_VERSION}-gcc" "gcc-toolset-${GCC_VERSION}-gcc-c++" make findutils
+    yum install -y "gcc-toolset-${GCC_VERSION}-gcc" "gcc-toolset-${GCC_VERSION}-gcc-c++" make findutils git
 
 # Install Java
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \


### PR DESCRIPTION
This PR contains the following changes:
- Add client version to the `client-heartbeat` counter.
- Fix dirty repo detection on the Java side, i.e. ignore untracked files.
- Add system counters tests which checks that the counter labels are similar across different MD implementations.