### PR TITLE
(BROKEN BUILD) [Java] Async DNS resolution.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -28,7 +28,6 @@ import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.StandbySnapshotDecoder;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
 import io.aeron.cluster.service.*;
-import io.aeron.driver.DefaultNameResolver;
 import io.aeron.driver.DutyCycleTracker;
 import io.aeron.driver.NameResolver;
 import io.aeron.driver.status.DutyCycleStallTracker;
@@ -1456,7 +1455,6 @@ public final class ConsensusModule implements AutoCloseable
         private boolean isLogMdc;
         private boolean useAgentInvoker = false;
         private ConsensusModuleStateExport boostrapState = null;
-        private NameResolver nameResolver;
         private boolean acceptStandbySnapshots = Configuration.acceptStandbySnapshots();
 
         /**
@@ -1860,12 +1858,6 @@ public final class ConsensusModule implements AutoCloseable
             {
                 egressPublisher = new EgressPublisher();
             }
-
-            if (null == nameResolver)
-            {
-                nameResolver = DefaultNameResolver.INSTANCE;
-            }
-            nameResolver.init(aeron.countersReader(), aeron::addCounter);
 
             final ChannelUri channelUri = ChannelUri.parse(logChannel());
             isLogMdc = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);
@@ -3944,24 +3936,25 @@ public final class ConsensusModule implements AutoCloseable
         }
 
         /**
-         * Get the {@link NameResolver} to use for resolving endpoints and control names.
+         * Deprecated for removal.
          *
-         * @return {@link NameResolver} to use for resolving endpoints and control names.
+         * @return {@code null}.
          */
+        @Deprecated
         public NameResolver nameResolver()
         {
-            return nameResolver;
+            return null;
         }
 
         /**
-         * Set the {@link NameResolver} to use for resolving endpoints and control names.
+         * Deprecated for removal.
          *
-         * @param nameResolver to use for resolving endpoints and control names.
+         * @param ignore as deprected.
          * @return this for fluent API.
          */
-        public Context nameResolver(final NameResolver nameResolver)
+        @Deprecated
+        public Context nameResolver(final NameResolver ignore)
         {
-            this.nameResolver = nameResolver;
             return this;
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -77,11 +77,6 @@ final class ClientCommandAdapter implements ControlledMessageHandler
     {
         long correlationId = 0;
 
-        if (conductor.notAcceptingClientCommands())
-        {
-            return Action.ABORT;
-        }
-
         try
         {
             switch (msgTypeId)

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.driver;
 
-import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -75,18 +74,10 @@ abstract class CommandProxy
 
     final void offer(final Runnable cmd)
     {
-        while (!commandQueue.offer(cmd))
+        if (!commandQueue.offer(cmd))
         {
-            if (!failCount.isClosed())
-            {
-                failCount.increment();
-            }
-
-            Thread.yield();
-            if (Thread.currentThread().isInterrupted())
-            {
-                throw new AgentTerminationException("interrupted");
-            }
+            // unreachable for ManyToOneConcurrentLinkedQueue
+            throw new IllegalStateException(commandQueue.getClass().getSimpleName() + ".offer failed!");
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import org.agrona.concurrent.AgentTerminationException;
+import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.status.AtomicCounter;
+
+import static io.aeron.driver.ThreadingMode.INVOKER;
+import static io.aeron.driver.ThreadingMode.SHARED;
+
+abstract class CommandProxy
+{
+    private final ThreadingMode threadingMode;
+    private final QueuedPipe<Runnable> commandQueue;
+    private final AtomicCounter failCount;
+    private final boolean notConcurrent;
+
+    CommandProxy(
+        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+    {
+        this.threadingMode = threadingMode;
+        this.commandQueue = commandQueue;
+        this.failCount = failCount;
+        notConcurrent = SHARED == threadingMode || INVOKER == threadingMode;
+    }
+
+    /**
+     * Is the driver conductor not concurrent with the sender and receiver threads.
+     *
+     * @return true if the {@link DriverConductor} is on the same thread as the sender and receiver.
+     */
+    public final boolean notConcurrent()
+    {
+        return notConcurrent;
+    }
+
+    /**
+     * Get the threading mode of the driver.
+     *
+     * @return ThreadingMode of the driver.
+     */
+    public final ThreadingMode threadingMode()
+    {
+        return threadingMode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString()
+    {
+        return getClass().getSimpleName() + "{" +
+            "threadingMode=" + threadingMode +
+            ", failCount=" + failCount +
+            '}';
+    }
+
+    final boolean isApplyingBackpressure()
+    {
+        return commandQueue.remainingCapacity() < 1;
+    }
+
+    final void offer(final Runnable cmd)
+    {
+        while (!commandQueue.offer(cmd))
+        {
+            if (!failCount.isClosed())
+            {
+                failCount.increment();
+            }
+
+            Thread.yield();
+            if (Thread.currentThread().isInterrupted())
+            {
+                throw new AgentTerminationException("interrupted");
+            }
+        }
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -90,7 +90,7 @@ abstract class CommandProxy
         }
     }
 
-    static int drain(
+    static int drainQueue(
         final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
         final int limit,
         final Consumer<Runnable> consumer)

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -548,7 +548,7 @@ public final class Configuration
     /**
      * Limit for the number of commands drained in one operation.
      */
-    public static final int COMMAND_DRAIN_LIMIT = 2;
+    public static final int COMMAND_DRAIN_LIMIT = 10;
 
     /**
      * Capacity for the command queues used between driver agents.

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -224,7 +224,7 @@ public final class DriverConductor implements Agent
         int workCount = 0;
         workCount += processTimers(nowNs);
         workCount += clientCommandAdapter.receive();
-        workCount += CommandProxy.drain(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        workCount += CommandProxy.drainQueue(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += nameResolver.doWork(cachedEpochClock.time());
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -44,7 +44,7 @@ import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
 import org.agrona.concurrent.EpochClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.NanoClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
@@ -84,7 +84,6 @@ public final class DriverConductor implements Agent
         SOCKET_RCVBUF_PARAM_NAME,
         SOCKET_SNDBUF_PARAM_NAME
     };
-
     private int nextSessionId = BitUtil.generateRandomisedId();
     private final long timerIntervalNs;
     private final long clientLivenessTimeoutNs;
@@ -100,7 +99,7 @@ public final class DriverConductor implements Agent
     private final ClientProxy clientProxy;
     private final RingBuffer toDriverCommands;
     private final ClientCommandAdapter clientCommandAdapter;
-    private final ManyToOneConcurrentArrayQueue<Runnable> driverCmdQueue;
+    private final ManyToOneConcurrentLinkedQueue<Runnable> driverCmdQueue;
     private final Object2ObjectHashMap<String, SendChannelEndpoint> sendChannelEndpointByChannelMap =
         new Object2ObjectHashMap<>();
     private final Object2ObjectHashMap<String, ReceiveChannelEndpoint> receiveChannelEndpointByChannelMap =
@@ -225,17 +224,12 @@ public final class DriverConductor implements Agent
         int workCount = 0;
         workCount += processTimers(nowNs);
         workCount += clientCommandAdapter.receive();
-        workCount += driverCmdQueue.drain(Runnable::run, Configuration.COMMAND_DRAIN_LIMIT);
+        workCount += CommandProxy.drain(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += nameResolver.doWork(cachedEpochClock.time());
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());
 
         return workCount;
-    }
-
-    boolean notAcceptingClientCommands()
-    {
-        return senderProxy.isApplyingBackpressure() || receiverProxy.isApplyingBackpressure();
     }
 
     @SuppressWarnings("MethodLength")

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -362,26 +362,29 @@ public final class DriverConductor implements Agent
     void onReResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        try
+        ctx.asyncTaskExecutor().execute(() ->
         {
-            final InetSocketAddress newAddress = UdpChannel.resolve(
-                endpoint, CommonContext.ENDPOINT_PARAM_NAME, true, nameResolver);
-
-            if (newAddress.isUnresolved())
+            try
             {
-                ctx.errorHandler().onError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
+                final InetSocketAddress newAddress = UdpChannel.resolve(
+                    endpoint, CommonContext.ENDPOINT_PARAM_NAME, true, nameResolver);
+
+                if (newAddress.isUnresolved())
+                {
+                    ctx.errorHandler().onError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
+                    errorCounter.increment();
+                }
+                else if (!address.equals(newAddress))
+                {
+                    senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
+                }
+            }
+            catch (final Exception ex)
+            {
+                ctx.errorHandler().onError(ex);
                 errorCounter.increment();
             }
-            else if (!address.equals(newAddress))
-            {
-                senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
-            }
-        }
-        catch (final Exception ex)
-        {
-            ctx.errorHandler().onError(ex);
-            errorCounter.increment();
-        }
+        });
     }
 
     void onReResolveControl(
@@ -390,26 +393,29 @@ public final class DriverConductor implements Agent
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        try
+        ctx.asyncTaskExecutor().execute(() ->
         {
-            final InetSocketAddress newAddress = UdpChannel.resolve(
-                control, CommonContext.MDC_CONTROL_PARAM_NAME, true, nameResolver);
-
-            if (newAddress.isUnresolved())
+            try
             {
-                ctx.errorHandler().onError(new AeronEvent("could not re-resolve: control=" + control));
+                final InetSocketAddress newAddress = UdpChannel.resolve(
+                    control, CommonContext.MDC_CONTROL_PARAM_NAME, true, nameResolver);
+
+                if (newAddress.isUnresolved())
+                {
+                    ctx.errorHandler().onError(new AeronEvent("could not re-resolve: control=" + control));
+                    errorCounter.increment();
+                }
+                else if (!address.equals(newAddress))
+                {
+                    receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress);
+                }
+            }
+            catch (final Exception ex)
+            {
+                ctx.errorHandler().onError(ex);
                 errorCounter.increment();
             }
-            else if (!address.equals(newAddress))
-            {
-                receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress);
-            }
-        }
-        catch (final Exception ex)
-        {
-            ctx.errorHandler().onError(ex);
-            errorCounter.increment();
-        }
+        });
     }
 
     IpcPublication getSharedIpcPublication(final long streamId)

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -19,7 +19,7 @@ import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.SendChannelEndpoint;
 import io.aeron.driver.media.UdpChannel;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -32,7 +32,9 @@ public final class DriverConductorProxy extends CommandProxy
     private DriverConductor driverConductor;
 
     DriverConductorProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -65,14 +65,8 @@ public final class DriverConductorProxy extends CommandProxy
     public void reResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        if (notConcurrent())
-        {
-            driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
-        }
-        else
-        {
-            offer(() -> driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address));
-        }
+        // safe, because DriverConductor uses the async thread to execute this call
+        driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
     }
 
     /**
@@ -89,14 +83,8 @@ public final class DriverConductorProxy extends CommandProxy
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        if (notConcurrent())
-        {
-            driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
-        }
-        else
-        {
-            offer(() -> driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address));
-        }
+        // safe, because DriverConductor uses the async thread to execute this call
+        driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -65,8 +65,14 @@ public final class DriverConductorProxy extends CommandProxy
     public void reResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        // safe, because DriverConductor uses the async thread to execute this call
-        driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
+        if (notConcurrent())
+        {
+            driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
+        }
+        else
+        {
+            offer(() -> driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address));
+        }
     }
 
     /**
@@ -83,8 +89,14 @@ public final class DriverConductorProxy extends CommandProxy
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        // safe, because DriverConductor uses the async thread to execute this call
-        driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
+        if (notConcurrent())
+        {
+            driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
+        }
+        else
+        {
+            offer(() -> driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address));
+        }
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -49,6 +49,9 @@ import java.nio.channels.DatagramChannel;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -434,6 +437,7 @@ public final class MediaDriver implements AutoCloseable
         private boolean reliableStream = Configuration.reliableStream();
         private boolean tetherSubscriptions = Configuration.tetherSubscriptions();
         private boolean rejoinStream = Configuration.rejoinStream();
+        private boolean ownsAsyncTaskExecutor;
 
         private long lowStorageWarningThreshold = Configuration.lowStorageWarningThreshold();
         private long timerIntervalNs = Configuration.timerIntervalNs();
@@ -502,6 +506,7 @@ public final class MediaDriver implements AutoCloseable
         private ThreadFactory receiverThreadFactory;
         private ThreadFactory sharedThreadFactory;
         private ThreadFactory sharedNetworkThreadFactory;
+        private Executor asyncTaskExecutor;
         private IdleStrategy conductorIdleStrategy;
         private IdleStrategy senderIdleStrategy;
         private IdleStrategy receiverIdleStrategy;
@@ -578,6 +583,14 @@ public final class MediaDriver implements AutoCloseable
         {
             if (IS_CLOSED_UPDATER.compareAndSet(this, 0, 1))
             {
+                if (ownsAsyncTaskExecutor)
+                {
+                    if (asyncTaskExecutor instanceof ExecutorService)
+                    {
+                        ((ExecutorService)asyncTaskExecutor).shutdownNow();
+                    }
+                }
+
                 CloseHelper.close(errorHandler, logFactory);
 
                 if (null != systemCounters)
@@ -2196,6 +2209,51 @@ public final class MediaDriver implements AutoCloseable
         }
 
         /**
+         * {@link Executor} to be used for asynchronous task execution in the {@link DriverConductor}.
+         *
+         * @return executor service for asynchronous tasks. Defaults to
+         * {@link java.util.concurrent.Executors#newSingleThreadExecutor(ThreadFactory)}.
+         */
+        public Executor asyncTaskExecutor()
+        {
+            return asyncTaskExecutor;
+        }
+
+        /**
+         * {@link Executor} to be used for asynchronous task execution in the {@link DriverConductor}.
+         *
+         * @param asyncTaskExecutor to be used for asynchronous task execution in the {@link DriverConductor}.
+         * @return this for a fluent API.
+         */
+        public Context asyncTaskExecutor(final Executor asyncTaskExecutor)
+        {
+            this.asyncTaskExecutor = asyncTaskExecutor;
+            return this;
+        }
+
+        /**
+         * Does this context own the {@link #asyncTaskExecutor()} client and this takes responsibility for closing it?
+         *
+         * @return does this context own the {@link #asyncTaskExecutor()} and this takes responsibility for closing it?
+         */
+        public boolean ownsAsyncTaskExecutor()
+        {
+            return ownsAsyncTaskExecutor;
+        }
+
+        /**
+         * Does this context own the {@link #asyncTaskExecutor()} client and this takes responsibility for closing it?
+         *
+         * @param ownsAsyncTaskExecutor does this context own the {@link #asyncTaskExecutor()}.
+         * @return this for a fluent API.
+         */
+        public Context ownsAsyncTaskExecutor(final boolean ownsAsyncTaskExecutor)
+        {
+            this.ownsAsyncTaskExecutor = ownsAsyncTaskExecutor;
+            return this;
+        }
+
+        /**
          * {@link IdleStrategy} to be used by the {@link Sender} when in {@link ThreadingMode#DEDICATED}.
          *
          * @return {@link IdleStrategy} to be used by the {@link Sender} when in {@link ThreadingMode#DEDICATED}.
@@ -3804,6 +3862,17 @@ public final class MediaDriver implements AutoCloseable
             if (null == channelSendTimestampClock)
             {
                 channelSendTimestampClock = new SystemEpochNanoClock();
+            }
+
+            if (null == asyncTaskExecutor)
+            {
+                ownsAsyncTaskExecutor = true;
+                asyncTaskExecutor = Executors.newSingleThreadExecutor((r) ->
+                {
+                    final Thread thread = new Thread(r, "async-task-executor");
+                    thread.setDaemon(true);
+                    return thread;
+                });
             }
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -539,8 +539,8 @@ public final class MediaDriver implements AutoCloseable
         private DataTransportPoller dataTransportPoller;
         private ControlTransportPoller controlTransportPoller;
         private ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue;
-        private OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
-        private OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
+        private ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
+        private ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
         private ReceiverProxy receiverProxy;
         private SenderProxy senderProxy;
         private DriverConductorProxy driverConductorProxy;
@@ -3538,23 +3538,23 @@ public final class MediaDriver implements AutoCloseable
             return channelSendTimestampClock;
         }
 
-        OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
+        ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
         {
             return receiverCommandQueue;
         }
 
-        Context receiverCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
+        Context receiverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
         {
             this.receiverCommandQueue = receiverCommandQueue;
             return this;
         }
 
-        OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
+        ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
         {
             return senderCommandQueue;
         }
 
-        Context senderCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
+        Context senderCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
         {
             this.senderCommandQueue = senderCommandQueue;
             return this;
@@ -3802,6 +3802,11 @@ public final class MediaDriver implements AutoCloseable
                 congestionControlSupplier = Configuration.congestionControlSupplier();
             }
 
+            if (null == threadingMode)
+            {
+                threadingMode = Configuration.threadingMode();
+            }
+
             if (null == driverCommandQueue)
             {
                 driverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
@@ -3809,12 +3814,12 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == receiverCommandQueue)
             {
-                receiverCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                receiverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == senderCommandQueue)
             {
-                senderCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                senderCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == retransmitUnicastDelayGenerator)
@@ -3837,11 +3842,6 @@ public final class MediaDriver implements AutoCloseable
             {
                 multicastFeedbackDelayGenerator = new OptimalMulticastDelayGenerator(
                     nakMulticastMaxBackoffNs, nakMulticastGroupSize);
-            }
-
-            if (null == threadingMode)
-            {
-                threadingMode = Configuration.threadingMode();
             }
 
             if (null == terminationValidator)

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -538,9 +538,9 @@ public final class MediaDriver implements AutoCloseable
         private LogFactory logFactory;
         private DataTransportPoller dataTransportPoller;
         private ControlTransportPoller controlTransportPoller;
-        private ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue;
-        private ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
-        private ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue;
         private ReceiverProxy receiverProxy;
         private SenderProxy senderProxy;
         private DriverConductorProxy driverConductorProxy;
@@ -3538,34 +3538,34 @@ public final class MediaDriver implements AutoCloseable
             return channelSendTimestampClock;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue()
         {
             return receiverCommandQueue;
         }
 
-        Context receiverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
+        Context receiverCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue)
         {
             this.receiverCommandQueue = receiverCommandQueue;
             return this;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue()
         {
             return senderCommandQueue;
         }
 
-        Context senderCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
+        Context senderCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue)
         {
             this.senderCommandQueue = senderCommandQueue;
             return this;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue()
         {
             return driverCommandQueue;
         }
 
-        Context driverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> queue)
+        Context driverCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> queue)
         {
             this.driverCommandQueue = queue;
             return this;
@@ -3809,17 +3809,17 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == driverCommandQueue)
             {
-                driverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                driverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == receiverCommandQueue)
             {
-                receiverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                receiverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == senderCommandQueue)
             {
-                senderCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == retransmitUnicastDelayGenerator)

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -24,8 +24,8 @@ import org.agrona.collections.ArrayListUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.NanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -33,7 +33,8 @@ import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
 
 import static io.aeron.driver.Configuration.PENDING_SETUPS_TIMEOUT_NS;
-import static io.aeron.driver.status.SystemCounterDescriptor.*;
+import static io.aeron.driver.status.SystemCounterDescriptor.BYTES_RECEIVED;
+import static io.aeron.driver.status.SystemCounterDescriptor.RESOLUTION_CHANGES;
 
 /**
  * Agent that receives messages streams and rebuilds {@link PublicationImage}s, plus iterates over them sending status
@@ -46,7 +47,7 @@ public final class Receiver implements Agent
     private final long reResolutionCheckIntervalNs;
     private long reResolutionDeadlineNs;
     private final DataTransportPoller dataTransportPoller;
-    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesReceived;
     private final AtomicCounter resolutionChanges;
     private final NanoClock nanoClock;

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -24,7 +24,7 @@ import org.agrona.collections.ArrayListUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.NanoClock;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -47,7 +47,7 @@ public final class Receiver implements Agent
     private final long reResolutionCheckIntervalNs;
     private long reResolutionDeadlineNs;
     private final DataTransportPoller dataTransportPoller;
-    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesReceived;
     private final AtomicCounter resolutionChanges;
     private final NanoClock nanoClock;
@@ -116,7 +116,7 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount = commandQueue.drain(Runnable::run, Configuration.COMMAND_DRAIN_LIMIT);
+        int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -116,7 +116,7 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,7 +169,7 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        // must add to the queue, because called from the async thread
+        // called from the async thread
         offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.UdpChannel;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -31,7 +31,9 @@ final class ReceiverProxy extends CommandProxy
     private Receiver receiver;
 
     ReceiverProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,14 +169,8 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        if (notConcurrent())
-        {
-            receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress);
-        }
-        else
-        {
-            offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
-        }
+        // must add to the queue, because called from the async thread
+        offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
     }
 
     void requestSetup(

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,8 +169,14 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        // called from the async thread
-        offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
+        if (notConcurrent())
+        {
+            receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress);
+        }
+        else
+        {
+            offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
+        }
     }
 
     void requestSetup(

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -129,7 +129,7 @@ public final class Sender extends SenderRhsPadding implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        final int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        final int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final long shortSendsBefore = shortSends.get();
         final int bytesSent = doSend(nowNs);

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -22,8 +22,8 @@ import io.aeron.driver.status.DutyCycleStallTracker;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.NanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -68,7 +68,7 @@ public final class Sender extends SenderRhsPadding implements Agent
     private final long reResolutionCheckIntervalNs;
     private final int dutyCycleRatio;
     private final ControlTransportPoller controlTransportPoller;
-    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesSent;
     private final AtomicCounter resolutionChanges;
     private final AtomicCounter shortSends;

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -17,7 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.ChannelUri;
 import io.aeron.driver.media.SendChannelEndpoint;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -30,7 +30,9 @@ final class SenderProxy extends CommandProxy
     private Sender sender;
 
     SenderProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,13 +117,7 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        if (notConcurrent())
-        {
-            sender.onResolutionChange(channelEndpoint, endpoint, newAddress);
-        }
-        else
-        {
-            offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
-        }
+        // must add to the queue, because called from the async thread
+        offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,7 +117,7 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        // must add to the queue, because called from the async thread
+        // called from the async thread
         offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -17,47 +17,22 @@ package io.aeron.driver;
 
 import io.aeron.ChannelUri;
 import io.aeron.driver.media.SendChannelEndpoint;
-import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.QueuedPipe;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
 
-import static io.aeron.driver.ThreadingMode.INVOKER;
-import static io.aeron.driver.ThreadingMode.SHARED;
-
 /**
  * Proxy for offering into the Sender Thread's command queue.
  */
-final class SenderProxy
+final class SenderProxy extends CommandProxy
 {
-    private final ThreadingMode threadingMode;
-    private final QueuedPipe<Runnable> commandQueue;
-    private final AtomicCounter failCount;
     private Sender sender;
 
     SenderProxy(
         final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
     {
-        this.threadingMode = threadingMode;
-        this.commandQueue = commandQueue;
-        this.failCount = failCount;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String toString()
-    {
-        return "SenderProxy{" +
-            "threadingMode=" + threadingMode +
-            ", failCount=" + failCount +
-            '}';
-    }
-
-    boolean isApplyingBackpressure()
-    {
-        return commandQueue.remainingCapacity() < 1;
+        super(threadingMode, commandQueue, failCount);
     }
 
     void sender(final Sender sender)
@@ -149,28 +124,6 @@ final class SenderProxy
         else
         {
             offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
-        }
-    }
-
-    private boolean notConcurrent()
-    {
-        return threadingMode == SHARED || threadingMode == INVOKER;
-    }
-
-    private void offer(final Runnable cmd)
-    {
-        while (!commandQueue.offer(cmd))
-        {
-            if (!failCount.isClosed())
-            {
-                failCount.increment();
-            }
-
-            Thread.yield();
-            if (Thread.currentThread().isInterrupted())
-            {
-                throw new AgentTerminationException("interrupted");
-            }
         }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,7 +117,13 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        // called from the async thread
-        offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
+        if (notConcurrent())
+        {
+            sender.onResolutionChange(channelEndpoint, endpoint, newAddress);
+        }
+        else
+        {
+            offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
+        }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -868,8 +868,28 @@ public final class UdpChannel
             validateConfiguration(uri);
 
             final String endpointValue = uri.get(ENDPOINT_PARAM_NAME);
-            return SocketAddressParser.parse(
-                endpointValue, ENDPOINT_PARAM_NAME, false, nameResolver);
+            return SocketAddressParser.parse(endpointValue, ENDPOINT_PARAM_NAME, false, nameResolver);
+        }
+        catch (final Exception ex)
+        {
+            throw new InvalidChannelException(ex);
+        }
+    }
+
+    /**
+     * Check if the address pointed to by the endpoint is multicast.
+     *
+     * @param uri to check.
+     * @return {@code true} if the destination uses multicast address.
+     */
+    public static boolean isMulticastDestinationAddress(final ChannelUri uri)
+    {
+        try
+        {
+            validateConfiguration(uri);
+
+            final String endpointValue = uri.get(ENDPOINT_PARAM_NAME);
+            return SocketAddressParser.isMulticastAddress(endpointValue);
         }
         catch (final Exception ex)
         {

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -1121,6 +1121,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+        driverConductor.doWork();
         driverProxy.removeSubscription(idSpy);
 
         while (true)
@@ -1216,6 +1217,7 @@ class DriverConductorTest
     {
         final long id1 = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long id2 = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_2);
+        driverConductor.doWork();
         driverProxy.removePublication(id1);
         driverProxy.removePublication(id2);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -36,7 +36,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
@@ -160,8 +160,7 @@ class DriverConductorTest
             1_000_000_000);
 
         final ThreadingMode threadingMode = ThreadingMode.DEDICATED;
-        final ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue =
-            new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+        final ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
         final DriverConductorProxy driverConductorProxy =
             new DriverConductorProxy(threadingMode, driverCommandQueue, mock(AtomicCounter.class));
         final MediaDriver.Context ctx = new MediaDriver.Context()

--- a/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
@@ -21,7 +21,11 @@ import io.aeron.driver.buffer.TestLogFactory;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.Tests;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.SystemEpochClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.agrona.concurrent.status.CountersManager;
@@ -71,7 +75,7 @@ class IpcPublicationTest
             .clientProxy(mock(ClientProxy.class))
             .senderProxy(senderProxy)
             .receiverProxy(receiverProxy)
-            .driverCommandQueue(new ManyToOneConcurrentArrayQueue<>(256))
+            .driverCommandQueue(new ManyToOneConcurrentLinkedQueue<>())
             .epochClock(SystemEpochClock.INSTANCE)
             .cachedEpochClock(new CachedEpochClock())
             .cachedNanoClock(new CachedNanoClock())

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -32,7 +32,10 @@ import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
 import org.agrona.concurrent.status.Position;
@@ -148,7 +151,7 @@ class ReceiverTest
             .controlTransportPoller(mockControlTransportPoller)
             .logFactory(new TestLogFactory())
             .systemCounters(mockSystemCounters)
-            .receiverCommandQueue(new OneToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
+            .receiverCommandQueue(new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
             .nanoClock(nanoClock)
             .cachedNanoClock(nanoClock)
             .senderCachedNanoClock(nanoClock)

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -232,7 +232,7 @@ class ReceiverTest
             SOURCE_IDENTITY,
             congestionControl);
 
-        final int messagesRead = CommandProxy.drain(
+        final int messagesRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -277,7 +277,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -345,7 +345,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -416,7 +416,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -491,7 +491,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader, initialTermOffset);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -17,7 +17,12 @@ package io.aeron.driver;
 
 import io.aeron.driver.buffer.RawLog;
 import io.aeron.driver.buffer.TestLogFactory;
-import io.aeron.driver.media.*;
+import io.aeron.driver.media.ControlTransportPoller;
+import io.aeron.driver.media.DataTransportPoller;
+import io.aeron.driver.media.ReceiveChannelEndpoint;
+import io.aeron.driver.media.ReceiveChannelEndpointThreadLocals;
+import io.aeron.driver.media.UdpChannel;
+import io.aeron.driver.media.WildcardPortManager;
 import io.aeron.driver.reports.LossReport;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.FrameDescriptor;
@@ -34,7 +39,7 @@ import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -110,8 +115,7 @@ class ReceiverTest
     private final InetSocketAddress senderAddress = new InetSocketAddress("localhost", 40123);
     private Receiver receiver;
     private ReceiverProxy receiverProxy;
-    private final ManyToOneConcurrentArrayQueue<Runnable> toConductorQueue =
-        new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final ManyToOneConcurrentLinkedQueue<Runnable> toConductorQueue = new ManyToOneConcurrentLinkedQueue<>();
     private final CongestionControl congestionControl = mock(CongestionControl.class);
     private final MediaDriver.Context ctx = new MediaDriver.Context()
         .systemCounters(mockSystemCounters)
@@ -151,7 +155,7 @@ class ReceiverTest
             .controlTransportPoller(mockControlTransportPoller)
             .logFactory(new TestLogFactory())
             .systemCounters(mockSystemCounters)
-            .receiverCommandQueue(new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
+            .receiverCommandQueue(new ManyToOneConcurrentLinkedQueue<>())
             .nanoClock(nanoClock)
             .cachedNanoClock(nanoClock)
             .senderCachedNanoClock(nanoClock)
@@ -228,7 +232,9 @@ class ReceiverTest
             SOURCE_IDENTITY,
             congestionControl);
 
-        final int messagesRead = toConductorQueue.drain(
+        final int messagesRead = CommandProxy.drain(
+            toConductorQueue,
+            Integer.MAX_VALUE,
             (e) ->
             {
                 // pass in new term buffer from conductor, which should trigger SM
@@ -271,7 +277,9 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = toConductorQueue.drain(
+        final int commandsRead = CommandProxy.drain(
+            toConductorQueue,
+            Integer.MAX_VALUE,
             (e) ->
             {
                 final PublicationImage image = new PublicationImage(
@@ -337,7 +345,9 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = toConductorQueue.drain(
+        final int commandsRead = CommandProxy.drain(
+            toConductorQueue,
+            Integer.MAX_VALUE,
             (e) ->
             {
                 final PublicationImage image = new PublicationImage(
@@ -406,7 +416,9 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = toConductorQueue.drain(
+        final int commandsRead = CommandProxy.drain(
+            toConductorQueue,
+            Integer.MAX_VALUE,
             (e) ->
             {
                 final PublicationImage image = new PublicationImage(
@@ -479,7 +491,9 @@ class ReceiverTest
         fillSetupFrame(setupHeader, initialTermOffset);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = toConductorQueue.drain(
+        final int commandsRead = CommandProxy.drain(
+            toConductorQueue,
+            Integer.MAX_VALUE,
             (e) ->
             {
                 final PublicationImage image = new PublicationImage(

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -31,7 +31,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -88,8 +88,7 @@ class SenderTest
     private final DataHeaderFlyweight dataHeader = new DataHeaderFlyweight();
     private final SetupFlyweight setupHeader = new SetupFlyweight();
     private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
-    private final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
-        new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
 
     private final HeaderWriter headerWriter = HeaderWriter.newInstance(HEADER);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -31,7 +31,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -88,8 +88,8 @@ class SenderTest
     private final DataHeaderFlyweight dataHeader = new DataHeaderFlyweight();
     private final SetupFlyweight setupHeader = new SetupFlyweight();
     private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
-    private final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
-        new OneToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
+        new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
 
     private final HeaderWriter headerWriter = HeaderWriter.newInstance(HEADER);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/media/SocketAddressParserTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/SocketAddressParserTest.java
@@ -18,6 +18,9 @@ package io.aeron.driver.media;
 import io.aeron.driver.DefaultNameResolver;
 import io.aeron.driver.NameResolver;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -26,9 +29,9 @@ import java.net.UnknownHostException;
 
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SocketAddressParserTest
 {
@@ -148,6 +151,48 @@ class SocketAddressParserTest
             LOOKUP_RESOLVER_HOSTNAME + ":" + LOOKUP_RESOLVER_PORT, ENDPOINT_PARAM_NAME, false, LOOKUP_RESOLVER);
         assertEquals(InetAddress.getByName(LOOKUP_RESOLVER_HOSTNAME), socketAddress.getAddress());
         assertEquals(LOOKUP_RESOLVER_PORT, socketAddress.getPort());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "127.0.0.1:8080, false",
+        "224.0.0.0:24, true",
+        "224.0.0.255:44444, true",
+        "239.255.255.250:1010, true",
+        "239.1.1.1:1111, true",
+        "233.251.255.255:5555, true",
+        "999.255.255.250:7777, false",
+        "a.b.c.d:7777, false",
+        "192.b.c.d:7777, false",
+        "192.168.0.1:1234, false",
+        "test:1234, false",
+        "[ff02::1]:1234, true",
+        "[Ff05::1:3]:80, true",
+        "[fF9E::108]:5555, true",
+        "[FF01:0:0:0:0:0:0:18C]:5555, true",
+        "[fe80::ce81:b1c:bd2c:69e%utun3]:8080, false",
+        "[fe80::1%lo0]:5555, false",
+        "[ff02:0:0:0:0:2]:7777, true"
+    })
+    void shouldCheckForMulticastAddress(final String hostAndPort, final boolean expected)
+    {
+        assertEquals(expected, SocketAddressParser.isMulticastAddress(hostAndPort));
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionIfValueIsNull()
+    {
+        assertThrowsExactly(NullPointerException.class, () -> SocketAddressParser.isMulticastAddress(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "a", "1.2.3", "[x]", "[f0:xx]:5" })
+    void shouldThrowIllegalArgumentExceptionIfValueIsInvalid(final String hostAndPort)
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> SocketAddressParser.isMulticastAddress(hostAndPort));
+        assertThat(exception.getMessage(), containsString(hostAndPort));
     }
 
     private void assertCorrectParse(final String host, final int port) throws UnknownHostException

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
@@ -283,9 +283,8 @@ class MultiModuleSharedDriverTest
         ConsensusModule consensusModule(final int clusterId, final String aeronDirectoryName)
         {
             final int nodeOffset = (clusterId * 100) + (nodeId * 10);
-            // The `:X` suffix will be removed by the `RedirectingNameResolver:lookup`
             final String ingressChannelWithInvalidEndpointFormatToBeRemovedByNameResolver =
-                "aeron:udp?term-length=64k|endpoint=node" + nodeId + ":2" + clusterId + "11" + nodeId + ":X";
+                "aeron:udp?term-length=64k|endpoint=node" + nodeId + ":2" + clusterId + "11" + nodeId;
             final ConsensusModule.Context ctx = new ConsensusModule.Context()
                 .clusterMemberId(nodeId)
                 .clusterId(clusterId)
@@ -297,7 +296,6 @@ class MultiModuleSharedDriverTest
                 .serviceStreamId(104 + nodeOffset)
                 .consensusModuleStreamId(105 + nodeOffset)
                 .ingressChannel(ingressChannelWithInvalidEndpointFormatToBeRemovedByNameResolver)
-                .nameResolver(nameResolver)
                 .replicationChannel("aeron:udp?endpoint=localhost:0");
 
             return ConsensusModule.launch(ctx);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -1072,7 +1072,6 @@ public final class TestNode implements AutoCloseable
         Context(final TestService[] services, final String nodeMappings)
         {
             mediaDriverContext.nameResolver(new RedirectingNameResolver(nodeMappings));
-            consensusModuleContext.nameResolver(new RedirectingNameResolver(nodeMappings));
 
             this.services = services;
             hasServiceTerminated = new AtomicBoolean[services.length];


### PR DESCRIPTION
This PR implements asynchronous DNS resolution in the Java MediaDriver including:
* Client commands: `ADD_RCV_DESTINATION` (spy and network), `REMOVE_RCV_DESTINATION`, `ADD_SUBSCRIPTION` (spy and network), `ADD_PUBLICATION`, `ADD_DESTINATION` and `REMOVE_DESTINATION`.
* Address re-resolution (`onReResolveControl` and `onReResolveEndpoint`) which are triggered by the receiver and sender threads respectively.
* `ConsensusModule#connectIngress` - check for multicast address is now done without invoking `NameResolver` API.

What is not included:
* Initial host name resolution, i.e. `DriverConductor#onStart`.
* `DriverNameResolver` - bootstrap neighbor resolution and duty cycle.