### PR TITLE
[Build] Set aeronmd rpath in the generated package.

### DIFF
--- a/aeron-driver/src/main/c/CMakeLists.txt
+++ b/aeron-driver/src/main/c/CMakeLists.txt
@@ -416,6 +416,9 @@ target_compile_definitions(aeron_driver PRIVATE -DAERON_DRIVER)
 target_compile_definitions(aeron_driver_static PRIVATE -DAERON_DRIVER)
 
 if (AERON_INSTALL_TARGETS)
+    if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+        set_target_properties(aeronmd PROPERTIES INSTALL_RPATH "\\\$ORIGIN/../lib")
+    endif ()
     install(
         TARGETS aeron_driver aeron_driver_static
         RUNTIME DESTINATION lib


### PR DESCRIPTION
When building a package, CMake will strip the rpath by default. This means that when you extract it and try to run aeronmd, it won't work:

```
$ readelf -d ./aeron-1.44.0-Linux/bin/aeronmd | grep 'R.*PATH'
$ ./aeron-1.44.0-Linux/bin/aeronmd
./aeron-1.44.0-Linux/bin/aeronmd: error while loading shared libraries: libaeron_driver.so: cannot open shared object file: No such file or directory
```

This change sets rpath for the packaged aeronmd binary:

```
$ readelf -d ./aeron-1.44.0-Linux/bin/aeronmd | grep 'R.*PATH'
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib]
$ ./aeron-1.44.0-Linux/bin/aeronmd
^CShutting down driver...
```