### PR TITLE
Prevent sanitiser errors when shutting down subscription and client in quick succession

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/Aeron.h
+++ b/aeron-client/src/main/cpp_wrapper/Aeron.h
@@ -79,6 +79,8 @@ public:
 
     ~Aeron()
     {
+        aeron_on_close_client_pair_t closePair = {emptyCallback, nullptr};
+        aeron_add_close_handler(m_aeron, &closePair);
         aeron_close(m_aeron);
         aeron_context_close(m_context.m_context);
 
@@ -984,6 +986,10 @@ private:
     {
         on_close_client_t &callback = *reinterpret_cast<on_close_client_t *>(clientd);
         callback();
+    }
+
+    static void emptyCallback(void *clientd)
+    {
     }
 };
 }

--- a/aeron-client/src/test/cpp_wrapper/SystemTest.cpp
+++ b/aeron-client/src/test/cpp_wrapper/SystemTest.cpp
@@ -192,3 +192,44 @@ TEST_F(SystemTest, shouldAddRemoveCloseHandler)
     EXPECT_EQ(1, closeCount1);
     EXPECT_EQ(0, closeCount2);
 }
+
+//
+// These tests will fail with the sanitizer if not implemented correctly.
+//
+
+TEST_F(SystemTest, shouldFreeSubscritionDataCorrectly)
+{
+    {
+        Context ctx;
+        ctx.useConductorAgentInvoker(false);
+
+        std::shared_ptr<Aeron> aeron = Aeron::connect(ctx);
+        int64_t i = aeron->addSubscription("aeron:ipc", 1000);
+        std::shared_ptr<Subscription> subscription;
+        do
+        {
+            subscription = aeron->findSubscription(i);
+        }
+        while (nullptr == subscription);
+    }
+}
+
+TEST_F(SystemTest, shouldFreeSubscritionDataCorrectlyWithInvoker)
+{
+    {
+        Context ctx;
+        ctx.useConductorAgentInvoker(true);
+        std::shared_ptr<Aeron> aeron = Aeron::connect(ctx);
+        AgentInvoker<ClientConductor> &invoker = aeron->conductorAgentInvoker();
+        invoker.start();
+
+        int64_t i = aeron->addSubscription("aeron:ipc", 1000);
+        std::shared_ptr<Subscription> subscription;
+        do
+        {
+            invoker.invoke();
+            subscription = aeron->findSubscription(i);
+        }
+        while (nullptr == subscription);
+    }
+}

--- a/aeron-client/src/test/cpp_wrapper/SystemTest.cpp
+++ b/aeron-client/src/test/cpp_wrapper/SystemTest.cpp
@@ -197,7 +197,7 @@ TEST_F(SystemTest, shouldAddRemoveCloseHandler)
 // These tests will fail with the sanitizer if not implemented correctly.
 //
 
-TEST_F(SystemTest, shouldFreeSubscritionDataCorrectly)
+TEST_F(SystemTest, shouldFreeSubscriptionDataCorrectly)
 {
     {
         Context ctx;
@@ -214,7 +214,7 @@ TEST_F(SystemTest, shouldFreeSubscritionDataCorrectly)
     }
 }
 
-TEST_F(SystemTest, shouldFreeSubscritionDataCorrectlyWithInvoker)
+TEST_F(SystemTest, shouldFreeSubscriptionDataCorrectlyWithInvoker)
 {
     {
         Context ctx;


### PR DESCRIPTION
Use the C client close handler to ensure that the client conductor thread drains before destructing the Aeron resources in the C++ wrapper.