### PR TITLE
[Java] Introduce SnapshotDurationTracker

### DIFF
--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -383,6 +383,17 @@ public final class AeronCounters
      */
     public static final int NODE_CONTROL_TOGGLE_TYPE_ID = 233;
 
+    /**
+     * The type id of the {@link Counter} used for keeping track of the maximum total snapshot duration.
+     */
+    public static final int CLUSTER_TOTAL_MAX_SNAPSHOT_DURATION_TYPE_ID = 234;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the count total snapshot duration
+     * has exceeded the threshold.
+     */
+    public static final int CLUSTER_TOTAL_SNAPSHOT_DURATION_THRESHOLD_EXCEEDED_TYPE_ID = 235;
+
     private AeronCounters()
     {
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/SnapshotDurationTracker.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/SnapshotDurationTracker.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.cluster.service;
+
+import org.agrona.concurrent.status.AtomicCounter;
+
+
+/**
+ * Snapshot duration tracker that tracks maximum snapshot duration and also keeps count of how many times a predefined
+ * duration threshold is breached.
+ */
+public class SnapshotDurationTracker
+{
+    private final AtomicCounter maxSnapshotDuration;
+    private final AtomicCounter snapshotDurationThresholdExceededCount;
+    private final long durationThresholdNs;
+    private long snapshotStartTimeNs = Long.MIN_VALUE;
+
+    /**
+     * Create a tracker to track max snapshot duration and breaches of a threshold.
+     *
+     * @param maxSnapshotDuration                     counter for tracking.
+     * @param snapshotDurationThresholdExceededCount  counter for tracking.
+     * @param durationThresholdNs                     to use for tracking breaches.
+     */
+    public SnapshotDurationTracker(
+        final AtomicCounter maxSnapshotDuration,
+        final AtomicCounter snapshotDurationThresholdExceededCount,
+        final long durationThresholdNs)
+    {
+        this.maxSnapshotDuration = maxSnapshotDuration;
+        this.snapshotDurationThresholdExceededCount = snapshotDurationThresholdExceededCount;
+        this.durationThresholdNs = durationThresholdNs;
+    }
+
+    /**
+     * Get max snapshot duration counter.
+     *
+     * @return max snapshot duration counter.
+     */
+    public AtomicCounter maxSnapshotDuration()
+    {
+        return maxSnapshotDuration;
+    }
+
+    /**
+     * Get counter tracking number of times {@link SnapshotDurationTracker#durationThresholdNs} was exceeded
+     *
+     * @return duration threshold exceeded counter.
+     */
+    public AtomicCounter snapshotDurationThresholdExceededCount()
+    {
+        return snapshotDurationThresholdExceededCount;
+    }
+
+    /**
+     * Called when snapshotting has started.
+     *
+     * @param timeNanos snapshot start time in nanoseconds.
+     */
+    public void onSnapshotBegin(final long timeNanos)
+    {
+        snapshotStartTimeNs = timeNanos;
+    }
+
+    /**
+     * Called when snapshot has been taken.
+     *
+     * @param timeNanos snapshot end time in nanoseconds.
+     */
+    public void onSnapshotEnd(final long timeNanos)
+    {
+        if (snapshotStartTimeNs != Long.MIN_VALUE)
+        {
+            final long snapshotDurationNs = timeNanos - snapshotStartTimeNs;
+
+            if (snapshotDurationNs > durationThresholdNs)
+            {
+                snapshotDurationThresholdExceededCount.increment();
+            }
+
+            maxSnapshotDuration.proposeMax(snapshotDurationNs);
+        }
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestCluster.java
@@ -318,6 +318,7 @@ public final class TestCluster implements AutoCloseable
                 .controlRequestChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL)
                 .controlResponseChannel(ARCHIVE_LOCAL_CONTROL_CHANNEL))
             .sessionTimeoutNs(TimeUnit.SECONDS.toNanos(10))
+            .totalSnapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
             .authenticatorSupplier(authenticationSupplier)
             .authorisationServiceSupplier(authorisationServiceSupplier)
             .timerServiceSupplier(timerServiceSupplier)

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
 import java.util.function.IntPredicate;
 import java.util.zip.CRC32;
 
@@ -641,6 +642,28 @@ public final class TestNode implements AutoCloseable
                 }
 
                 keepAlive.run();
+            }
+        }
+    }
+
+    public static class SleepOnSnapshotTestService extends TestNode.TestService
+    {
+        long sleepNsWhenTakingSnapshot = Long.MIN_VALUE;
+
+        public TestService sleepNsOnTakeSnapshot(final long sleepNsWhenTakingSnapshot)
+        {
+            this.sleepNsWhenTakingSnapshot = sleepNsWhenTakingSnapshot;
+            return this;
+        }
+
+        @Override
+        public void onTakeSnapshot(final ExclusivePublication snapshotPublication)
+        {
+            super.onTakeSnapshot(snapshotPublication);
+
+            if (sleepNsWhenTakingSnapshot > 0)
+            {
+                LockSupport.parkNanos(sleepNsWhenTakingSnapshot);
             }
         }
     }


### PR DESCRIPTION
This PR introduces a set of counters that enable monitoring of snapshot duration within Cluster's Consensus Module:
* `AeronCounters#CLUSTER_CONSENSUS_MODULE_MAX_SNAPSHOT_DURATION_TYPE_ID` to track maximum snapshot duration.
* `AeronCounters#CLUSTER_CONSENSUS_MODULE_SNAPSHOT_DURATION_THRESHOLD_EXCEEDED_TYPE_ID` to track number of times a predefined threshold value (see below) has been exceeded.

Threshold value can be set via `aeron.cluster.consensus.module.snapshot.threshold` property or via `io.aeron.cluster.ConsensusModule.Context#snapshotDurationThresholdNs(long)`.