### PR TITLE
[Java] Re-assemble header for fragmented messages.

### DIFF
--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -15,13 +15,19 @@
  */
 package io.aeron;
 
+import io.aeron.logbuffer.Header;
+import io.aeron.protocol.HeaderFlyweight;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
+
+import static io.aeron.logbuffer.FrameDescriptor.*;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static io.aeron.protocol.DataHeaderFlyweight.RESERVED_VALUE_OFFSET;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
 /**
  * Reusable Builder for appending a sequence of buffer fragments which grows internal capacity as needed.
@@ -39,7 +45,8 @@ public final class BufferBuilder
     private final boolean isDirect;
     private int limit;
     private int nextTermOffset;
-    private final UnsafeBuffer buffer;
+    private final UnsafeBuffer buffer = new UnsafeBuffer();
+    private final UnsafeBuffer headerBuffer = new UnsafeBuffer();
 
     /**
      * Construct a buffer builder with an initial capacity of zero and isDirect false.
@@ -69,21 +76,27 @@ public final class BufferBuilder
     {
         if (initialCapacity < 0 || initialCapacity > MAX_CAPACITY)
         {
-            throw new IllegalArgumentException(
-                "initialCapacity outside range 0 - " + MAX_CAPACITY +
+            throw new IllegalArgumentException("initialCapacity outside range 0 - " + MAX_CAPACITY +
                 ": initialCapacity=" + initialCapacity);
         }
 
         this.isDirect = isDirect;
         if (isDirect)
         {
-            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(initialCapacity);
-            byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-            this.buffer = new UnsafeBuffer(byteBuffer);
+            if (initialCapacity > 0)
+            {
+                buffer.wrap(newDirectBuffer(initialCapacity));
+            }
+            headerBuffer.wrap(newDirectBuffer(HEADER_LENGTH));
         }
         else
         {
-            buffer = new UnsafeBuffer(new byte[initialCapacity]);
+            if (initialCapacity > 0)
+            {
+
+                buffer.wrap(new byte[initialCapacity]);
+            }
+            headerBuffer.wrap(new byte[HEADER_LENGTH]);
         }
     }
 
@@ -172,7 +185,11 @@ public final class BufferBuilder
      */
     public BufferBuilder compact()
     {
-        resize(Math.max(INIT_MIN_CAPACITY, limit));
+        final int newCapacity = Math.max(INIT_MIN_CAPACITY, limit);
+        if (newCapacity < buffer.capacity())
+        {
+            resize(newCapacity);
+        }
 
         return this;
     }
@@ -193,6 +210,51 @@ public final class BufferBuilder
         limit += length;
 
         return this;
+    }
+
+    /**
+     * Capture information available in the header of the very first frame. In particular, it saves the
+     * {@link Header#reservedValue()} as it is only set on the first header.
+     *
+     * @param header of the first frame.
+     * @return the builder for fluent API usage.
+     */
+    public BufferBuilder captureFirstHeader(final Header header)
+    {
+        verifyFlags(header, BEGIN_FRAG_FLAG);
+
+        headerBuffer.putLong(RESERVED_VALUE_OFFSET, header.reservedValue(), LITTLE_ENDIAN);
+
+        return this;
+    }
+
+    /**
+     * Capture information available in the header of the last frame, i.e. saves all the fields before the
+     * {@link Header#reservedValue()} and sets the {@link io.aeron.logbuffer.FrameDescriptor#BEGIN_FRAG_FLAG} bit
+     * on the {@code flags}.
+     *
+     * @param header of the first frame.
+     * @return updated header.
+     */
+    public Header prepareCompleteHeader(final Header header)
+    {
+        final byte flags = verifyFlags(header, END_FRAG_FLAG);
+
+        // copy all the fields except the `reserved value`
+        headerBuffer.putBytes(0, header.buffer(), header.offset(), RESERVED_VALUE_OFFSET);
+        // set the BEGIN_FRAG_FLAG to mark the message as unfragmented
+        headerBuffer.putByte(FLAGS_OFFSET, (byte)(flags | BEGIN_FRAG_FLAG));
+
+        // point the Header object at the patched data
+        header.buffer(headerBuffer);
+        header.offset(0);
+
+        return header;
+    }
+
+    UnsafeBuffer headerBuffer()
+    {
+        return headerBuffer;
     }
 
     private void ensureCapacity(final int additionalLength)
@@ -218,8 +280,7 @@ public final class BufferBuilder
     {
         if (isDirect)
         {
-            final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(newCapacity);
-            byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            final ByteBuffer byteBuffer = newDirectBuffer(newCapacity);
             buffer.getBytes(0, byteBuffer, 0, limit);
             buffer.wrap(byteBuffer);
         }
@@ -227,6 +288,28 @@ public final class BufferBuilder
         {
             buffer.wrap(Arrays.copyOf(buffer.byteArray(), newCapacity));
         }
+    }
+
+    private static ByteBuffer newDirectBuffer(final int newCapacity)
+    {
+        final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(newCapacity);
+        byteBuffer.order(LITTLE_ENDIAN);
+        return byteBuffer;
+    }
+
+    private static byte verifyFlags(final Header header, final byte bits)
+    {
+        final byte flags = header.flags();
+        if (bits != (flags & bits))
+        {
+            final StringBuilder builder = new StringBuilder(64);
+            builder.append("invalid frame, i.e. the (");
+            HeaderFlyweight.appendFlagsAsChars(bits, builder);
+            builder.append(") bit must be set in flags, got: ");
+            HeaderFlyweight.appendFlagsAsChars(flags, builder);
+            throw new IllegalArgumentException(builder.toString());
+        }
+        return flags;
     }
 
     static int findSuitableCapacity(final int capacity, final long requiredCapacity)
@@ -239,6 +322,7 @@ public final class BufferBuilder
             if (newCapacity > MAX_CAPACITY)
             {
                 newCapacity = MAX_CAPACITY;
+                break;
             }
         }
 

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -24,8 +24,9 @@ import org.agrona.concurrent.UnsafeBuffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static io.aeron.logbuffer.FrameDescriptor.*;
-import static io.aeron.protocol.DataHeaderFlyweight.*;
+import static io.aeron.logbuffer.FrameDescriptor.BEGIN_FRAG_FLAG;
+import static io.aeron.logbuffer.FrameDescriptor.FLAGS_OFFSET;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
 import static io.aeron.protocol.HeaderFlyweight.FRAME_LENGTH_FIELD_OFFSET;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 
@@ -220,9 +221,10 @@ public final class BufferBuilder
      */
     public BufferBuilder firstHeader(final Header header)
     {
-        completeHeader.initialTermId(header.initialTermId());
-        completeHeader.positionBitsToShift(header.positionBitsToShift());
-        completeHeader.offset(0);
+        completeHeader
+            .initialTermId(header.initialTermId())
+            .positionBitsToShift(header.positionBitsToShift())
+            .offset(0);
         completeHeader.buffer(headerBuffer);
 
         headerBuffer.putBytes(0, header.buffer(), header.offset(), HEADER_LENGTH);

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -218,12 +218,13 @@ public final class BufferBuilder
      * @param header of the first frame.
      * @return the builder for fluent API usage.
      */
-    public BufferBuilder captureFirstHeader(final Header header)
+    public BufferBuilder firstHeader(final Header header)
     {
         completeHeader.initialTermId(header.initialTermId());
         completeHeader.positionBitsToShift(header.positionBitsToShift());
         completeHeader.offset(0);
         completeHeader.buffer(headerBuffer);
+
         headerBuffer.putBytes(0, header.buffer(), header.offset(), HEADER_LENGTH);
         return this;
     }
@@ -235,7 +236,7 @@ public final class BufferBuilder
      * @param header of the last frame.
      * @return complete message header.
      */
-    public Header prepareCompleteHeader(final Header header)
+    public Header completeHeader(final Header header)
     {
         // compute the `frame length` of the complete message
         final int firstFrameLength = headerBuffer.getInt(FRAME_LENGTH_FIELD_OFFSET, LITTLE_ENDIAN);

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -224,8 +224,8 @@ public final class BufferBuilder
         completeHeader
             .initialTermId(header.initialTermId())
             .positionBitsToShift(header.positionBitsToShift())
-            .offset(0);
-        completeHeader.buffer(headerBuffer);
+            .offset(0)
+            .buffer(headerBuffer);
 
         headerBuffer.putBytes(0, header.buffer(), header.offset(), HEADER_LENGTH);
         return this;

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -261,8 +261,8 @@ public final class BufferBuilder
             {
                 throw new IllegalStateException(
                     "insufficient capacity: maxCapacity=" + MAX_CAPACITY +
-                        " limit=" + limit +
-                        " additionalLength=" + additionalLength);
+                    " limit=" + limit +
+                    " additionalLength=" + additionalLength);
             }
 
             resize(findSuitableCapacity(capacity, requiredCapacity));

--- a/aeron-client/src/main/java/io/aeron/BufferBuilder.java
+++ b/aeron-client/src/main/java/io/aeron/BufferBuilder.java
@@ -16,6 +16,7 @@
 package io.aeron;
 
 import io.aeron.logbuffer.Header;
+import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.HeaderFlyweight;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -238,8 +239,11 @@ public final class BufferBuilder
     {
         final byte flags = verifyFlags(header, END_FRAG_FLAG);
 
-        // set the `frame length` of the complete message
-        headerBuffer.putInt(FRAME_LENGTH_FIELD_OFFSET, limit + HEADER_LENGTH, LITTLE_ENDIAN);
+        // compute the `frame length` of the complete message
+        final int firstFrameLength = headerBuffer.getInt(FRAME_LENGTH_FIELD_OFFSET, LITTLE_ENDIAN);
+        final int fragmentedMessageLength = LogBufferDescriptor.computeFragmentedFrameLength(
+            limit, firstFrameLength - HEADER_LENGTH);
+        headerBuffer.putInt(FRAME_LENGTH_FIELD_OFFSET, fragmentedMessageLength, LITTLE_ENDIAN);
 
         // set the BEGIN_FRAG_FLAG to mark the message as unfragmented
         headerBuffer.putByte(FLAGS_OFFSET, (byte)(flags | BEGIN_FRAG_FLAG));

--- a/aeron-client/src/main/java/io/aeron/ConcurrentPublication.java
+++ b/aeron-client/src/main/java/io/aeron/ConcurrentPublication.java
@@ -391,7 +391,7 @@ public final class ConcurrentPublication extends Publication
         final int length,
         final ReservedValueSupplier reservedValueSupplier)
     {
-        final int framedLength = computeFramedLength(length, maxPayloadLength);
+        final int framedLength = computeFragmentedFrameLength(length, maxPayloadLength);
         final int termLength = termBuffer.capacity();
 
         final long rawTail = logMetaDataBuffer.getAndAddLong(tailCounterOffset, framedLength);
@@ -503,7 +503,7 @@ public final class ConcurrentPublication extends Publication
         final ReservedValueSupplier reservedValueSupplier)
     {
         final int length = lengthOne + lengthTwo;
-        final int framedLength = computeFramedLength(length, maxPayloadLength);
+        final int framedLength = computeFragmentedFrameLength(length, maxPayloadLength);
         final int termLength = termBuffer.capacity();
 
         final long rawTail = logMetaDataBuffer.getAndAddLong(tailCounterOffset, framedLength);
@@ -634,7 +634,7 @@ public final class ConcurrentPublication extends Publication
         final int length,
         final ReservedValueSupplier reservedValueSupplier)
     {
-        final int framedLength = computeFramedLength(length, maxPayloadLength);
+        final int framedLength = computeFragmentedFrameLength(length, maxPayloadLength);
         final int termLength = termBuffer.capacity();
 
         final long rawTail = logMetaDataBuffer.getAndAddLong(tailCounterOffset, framedLength);

--- a/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
@@ -126,7 +126,7 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
         {
             final BufferBuilder builder = getBufferBuilder(header.sessionId());
             builder.reset()
-                .captureFirstHeader(header)
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -144,7 +144,7 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
                     if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
                     {
                         action = delegate.onFragment(
-                            builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
+                            builder.buffer(), 0, builder.limit(), builder.completeHeader(header));
 
                         if (Action.ABORT == action)
                         {

--- a/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ControlledFragmentAssembler.java
@@ -126,6 +126,7 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
         {
             final BufferBuilder builder = getBufferBuilder(header.sessionId());
             builder.reset()
+                .captureFirstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -142,7 +143,8 @@ public class ControlledFragmentAssembler implements ControlledFragmentHandler
 
                     if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
                     {
-                        action = delegate.onFragment(builder.buffer(), 0, builder.limit(), header);
+                        action = delegate.onFragment(
+                            builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
 
                         if (Action.ABORT == action)
                         {

--- a/aeron-client/src/main/java/io/aeron/ExclusivePublication.java
+++ b/aeron-client/src/main/java/io/aeron/ExclusivePublication.java
@@ -24,8 +24,6 @@ import org.agrona.concurrent.status.ReadablePosition;
 
 import static io.aeron.logbuffer.FrameDescriptor.*;
 import static io.aeron.logbuffer.LogBufferDescriptor.*;
-import static io.aeron.logbuffer.LogBufferDescriptor.TERM_TAIL_COUNTERS_OFFSET;
-import static io.aeron.logbuffer.LogBufferDescriptor.packTail;
 import static io.aeron.protocol.DataHeaderFlyweight.*;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.agrona.BitUtil.SIZE_OF_LONG;

--- a/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
@@ -132,6 +132,7 @@ public class FragmentAssembler implements FragmentHandler
         {
             final BufferBuilder builder = getBufferBuilder(header.sessionId());
             builder.reset()
+                .captureFirstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -146,7 +147,8 @@ public class FragmentAssembler implements FragmentHandler
 
                     if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
                     {
-                        delegate.onFragment(builder.buffer(), 0, builder.limit(), header);
+                        delegate.onFragment(
+                            builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
                         builder.reset();
                     }
                     else

--- a/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/FragmentAssembler.java
@@ -132,7 +132,7 @@ public class FragmentAssembler implements FragmentHandler
         {
             final BufferBuilder builder = getBufferBuilder(header.sessionId());
             builder.reset()
-                .captureFirstHeader(header)
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -148,7 +148,7 @@ public class FragmentAssembler implements FragmentHandler
                     if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
                     {
                         delegate.onFragment(
-                            builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
+                            builder.buffer(), 0, builder.limit(), builder.completeHeader(header));
                         builder.reset();
                     }
                     else

--- a/aeron-client/src/main/java/io/aeron/ImageControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ImageControlledFragmentAssembler.java
@@ -117,7 +117,7 @@ public class ImageControlledFragmentAssembler implements ControlledFragmentHandl
         else if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
-                .captureFirstHeader(header)
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -130,7 +130,7 @@ public class ImageControlledFragmentAssembler implements ControlledFragmentHandl
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
                 action = delegate.onFragment(
-                    builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
+                    builder.buffer(), 0, builder.limit(), builder.completeHeader(header));
 
                 if (Action.ABORT == action)
                 {

--- a/aeron-client/src/main/java/io/aeron/ImageControlledFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ImageControlledFragmentAssembler.java
@@ -117,6 +117,7 @@ public class ImageControlledFragmentAssembler implements ControlledFragmentHandl
         else if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
+                .captureFirstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -128,7 +129,8 @@ public class ImageControlledFragmentAssembler implements ControlledFragmentHandl
 
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
-                action = delegate.onFragment(builder.buffer(), 0, builder.limit(), header);
+                action = delegate.onFragment(
+                    builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
 
                 if (Action.ABORT == action)
                 {

--- a/aeron-client/src/main/java/io/aeron/ImageFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ImageFragmentAssembler.java
@@ -122,7 +122,7 @@ public class ImageFragmentAssembler implements FragmentHandler
         if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
-                .captureFirstHeader(header)
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -132,7 +132,7 @@ public class ImageFragmentAssembler implements FragmentHandler
 
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
-                delegate.onFragment(builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
+                delegate.onFragment(builder.buffer(), 0, builder.limit(), builder.completeHeader(header));
                 builder.reset();
             }
             else

--- a/aeron-client/src/main/java/io/aeron/ImageFragmentAssembler.java
+++ b/aeron-client/src/main/java/io/aeron/ImageFragmentAssembler.java
@@ -122,6 +122,7 @@ public class ImageFragmentAssembler implements FragmentHandler
         if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
+                .captureFirstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -131,7 +132,7 @@ public class ImageFragmentAssembler implements FragmentHandler
 
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
-                delegate.onFragment(builder.buffer(), 0, builder.limit(), header);
+                delegate.onFragment(builder.buffer(), 0, builder.limit(), builder.prepareCompleteHeader(header));
                 builder.reset();
             }
             else

--- a/aeron-client/src/main/java/io/aeron/Publication.java
+++ b/aeron-client/src/main/java/io/aeron/Publication.java
@@ -118,7 +118,7 @@ public abstract class Publication implements AutoCloseable
         this.termBufferLength = logBuffers.termLength();
         this.maxMessageLength = FrameDescriptor.computeMaxMessageLength(termBufferLength);
         this.maxPayloadLength = LogBufferDescriptor.mtuLength(logMetaDataBuffer) - HEADER_LENGTH;
-        this.maxFramedLength = computeFramedLength(maxMessageLength, maxPayloadLength);
+        this.maxFramedLength = computeFragmentedFrameLength(maxMessageLength, maxPayloadLength);
         this.maxPossiblePosition = termBufferLength * (1L << 31);
         this.conductor = clientConductor;
         this.channel = channel;
@@ -677,15 +677,6 @@ public abstract class Publication implements AutoCloseable
             throw new IllegalArgumentException(
                 "message exceeds maxMessageLength of " + maxMessageLength + ", length=" + length);
         }
-    }
-
-    static int computeFramedLength(final int length, final int maxPayloadLength)
-    {
-        final int numMaxPayloads = length / maxPayloadLength;
-        final int remainingPayload = length % maxPayloadLength;
-        final int lastFrameLength = remainingPayload > 0 ? align(remainingPayload + HEADER_LENGTH, FRAME_ALIGNMENT) : 0;
-
-        return (numMaxPayloads * (maxPayloadLength + HEADER_LENGTH)) + lastFrameLength;
     }
 
     static int validateAndComputeLength(final int lengthOne, final int lengthTwo)

--- a/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
@@ -100,10 +100,12 @@ public final class Header
      * Set the number of times to left shift the term count to multiply by term length.
      *
      * @param positionBitsToShift number of times to left shift the term count to multiply by term length.
+     * @return this for a fluent API.
      */
-    public void positionBitsToShift(final int positionBitsToShift)
+    public Header positionBitsToShift(final int positionBitsToShift)
     {
         this.positionBitsToShift = positionBitsToShift;
+        return this;
     }
 
     /**
@@ -120,10 +122,12 @@ public final class Header
      * Get the initial term id this stream started at.
      *
      * @param initialTermId the initial term id this stream started at.
+     * @return this for a fluent API.
      */
-    public void initialTermId(final int initialTermId)
+    public Header initialTermId(final int initialTermId)
     {
         this.initialTermId = initialTermId;
+        return this;
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
@@ -80,7 +80,8 @@ public final class Header
     public long position()
     {
         final int frameLength = buffer.getInt(offset, LITTLE_ENDIAN);
-        final int resultingOffset = BitUtil.align(offset + frameLength, FRAME_ALIGNMENT);
+        final int termOffset = buffer.getInt(offset + TERM_OFFSET_FIELD_OFFSET, LITTLE_ENDIAN);
+        final int resultingOffset = BitUtil.align(termOffset + frameLength, FRAME_ALIGNMENT);
         final int termId = buffer.getInt(offset + TERM_ID_FIELD_OFFSET, LITTLE_ENDIAN);
         return computePosition(termId, resultingOffset, positionBitsToShift, initialTermId);
     }
@@ -106,9 +107,9 @@ public final class Header
     }
 
     /**
-     * Set the offset at which the header begins in the log.
+     * Set the offset at which the header begins in the buffer.
      *
-     * @param offset at which the header begins in the log.
+     * @param offset at which the header begins in the buffer.
      */
     public void offset(final int offset)
     {
@@ -116,9 +117,9 @@ public final class Header
     }
 
     /**
-     * The offset at which the frame begins.
+     * The offset at which the frame begins in the buffer.
      *
-     * @return offset at which the frame begins.
+     * @return offset at which the frame begins in the buffer.
      */
     public int offset()
     {
@@ -189,13 +190,13 @@ public final class Header
     }
 
     /**
-     * The offset in the term at which the frame begins. This will be the same as {@link #offset()}
+     * The offset in the term at which the frame begins.
      *
      * @return the offset in the term at which the frame begins.
      */
     public int termOffset()
     {
-        return offset;
+        return buffer.getInt(offset + TERM_OFFSET_FIELD_OFFSET, LITTLE_ENDIAN);
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
@@ -31,8 +31,8 @@ import static io.aeron.logbuffer.LogBufferDescriptor.computePosition;
  */
 public final class Header
 {
-    private final int positionBitsToShift;
-    private final int initialTermId;
+    private int positionBitsToShift;
+    private int initialTermId;
     private int offset = 0;
     private DirectBuffer buffer;
     private final Object context;
@@ -97,6 +97,16 @@ public final class Header
     }
 
     /**
+     * Set the number of times to left shift the term count to multiply by term length.
+     *
+     * @param positionBitsToShift number of times to left shift the term count to multiply by term length.
+     */
+    public void positionBitsToShift(final int positionBitsToShift)
+    {
+        this.positionBitsToShift = positionBitsToShift;
+    }
+
+    /**
      * Get the initial term id this stream started at.
      *
      * @return the initial term id this stream started at.
@@ -104,6 +114,16 @@ public final class Header
     public int initialTermId()
     {
         return initialTermId;
+    }
+
+    /**
+     * Get the initial term id this stream started at.
+     *
+     * @param initialTermId the initial term id this stream started at.
+     */
+    public void initialTermId(final int initialTermId)
+    {
+        this.initialTermId = initialTermId;
     }
 
     /**

--- a/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
+++ b/aeron-client/src/main/java/io/aeron/logbuffer/Header.java
@@ -134,10 +134,12 @@ public final class Header
      * Set the offset at which the header begins in the buffer.
      *
      * @param offset at which the header begins in the buffer.
+     * @return this for a fluent API.
      */
-    public void offset(final int offset)
+    public Header offset(final int offset)
     {
         this.offset = offset;
+        return this;
     }
 
     /**
@@ -164,13 +166,15 @@ public final class Header
      * The {@link org.agrona.DirectBuffer} containing the header.
      *
      * @param buffer {@link org.agrona.DirectBuffer} containing the header.
+     * @return this for a fluent API.
      */
-    public void buffer(final DirectBuffer buffer)
+    public Header buffer(final DirectBuffer buffer)
     {
         if (buffer != this.buffer)
         {
             this.buffer = buffer;
         }
+        return this;
     }
 
     /**

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -333,7 +333,7 @@ class BufferBuilderTest
         header.offset(headerFlyweight.wrapAdjustment());
         final DirectBuffer originalHeaderBuffer = header.buffer();
 
-        assertSame(bufferBuilder, bufferBuilder.captureFirstHeader(header));
+        assertSame(bufferBuilder, bufferBuilder.firstHeader(header));
 
         assertEquals(0, bufferBuilder.capacity());
         assertEquals(0, bufferBuilder.limit());
@@ -384,7 +384,7 @@ class BufferBuilderTest
         header.buffer(new UnsafeBuffer(headerFlyweight.byteArray()));
         header.offset(headerFlyweight.wrapAdjustment());
 
-        assertSame(bufferBuilder, bufferBuilder.captureFirstHeader(header));
+        assertSame(bufferBuilder, bufferBuilder.firstHeader(header));
 
         final int flags = 0b0110_0110;
         headerFlyweight.wrap(new byte[88], 19, 42);
@@ -401,7 +401,7 @@ class BufferBuilderTest
         header.offset(headerFlyweight.wrapAdjustment());
         final DirectBuffer originalHeaderBuffer = header.buffer();
 
-        final Header completeHeader = bufferBuilder.prepareCompleteHeader(header);
+        final Header completeHeader = bufferBuilder.completeHeader(header);
         assertNotSame(header, completeHeader);
 
         assertEquals(INIT_MIN_CAPACITY, bufferBuilder.capacity());

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import static io.aeron.BufferBuilder.INIT_MIN_CAPACITY;
 import static io.aeron.logbuffer.FrameDescriptor.*;
 import static io.aeron.logbuffer.LogBufferDescriptor.computeFragmentedFrameLength;
-import static io.aeron.protocol.DataHeaderFlyweight.EOS_FLAG;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
 import static io.aeron.protocol.HeaderFlyweight.*;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
@@ -422,36 +421,6 @@ class BufferBuilderTest
         assertEquals(streamId, header.streamId());
         assertEquals(termId, header.termId());
         assertEquals(reservedValue, header.reservedValue());
-    }
-
-    @Test
-    void shouldThrowAnExceptionIfPrepareCompleteHeaderIsCalledWithNonLastFragment()
-    {
-        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
-        headerFlyweight.wrap(new byte[64], 32, 32);
-        headerFlyweight.flags((byte)0b1011_1111);
-        final Header header = new Header(0, 16);
-        header.buffer(headerFlyweight);
-
-        final IllegalArgumentException exception =
-            assertThrowsExactly(IllegalArgumentException.class, () -> bufferBuilder.prepareCompleteHeader(header));
-        assertEquals("invalid frame, i.e. the (01000000) bit must be set in flags, got: 10111111",
-            exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowAnExceptionIfCaptureFirstHeaderIsCalledWithInvalidFlags()
-    {
-        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
-        headerFlyweight.wrap(new byte[64], 32, 32);
-        headerFlyweight.flags((short)(END_FRAG_FLAG | EOS_FLAG | 3));
-        final Header header = new Header(0, 16);
-        header.buffer(headerFlyweight);
-
-        final IllegalArgumentException exception =
-            assertThrowsExactly(IllegalArgumentException.class, () -> bufferBuilder.captureFirstHeader(header));
-        assertEquals("invalid frame, i.e. the (10000000) bit must be set in flags, got: 01100011",
-            exception.getMessage());
     }
 
     @Test

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -353,6 +353,11 @@ class BufferBuilderTest
     @Test
     void shouldPrepareCompleteHeader()
     {
+        final UnsafeBuffer data = new UnsafeBuffer(new byte[999]);
+        bufferBuilder.append(data, 0, data.capacity());
+        assertEquals(INIT_MIN_CAPACITY, bufferBuilder.capacity());
+        assertEquals(data.capacity(), bufferBuilder.limit());
+
         final long reservedValue = 0xCAFE_BABE_DEAD_BEEFL;
         final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
         headerFlyweight.wrap(new byte[44], 1, 39);
@@ -389,15 +394,15 @@ class BufferBuilderTest
 
         assertSame(header, bufferBuilder.prepareCompleteHeader(header));
 
-        assertEquals(0, bufferBuilder.capacity());
-        assertEquals(0, bufferBuilder.limit());
+        assertEquals(INIT_MIN_CAPACITY, bufferBuilder.capacity());
+        assertEquals(data.capacity(), bufferBuilder.limit());
         assertNotSame(originalHeaderBuffer, header.buffer());
         assertSame(bufferBuilder.headerBuffer(), header.buffer());
         assertNotSame(bufferBuilder.headerBuffer(), bufferBuilder.buffer());
         assertEquals(0, header.offset());
         assertEquals(2, header.initialTermId());
         assertEquals(3, header.positionBitsToShift());
-        assertEquals(256, header.frameLength());
+        assertEquals(bufferBuilder.limit() + HEADER_LENGTH, header.frameLength());
         assertEquals((byte)(flags | BEGIN_FRAG_FLAG), header.flags());
         assertNotEquals(0, header.flags() & BEGIN_FRAG_FLAG);
         assertEquals(48, header.termOffset());

--- a/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
+++ b/aeron-client/src/test/java/io/aeron/BufferBuilderTest.java
@@ -15,47 +15,62 @@
  */
 package io.aeron;
 
-import org.junit.jupiter.api.Test;
+import io.aeron.logbuffer.Header;
+import io.aeron.protocol.DataHeaderFlyweight;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.aeron.BufferBuilder.INIT_MIN_CAPACITY;
+import static io.aeron.logbuffer.FrameDescriptor.*;
+import static io.aeron.protocol.DataHeaderFlyweight.EOS_FLAG;
+import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static io.aeron.protocol.HeaderFlyweight.*;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BufferBuilderTest
 {
     private final BufferBuilder bufferBuilder = new BufferBuilder();
 
-    @Test
-    void shouldFindMaxCapacityWhenRequested()
+    @ParameterizedTest
+    @CsvSource({
+        "0,0,4096", "4095,1,4096", "4096,7,4096", "100,200,4096", "101,5000,6144", "5000,8080,11250",
+        "6666,11111,14998", "0,2147483639,2147483639", "2048,2147483647,2147483639", "5,1000000000000,2147483639" })
+    void shouldFindSuitableCapacity(final int capacity, final long requiredCapacity, final int expected)
     {
-        assertEquals(
-            BufferBuilder.MAX_CAPACITY,
-            BufferBuilder.findSuitableCapacity(0, BufferBuilder.MAX_CAPACITY));
+        assertEquals(expected, BufferBuilder.findSuitableCapacity(capacity, requiredCapacity));
     }
 
     @Test
     void shouldInitialiseToDefaultValues()
     {
         assertEquals(0, bufferBuilder.capacity());
-        assertEquals(0, bufferBuilder.buffer().capacity());
         assertEquals(0, bufferBuilder.limit());
+        assertEquals(0, bufferBuilder.buffer().capacity());
+        assertNull(bufferBuilder.buffer().byteBuffer());
+        assertArrayEquals(ArrayUtil.EMPTY_BYTE_ARRAY, bufferBuilder.buffer().byteArray());
     }
 
     @Test
     void shouldGrowDirectBuffer()
     {
         final BufferBuilder builder = new BufferBuilder(0, true);
+        assertEquals(0, builder.limit());
         assertEquals(0, builder.capacity());
         assertEquals(0, builder.buffer().capacity());
-        assertEquals(0, builder.limit());
 
         final int appendedLength = 10;
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(new byte[appendedLength]);
@@ -64,6 +79,64 @@ class BufferBuilderTest
         assertEquals(INIT_MIN_CAPACITY, builder.capacity());
         assertEquals(INIT_MIN_CAPACITY, builder.buffer().capacity());
         assertEquals(appendedLength, builder.limit());
+        assertNotNull(builder.buffer().byteBuffer());
+        assertTrue(builder.buffer().byteBuffer().isDirect());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void shouldCreateHaderBuffer(final boolean isDirect)
+    {
+        final BufferBuilder builder = new BufferBuilder(0, isDirect);
+        assertNotNull(builder.buffer());
+        assertNotNull(builder.headerBuffer());
+        assertNotSame(builder.headerBuffer(), builder.buffer());
+
+        assertEquals(0, builder.capacity());
+        assertEquals(0, builder.limit());
+        assertEquals(0, builder.buffer().capacity());
+
+        assertEquals(HEADER_LENGTH, builder.headerBuffer().capacity());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, Integer.MAX_VALUE, Integer.MAX_VALUE - 7 })
+    void shouldThrowIllegalArgumentExceptionIfInitialCapacityIsOutOfRange(final int initialCapacity)
+    {
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> new BufferBuilder(initialCapacity));
+        assertEquals(
+            "initialCapacity outside range 0 - 2147483639: initialCapacity=" + initialCapacity, exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 65, 1000000 })
+    void shouldThrowIllegalArgumentExceptionIfLimitIsOutOfRange(final int limit)
+    {
+        final BufferBuilder builder = new BufferBuilder(0);
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> builder.limit(limit));
+        assertEquals("limit outside range: capacity=" + builder.capacity() + " limit=" + limit,
+            exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { Integer.MAX_VALUE, Integer.MAX_VALUE - 23 })
+    void shouldThrowIllegalStateExceptionIfDataExceedsMaxCapacity(final int length)
+    {
+        final UnsafeBuffer src = new UnsafeBuffer(new byte[16]);
+        src.putLong(0, Long.MAX_VALUE);
+        src.putLong(SIZE_OF_LONG, Long.MIN_VALUE);
+
+        final BufferBuilder builder = new BufferBuilder(64);
+        builder.append(src, 0, src.capacity());
+        assertEquals(src.capacity(), builder.limit());
+
+        final IllegalStateException exception =
+            assertThrowsExactly(IllegalStateException.class, () -> builder.append(src, 0, length));
+        assertEquals(
+            "insufficient capacity: maxCapacity=2147483639 limit=" + builder.limit() +
+            " additionalLength=" + length, exception.getMessage());
     }
 
     @Test
@@ -74,6 +147,7 @@ class BufferBuilderTest
         bufferBuilder.append(srcBuffer, 0, 0);
 
         assertEquals(0, bufferBuilder.limit());
+        assertEquals(0, bufferBuilder.capacity());
     }
 
     @Test
@@ -146,6 +220,7 @@ class BufferBuilderTest
         final UnsafeBuffer srcBuffer = new UnsafeBuffer(buffer);
 
         final BufferBuilder bufferBuilder = new BufferBuilder(bufferLength);
+        final int initialCapacity = bufferBuilder.capacity();
 
         bufferBuilder.append(srcBuffer, 0, bufferLength);
 
@@ -153,7 +228,7 @@ class BufferBuilderTest
         bufferBuilder.buffer().getBytes(0, temp, 0, bufferLength);
 
         assertEquals(bufferLength, bufferBuilder.limit());
-        assertEquals(bufferLength, bufferBuilder.capacity());
+        assertEquals(initialCapacity, bufferBuilder.capacity());
         assertArrayEquals(temp, buffer);
     }
 
@@ -230,5 +305,187 @@ class BufferBuilderTest
 
         assertEquals(buffer.length * 3, bufferBuilder.limit());
         assertThat(bufferBuilder.capacity(), lessThan(expandedCapacity));
+        assertEquals(bufferBuilder.limit(), bufferBuilder.capacity());
+    }
+
+    @Test
+    void captureFirstHeader()
+    {
+        final long reservedValue = Long.MAX_VALUE - 117;
+        final int offset = 40;
+        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
+        headerFlyweight.wrap(new byte[100], offset, 50);
+        headerFlyweight.frameLength(512);
+        headerFlyweight.version((short)0xA);
+        headerFlyweight.flags((short)0b1111_1111);
+        headerFlyweight.headerType(HDR_TYPE_RTTM);
+        headerFlyweight.termOffset(124);
+        headerFlyweight.sessionId(-890);
+        headerFlyweight.streamId(555);
+        headerFlyweight.termId(42);
+        headerFlyweight.reservedValue(reservedValue);
+
+        final Header header = new Header(5, 3);
+        header.buffer(new UnsafeBuffer(headerFlyweight.byteArray()));
+        header.offset(headerFlyweight.wrapAdjustment());
+        final DirectBuffer originalHeaderBuffer = header.buffer();
+
+        assertSame(bufferBuilder, bufferBuilder.captureFirstHeader(header));
+
+        assertEquals(0, bufferBuilder.capacity());
+        assertEquals(0, bufferBuilder.limit());
+        assertSame(originalHeaderBuffer, header.buffer());
+        assertNotSame(bufferBuilder.buffer(), header.buffer());
+        assertNotSame(bufferBuilder.headerBuffer(), header.buffer());
+
+        headerFlyweight.wrap(bufferBuilder.headerBuffer(), 0, HEADER_LENGTH);
+        assertEquals(0, headerFlyweight.frameLength());
+        assertEquals(0, headerFlyweight.version());
+        assertEquals(0, headerFlyweight.flags());
+        assertEquals(0, headerFlyweight.headerType());
+        assertEquals(0, headerFlyweight.termOffset());
+        assertEquals(0, headerFlyweight.sessionId());
+        assertEquals(0, headerFlyweight.streamId());
+        assertEquals(0, headerFlyweight.termId());
+        assertEquals(reservedValue, headerFlyweight.reservedValue());
+    }
+
+    @Test
+    void shouldPrepareCompleteHeader()
+    {
+        final long reservedValue = 0xCAFE_BABE_DEAD_BEEFL;
+        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
+        headerFlyweight.wrap(new byte[44], 1, 39);
+        headerFlyweight.frameLength(1);
+        headerFlyweight.version((short)1);
+        headerFlyweight.flags(UNFRAGMENTED);
+        headerFlyweight.headerType(1);
+        headerFlyweight.termOffset(1);
+        headerFlyweight.sessionId(1);
+        headerFlyweight.streamId(1);
+        headerFlyweight.termId(1);
+        headerFlyweight.reservedValue(reservedValue);
+
+        final Header header = new Header(2, 3);
+        header.buffer(new UnsafeBuffer(headerFlyweight.byteArray()));
+        header.offset(headerFlyweight.wrapAdjustment());
+
+        assertSame(bufferBuilder, bufferBuilder.captureFirstHeader(header));
+
+        final int flags = 0b0101_0101;
+        headerFlyweight.wrap(new byte[88], 19, 42);
+        headerFlyweight.frameLength(256);
+        headerFlyweight.version((short)0xC);
+        headerFlyweight.flags((short)flags);
+        headerFlyweight.headerType(HDR_TYPE_ATS_SETUP);
+        headerFlyweight.termOffset(48);
+        headerFlyweight.sessionId(999);
+        headerFlyweight.streamId(4);
+        headerFlyweight.termId(39);
+        headerFlyweight.reservedValue(Long.MIN_VALUE);
+        header.buffer(new UnsafeBuffer(headerFlyweight.byteArray()));
+        header.offset(headerFlyweight.wrapAdjustment());
+        final DirectBuffer originalHeaderBuffer = header.buffer();
+
+        assertSame(header, bufferBuilder.prepareCompleteHeader(header));
+
+        assertEquals(0, bufferBuilder.capacity());
+        assertEquals(0, bufferBuilder.limit());
+        assertNotSame(originalHeaderBuffer, header.buffer());
+        assertSame(bufferBuilder.headerBuffer(), header.buffer());
+        assertNotSame(bufferBuilder.headerBuffer(), bufferBuilder.buffer());
+        assertEquals(0, header.offset());
+        assertEquals(2, header.initialTermId());
+        assertEquals(3, header.positionBitsToShift());
+        assertEquals(256, header.frameLength());
+        assertEquals((byte)(flags | BEGIN_FRAG_FLAG), header.flags());
+        assertNotEquals(0, header.flags() & BEGIN_FRAG_FLAG);
+        assertEquals(48, header.termOffset());
+        assertEquals(999, header.sessionId());
+        assertEquals(4, header.streamId());
+        assertEquals(39, header.termId());
+        assertEquals(reservedValue, header.reservedValue());
+        assertEquals((byte)0xC, bufferBuilder.headerBuffer().getByte(VERSION_FIELD_OFFSET));
+        assertEquals((short)HDR_TYPE_ATS_SETUP, bufferBuilder.headerBuffer().getShort(TYPE_FIELD_OFFSET));
+    }
+
+    @Test
+    void shouldThrowAnExceptionIfPrepareCompleteHeaderIsCalledWithNonLastFragment()
+    {
+        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
+        headerFlyweight.wrap(new byte[64], 32, 32);
+        headerFlyweight.flags((byte)0b1011_1111);
+        final Header header = new Header(0, 16);
+        header.buffer(headerFlyweight);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> bufferBuilder.prepareCompleteHeader(header));
+        assertEquals("invalid frame, i.e. the (01000000) bit must be set in flags, got: 10111111",
+            exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowAnExceptionIfCaptureFirstHeaderIsCalledWithInvalidFlags()
+    {
+        final DataHeaderFlyweight headerFlyweight = new DataHeaderFlyweight();
+        headerFlyweight.wrap(new byte[64], 32, 32);
+        headerFlyweight.flags((short)(END_FRAG_FLAG | EOS_FLAG | 3));
+        final Header header = new Header(0, 16);
+        header.buffer(headerFlyweight);
+
+        final IllegalArgumentException exception =
+            assertThrowsExactly(IllegalArgumentException.class, () -> bufferBuilder.captureFirstHeader(header));
+        assertEquals("invalid frame, i.e. the (10000000) bit must be set in flags, got: 01100011",
+            exception.getMessage());
+    }
+
+    @Test
+    void compactEmptyBufferIsAnOp()
+    {
+        assertSame(bufferBuilder, bufferBuilder.compact());
+
+        assertEquals(0, bufferBuilder.capacity());
+        assertEquals(0, bufferBuilder.limit());
+        assertEquals(0, bufferBuilder.buffer().capacity());
+    }
+
+    @Test
+    void compactIsANoOpIfTheCapacityIsNotDecreasing()
+    {
+        assertSame(bufferBuilder, bufferBuilder.append(new UnsafeBuffer(new byte[5]), 0, 3));
+        assertEquals(3, bufferBuilder.limit());
+        assertEquals(INIT_MIN_CAPACITY, bufferBuilder.capacity());
+        final MutableDirectBuffer originalBuffer = bufferBuilder.buffer();
+        assertEquals(INIT_MIN_CAPACITY, originalBuffer.capacity());
+
+        assertSame(bufferBuilder, bufferBuilder.compact());
+
+        assertEquals(3, bufferBuilder.limit());
+        assertEquals(INIT_MIN_CAPACITY, bufferBuilder.capacity());
+        assertSame(originalBuffer, bufferBuilder.buffer());
+        assertEquals(INIT_MIN_CAPACITY, originalBuffer.capacity());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void shouldNotChangeHeaderBufferUponResize(final boolean isDirect)
+    {
+        final BufferBuilder builder = new BufferBuilder(0, isDirect);
+        final UnsafeBuffer headerBuffer = builder.headerBuffer();
+        final ByteBuffer headerByteBuffer = headerBuffer.byteBuffer();
+        final byte[] headerByteArray = headerBuffer.byteArray();
+        headerBuffer.setMemory(0, headerBuffer.capacity(), (byte)0xFA);
+
+        final UnsafeBuffer src = new UnsafeBuffer(new byte[100]);
+        ThreadLocalRandom.current().nextBytes(src.byteArray());
+        builder.append(src, 0, src.capacity());
+
+        assertSame(headerBuffer, builder.headerBuffer());
+        assertSame(headerByteBuffer, builder.headerBuffer().byteBuffer());
+        assertSame(headerByteArray, builder.headerBuffer().byteArray());
+        for (int i = 0; i < headerBuffer.capacity(); i++)
+        {
+            assertEquals((byte)0xFA, headerBuffer.getByte(i));
+        }
     }
 }

--- a/aeron-client/src/test/java/io/aeron/FragmentAssemblerTest.java
+++ b/aeron-client/src/test/java/io/aeron/FragmentAssemblerTest.java
@@ -85,7 +85,7 @@ class FragmentAssemblerTest
 
         final Header capturedHeader = headerArg.getValue();
         assertEquals(SESSION_ID, capturedHeader.sessionId());
-        assertEquals(FrameDescriptor.END_FRAG_FLAG, capturedHeader.flags());
+        assertEquals(FrameDescriptor.UNFRAGMENTED, capturedHeader.flags());
     }
 
     @Test
@@ -116,7 +116,7 @@ class FragmentAssemblerTest
 
         final Header capturedHeader = headerArg.getValue();
         assertEquals(SESSION_ID, capturedHeader.sessionId());
-        assertEquals(FrameDescriptor.END_FRAG_FLAG, capturedHeader.flags());
+        assertEquals(FrameDescriptor.UNFRAGMENTED, capturedHeader.flags());
     }
 
     @Test

--- a/aeron-client/src/test/java/io/aeron/FragmentAssemblerTest.java
+++ b/aeron-client/src/test/java/io/aeron/FragmentAssemblerTest.java
@@ -15,20 +15,20 @@
  */
 package io.aeron;
 
-import org.agrona.BitUtil;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.logbuffer.Header;
 import io.aeron.logbuffer.LogBufferDescriptor;
+import org.agrona.BitUtil;
 import org.agrona.concurrent.UnsafeBuffer;
-
-import java.nio.ByteOrder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static io.aeron.protocol.DataHeaderFlyweight.SESSION_ID_FIELD_OFFSET;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -38,7 +38,7 @@ class FragmentAssemblerTest
     private static final int INITIAL_TERM_ID = 3;
 
     private final FragmentHandler delegateFragmentHandler = mock(FragmentHandler.class);
-    private final UnsafeBuffer termBuffer = mock(UnsafeBuffer.class);
+    private final UnsafeBuffer termBuffer = new UnsafeBuffer(new byte[1024]);
     private final Header header = spy(new Header(INITIAL_TERM_ID, LogBufferDescriptor.TERM_MIN_LENGTH));
     private final FragmentAssembler assembler = new FragmentAssembler(delegateFragmentHandler);
 
@@ -46,7 +46,8 @@ class FragmentAssemblerTest
     void setUp()
     {
         header.buffer(termBuffer);
-        when(termBuffer.getInt(anyInt(), any(ByteOrder.class))).thenReturn(SESSION_ID);
+        header.offset(16);
+        termBuffer.putInt(header.offset() + SESSION_ID_FIELD_OFFSET, SESSION_ID, LITTLE_ENDIAN);
     }
 
     @Test

--- a/aeron-client/src/test/java/io/aeron/logbuffer/HeaderTest.java
+++ b/aeron-client/src/test/java/io/aeron/logbuffer/HeaderTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.logbuffer;
+
+import io.aeron.protocol.DataHeaderFlyweight;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HeaderTest
+{
+    @Test
+    void constructorInitializedData()
+    {
+        final int initialTermId = 18;
+        final BigDecimal context = BigDecimal.valueOf(Long.MAX_VALUE);
+        final int positionBitsToShift = 2;
+        final Header header = new Header(initialTermId, positionBitsToShift, context);
+
+        assertEquals(initialTermId, header.initialTermId());
+        assertEquals(positionBitsToShift, header.positionBitsToShift());
+        assertEquals(context, header.context());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0,2,100,1024,5,1172", "42,16,13,4096,46,266272", "1,30,1024,1073741824,111,119185343488" })
+    void positionCalculationTheEndOfTheMessageInTheLog(
+        final int initialTermId,
+        final int positionBitsToShift,
+        final int frameLength,
+        final int termOffset,
+        final int termId,
+        final long expectedPosition)
+    {
+        final DataHeaderFlyweight dataHeaderFlyweight = new DataHeaderFlyweight();
+        final Header header = new Header(initialTermId, positionBitsToShift);
+        header.buffer(dataHeaderFlyweight);
+        header.offset(0);
+        dataHeaderFlyweight.wrap(new byte[64], 16, 32);
+        dataHeaderFlyweight.frameLength(frameLength);
+        dataHeaderFlyweight.termId(termId);
+        dataHeaderFlyweight.termOffset(termOffset);
+
+        assertEquals(expectedPosition, header.position());
+    }
+
+    @Test
+    void offsetIsRelativeToTheBufferStart()
+    {
+        final Header header = new Header(42, 3, "xyz");
+
+        assertEquals(0, header.offset());
+
+        header.offset(142);
+
+        assertEquals(142, header.offset());
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "103,0x3,0x1A,0x6,2080,-46234,333,5,909090909090909",
+        "512,0x1,0xC,0x1,1073741824,42,-876,1543,-4632842384627834687" })
+    void shouldReadDataFromTheBuffer(
+        final int frameLength,
+        final byte version,
+        final byte flags,
+        final short type,
+        final int termOffset,
+        final int sessionId,
+        final int streamId,
+        final int termId,
+        final long reservedValue)
+    {
+        final byte[] array = new byte[100];
+        final int offset = 16;
+        final DataHeaderFlyweight dataHeaderFlyweight = new DataHeaderFlyweight();
+        dataHeaderFlyweight.wrap(array, offset, 64);
+
+        dataHeaderFlyweight.frameLength(frameLength)
+            .version(version)
+            .flags(flags)
+            .headerType(type);
+
+        dataHeaderFlyweight
+            .termOffset(termOffset)
+            .sessionId(sessionId)
+            .streamId(streamId)
+            .termId(termId)
+            .reservedValue(reservedValue);
+
+
+        final Header header = new Header(5, 22);
+        header.buffer(new UnsafeBuffer(array));
+        header.offset(offset);
+
+        assertEquals(frameLength, header.frameLength());
+        assertEquals(flags, header.flags());
+        assertEquals(type, header.type());
+        assertEquals(termOffset, header.termOffset());
+        assertEquals(sessionId, header.sessionId());
+        assertEquals(streamId, header.streamId());
+        assertEquals(termId, header.termId());
+        assertEquals(reservedValue, header.reservedValue());
+    }
+}

--- a/aeron-client/src/test/java/io/aeron/logbuffer/HeaderTest.java
+++ b/aeron-client/src/test/java/io/aeron/logbuffer/HeaderTest.java
@@ -119,4 +119,28 @@ class HeaderTest
         assertEquals(termId, header.termId());
         assertEquals(reservedValue, header.reservedValue());
     }
+
+    @Test
+    void shouldOverrideInitialTermId()
+    {
+        final int initialTermId = -178;
+        final int newInitialTermId = 871;
+        final Header header = new Header(initialTermId, 3);
+        assertEquals(initialTermId, header.initialTermId());
+
+        header.initialTermId(newInitialTermId);
+        assertEquals(newInitialTermId, header.initialTermId());
+    }
+
+    @Test
+    void shouldOverridePositionBitsToShift()
+    {
+        final int positionBitsToShift = -6;
+        final int newPositionBitsToShift = 20;
+        final Header header = new Header(42, positionBitsToShift);
+        assertEquals(positionBitsToShift, header.positionBitsToShift());
+
+        header.positionBitsToShift(newPositionBitsToShift);
+        assertEquals(newPositionBitsToShift, header.positionBitsToShift());
+    }
 }

--- a/aeron-client/src/test/java/io/aeron/logbuffer/LogBufferDescriptorTest.java
+++ b/aeron-client/src/test/java/io/aeron/logbuffer/LogBufferDescriptorTest.java
@@ -17,6 +17,8 @@ package io.aeron.logbuffer;
 
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.nio.ByteBuffer;
 
@@ -79,5 +81,13 @@ class LogBufferDescriptorTest
         assertEquals(packTail(termId + 18, 2048), rawTail(metadataBuffer, 1));
         assertEquals(packTail(termId - 19, 4096), rawTail(metadataBuffer, 2));
         assertEquals(termCount, activeTermCount(metadataBuffer));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0,1376,0", "10,1024,64", "2048,2048,2080", "4096,1024,4224", "7997,992,8288" })
+    void shouldComputeFragmentedFrameLength(
+        final int length, final int maxPayloadLength, final int frameLength)
+    {
+        assertEquals(LogBufferDescriptor.computeFragmentedFrameLength(length, maxPayloadLength), frameLength);
     }
 }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/LogAdapter.java
@@ -154,6 +154,7 @@ final class LogAdapter implements ControlledFragmentHandler
         else if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -165,7 +166,7 @@ final class LogAdapter implements ControlledFragmentHandler
 
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
-                action = onMessage(builder.buffer(), 0, header);
+                action = onMessage(builder.buffer(), 0, builder.completeHeader(header));
 
                 if (Action.ABORT == action)
                 {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/BoundedLogAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/BoundedLogAdapter.java
@@ -72,6 +72,7 @@ final class BoundedLogAdapter implements ControlledFragmentHandler, AutoCloseabl
         else if ((flags & BEGIN_FRAG_FLAG) == BEGIN_FRAG_FLAG)
         {
             builder.reset()
+                .firstHeader(header)
                 .append(buffer, offset, length)
                 .nextTermOffset(BitUtil.align(offset + length + HEADER_LENGTH, FRAME_ALIGNMENT));
         }
@@ -83,7 +84,7 @@ final class BoundedLogAdapter implements ControlledFragmentHandler, AutoCloseabl
 
             if ((flags & END_FRAG_FLAG) == END_FRAG_FLAG)
             {
-                action = onMessage(builder.buffer(), 0, builder.limit(), header);
+                action = onMessage(builder.buffer(), 0, builder.limit(), builder.completeHeader(header));
 
                 if (Action.ABORT == action)
                 {

--- a/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/FragmentedMessageTest.java
@@ -38,7 +38,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 
-import static io.aeron.logbuffer.FrameDescriptor.END_FRAG_FLAG;
+import static io.aeron.logbuffer.FrameDescriptor.UNFRAGMENTED;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -135,7 +135,7 @@ class FragmentedMessageTest
                 assertEquals(srcBuffer.getByte(i), capturedBuffer.getByte(i), "same at i=" + i);
             }
 
-            assertEquals(END_FRAG_FLAG, headerArg.getValue().flags());
+            assertEquals(UNFRAGMENTED, headerArg.getValue().flags());
         }
     }
 }

--- a/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/PubAndSubTest.java
@@ -21,19 +21,14 @@ import io.aeron.driver.ext.DebugChannelEndpointConfiguration;
 import io.aeron.driver.ext.DebugSendChannelEndpoint;
 import io.aeron.driver.ext.LossGenerator;
 import io.aeron.exceptions.RegistrationException;
-import io.aeron.logbuffer.FragmentHandler;
-import io.aeron.logbuffer.Header;
-import io.aeron.logbuffer.RawBlockHandler;
-import io.aeron.test.InterruptAfter;
-import io.aeron.test.InterruptingTestCallback;
-import io.aeron.test.SlowTest;
-import io.aeron.test.SystemTestWatcher;
-import io.aeron.test.Tests;
+import io.aeron.logbuffer.*;
+import io.aeron.test.*;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
+import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -46,26 +41,24 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static io.aeron.SystemTests.verifyLossOccurredForStream;
-import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
-import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static io.aeron.logbuffer.FrameDescriptor.*;
+import static io.aeron.protocol.DataHeaderFlyweight.*;
+import static io.aeron.protocol.HeaderFlyweight.CURRENT_VERSION;
+import static io.aeron.protocol.HeaderFlyweight.HDR_TYPE_RSP_SETUP;
 import static java.util.Arrays.asList;
 import static org.agrona.BitUtil.SIZE_OF_INT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(InterruptingTestCallback.class)
 class PubAndSubTest
@@ -101,6 +94,8 @@ class PubAndSubTest
     private void launch(final String channel)
     {
         context
+            .dirDeleteOnStart(true)
+            .dirDeleteOnShutdown(true)
             .threadingMode(THREADING_MODE)
             .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500))
             .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100));
@@ -867,6 +862,308 @@ class PubAndSubTest
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("fragmentAssemblers")
+    @SuppressWarnings("MethodLength")
+    void shouldReturnCompleteHeaderForAssembledMessages(final Class<?> assemblerClass)
+        throws ReflectiveOperationException
+    {
+        final ArrayList<ExpectedFragment> messages = new ArrayList<>();
+        final MutableInteger messageIndex = new MutableInteger();
+        final FragmentHandler rawFragmentHandler =
+            (buffer, offset, length, header) -> verifyFragment(buffer, offset, length, header, messageIndex, messages);
+        final FragmentHandler fragmentAssembler;
+        final ControlledFragmentHandler controlledFragmentAssembler;
+        if (FragmentHandler.class.isAssignableFrom(assemblerClass))
+        {
+            fragmentAssembler = (FragmentHandler)assemblerClass.getConstructor(FragmentHandler.class)
+                .newInstance(rawFragmentHandler);
+            controlledFragmentAssembler = null;
+        }
+        else
+        {
+            final ControlledFragmentHandler delegate = (buffer, offset, length, header) ->
+            {
+                rawFragmentHandler.onFragment(buffer, offset, length, header);
+                return ControlledFragmentHandler.Action.COMMIT;
+            };
+            controlledFragmentAssembler =
+                (ControlledFragmentHandler)assemblerClass.getConstructor(ControlledFragmentHandler.class)
+                    .newInstance(delegate);
+            fragmentAssembler = null;
+        }
+
+        final int mtu = 2048;
+        final int maxPayloadLength = mtu - HEADER_LENGTH;
+        final int termLength = 64 * 1024;
+        final int paddingLength = 1376;
+        final int termOffset = termLength - paddingLength;
+        final int initialTermId = 5;
+        final int termId = 13;
+        final long initialPosition = termLength * (termId - initialTermId) + termOffset;
+        final UnsafeBuffer data = new UnsafeBuffer(new byte[maxPayloadLength * 3 + 317]);
+        ThreadLocalRandom.current().nextBytes(data.byteArray());
+        launch("aeron:ipc?mtu=" + mtu + "|term-length=64K|init-term-id=" + initialTermId +
+            "|term-id=" + termId + "|term-offset=" + termOffset);
+
+        try (Subscription unfragmentedSubscription =
+            subscribingClient.addSubscription(subscription.channel(), STREAM_ID))
+        {
+            Tests.awaitConnected(publication);
+            Tests.awaitConnected(subscription);
+            Tests.awaitConnected(unfragmentedSubscription);
+
+            final BufferClaim bufferClaim = new BufferClaim();
+            long position;
+            final int firstMessageLength = 100;
+            while ((position = publication.tryClaim(firstMessageLength, bufferClaim)) < 0)
+            {
+                Tests.yield();
+            }
+            final int headerType = HDR_TYPE_RSP_SETUP;
+            final byte expectedFlags = (byte)(BEGIN_END_AND_EOS_FLAGS | 0xA);
+            final long reservedValue = 13131313139871L;
+            bufferClaim.headerType(headerType);
+            bufferClaim.flags(expectedFlags);
+            bufferClaim.reservedValue(reservedValue);
+            bufferClaim.buffer().putBytes(bufferClaim.offset(), data, 0, firstMessageLength);
+            bufferClaim.commit();
+
+            final long secondReservedValue = -4239462982749823794L;
+            final MutableLong fragmentedReservedValue = new MutableLong(secondReservedValue);
+            final ReservedValueSupplier reservedValueSupplier =
+                (tb, to, fl) -> fragmentedReservedValue.getAndAdd(reservedValue);
+            while ((position = publication.offer(data, 0, data.capacity(), reservedValueSupplier)) < 0)
+            {
+                Tests.yield();
+            }
+            final int fragmentedMessageLength =
+                LogBufferDescriptor.computeFragmentedFrameLength(data.capacity(), maxPayloadLength);
+
+            while ((position = publication.tryClaim(maxPayloadLength, bufferClaim)) < 0)
+            {
+                Tests.yield();
+            }
+            bufferClaim.headerType(HDR_TYPE_SM);
+            bufferClaim.flags((byte)0xFF);
+            bufferClaim.reservedValue(42);
+            bufferClaim.buffer().putBytes(bufferClaim.offset(), data, 0, maxPayloadLength);
+            bufferClaim.commit();
+
+            messageIndex.set(0);
+            messages.clear();
+            messages.add(new ExpectedFragment(
+                firstMessageLength + HEADER_LENGTH,
+                CURRENT_VERSION,
+                expectedFlags,
+                (short)headerType,
+                termOffset,
+                publication.sessionId(),
+                STREAM_ID,
+                termId,
+                reservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                BitUtil.align(initialPosition + firstMessageLength + HEADER_LENGTH, FRAME_ALIGNMENT),
+                data,
+                0,
+                firstMessageLength));
+            messages.add(new ExpectedFragment(
+                fragmentedMessageLength,
+                CURRENT_VERSION,
+                (byte)BEGIN_AND_END_FLAGS,
+                (short)HDR_TYPE_DATA,
+                0,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                secondReservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                ((termId + 1 - initialTermId) * termLength) + fragmentedMessageLength,
+                data,
+                0,
+                data.capacity()));
+            messages.add(new ExpectedFragment(
+                mtu,
+                CURRENT_VERSION,
+                (byte)0xFF,
+                (short)HDR_TYPE_SM,
+                fragmentedMessageLength,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                42,
+                initialTermId,
+                publication.positionBitsToShift(),
+                position,
+                data,
+                0,
+                maxPayloadLength));
+
+            if (null != fragmentAssembler)
+            {
+                while (messages.size() != messageIndex.get())
+                {
+                    if (0 == subscription.poll(fragmentAssembler, 10))
+                    {
+                        Tests.yield();
+                    }
+                }
+            }
+            else
+            {
+                while (messages.size() != messageIndex.get())
+                {
+                    if (0 == subscription.controlledPoll(controlledFragmentAssembler, 10))
+                    {
+                        Tests.yield();
+                    }
+                }
+            }
+
+            messageIndex.set(0);
+            messages.clear();
+            messages.add(new ExpectedFragment(
+                firstMessageLength + HEADER_LENGTH,
+                CURRENT_VERSION,
+                expectedFlags,
+                (short)headerType,
+                termOffset,
+                publication.sessionId(),
+                STREAM_ID,
+                termId,
+                reservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                BitUtil.align(initialPosition + firstMessageLength + HEADER_LENGTH, FRAME_ALIGNMENT),
+                data,
+                0,
+                firstMessageLength));
+            messages.add(new ExpectedFragment(
+                mtu,
+                CURRENT_VERSION,
+                BEGIN_FRAG_FLAG,
+                (short)HDR_TYPE_DATA,
+                0,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                secondReservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                (termId + 1 - initialTermId) * termLength + mtu,
+                data,
+                0,
+                maxPayloadLength));
+            messages.add(new ExpectedFragment(
+                mtu,
+                CURRENT_VERSION,
+                (byte)0,
+                (short)HDR_TYPE_DATA,
+                mtu,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                secondReservedValue + reservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                ((termId + 1 - initialTermId) * termLength) + 2 * mtu,
+                data,
+                maxPayloadLength,
+                maxPayloadLength));
+            messages.add(new ExpectedFragment(
+                mtu,
+                CURRENT_VERSION,
+                (byte)0,
+                (short)HDR_TYPE_DATA,
+                2 * mtu,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                secondReservedValue + 2 * reservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                ((termId + 1 - initialTermId) * termLength) + 3 * mtu,
+                data,
+                2 * maxPayloadLength,
+                maxPayloadLength));
+            messages.add(new ExpectedFragment(
+                317 + HEADER_LENGTH,
+                CURRENT_VERSION,
+                END_FRAG_FLAG,
+                (short)HDR_TYPE_DATA,
+                3 * mtu,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                secondReservedValue + 3 * reservedValue,
+                initialTermId,
+                publication.positionBitsToShift(),
+                ((termId + 1 - initialTermId) * termLength) + fragmentedMessageLength,
+                data,
+                3 * maxPayloadLength,
+                317));
+            messages.add(new ExpectedFragment(
+                mtu,
+                CURRENT_VERSION,
+                (byte)0xFF,
+                (short)HDR_TYPE_SM,
+                fragmentedMessageLength,
+                publication.sessionId(),
+                STREAM_ID,
+                termId + 1,
+                42,
+                initialTermId,
+                publication.positionBitsToShift(),
+                position,
+                data,
+                0,
+                maxPayloadLength));
+
+            while (messages.size() != messageIndex.get())
+            {
+                if (0 == unfragmentedSubscription.poll(rawFragmentHandler, 1))
+                {
+                    Tests.yield();
+                }
+            }
+        }
+    }
+
+    private static void verifyFragment(
+        final DirectBuffer buffer,
+        final int offset,
+        final int length,
+        final Header header,
+        final MutableInteger messageIndex,
+        final ArrayList<ExpectedFragment> messages)
+    {
+        final int index = messageIndex.getAndIncrement();
+        final Supplier<String> errorMsg = () -> "index=" + index;
+        final ExpectedFragment expectedFragment = messages.get(index);
+        assertEquals(expectedFragment.frameLength, header.frameLength(), errorMsg);
+        assertEquals(
+            expectedFragment.version,
+            header.buffer().getByte(header.offset() + VERSION_FIELD_OFFSET),
+            errorMsg);
+        assertEquals(expectedFragment.flags, header.flags(), errorMsg);
+        assertEquals(expectedFragment.type, (short)header.type(), errorMsg);
+        assertEquals(expectedFragment.termOffset, header.termOffset(), errorMsg);
+        assertEquals(expectedFragment.sessionId, header.sessionId(), errorMsg);
+        assertEquals(expectedFragment.streamId, header.streamId(), errorMsg);
+        assertEquals(expectedFragment.termId, header.termId(), errorMsg);
+        assertEquals(expectedFragment.reservedValue, header.reservedValue(), errorMsg);
+        assertEquals(expectedFragment.initialTermId, header.initialTermId(), errorMsg);
+        assertEquals(expectedFragment.positionBitsToShift, header.positionBitsToShift(), errorMsg);
+        assertEquals(expectedFragment.position, header.position(), errorMsg);
+        assertEquals(expectedFragment.payload.length, length, errorMsg);
+        for (int i = 0; i < length; i++)
+        {
+            assertEquals(expectedFragment.payload[i], buffer.getByte(offset + i), errorMsg);
+        }
+    }
+
     private void publishMessage()
     {
         buffer.putInt(0, 1);
@@ -909,6 +1206,65 @@ class PubAndSubTest
             {
                 Tests.yield();
             }
+        }
+    }
+
+    private static List<Class<?>> fragmentAssemblers()
+    {
+        return Arrays.asList(
+            FragmentAssembler.class,
+            ImageFragmentAssembler.class,
+            ControlledFragmentAssembler.class,
+            ImageControlledFragmentAssembler.class);
+    }
+
+    private static final class ExpectedFragment
+    {
+        final int frameLength;
+        final byte version;
+        final byte flags;
+        final short type;
+        final int termOffset;
+        final int sessionId;
+        final int streamId;
+        final int termId;
+        final long reservedValue;
+        final int initialTermId;
+        final int positionBitsToShift;
+        final long position;
+        final byte[] payload;
+
+        private ExpectedFragment(
+            final int frameLength,
+            final byte version,
+            final byte flags,
+            final short type,
+            final int termOffset,
+            final int sessionId,
+            final int streamId,
+            final int termId,
+            final long reservedValue,
+            final int initialTermId,
+            final int positionBitsToShift,
+            final long position,
+            final UnsafeBuffer payload,
+            final int payloadOffset,
+            final int payloadLength)
+        {
+            this.frameLength = frameLength;
+            this.version = version;
+            this.flags = flags;
+            this.type = type;
+            this.termOffset = termOffset;
+            this.sessionId = sessionId;
+            this.streamId = streamId;
+            this.termId = termId;
+            this.reservedValue = reservedValue;
+            this.initialTermId = initialTermId;
+            this.positionBitsToShift = positionBitsToShift;
+            this.position = position;
+            this.payload = new byte[payloadLength];
+            payload.getBytes(payloadOffset, this.payload);
         }
     }
 }


### PR DESCRIPTION
Re-assemble header of the fragmented message so that it represents a complete message, i.e.:
* Compute `frameLength` for the entire message.
* Set the `BEGIN_FRAG_FLAG` on the `flags` to mark message as unfragmented.
* Preserve `termOffset`, `termId`, `sessionId`, `streamId` and `reserevedValue` of the first fragmented header.