### PR TITLE
[Java] Async DNS resolution.

### DIFF
--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 
 import static io.aeron.agent.EventConfiguration.parseEventCodes;
+import static io.aeron.driver.Configuration.ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME;
+import static io.aeron.driver.Configuration.asyncTaskExecutorThreadCount;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,6 +56,61 @@ public class EventConfigurationTest
         finally
         {
             System.setErr(err);
+        }
+    }
+
+    @Test
+    void asyncTaskExecutorThreadCountReturnsOneByDefault()
+    {
+        assertEquals(1, asyncTaskExecutorThreadCount());
+        try
+        {
+        }
+        finally
+        {
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
+        }
+    }
+
+    @Test
+    void asyncTaskExecutorThreadCountReturnsZeroIfNegative()
+    {
+        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "-123");
+        try
+        {
+            assertEquals(0, asyncTaskExecutorThreadCount());
+        }
+        finally
+        {
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
+        }
+    }
+
+    @Test
+    void asyncTaskExecutorThreadCountReturnsAssignedValue()
+    {
+        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "4");
+        try
+        {
+            assertEquals(4, asyncTaskExecutorThreadCount());
+        }
+        finally
+        {
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
+        }
+    }
+
+    @Test
+    void asyncTaskExecutorThreadCountReturnsOneIfInvalid()
+    {
+        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "abc");
+        try
+        {
+            assertEquals(1, asyncTaskExecutorThreadCount());
+        }
+        finally
+        {
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
         }
     }
 

--- a/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
+++ b/aeron-agent/src/test/java/io/aeron/agent/EventConfigurationTest.java
@@ -16,6 +16,8 @@
 package io.aeron.agent;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -23,8 +25,8 @@ import java.util.Collections;
 import java.util.EnumSet;
 
 import static io.aeron.agent.EventConfiguration.parseEventCodes;
-import static io.aeron.driver.Configuration.ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME;
-import static io.aeron.driver.Configuration.asyncTaskExecutorThreadCount;
+import static io.aeron.driver.Configuration.ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME;
+import static io.aeron.driver.Configuration.asyncTaskExecutorThreads;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -60,57 +62,44 @@ public class EventConfigurationTest
     }
 
     @Test
-    void asyncTaskExecutorThreadCountReturnsOneByDefault()
+    void asyncTaskExecutorThreadsReturnsOneByDefault()
     {
-        assertEquals(1, asyncTaskExecutorThreadCount());
+        assertEquals(1, asyncTaskExecutorThreads());
         try
         {
         }
         finally
         {
-            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { -123, 4, 0, Integer.MAX_VALUE })
+    void asyncTaskExecutorThreadsReturnsZeroIfNegative(final int threads)
+    {
+        System.setProperty(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME, Integer.toString(threads));
+        try
+        {
+            assertEquals(threads, asyncTaskExecutorThreads());
+        }
+        finally
+        {
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME);
         }
     }
 
     @Test
-    void asyncTaskExecutorThreadCountReturnsZeroIfNegative()
+    void asyncTaskExecutorThreadsReturnsOneIfInvalid()
     {
-        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "-123");
+        System.setProperty(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME, "abc");
         try
         {
-            assertEquals(0, asyncTaskExecutorThreadCount());
+            assertEquals(1, asyncTaskExecutorThreads());
         }
         finally
         {
-            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
-        }
-    }
-
-    @Test
-    void asyncTaskExecutorThreadCountReturnsAssignedValue()
-    {
-        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "4");
-        try
-        {
-            assertEquals(4, asyncTaskExecutorThreadCount());
-        }
-        finally
-        {
-            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
-        }
-    }
-
-    @Test
-    void asyncTaskExecutorThreadCountReturnsOneIfInvalid()
-    {
-        System.setProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, "abc");
-        try
-        {
-            assertEquals(1, asyncTaskExecutorThreadCount());
-        }
-        finally
-        {
-            System.clearProperty(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME);
+            System.clearProperty(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME);
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModule.java
@@ -28,7 +28,6 @@ import io.aeron.cluster.codecs.MessageHeaderDecoder;
 import io.aeron.cluster.codecs.StandbySnapshotDecoder;
 import io.aeron.cluster.codecs.mark.ClusterComponentType;
 import io.aeron.cluster.service.*;
-import io.aeron.driver.DefaultNameResolver;
 import io.aeron.driver.DutyCycleTracker;
 import io.aeron.driver.NameResolver;
 import io.aeron.driver.status.DutyCycleStallTracker;
@@ -1456,7 +1455,6 @@ public final class ConsensusModule implements AutoCloseable
         private boolean isLogMdc;
         private boolean useAgentInvoker = false;
         private ConsensusModuleStateExport boostrapState = null;
-        private NameResolver nameResolver;
         private boolean acceptStandbySnapshots = Configuration.acceptStandbySnapshots();
 
         /**
@@ -1860,12 +1858,6 @@ public final class ConsensusModule implements AutoCloseable
             {
                 egressPublisher = new EgressPublisher();
             }
-
-            if (null == nameResolver)
-            {
-                nameResolver = DefaultNameResolver.INSTANCE;
-            }
-            nameResolver.init(aeron.countersReader(), aeron::addCounter);
 
             final ChannelUri channelUri = ChannelUri.parse(logChannel());
             isLogMdc = channelUri.isUdp() && null == channelUri.get(ENDPOINT_PARAM_NAME);
@@ -3944,24 +3936,25 @@ public final class ConsensusModule implements AutoCloseable
         }
 
         /**
-         * Get the {@link NameResolver} to use for resolving endpoints and control names.
+         * Deprecated for removal.
          *
-         * @return {@link NameResolver} to use for resolving endpoints and control names.
+         * @return {@code null}.
          */
+        @Deprecated
         public NameResolver nameResolver()
         {
-            return nameResolver;
+            return null;
         }
 
         /**
-         * Set the {@link NameResolver} to use for resolving endpoints and control names.
+         * Deprecated for removal.
          *
-         * @param nameResolver to use for resolving endpoints and control names.
+         * @param ignore as deprected.
          * @return this for fluent API.
          */
-        public Context nameResolver(final NameResolver nameResolver)
+        @Deprecated
+        public Context nameResolver(final NameResolver ignore)
         {
-            this.nameResolver = nameResolver;
             return this;
         }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -44,8 +44,6 @@ import org.agrona.collections.*;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.status.CountersReader;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -3301,33 +3299,17 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
         }
     }
 
-    private boolean isIngressMulticast(final ChannelUri ingressUri)
-    {
-        if (!ingressUri.containsKey(ENDPOINT_PARAM_NAME))
-        {
-            ingressUri.put(ENDPOINT_PARAM_NAME, thisMember.ingressEndpoint());
-        }
-
-        final InetSocketAddress address = UdpChannel.destinationAddress(ingressUri, ctx.nameResolver());
-
-        // assume that if not resolved is a non-multicast address
-        final InetAddress inetAddress;
-        return !address.isUnresolved() &&
-            null != (inetAddress = address.getAddress()) &&
-            inetAddress.isMulticastAddress();
-    }
-
     private void connectIngress()
     {
         final ChannelUri ingressUri = ChannelUri.parse(ctx.ingressChannel());
-        if (Cluster.Role.LEADER != role && isIngressMulticast(ingressUri))
-        {
-            return; // don't subscribe to ingress if follower and multicast ingress
-        }
-
         if (!ingressUri.containsKey(ENDPOINT_PARAM_NAME))
         {
             ingressUri.put(ENDPOINT_PARAM_NAME, thisMember.ingressEndpoint());
+        }
+
+        if (Cluster.Role.LEADER != role && UdpChannel.isMulticastDestinationAddress(ingressUri))
+        {
+            return; // don't subscribe to ingress if follower and multicast ingress
         }
 
         final Subscription subscription = aeron.addSubscription(

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -77,6 +77,11 @@ final class ClientCommandAdapter implements ControlledMessageHandler
     {
         long correlationId = 0;
 
+        if (conductor.notAcceptingClientCommands())
+        {
+            return Action.ABORT;
+        }
+
         try
         {
             switch (msgTypeId)

--- a/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ClientCommandAdapter.java
@@ -77,11 +77,6 @@ final class ClientCommandAdapter implements ControlledMessageHandler
     {
         long correlationId = 0;
 
-        if (conductor.notAcceptingClientCommands())
-        {
-            return Action.ABORT;
-        }
-
         try
         {
             switch (msgTypeId)

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.driver;
 
-import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -75,18 +74,10 @@ abstract class CommandProxy
 
     final void offer(final Runnable cmd)
     {
-        while (!commandQueue.offer(cmd))
+        if (!commandQueue.offer(cmd))
         {
-            if (!failCount.isClosed())
-            {
-                failCount.increment();
-            }
-
-            Thread.yield();
-            if (Thread.currentThread().isInterrupted())
-            {
-                throw new AgentTerminationException("interrupted");
-            }
+            // unreachable for ManyToOneConcurrentLinkedQueue
+            throw new IllegalStateException(commandQueue.getClass().getSimpleName() + ".offer failed!");
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import org.agrona.concurrent.AgentTerminationException;
+import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.status.AtomicCounter;
+
+import static io.aeron.driver.ThreadingMode.INVOKER;
+import static io.aeron.driver.ThreadingMode.SHARED;
+
+abstract class CommandProxy
+{
+    private final ThreadingMode threadingMode;
+    private final QueuedPipe<Runnable> commandQueue;
+    private final AtomicCounter failCount;
+    private final boolean notConcurrent;
+
+    CommandProxy(
+        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+    {
+        this.threadingMode = threadingMode;
+        this.commandQueue = commandQueue;
+        this.failCount = failCount;
+        notConcurrent = SHARED == threadingMode || INVOKER == threadingMode;
+    }
+
+    /**
+     * Is the driver conductor not concurrent with the sender and receiver threads.
+     *
+     * @return true if the {@link DriverConductor} is on the same thread as the sender and receiver.
+     */
+    public final boolean notConcurrent()
+    {
+        return notConcurrent;
+    }
+
+    /**
+     * Get the threading mode of the driver.
+     *
+     * @return ThreadingMode of the driver.
+     */
+    public final ThreadingMode threadingMode()
+    {
+        return threadingMode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString()
+    {
+        return getClass().getSimpleName() + "{" +
+            "threadingMode=" + threadingMode +
+            ", failCount=" + failCount +
+            '}';
+    }
+
+    final boolean isApplyingBackpressure()
+    {
+        return commandQueue.remainingCapacity() < 1;
+    }
+
+    final void offer(final Runnable cmd)
+    {
+        while (!commandQueue.offer(cmd))
+        {
+            if (!failCount.isClosed())
+            {
+                failCount.increment();
+            }
+
+            Thread.yield();
+            if (Thread.currentThread().isInterrupted())
+            {
+                throw new AgentTerminationException("interrupted");
+            }
+        }
+    }
+}

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -90,7 +90,7 @@ abstract class CommandProxy
         }
     }
 
-    static int drain(
+    static int drainQueue(
         final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
         final int limit,
         final Consumer<Runnable> consumer)

--- a/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/CommandProxy.java
@@ -25,6 +25,7 @@ import static io.aeron.driver.ThreadingMode.SHARED;
 
 abstract class CommandProxy
 {
+    static final Consumer<Runnable> RUN_TASK = Runnable::run;
     private final ThreadingMode threadingMode;
     private final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue;
     private final AtomicCounter failCount;
@@ -82,9 +83,7 @@ abstract class CommandProxy
     }
 
     static int drainQueue(
-        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
-        final int limit,
-        final Consumer<Runnable> consumer)
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue, final int limit, final Consumer<Runnable> consumer)
     {
         int workCount = 0;
         for (int i = 0; i < limit; i++)

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -554,7 +554,7 @@ public final class Configuration
     /**
      * Capacity for the command queues used between driver agents.
      */
-    public static final int CMD_QUEUE_CAPACITY = 128;
+    public static final int CMD_QUEUE_CAPACITY = 1024;
 
     /**
      * Timeout on cleaning up pending SETUP message state on subscriber.

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -780,10 +780,10 @@ public final class Configuration
     public static final String RECEIVER_WILDCARD_PORT_RANGE_PROP_NAME = "aeron.receiver.wildcard.port.range";
 
     /**
-     * Property name to configure the number of async executor threads. Defaults to {@code 1}. Value of zero means no
-     * asynchronous threads will be created, i.e. execution will be done on the caller thread.
+     * Property name to configure the number of async executor threads. Defaults to {@code 1}. Negative value or zero
+     * means no asynchronous threads should be created, i.e. execution will be done on the conductor thread.
      */
-    public static final String ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME = "aeron.driver.async.executor.thread.count";
+    public static final String ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME = "aeron.driver.async.executor.threads";
 
     /**
      * {@link Executor} that run tasks on the caller thread.
@@ -1562,12 +1562,11 @@ public final class Configuration
      * Number of async executor threads.
      *
      * @return number of threads, defaults to one.
-     * @see #ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME
+     * @see #ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME
      */
-    public static int asyncTaskExecutorThreadCount()
+    public static int asyncTaskExecutorThreads()
     {
-        final Integer integer = getInteger(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, 1);
-        return integer < 0 ? 0 : integer;
+        return getInteger(ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME, 1);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -548,7 +548,7 @@ public final class Configuration
     /**
      * Limit for the number of commands drained in one operation.
      */
-    public static final int COMMAND_DRAIN_LIMIT = 5;
+    public static final int COMMAND_DRAIN_LIMIT = 1;
 
     /**
      * Capacity for the command queues used between driver agents.

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -36,6 +36,7 @@ import org.agrona.concurrent.status.StatusIndicator;
 
 import java.net.InetSocketAddress;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static io.aeron.driver.ThreadingMode.DEDICATED;
@@ -777,6 +778,17 @@ public final class Configuration
      * Property name for wildcard port range for the Receiver.
      */
     public static final String RECEIVER_WILDCARD_PORT_RANGE_PROP_NAME = "aeron.receiver.wildcard.port.range";
+
+    /**
+     * Property name to configure the number of async executor threads. Defaults to {@code 1}. Value of zero means no
+     * asynchronous threads will be created, i.e. execution will be done on the caller thread.
+     */
+    public static final String ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME = "aeron.driver.async.executor.thread.count";
+
+    /**
+     * {@link Executor} that run tasks on the caller thread.
+     */
+    public static final Executor CALLER_RUNS_TASK_EXECUTOR = Runnable::run;
 
     /**
      * Should the driver configuration be printed on start.
@@ -1543,6 +1555,19 @@ public final class Configuration
     public static String receiverWildcardPortRange()
     {
         return getProperty(RECEIVER_WILDCARD_PORT_RANGE_PROP_NAME);
+    }
+
+
+    /**
+     * Number of async executor threads.
+     *
+     * @return number of threads, defaults to one.
+     * @see #ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME
+     */
+    public static int asyncTaskExecutorThreadCount()
+    {
+        final Integer integer = getInteger(ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME, 1);
+        return integer < 0 ? 0 : integer;
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -548,7 +548,7 @@ public final class Configuration
     /**
      * Limit for the number of commands drained in one operation.
      */
-    public static final int COMMAND_DRAIN_LIMIT = 10;
+    public static final int COMMAND_DRAIN_LIMIT = 5;
 
     /**
      * Capacity for the command queues used between driver agents.

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -548,7 +548,7 @@ public final class Configuration
     /**
      * Limit for the number of commands drained in one operation.
      */
-    public static final int COMMAND_DRAIN_LIMIT = 2;
+    public static final int COMMAND_DRAIN_LIMIT = 10;
 
     /**
      * Capacity for the command queues used between driver agents.

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -226,7 +226,7 @@ public final class DriverConductor implements Agent
         int workCount = 0;
         workCount += processTimers(nowNs);
         workCount += clientCommandAdapter.receive();
-        workCount += CommandProxy.drain(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        workCount += CommandProxy.drainQueue(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += nameResolver.doWork(cachedEpochClock.time());
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -152,7 +152,7 @@ public final class DriverConductor implements Agent
         dutyCycleTracker = ctx.conductorDutyCycleTracker();
 
         asyncTaskExecutor = ctx.asyncTaskExecutor();
-        asyncExecutionDisabled = ctx.asyncTaskExecutorThreadCount() <= 0;
+        asyncExecutionDisabled = ctx.asyncTaskExecutorThreads() <= 0;
 
         countersManager = ctx.countersManager();
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -49,8 +49,10 @@ import org.agrona.concurrent.status.UnsafeBufferPosition;
 import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.concurrent.Callable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static io.aeron.ChannelUri.SPY_QUALIFIER;
 import static io.aeron.CommonContext.*;
@@ -217,8 +219,8 @@ public final class DriverConductor implements Agent
 
         int workCount = 0;
         workCount += processTimers(nowNs);
-        workCount += driverCmdQueue.drain(Runnable::run, Configuration.COMMAND_DRAIN_LIMIT);
         workCount += clientCommandAdapter.receive();
+        workCount += driverCmdQueue.drain(Runnable::run, Configuration.COMMAND_DRAIN_LIMIT);
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += nameResolver.doWork(cachedEpochClock.time());
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());
@@ -464,74 +466,81 @@ public final class DriverConductor implements Agent
         final long clientId,
         final boolean isExclusive)
     {
-        final UdpChannel udpChannel = UdpChannel.parse(channel, nameResolver);
-        final ChannelUri channelUri = udpChannel.channelUri();
-        final PublicationParams params = getPublicationParams(channelUri, ctx, this, false);
-        validateEndpointForPublication(udpChannel);
-        validateControlForPublication(udpChannel);
-        validateMtuForMaxMessage(params, channel);
-        validateResponseSubscription(params);
-
-        final SendChannelEndpoint channelEndpoint = getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
-
-        NetworkPublication publication = null;
-        if (!isExclusive)
-        {
-            publication = findPublication(networkPublications, streamId, channelEndpoint, params.responseCorrelationId);
-        }
-
-        final PublicationImage responsePublicationImage = findResponsePublicationImage(params);
-
-        boolean isNewPublication = false;
-        if (null == publication)
-        {
-            if (params.hasSessionId)
-            {
-                checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm(), channel);
-            }
-
-            publication = newNetworkPublication(
-                correlationId, clientId, streamId, channel, udpChannel, channelEndpoint, params, isExclusive);
-
-            isNewPublication = true;
-        }
-        else
-        {
-            confirmMatch(
-                channelUri,
-                params,
-                publication.rawLog(),
-                publication.sessionId(),
-                publication.channel(),
-                publication.initialTermId(),
-                publication.startingTermId(),
-                publication.startingTermOffset());
-
-            validateSpiesSimulateConnection(
-                params, publication.spiesSimulateConnection(), channel, publication.channel());
-        }
-
-        publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
-
-        clientProxy.onPublicationReady(
+        executeAsyncClientTask(
             correlationId,
-            publication.registrationId(),
-            streamId,
-            publication.sessionId(),
-            publication.rawLog().fileName(),
-            publication.publisherLimitId(),
-            channelEndpoint.statusIndicatorCounterId(),
-            isExclusive);
+            () -> UdpChannel.parse(channel, nameResolver, false),
+            (udpChannel) ->
+            {
+                final ChannelUri channelUri = udpChannel.channelUri();
+                final PublicationParams params = getPublicationParams(channelUri, ctx, this, false);
+                validateEndpointForPublication(udpChannel);
+                validateControlForPublication(udpChannel);
+                validateMtuForMaxMessage(params, channel);
+                validateResponseSubscription(params);
 
-        if (isNewPublication)
-        {
-            linkSpies(subscriptionLinks, publication);
-        }
+                final SendChannelEndpoint channelEndpoint =
+                    getOrCreateSendChannelEndpoint(params, udpChannel, correlationId);
 
-        if (null != responsePublicationImage)
-        {
-            responsePublicationImage.responseSessionId(publication.sessionId());
-        }
+                NetworkPublication publication = null;
+                if (!isExclusive)
+                {
+                    publication =
+                        findPublication(networkPublications, streamId, channelEndpoint, params.responseCorrelationId);
+                }
+
+                final PublicationImage responsePublicationImage = findResponsePublicationImage(params);
+
+                boolean isNewPublication = false;
+                if (null == publication)
+                {
+                    if (params.hasSessionId)
+                    {
+                        checkForSessionClash(params.sessionId, streamId, udpChannel.canonicalForm(), channel);
+                    }
+
+                    publication = newNetworkPublication(
+                        correlationId, clientId, streamId, channel, udpChannel, channelEndpoint, params, isExclusive);
+
+                    isNewPublication = true;
+                }
+                else
+                {
+                    confirmMatch(
+                        channelUri,
+                        params,
+                        publication.rawLog(),
+                        publication.sessionId(),
+                        publication.channel(),
+                        publication.initialTermId(),
+                        publication.startingTermId(),
+                        publication.startingTermOffset());
+
+                    validateSpiesSimulateConnection(
+                        params, publication.spiesSimulateConnection(), channel, publication.channel());
+                }
+
+                publicationLinks.add(new PublicationLink(correlationId, getOrAddClient(clientId), publication));
+
+                clientProxy.onPublicationReady(
+                    correlationId,
+                    publication.registrationId(),
+                    streamId,
+                    publication.sessionId(),
+                    publication.rawLog().fileName(),
+                    publication.publisherLimitId(),
+                    channelEndpoint.statusIndicatorCounterId(),
+                    isExclusive);
+
+                if (isNewPublication)
+                {
+                    linkSpies(subscriptionLinks, publication);
+                }
+
+                if (null != responsePublicationImage)
+                {
+                    responsePublicationImage.responseSessionId(publication.sessionId());
+                }
+            });
     }
 
     private PublicationImage findResponsePublicationImage(final PublicationParams params)
@@ -934,34 +943,40 @@ public final class DriverConductor implements Agent
     void onAddNetworkSubscription(
         final String channel, final int streamId, final long registrationId, final long clientId)
     {
-        final UdpChannel udpChannel = UdpChannel.parse(channel, nameResolver);
-        final ControlMode controlMode = udpChannel.controlMode();
+        executeAsyncClientTask(
+            registrationId,
+            () -> UdpChannel.parse(channel, nameResolver, false),
+            (udpChannel) ->
+            {
+                final ControlMode controlMode = udpChannel.controlMode();
 
-        validateControlForSubscription(udpChannel);
-        validateTimestampConfiguration(udpChannel);
+                validateControlForSubscription(udpChannel);
+                validateTimestampConfiguration(udpChannel);
 
-        final SubscriptionParams params = SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
-        checkForClashingSubscription(params, udpChannel, streamId);
+                final SubscriptionParams params =
+                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
+                checkForClashingSubscription(params, udpChannel, streamId);
 
-        final ReceiveChannelEndpoint channelEndpoint = getOrCreateReceiveChannelEndpoint(
-            params, udpChannel, registrationId);
+                final ReceiveChannelEndpoint channelEndpoint = getOrCreateReceiveChannelEndpoint(
+                    params, udpChannel, registrationId);
 
-        final NetworkSubscriptionLink subscription = new NetworkSubscriptionLink(
-            registrationId, channelEndpoint, streamId, channel, getOrAddClient(clientId), params);
+                final NetworkSubscriptionLink subscription = new NetworkSubscriptionLink(
+                    registrationId, channelEndpoint, streamId, channel, getOrAddClient(clientId), params);
 
-        subscriptionLinks.add(subscription);
+                subscriptionLinks.add(subscription);
 
-        if (ControlMode.RESPONSE == controlMode)
-        {
-            channelEndpoint.incResponseRefToStream(subscription.streamId);
-        }
-        else
-        {
-            addNetworkSubscriptionToReceiver(subscription);
-        }
+                if (ControlMode.RESPONSE == controlMode)
+                {
+                    channelEndpoint.incResponseRefToStream(subscription.streamId);
+                }
+                else
+                {
+                    addNetworkSubscriptionToReceiver(subscription);
+                }
 
-        clientProxy.onSubscriptionReady(registrationId, channelEndpoint.statusIndicatorCounter().id());
-        linkMatchingImages(subscription);
+                clientProxy.onSubscriptionReady(registrationId, channelEndpoint.statusIndicatorCounter().id());
+                linkMatchingImages(subscription);
+            });
     }
 
     private void addNetworkSubscriptionToReceiver(final NetworkSubscriptionLink subscription)
@@ -1012,29 +1027,35 @@ public final class DriverConductor implements Agent
 
     void onAddSpySubscription(final String channel, final int streamId, final long registrationId, final long clientId)
     {
-        final UdpChannel udpChannel = UdpChannel.parse(channel, nameResolver);
-        final SubscriptionParams params = SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
-        final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
-            registrationId, udpChannel, streamId, getOrAddClient(clientId), params);
-
-        subscriptionLinks.add(subscriptionLink);
-        clientProxy.onSubscriptionReady(registrationId, ChannelEndpointStatus.NO_ID_ALLOCATED);
-
-        for (int i = 0, size = networkPublications.size(); i < size; i++)
-        {
-            final NetworkPublication publication = networkPublications.get(i);
-            if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+        executeAsyncClientTask(
+            registrationId,
+            () -> UdpChannel.parse(channel, nameResolver, false),
+            (udpChannel) ->
             {
-                clientProxy.onAvailableImage(
-                    publication.registrationId(),
-                    streamId,
-                    publication.sessionId(),
-                    registrationId,
-                    linkSpy(publication, subscriptionLink).id(),
-                    publication.rawLog().fileName(),
-                    CommonContext.IPC_CHANNEL);
-            }
-        }
+                final SubscriptionParams params =
+                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
+                final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
+                    registrationId, udpChannel, streamId, getOrAddClient(clientId), params);
+
+                subscriptionLinks.add(subscriptionLink);
+                clientProxy.onSubscriptionReady(registrationId, ChannelEndpointStatus.NO_ID_ALLOCATED);
+
+                for (int i = 0, size = networkPublications.size(); i < size; i++)
+                {
+                    final NetworkPublication publication = networkPublications.get(i);
+                    if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+                    {
+                        clientProxy.onAvailableImage(
+                            publication.registrationId(),
+                            streamId,
+                            publication.sessionId(),
+                            registrationId,
+                            linkSpy(publication, subscriptionLink).id(),
+                            publication.rawLog().fileName(),
+                            CommonContext.IPC_CHANNEL);
+                    }
+                }
+            });
     }
 
     void onRemoveSubscription(final long registrationId, final long correlationId)
@@ -1181,61 +1202,78 @@ public final class DriverConductor implements Agent
 
     void onAddRcvSpyDestination(final long registrationId, final String destinationChannel, final long correlationId)
     {
-        final UdpChannel udpChannel = UdpChannel.parse(destinationChannel, nameResolver);
-        final SubscriptionParams params = SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
-        final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
-
-        if (null == mdsSubscriptionLink)
-        {
-            throw new ControlProtocolException(UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
-        }
-
-        final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
-            registrationId, udpChannel, mdsSubscriptionLink.streamId(), mdsSubscriptionLink.aeronClient(), params);
-
-        subscriptionLinks.add(subscriptionLink);
-        clientProxy.operationSucceeded(correlationId);
-
-        for (int i = 0, size = networkPublications.size(); i < size; i++)
-        {
-            final NetworkPublication publication = networkPublications.get(i);
-            if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+        executeAsyncClientTask(
+            correlationId,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, false),
+            (udpChannel) ->
             {
-                clientProxy.onAvailableImage(
-                    publication.registrationId(),
-                    mdsSubscriptionLink.streamId(),
-                    publication.sessionId(),
+                final SubscriptionParams params =
+                    SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
+                final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
+
+                if (null == mdsSubscriptionLink)
+                {
+                    throw new ControlProtocolException(
+                        UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
+                }
+
+                final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
                     registrationId,
-                    linkSpy(publication, subscriptionLink).id(),
-                    publication.rawLog().fileName(),
-                    CommonContext.IPC_CHANNEL);
-            }
-        }
+                    udpChannel,
+                    mdsSubscriptionLink.streamId(),
+                    mdsSubscriptionLink.aeronClient(),
+                    params);
+
+                subscriptionLinks.add(subscriptionLink);
+                clientProxy.operationSucceeded(correlationId);
+
+                for (int i = 0, size = networkPublications.size(); i < size; i++)
+                {
+                    final NetworkPublication publication = networkPublications.get(i);
+                    if (subscriptionLink.matches(publication) && publication.isAcceptingSubscriptions())
+                    {
+                        clientProxy.onAvailableImage(
+                            publication.registrationId(),
+                            mdsSubscriptionLink.streamId(),
+                            publication.sessionId(),
+                            registrationId,
+                            linkSpy(publication, subscriptionLink).id(),
+                            publication.rawLog().fileName(),
+                            CommonContext.IPC_CHANNEL);
+                    }
+                }
+            });
     }
 
     void onAddRcvNetworkDestination(
         final long registrationId, final String destinationChannel, final long correlationId)
     {
-        final UdpChannel udpChannel = UdpChannel.parse(destinationChannel, nameResolver, true);
-        validateDestinationUri(udpChannel.channelUri(), destinationChannel);
+        executeAsyncClientTask(
+            correlationId,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
+            (udpChannel) ->
+            {
+                validateDestinationUri(udpChannel.channelUri(), destinationChannel);
 
-        final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
+                final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
 
-        if (null == mdsSubscriptionLink)
-        {
-            throw new ControlProtocolException(UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
-        }
+                if (null == mdsSubscriptionLink)
+                {
+                    throw new ControlProtocolException(
+                        UNKNOWN_SUBSCRIPTION, "unknown MDS subscription: " + registrationId);
+                }
 
-        final ReceiveChannelEndpoint receiveChannelEndpoint = mdsSubscriptionLink.channelEndpoint();
+                final ReceiveChannelEndpoint receiveChannelEndpoint = mdsSubscriptionLink.channelEndpoint();
 
-        final AtomicCounter localSocketAddressIndicator = ReceiveLocalSocketAddress.allocate(
-            tempBuffer, countersManager, registrationId, receiveChannelEndpoint.statusIndicatorCounter().id());
+                final AtomicCounter localSocketAddressIndicator = ReceiveLocalSocketAddress.allocate(
+                    tempBuffer, countersManager, registrationId, receiveChannelEndpoint.statusIndicatorCounter().id());
 
-        final ReceiveDestinationTransport transport = new ReceiveDestinationTransport(
-            udpChannel, ctx, localSocketAddressIndicator, receiveChannelEndpoint);
+                final ReceiveDestinationTransport transport = new ReceiveDestinationTransport(
+                    udpChannel, ctx, localSocketAddressIndicator, receiveChannelEndpoint);
 
-        receiverProxy.addDestination(receiveChannelEndpoint, transport);
-        clientProxy.operationSucceeded(correlationId);
+                receiverProxy.addDestination(receiveChannelEndpoint, transport);
+                clientProxy.operationSucceeded(correlationId);
+            });
     }
 
     void onRemoveRcvDestination(final long registrationId, final String destinationChannel, final long correlationId)
@@ -1288,9 +1326,16 @@ public final class DriverConductor implements Agent
         }
 
         receiveChannelEndpoint.validateAllowsDestinationControl();
-        receiverProxy.removeDestination(
-            receiveChannelEndpoint, UdpChannel.parse(destinationChannel, nameResolver, true));
-        clientProxy.operationSucceeded(correlationId);
+
+        final ReceiveChannelEndpoint endpoint = receiveChannelEndpoint;
+        executeAsyncClientTask(
+            correlationId,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
+            (udpChannel) ->
+            {
+                receiverProxy.removeDestination(endpoint, udpChannel);
+                clientProxy.operationSucceeded(correlationId);
+            });
     }
 
     void closeReceiveDestinationIndicators(final ReceiveDestinationTransport destinationTransport)
@@ -1367,6 +1412,36 @@ public final class DriverConductor implements Agent
         }
 
         return subscriberPositions;
+    }
+
+    <T> void executeAsyncClientTask(
+        final long correlationId, final Callable<T> asyncTask, final Consumer<T> driverCommand)
+    {
+        ctx.asyncTaskExecutor().execute(() ->
+        {
+            final T value;
+            try
+            {
+                value = asyncTask.call();
+            }
+            catch (final Exception ex)
+            {
+                ctx.driverConductorProxy().offer(() -> clientCommandAdapter.onError(correlationId, ex));
+                return;
+            }
+
+            ctx.driverConductorProxy().offer(() ->
+            {
+                try
+                {
+                    driverCommand.accept(value);
+                }
+                catch (final Exception ex)
+                {
+                    clientCommandAdapter.onError(correlationId, ex);
+                }
+            });
+        });
     }
 
     private static NetworkPublication findPublication(

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -36,6 +36,7 @@ import io.aeron.status.ChannelEndpointStatus;
 import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.LangUtil;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Object2ObjectHashMap;
 import org.agrona.collections.ObjectHashSet;
@@ -475,8 +476,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             correlationId,
             () -> UdpChannel.parse(channel, nameResolver, false),
-            (udpChannel) ->
+            (asyncResult) ->
             {
+                final UdpChannel udpChannel = asyncResult.get();
                 final ChannelUri channelUri = udpChannel.channelUri();
                 final PublicationParams params = getPublicationParams(channelUri, ctx, this, false);
                 validateEndpointForPublication(udpChannel);
@@ -952,8 +954,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             registrationId,
             () -> UdpChannel.parse(channel, nameResolver, false),
-            (udpChannel) ->
+            (asyncResult) ->
             {
+                final UdpChannel udpChannel = asyncResult.get();
                 final ControlMode controlMode = udpChannel.controlMode();
 
                 validateControlForSubscription(udpChannel);
@@ -1036,8 +1039,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             registrationId,
             () -> UdpChannel.parse(channel, nameResolver, false),
-            (udpChannel) ->
+            (asyncResult) ->
             {
+                final UdpChannel udpChannel = asyncResult.get();
                 final SubscriptionParams params =
                     SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
                 final SpySubscriptionLink subscriptionLink = new SpySubscriptionLink(
@@ -1211,8 +1215,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             correlationId,
             () -> UdpChannel.parse(destinationChannel, nameResolver, false),
-            (udpChannel) ->
+            (asyncResult) ->
             {
+                final UdpChannel udpChannel = asyncResult.get();
                 final SubscriptionParams params =
                     SubscriptionParams.getSubscriptionParams(udpChannel.channelUri(), ctx);
                 final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
@@ -1257,8 +1262,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             correlationId,
             () -> UdpChannel.parse(destinationChannel, nameResolver, true),
-            (udpChannel) ->
+            (asyncResult) ->
             {
+                final UdpChannel udpChannel = asyncResult.get();
                 validateDestinationUri(udpChannel.channelUri(), destinationChannel);
 
                 final SubscriptionLink mdsSubscriptionLink = findMdsSubscriptionLink(subscriptionLinks, registrationId);
@@ -1337,9 +1343,9 @@ public final class DriverConductor implements Agent
         executeAsyncClientTask(
             correlationId,
             () -> UdpChannel.parse(destinationChannel, nameResolver, true),
-            (udpChannel) ->
+            (asyncResult) ->
             {
-                receiverProxy.removeDestination(endpoint, udpChannel);
+                receiverProxy.removeDestination(endpoint, asyncResult.get());
                 clientProxy.operationSucceeded(correlationId);
             });
     }
@@ -1421,26 +1427,26 @@ public final class DriverConductor implements Agent
     }
 
     <T> void executeAsyncClientTask(
-        final long correlationId, final Callable<T> asyncTask, final Consumer<T> driverCommand)
+        final long correlationId, final Callable<T> asyncTask, final Consumer<AsyncResult<T>> driverCommand)
     {
         ctx.asyncTaskExecutor().execute(() ->
         {
-            final T value;
+            AsyncResult<T> tmp;
             try
             {
-                value = asyncTask.call();
+                tmp = AsyncResult.of(asyncTask.call());
             }
             catch (final Exception ex)
             {
-                ctx.driverConductorProxy().offer(() -> clientCommandAdapter.onError(correlationId, ex));
-                return;
+                tmp = AsyncResult.error(ex);
             }
 
+            final AsyncResult<T> asyncResult = tmp;
             ctx.driverConductorProxy().offer(() ->
             {
                 try
                 {
-                    driverCommand.accept(value);
+                    driverCommand.accept(asyncResult);
                 }
                 catch (final Exception ex)
                 {
@@ -2445,6 +2451,25 @@ public final class DriverConductor implements Agent
         else
         {
             return ctx.unicastFeedbackDelayGenerator();
+        }
+    }
+
+    private interface AsyncResult<T>
+    {
+        T get();
+
+        static <T> AsyncResult<T> of(final T value)
+        {
+            return () -> value;
+        }
+
+        static <T> AsyncResult<T> error(final Exception ex)
+        {
+            return () ->
+            {
+                LangUtil.rethrowUnchecked(ex);
+                return null;
+            };
         }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -226,7 +226,8 @@ public final class DriverConductor implements Agent
         int workCount = 0;
         workCount += processTimers(nowNs);
         workCount += clientCommandAdapter.receive();
-        workCount += CommandProxy.drainQueue(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        workCount +=
+            CommandProxy.drainQueue(driverCmdQueue, Configuration.COMMAND_DRAIN_LIMIT, CommandProxy.RUN_TASK);
         workCount += trackStreamPositions(workCount, nowNs);
         workCount += nameResolver.doWork(cachedEpochClock.time());
         workCount += freeEndOfLifeResources(ctx.resourceFreeLimit());

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -56,7 +56,6 @@ import org.agrona.concurrent.status.UnsafeBufferPosition;
 import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.concurrent.Callable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -501,7 +500,8 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
+            channel,
+            false,
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -979,7 +979,8 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             registrationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
+            channel,
+            false,
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1064,7 +1065,8 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             registrationId,
-            () -> UdpChannel.parse(channel, nameResolver, false),
+            channel,
+            false,
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1240,7 +1242,8 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, false),
+            destinationChannel,
+            false,
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1287,7 +1290,8 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
+            destinationChannel,
+            true,
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1368,7 +1372,8 @@ public final class DriverConductor implements Agent
         final ReceiveChannelEndpoint endpoint = receiveChannelEndpoint;
         executeAsyncClientTask(
             correlationId,
-            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
+            destinationChannel,
+            true,
             (asyncResult) ->
             {
                 receiverProxy.removeDestination(endpoint, asyncResult.get());
@@ -1452,22 +1457,25 @@ public final class DriverConductor implements Agent
         return subscriberPositions;
     }
 
-    <T> void executeAsyncClientTask(
-        final long correlationId, final Callable<T> asyncTask, final Consumer<AsyncResult<T>> driverCommand)
+    void executeAsyncClientTask(
+        final long correlationId,
+        final String channel,
+        final boolean isDestination,
+        final Consumer<AsyncResult<UdpChannel>> driverCommand)
     {
         ctx.asyncTaskExecutor().execute(() ->
         {
-            AsyncResult<T> tmp;
+            AsyncResult<UdpChannel> tmp;
             try
             {
-                tmp = AsyncResult.of(asyncTask.call());
+                tmp = AsyncResult.of(UdpChannel.parse(channel, nameResolver, isDestination));
             }
             catch (final Exception ex)
             {
                 tmp = AsyncResult.error(ex);
             }
 
-            final AsyncResult<T> asyncResult = tmp;
+            final AsyncResult<UdpChannel> asyncResult = tmp;
             ctx.driverConductorProxy().offer(() ->
             {
                 try

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -486,8 +486,7 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            channel,
-            false,
+            () -> UdpChannel.parse(channel, nameResolver, false),
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -965,8 +964,7 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             registrationId,
-            channel,
-            false,
+            () -> UdpChannel.parse(channel, nameResolver, false),
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1051,8 +1049,7 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             registrationId,
-            channel,
-            false,
+            () -> UdpChannel.parse(channel, nameResolver, false),
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1228,8 +1225,7 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            destinationChannel,
-            false,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, false),
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1276,8 +1272,7 @@ public final class DriverConductor implements Agent
     {
         executeAsyncClientTask(
             correlationId,
-            destinationChannel,
-            true,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
             (asyncResult) ->
             {
                 final UdpChannel udpChannel = asyncResult.get();
@@ -1358,8 +1353,7 @@ public final class DriverConductor implements Agent
         final ReceiveChannelEndpoint endpoint = receiveChannelEndpoint;
         executeAsyncClientTask(
             correlationId,
-            destinationChannel,
-            true,
+            () -> UdpChannel.parse(destinationChannel, nameResolver, true),
             (asyncResult) ->
             {
                 receiverProxy.removeDestination(endpoint, asyncResult.get());
@@ -1445,21 +1439,19 @@ public final class DriverConductor implements Agent
 
     private void executeAsyncClientTask(
         final long correlationId,
-        final String channel,
-        final boolean isDestination,
+        final Supplier<UdpChannel> asyncTask,
         final Consumer<Supplier<UdpChannel>> command)
     {
-        final Supplier<UdpChannel> parsedChannel = () -> UdpChannel.parse(channel, nameResolver, isDestination);
         if (asyncExecutionDisabled)
         {
-            command.accept(parsedChannel);
+            command.accept(asyncTask);
         }
         else
         {
             asyncClientCommandInFlight = true;
             asyncTaskExecutor.execute(() ->
             {
-                final AsyncResult<UdpChannel> asyncResult = AsyncResult.of(parsedChannel);
+                final AsyncResult<UdpChannel> asyncResult = AsyncResult.of(asyncTask);
                 addToCommandQueue(() ->
                 {
                     try

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -40,7 +40,13 @@ import org.agrona.LangUtil;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.collections.Object2ObjectHashMap;
 import org.agrona.collections.ObjectHashSet;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.Agent;
+import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.EpochClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.NanoClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersManager;
@@ -363,26 +369,39 @@ public final class DriverConductor implements Agent
     {
         ctx.asyncTaskExecutor().execute(() ->
         {
+            AsyncResult<InetSocketAddress> tmp;
             try
             {
-                final InetSocketAddress newAddress = UdpChannel.resolve(
-                    endpoint, CommonContext.ENDPOINT_PARAM_NAME, true, nameResolver);
-
-                if (newAddress.isUnresolved())
-                {
-                    ctx.errorHandler().onError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
-                    errorCounter.increment();
-                }
-                else if (!address.equals(newAddress))
-                {
-                    senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
-                }
+                tmp = AsyncResult.of(UdpChannel.resolve(
+                    endpoint, CommonContext.ENDPOINT_PARAM_NAME, true, nameResolver));
             }
             catch (final Exception ex)
             {
-                ctx.errorHandler().onError(ex);
-                errorCounter.increment();
+                tmp = AsyncResult.error(ex);
             }
+
+            final AsyncResult<InetSocketAddress> asyncResult = tmp;
+            ctx.driverConductorProxy().offer(() ->
+            {
+                try
+                {
+                    final InetSocketAddress newAddress = asyncResult.get();
+                    if (newAddress.isUnresolved())
+                    {
+                        ctx.errorHandler().onError(new AeronEvent("could not re-resolve: endpoint=" + endpoint));
+                        errorCounter.increment();
+                    }
+                    else if (!address.equals(newAddress))
+                    {
+                        senderProxy.onResolutionChange(channelEndpoint, endpoint, newAddress);
+                    }
+                }
+                catch (final Exception ex)
+                {
+                    ctx.errorHandler().onError(ex);
+                    errorCounter.increment();
+                }
+            });
         });
     }
 
@@ -394,26 +413,39 @@ public final class DriverConductor implements Agent
     {
         ctx.asyncTaskExecutor().execute(() ->
         {
+            AsyncResult<InetSocketAddress> tmp;
             try
             {
-                final InetSocketAddress newAddress = UdpChannel.resolve(
-                    control, CommonContext.MDC_CONTROL_PARAM_NAME, true, nameResolver);
-
-                if (newAddress.isUnresolved())
-                {
-                    ctx.errorHandler().onError(new AeronEvent("could not re-resolve: control=" + control));
-                    errorCounter.increment();
-                }
-                else if (!address.equals(newAddress))
-                {
-                    receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress);
-                }
+                tmp = AsyncResult.of(UdpChannel.resolve(
+                    control, CommonContext.MDC_CONTROL_PARAM_NAME, true, nameResolver));
             }
             catch (final Exception ex)
             {
-                ctx.errorHandler().onError(ex);
-                errorCounter.increment();
+                tmp = AsyncResult.error(ex);
             }
+
+            final AsyncResult<InetSocketAddress> asyncResult = tmp;
+            ctx.driverConductorProxy().offer(() ->
+            {
+                try
+                {
+                    final InetSocketAddress newAddress = asyncResult.get();
+                    if (newAddress.isUnresolved())
+                    {
+                        ctx.errorHandler().onError(new AeronEvent("could not re-resolve: control=" + control));
+                        errorCounter.increment();
+                    }
+                    else if (!address.equals(newAddress))
+                    {
+                        receiverProxy.onResolutionChange(channelEndpoint, udpChannel, newAddress);
+                    }
+                }
+                catch (final Exception ex)
+                {
+                    ctx.errorHandler().onError(ex);
+                    errorCounter.increment();
+                }
+            });
         });
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -19,7 +19,7 @@ import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.SendChannelEndpoint;
 import io.aeron.driver.media.UdpChannel;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -32,7 +32,9 @@ public final class DriverConductorProxy extends CommandProxy
     private DriverConductor driverConductor;
 
     DriverConductorProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -65,14 +65,8 @@ public final class DriverConductorProxy extends CommandProxy
     public void reResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        if (notConcurrent())
-        {
-            driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
-        }
-        else
-        {
-            offer(() -> driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address));
-        }
+        // safe, because DriverConductor uses the async thread to execute this call
+        driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
     }
 
     /**
@@ -89,14 +83,8 @@ public final class DriverConductorProxy extends CommandProxy
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        if (notConcurrent())
-        {
-            driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
-        }
-        else
-        {
-            offer(() -> driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address));
-        }
+        // safe, because DriverConductor uses the async thread to execute this call
+        driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductorProxy.java
@@ -65,8 +65,14 @@ public final class DriverConductorProxy extends CommandProxy
     public void reResolveEndpoint(
         final String endpoint, final SendChannelEndpoint channelEndpoint, final InetSocketAddress address)
     {
-        // safe, because DriverConductor uses the async thread to execute this call
-        driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
+        if (notConcurrent())
+        {
+            driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address);
+        }
+        else
+        {
+            offer(() -> driverConductor.onReResolveEndpoint(endpoint, channelEndpoint, address));
+        }
     }
 
     /**
@@ -83,8 +89,14 @@ public final class DriverConductorProxy extends CommandProxy
         final ReceiveChannelEndpoint channelEndpoint,
         final InetSocketAddress address)
     {
-        // safe, because DriverConductor uses the async thread to execute this call
-        driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
+        if (notConcurrent())
+        {
+            driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address);
+        }
+        else
+        {
+            offer(() -> driverConductor.onReResolveControl(endpoint, udpChannel, channelEndpoint, address));
+        }
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -49,6 +49,9 @@ import java.nio.channels.DatagramChannel;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -434,6 +437,7 @@ public final class MediaDriver implements AutoCloseable
         private boolean reliableStream = Configuration.reliableStream();
         private boolean tetherSubscriptions = Configuration.tetherSubscriptions();
         private boolean rejoinStream = Configuration.rejoinStream();
+        private boolean ownsAsyncTaskExecutor;
 
         private long lowStorageWarningThreshold = Configuration.lowStorageWarningThreshold();
         private long timerIntervalNs = Configuration.timerIntervalNs();
@@ -502,6 +506,7 @@ public final class MediaDriver implements AutoCloseable
         private ThreadFactory receiverThreadFactory;
         private ThreadFactory sharedThreadFactory;
         private ThreadFactory sharedNetworkThreadFactory;
+        private Executor asyncTaskExecutor;
         private IdleStrategy conductorIdleStrategy;
         private IdleStrategy senderIdleStrategy;
         private IdleStrategy receiverIdleStrategy;
@@ -578,6 +583,14 @@ public final class MediaDriver implements AutoCloseable
         {
             if (IS_CLOSED_UPDATER.compareAndSet(this, 0, 1))
             {
+                if (ownsAsyncTaskExecutor)
+                {
+                    if (asyncTaskExecutor instanceof ExecutorService)
+                    {
+                        ((ExecutorService)asyncTaskExecutor).shutdownNow();
+                    }
+                }
+
                 CloseHelper.close(errorHandler, logFactory);
 
                 if (null != systemCounters)
@@ -2196,6 +2209,51 @@ public final class MediaDriver implements AutoCloseable
         }
 
         /**
+         * {@link Executor} to be used for asynchronous task execution in the {@link DriverConductor}.
+         *
+         * @return executor service for asynchronous tasks. Defaults to
+         * {@link java.util.concurrent.Executors#newSingleThreadExecutor(ThreadFactory)}.
+         */
+        public Executor asyncTaskExecutor()
+        {
+            return asyncTaskExecutor;
+        }
+
+        /**
+         * {@link Executor} to be used for asynchronous task execution in the {@link DriverConductor}.
+         *
+         * @param asyncTaskExecutor to be used for asynchronous task execution in the {@link DriverConductor}.
+         * @return this for a fluent API.
+         */
+        public Context asyncTaskExecutor(final Executor asyncTaskExecutor)
+        {
+            this.asyncTaskExecutor = asyncTaskExecutor;
+            return this;
+        }
+
+        /**
+         * Does this context own the {@link #asyncTaskExecutor()} client and this takes responsibility for closing it?
+         *
+         * @return does this context own the {@link #asyncTaskExecutor()} and this takes responsibility for closing it?
+         */
+        public boolean ownsAsyncTaskExecutor()
+        {
+            return ownsAsyncTaskExecutor;
+        }
+
+        /**
+         * Does this context own the {@link #asyncTaskExecutor()} client and this takes responsibility for closing it?
+         *
+         * @param ownsAsyncTaskExecutor does this context own the {@link #asyncTaskExecutor()}.
+         * @return this for a fluent API.
+         */
+        public Context ownsAsyncTaskExecutor(final boolean ownsAsyncTaskExecutor)
+        {
+            this.ownsAsyncTaskExecutor = ownsAsyncTaskExecutor;
+            return this;
+        }
+
+        /**
          * {@link IdleStrategy} to be used by the {@link Sender} when in {@link ThreadingMode#DEDICATED}.
          *
          * @return {@link IdleStrategy} to be used by the {@link Sender} when in {@link ThreadingMode#DEDICATED}.
@@ -3804,6 +3862,17 @@ public final class MediaDriver implements AutoCloseable
             if (null == channelSendTimestampClock)
             {
                 channelSendTimestampClock = new SystemEpochNanoClock();
+            }
+
+            if (null == asyncTaskExecutor)
+            {
+                ownsAsyncTaskExecutor = true;
+                asyncTaskExecutor = Executors.newSingleThreadExecutor((r) ->
+                {
+                    final Thread thread = new Thread(r, "async-task-executor");
+                    thread.setDaemon(true);
+                    return thread;
+                });
             }
         }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -539,8 +539,8 @@ public final class MediaDriver implements AutoCloseable
         private DataTransportPoller dataTransportPoller;
         private ControlTransportPoller controlTransportPoller;
         private ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue;
-        private OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
-        private OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
+        private ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
+        private ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
         private ReceiverProxy receiverProxy;
         private SenderProxy senderProxy;
         private DriverConductorProxy driverConductorProxy;
@@ -3538,23 +3538,23 @@ public final class MediaDriver implements AutoCloseable
             return channelSendTimestampClock;
         }
 
-        OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
+        ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
         {
             return receiverCommandQueue;
         }
 
-        Context receiverCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
+        Context receiverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
         {
             this.receiverCommandQueue = receiverCommandQueue;
             return this;
         }
 
-        OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
+        ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
         {
             return senderCommandQueue;
         }
 
-        Context senderCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
+        Context senderCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
         {
             this.senderCommandQueue = senderCommandQueue;
             return this;
@@ -3802,6 +3802,11 @@ public final class MediaDriver implements AutoCloseable
                 congestionControlSupplier = Configuration.congestionControlSupplier();
             }
 
+            if (null == threadingMode)
+            {
+                threadingMode = Configuration.threadingMode();
+            }
+
             if (null == driverCommandQueue)
             {
                 driverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
@@ -3809,12 +3814,12 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == receiverCommandQueue)
             {
-                receiverCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                receiverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == senderCommandQueue)
             {
-                senderCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                senderCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == retransmitUnicastDelayGenerator)
@@ -3837,11 +3842,6 @@ public final class MediaDriver implements AutoCloseable
             {
                 multicastFeedbackDelayGenerator = new OptimalMulticastDelayGenerator(
                     nakMulticastMaxBackoffNs, nakMulticastGroupSize);
-            }
-
-            if (null == threadingMode)
-            {
-                threadingMode = Configuration.threadingMode();
             }
 
             if (null == terminationValidator)

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -541,8 +541,8 @@ public final class MediaDriver implements AutoCloseable
         private DataTransportPoller dataTransportPoller;
         private ControlTransportPoller controlTransportPoller;
         private ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue;
-        private ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue;
-        private ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue;
+        private OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
+        private OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
         private ReceiverProxy receiverProxy;
         private SenderProxy senderProxy;
         private DriverConductorProxy driverConductorProxy;
@@ -3563,23 +3563,23 @@ public final class MediaDriver implements AutoCloseable
             return channelSendTimestampClock;
         }
 
-        ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue()
+        OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
         {
             return receiverCommandQueue;
         }
 
-        Context receiverCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue)
+        Context receiverCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
         {
             this.receiverCommandQueue = receiverCommandQueue;
             return this;
         }
 
-        ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue()
+        OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
         {
             return senderCommandQueue;
         }
 
-        Context senderCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue)
+        Context senderCommandQueue(final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
         {
             this.senderCommandQueue = senderCommandQueue;
             return this;
@@ -3839,12 +3839,12 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == receiverCommandQueue)
             {
-                receiverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
+                receiverCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == senderCommandQueue)
             {
-                senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
+                senderCommandQueue = new OneToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
             }
 
             if (null == retransmitUnicastDelayGenerator)

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -538,9 +538,9 @@ public final class MediaDriver implements AutoCloseable
         private LogFactory logFactory;
         private DataTransportPoller dataTransportPoller;
         private ControlTransportPoller controlTransportPoller;
-        private ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue;
-        private ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue;
-        private ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue;
+        private ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue;
         private ReceiverProxy receiverProxy;
         private SenderProxy senderProxy;
         private DriverConductorProxy driverConductorProxy;
@@ -3538,34 +3538,34 @@ public final class MediaDriver implements AutoCloseable
             return channelSendTimestampClock;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue()
         {
             return receiverCommandQueue;
         }
 
-        Context receiverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> receiverCommandQueue)
+        Context receiverCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> receiverCommandQueue)
         {
             this.receiverCommandQueue = receiverCommandQueue;
             return this;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue()
         {
             return senderCommandQueue;
         }
 
-        Context senderCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue)
+        Context senderCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue)
         {
             this.senderCommandQueue = senderCommandQueue;
             return this;
         }
 
-        ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue()
+        ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue()
         {
             return driverCommandQueue;
         }
 
-        Context driverCommandQueue(final ManyToOneConcurrentArrayQueue<Runnable> queue)
+        Context driverCommandQueue(final ManyToOneConcurrentLinkedQueue<Runnable> queue)
         {
             this.driverCommandQueue = queue;
             return this;
@@ -3809,17 +3809,17 @@ public final class MediaDriver implements AutoCloseable
 
             if (null == driverCommandQueue)
             {
-                driverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                driverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == receiverCommandQueue)
             {
-                receiverCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                receiverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == senderCommandQueue)
             {
-                senderCommandQueue = new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+                senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
             }
 
             if (null == retransmitUnicastDelayGenerator)

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -484,7 +484,7 @@ public final class MediaDriver implements AutoCloseable
         private int lossReportBufferLength = Configuration.lossReportBufferLength();
         private int sendToStatusMessagePollRatio = Configuration.sendToStatusMessagePollRatio();
         private int resourceFreeLimit = Configuration.resourceFreeLimit();
-        private int asyncTaskExecutorThreadCount = Configuration.asyncTaskExecutorThreadCount();
+        private int asyncTaskExecutorThreads = Configuration.asyncTaskExecutorThreads();
 
         private Long receiverGroupTag = Configuration.groupTag();
         private long flowControlGroupTag = Configuration.flowControlGroupTag();
@@ -2214,22 +2214,22 @@ public final class MediaDriver implements AutoCloseable
          * Returns the number of threads for async task executor.
          *
          * @return number of threads.
-         * @see Configuration#ASYNC_TASK_EXECUTOR_THREAD_COUNT_PROP_NAME
+         * @see Configuration#ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME
          */
-        public int asyncTaskExecutorThreadCount()
+        public int asyncTaskExecutorThreads()
         {
-            return asyncTaskExecutorThreadCount;
+            return asyncTaskExecutorThreads;
         }
 
         /**
          * Sets the number of threads for async task executor.
          *
-         * @param asyncTaskExecutorThreadCount number of async worker threads.
+         * @param asyncTaskExecutorThreads number of async worker threads.
          * @return this for a fluent API.
          */
-        public Context asyncTaskExecutorThreadCount(final int asyncTaskExecutorThreadCount)
+        public Context asyncTaskExecutorThreads(final int asyncTaskExecutorThreads)
         {
-            this.asyncTaskExecutorThreadCount = asyncTaskExecutorThreadCount;
+            this.asyncTaskExecutorThreads = asyncTaskExecutorThreads;
             return this;
         }
 
@@ -2237,7 +2237,7 @@ public final class MediaDriver implements AutoCloseable
          * {@link Executor} to be used for asynchronous task execution in the {@link DriverConductor}.
          *
          * @return executor service for asynchronous tasks. If not explicitly assigned uses
-         * {@link #asyncTaskExecutorThreadCount()} to size the thread pool.
+         * {@link #asyncTaskExecutorThreads()} to size the thread pool.
          */
         public Executor asyncTaskExecutor()
         {
@@ -3892,7 +3892,7 @@ public final class MediaDriver implements AutoCloseable
             if (null == asyncTaskExecutor)
             {
                 ownsAsyncTaskExecutor = true;
-                if (asyncTaskExecutorThreadCount <= 0)
+                if (asyncTaskExecutorThreads <= 0)
                 {
                     asyncTaskExecutor = CALLER_RUNS_TASK_EXECUTOR;
                 }
@@ -3900,7 +3900,7 @@ public final class MediaDriver implements AutoCloseable
                 {
                     final AtomicInteger id = new AtomicInteger();
                     asyncTaskExecutor = Executors.newFixedThreadPool(
-                        asyncTaskExecutorThreadCount,
+                        asyncTaskExecutorThreads,
                         (r) ->
                         {
                             final Thread thread = new Thread(r, "async-task-executor-" + id.getAndIncrement());

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -24,8 +24,8 @@ import org.agrona.collections.ArrayListUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.NanoClock;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -47,7 +47,7 @@ public final class Receiver implements Agent
     private final long reResolutionCheckIntervalNs;
     private long reResolutionDeadlineNs;
     private final DataTransportPoller dataTransportPoller;
-    private final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue;
+    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesReceived;
     private final AtomicCounter resolutionChanges;
     private final NanoClock nanoClock;
@@ -116,8 +116,7 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount =
-            CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, CommandProxy.RUN_TASK);
+        int workCount = commandQueue.drain(CommandProxy.RUN_TASK, Configuration.COMMAND_DRAIN_LIMIT);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -24,8 +24,8 @@ import org.agrona.collections.ArrayListUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.NanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -33,7 +33,8 @@ import java.nio.channels.SelectionKey;
 import java.util.ArrayList;
 
 import static io.aeron.driver.Configuration.PENDING_SETUPS_TIMEOUT_NS;
-import static io.aeron.driver.status.SystemCounterDescriptor.*;
+import static io.aeron.driver.status.SystemCounterDescriptor.BYTES_RECEIVED;
+import static io.aeron.driver.status.SystemCounterDescriptor.RESOLUTION_CHANGES;
 
 /**
  * Agent that receives messages streams and rebuilds {@link PublicationImage}s, plus iterates over them sending status
@@ -46,7 +47,7 @@ public final class Receiver implements Agent
     private final long reResolutionCheckIntervalNs;
     private long reResolutionDeadlineNs;
     private final DataTransportPoller dataTransportPoller;
-    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesReceived;
     private final AtomicCounter resolutionChanges;
     private final NanoClock nanoClock;

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -24,7 +24,7 @@ import org.agrona.collections.ArrayListUtil;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.NanoClock;
 import org.agrona.concurrent.status.AtomicCounter;
 
@@ -47,7 +47,7 @@ public final class Receiver implements Agent
     private final long reResolutionCheckIntervalNs;
     private long reResolutionDeadlineNs;
     private final DataTransportPoller dataTransportPoller;
-    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesReceived;
     private final AtomicCounter resolutionChanges;
     private final NanoClock nanoClock;
@@ -116,7 +116,7 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount = commandQueue.drain(Runnable::run, Configuration.COMMAND_DRAIN_LIMIT);
+        int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -116,7 +116,7 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Receiver.java
@@ -116,7 +116,8 @@ public final class Receiver implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        int workCount =
+            CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, CommandProxy.RUN_TASK);
 
         final int bytesReceived = dataTransportPoller.pollTransports();
         totalBytesReceived.getAndAddOrdered(bytesReceived);

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,7 +169,7 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        // must add to the queue, because called from the async thread
+        // called from the async thread
         offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.UdpChannel;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -32,7 +32,7 @@ final class ReceiverProxy extends CommandProxy
 
     ReceiverProxy(
         final ThreadingMode threadingMode,
-        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final OneToOneConcurrentArrayQueue<Runnable> commandQueue,
         final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -18,7 +18,7 @@ package io.aeron.driver;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import io.aeron.driver.media.ReceiveDestinationTransport;
 import io.aeron.driver.media.UdpChannel;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -31,7 +31,9 @@ final class ReceiverProxy extends CommandProxy
     private Receiver receiver;
 
     ReceiverProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,14 +169,8 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        if (notConcurrent())
-        {
-            receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress);
-        }
-        else
-        {
-            offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
-        }
+        // must add to the queue, because called from the async thread
+        offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
     }
 
     void requestSetup(

--- a/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/ReceiverProxy.java
@@ -169,8 +169,14 @@ final class ReceiverProxy extends CommandProxy
     void onResolutionChange(
         final ReceiveChannelEndpoint channelEndpoint, final UdpChannel udpChannel, final InetSocketAddress newAddress)
     {
-        // called from the async thread
-        offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
+        if (notConcurrent())
+        {
+            receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress);
+        }
+        else
+        {
+            offer(() -> receiver.onResolutionChange(channelEndpoint, udpChannel, newAddress));
+        }
     }
 
     void requestSetup(

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -22,8 +22,8 @@ import io.aeron.driver.status.DutyCycleStallTracker;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.NanoClock;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -66,7 +66,7 @@ public final class Sender extends SenderRhsPadding implements Agent
     private final long reResolutionCheckIntervalNs;
     private final int dutyCycleRatio;
     private final ControlTransportPoller controlTransportPoller;
-    private final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue;
+    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesSent;
     private final AtomicCounter resolutionChanges;
     private final AtomicCounter shortSends;
@@ -129,8 +129,7 @@ public final class Sender extends SenderRhsPadding implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        final int workCount =
-            CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, CommandProxy.RUN_TASK);
+        final int workCount = commandQueue.drain(CommandProxy.RUN_TASK, Configuration.COMMAND_DRAIN_LIMIT);
 
         final long shortSendsBefore = shortSends.get();
         final int bytesSent = doSend(nowNs);

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -129,7 +129,7 @@ public final class Sender extends SenderRhsPadding implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        final int workCount = CommandProxy.drain(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        final int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
 
         final long shortSendsBefore = shortSends.get();
         final int bytesSent = doSend(nowNs);

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -129,7 +129,8 @@ public final class Sender extends SenderRhsPadding implements Agent
         cachedNanoClock.update(nowNs);
         dutyCycleTracker.measureAndUpdate(nowNs);
 
-        final int workCount = CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, Runnable::run);
+        final int workCount =
+            CommandProxy.drainQueue(commandQueue, Configuration.COMMAND_DRAIN_LIMIT, CommandProxy.RUN_TASK);
 
         final long shortSendsBefore = shortSends.get();
         final int bytesSent = doSend(nowNs);

--- a/aeron-driver/src/main/java/io/aeron/driver/Sender.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Sender.java
@@ -22,8 +22,8 @@ import io.aeron.driver.status.DutyCycleStallTracker;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.Agent;
 import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.NanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -68,7 +68,7 @@ public final class Sender extends SenderRhsPadding implements Agent
     private final long reResolutionCheckIntervalNs;
     private final int dutyCycleRatio;
     private final ControlTransportPoller controlTransportPoller;
-    private final OneToOneConcurrentArrayQueue<Runnable> commandQueue;
+    private final ManyToOneConcurrentArrayQueue<Runnable> commandQueue;
     private final AtomicCounter totalBytesSent;
     private final AtomicCounter resolutionChanges;
     private final AtomicCounter shortSends;

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -17,7 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.ChannelUri;
 import io.aeron.driver.media.SendChannelEndpoint;
-import org.agrona.concurrent.QueuedPipe;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -30,7 +30,9 @@ final class SenderProxy extends CommandProxy
     private Sender sender;
 
     SenderProxy(
-        final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
+        final ThreadingMode threadingMode,
+        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);
     }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -17,7 +17,7 @@ package io.aeron.driver;
 
 import io.aeron.ChannelUri;
 import io.aeron.driver.media.SendChannelEndpoint;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
@@ -31,7 +31,7 @@ final class SenderProxy extends CommandProxy
 
     SenderProxy(
         final ThreadingMode threadingMode,
-        final ManyToOneConcurrentLinkedQueue<Runnable> commandQueue,
+        final OneToOneConcurrentArrayQueue<Runnable> commandQueue,
         final AtomicCounter failCount)
     {
         super(threadingMode, commandQueue, failCount);

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,13 +117,7 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        if (notConcurrent())
-        {
-            sender.onResolutionChange(channelEndpoint, endpoint, newAddress);
-        }
-        else
-        {
-            offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
-        }
+        // must add to the queue, because called from the async thread
+        offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,7 +117,7 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        // must add to the queue, because called from the async thread
+        // called from the async thread
         offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -17,47 +17,22 @@ package io.aeron.driver;
 
 import io.aeron.ChannelUri;
 import io.aeron.driver.media.SendChannelEndpoint;
-import org.agrona.concurrent.AgentTerminationException;
 import org.agrona.concurrent.QueuedPipe;
 import org.agrona.concurrent.status.AtomicCounter;
 
 import java.net.InetSocketAddress;
 
-import static io.aeron.driver.ThreadingMode.INVOKER;
-import static io.aeron.driver.ThreadingMode.SHARED;
-
 /**
  * Proxy for offering into the Sender Thread's command queue.
  */
-final class SenderProxy
+final class SenderProxy extends CommandProxy
 {
-    private final ThreadingMode threadingMode;
-    private final QueuedPipe<Runnable> commandQueue;
-    private final AtomicCounter failCount;
     private Sender sender;
 
     SenderProxy(
         final ThreadingMode threadingMode, final QueuedPipe<Runnable> commandQueue, final AtomicCounter failCount)
     {
-        this.threadingMode = threadingMode;
-        this.commandQueue = commandQueue;
-        this.failCount = failCount;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public String toString()
-    {
-        return "SenderProxy{" +
-            "threadingMode=" + threadingMode +
-            ", failCount=" + failCount +
-            '}';
-    }
-
-    boolean isApplyingBackpressure()
-    {
-        return commandQueue.remainingCapacity() < 1;
+        super(threadingMode, commandQueue, failCount);
     }
 
     void sender(final Sender sender)
@@ -149,28 +124,6 @@ final class SenderProxy
         else
         {
             offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
-        }
-    }
-
-    private boolean notConcurrent()
-    {
-        return threadingMode == SHARED || threadingMode == INVOKER;
-    }
-
-    private void offer(final Runnable cmd)
-    {
-        while (!commandQueue.offer(cmd))
-        {
-            if (!failCount.isClosed())
-            {
-                failCount.increment();
-            }
-
-            Thread.yield();
-            if (Thread.currentThread().isInterrupted())
-            {
-                throw new AgentTerminationException("interrupted");
-            }
         }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/SenderProxy.java
@@ -117,7 +117,13 @@ final class SenderProxy extends CommandProxy
     void onResolutionChange(
         final SendChannelEndpoint channelEndpoint, final String endpoint, final InetSocketAddress newAddress)
     {
-        // called from the async thread
-        offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
+        if (notConcurrent())
+        {
+            sender.onResolutionChange(channelEndpoint, endpoint, newAddress);
+        }
+        else
+        {
+            offer(() -> sender.onResolutionChange(channelEndpoint, endpoint, newAddress));
+        }
     }
 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -868,8 +868,28 @@ public final class UdpChannel
             validateConfiguration(uri);
 
             final String endpointValue = uri.get(ENDPOINT_PARAM_NAME);
-            return SocketAddressParser.parse(
-                endpointValue, ENDPOINT_PARAM_NAME, false, nameResolver);
+            return SocketAddressParser.parse(endpointValue, ENDPOINT_PARAM_NAME, false, nameResolver);
+        }
+        catch (final Exception ex)
+        {
+            throw new InvalidChannelException(ex);
+        }
+    }
+
+    /**
+     * Check if the address pointed to by the endpoint is multicast.
+     *
+     * @param uri to check.
+     * @return {@code true} if the destination uses multicast address.
+     */
+    public static boolean isMulticastDestinationAddress(final ChannelUri uri)
+    {
+        try
+        {
+            validateConfiguration(uri);
+
+            final String endpointValue = uri.get(ENDPOINT_PARAM_NAME);
+            return SocketAddressParser.isMulticastAddress(endpointValue);
         }
         catch (final Exception ex)
         {

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -196,7 +196,8 @@ class DriverConductorTest
             .nameResolverTimeTracker(nameResolverTimeTracker)
             .senderPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, true))
             .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false))
-            .asyncTaskExecutor(Runnable::run);
+            .asyncTaskExecutor(CALLER_RUNS_TASK_EXECUTOR)
+            .asyncTaskExecutorThreadCount(0);
 
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
         driverConductor = new DriverConductor(ctx);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -1858,8 +1858,8 @@ class DriverConductorTest
     @Test
     void shouldThrowExceptionWhenSendDestinationHasControlModeResponseSet()
     {
-        final Exception exception = assertThrows(InvalidChannelException.class,
-            () -> driverConductor.onAddSendDestination(0, "aeron:udp?control-mode=response", 0)
+        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
+            () -> driverConductor.onAddSendDestination(13, "aeron:udp?control-mode=response", 19)
         );
 
         assertThat(exception.getMessage(), containsString(MDC_CONTROL_MODE_PARAM_NAME));
@@ -1869,8 +1869,8 @@ class DriverConductorTest
     @Test
     void shouldThrowExceptionWhenSendDestinationHasResponseCorrelationIdSet()
     {
-        final Exception exception = assertThrows(InvalidChannelException.class,
-            () -> driverConductor.onAddSendDestination(0, "aeron:udp?response-correlation-id=1234", 0)
+        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
+            () -> driverConductor.onAddSendDestination(4, "aeron:udp?response-correlation-id=1234", 8)
         );
 
         assertThat(exception.getMessage(), containsString(RESPONSE_CORRELATION_ID_PARAM_NAME));
@@ -1879,8 +1879,8 @@ class DriverConductorTest
     @Test
     void shouldThrowExceptionWhenRcvDestinationHasControlModeResponseSet()
     {
-        final Exception exception = assertThrows(InvalidChannelException.class,
-            () -> driverConductor.onAddRcvDestination(0, "aeron:udp?control-mode=response", 0)
+        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
+            () -> driverConductor.onAddRcvDestination(5, "aeron:udp?control-mode=response", 7)
         );
 
         assertEquals(
@@ -1891,8 +1891,9 @@ class DriverConductorTest
     @Test
     void shouldThrowExceptionWhenRcvDestinationHasResponseCorrelationIdSet()
     {
-        final Exception exception = assertThrows(InvalidChannelException.class,
-            () -> driverConductor.onAddRcvDestination(0, "aeron:udp?endpoint=localhost:8080|response-correlation-id=1234", 0)
+        final Exception exception = assertThrowsExactly(InvalidChannelException.class,
+            () -> driverConductor.onAddRcvDestination(
+            42, "aeron:udp?endpoint=localhost:8080|response-correlation-id=1234", 1)
         );
 
         assertThat(

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -337,6 +337,7 @@ class DriverConductorTest
         driverProxy.removeSubscription(id);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
         verify(receiverProxy).closeReceiveChannelEndpoint(any());
@@ -418,6 +419,7 @@ class DriverConductorTest
         driverProxy.removeSubscription(id2);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         assertEquals(1, receiveChannelEndpoint.distinctSubscriptionCount());
     }
@@ -448,6 +450,7 @@ class DriverConductorTest
         driverProxy.removeSubscription(id3);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         assertEquals(1, receiveChannelEndpoint.distinctSubscriptionCount());
 
@@ -464,6 +467,7 @@ class DriverConductorTest
         final long id = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removePublication(id + 1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final InOrder inOrder = inOrder(senderProxy, mockClientProxy);
@@ -499,6 +503,7 @@ class DriverConductorTest
         final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
         driverProxy.removeSubscription(id1 + 100);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final InOrder inOrder = inOrder(receiverProxy, mockClientProxy);
@@ -888,6 +893,7 @@ class DriverConductorTest
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
         assertNotNull(ipcPublication);
@@ -906,6 +912,7 @@ class DriverConductorTest
     {
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
         final long idPubOne = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final IpcPublication ipcPublicationOne = driverConductor.getSharedIpcPublication(STREAM_ID_1);
@@ -941,6 +948,7 @@ class DriverConductorTest
         final long idSub = driverProxy.addSubscription(CHANNEL_IPC, STREAM_ID_1);
         final long idPub = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
@@ -1006,6 +1014,8 @@ class DriverConductorTest
         final long idAdd2 = driverProxy.addPublication(CHANNEL_IPC, STREAM_ID_1);
         driverProxy.removeSubscription(idAdd1);
 
+        driverConductor.doWork();
+        driverConductor.doWork();
         driverConductor.doWork();
 
         IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
@@ -1075,6 +1085,7 @@ class DriverConductorTest
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1095,6 +1106,7 @@ class DriverConductorTest
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1139,6 +1151,7 @@ class DriverConductorTest
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
         verify(senderProxy, times(1)).newNetworkPublication(captor.capture());
@@ -1157,6 +1170,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1555,6 +1569,7 @@ class DriverConductorTest
         driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
         assertNotNull(ipcPublication);
@@ -1574,6 +1589,7 @@ class DriverConductorTest
         driverProxy.addSubscription(channelIpcAndSessionId, STREAM_ID_1);
         driverProxy.addPublication(channelIpcAndSessionId, STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
@@ -1616,6 +1632,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_IPC + sessionIdPubParam, STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         final IpcPublication ipcPublication = driverConductor.getSharedIpcPublication(STREAM_ID_1);
         assertNotNull(ipcPublication);
@@ -1632,6 +1649,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1673,8 +1691,8 @@ class DriverConductorTest
         final int sessionId = -4097;
         final String sessionIdParam = "|" + CommonContext.SESSION_ID_PARAM_NAME + "=" + sessionId;
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdParam), STREAM_ID_1);
+        driverConductor.doWork();
         driverProxy.addPublication(CHANNEL_4000 + sessionIdParam, STREAM_ID_1);
-
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1698,6 +1716,7 @@ class DriverConductorTest
         driverProxy.addSubscription(spyForChannel(CHANNEL_4000 + sessionIdSubParam), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000 + sessionIdPubParam, STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1738,6 +1757,7 @@ class DriverConductorTest
         final long id2 = driverProxy.addPublication(CHANNEL_TAG_ID_1, STREAM_ID_2);
 
         driverConductor.doWork();
+        driverConductor.doWork();
         verify(mockErrorHandler, never()).onError(any());
 
         verify(senderProxy).registerSendChannelEndpoint(any());
@@ -1759,6 +1779,7 @@ class DriverConductorTest
         final long id2 = driverProxy.addSubscription(CHANNEL_TAG_ID_1, STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
         verify(mockErrorHandler, never()).onError(any());
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
@@ -1766,6 +1787,7 @@ class DriverConductorTest
         driverProxy.removeSubscription(id1);
         driverProxy.removeSubscription(id2);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         verify(receiverProxy).closeReceiveChannelEndpoint(any());
@@ -1778,12 +1800,14 @@ class DriverConductorTest
         final long id2 = driverProxy.addSubscription(CHANNEL_SUB_CONTROL_MODE_MANUAL, STREAM_ID_1);
 
         driverConductor.doWork();
+        driverConductor.doWork();
 
         verify(receiverProxy, times(2)).registerReceiveChannelEndpoint(any());
 
         driverProxy.removeSubscription(id1);
         driverProxy.removeSubscription(id2);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         verify(receiverProxy, times(2)).closeReceiveChannelEndpoint(any());
@@ -1797,6 +1821,7 @@ class DriverConductorTest
         driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_TAG_ID_1), STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);
@@ -1818,6 +1843,7 @@ class DriverConductorTest
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_TAG_ID_1), STREAM_ID_1);
         driverProxy.addPublication(CHANNEL_4000_TAG_ID_1, STREAM_ID_1);
 
+        driverConductor.doWork();
         driverConductor.doWork();
 
         final ArgumentCaptor<NetworkPublication> captor = ArgumentCaptor.forClass(NetworkPublication.class);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -76,7 +76,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 class DriverConductorTest
 {
     private static final String CHANNEL_4000 = "aeron:udp?endpoint=localhost:4000";
@@ -161,6 +160,11 @@ class DriverConductorTest
             spySystemCounters.get(NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED),
             1_000_000_000);
 
+        final ThreadingMode threadingMode = ThreadingMode.DEDICATED;
+        final ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue =
+            new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+        final DriverConductorProxy driverConductorProxy =
+            new DriverConductorProxy(threadingMode, driverCommandQueue, mock(AtomicCounter.class));
         final MediaDriver.Context ctx = new MediaDriver.Context()
             .tempBuffer(new UnsafeBuffer(new byte[METADATA_LENGTH]))
             .timerIntervalNs(DEFAULT_TIMER_INTERVAL_NS)
@@ -168,7 +172,7 @@ class DriverConductorTest
             .ipcTermBufferLength(TERM_BUFFER_LENGTH)
             .unicastFlowControlSupplier(Configuration.unicastFlowControlSupplier())
             .multicastFlowControlSupplier(Configuration.multicastFlowControlSupplier())
-            .driverCommandQueue(new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
+            .driverCommandQueue(driverCommandQueue)
             .errorHandler(mockErrorHandler)
             .logFactory(new TestLogFactory())
             .countersManager(spyCountersManager)
@@ -186,18 +190,20 @@ class DriverConductorTest
             .systemCounters(spySystemCounters)
             .receiverProxy(receiverProxy)
             .senderProxy(senderProxy)
-            .driverConductorProxy(mockDriverConductorProxy)
+            .driverConductorProxy(driverConductorProxy)
             .receiveChannelEndpointThreadLocals(new ReceiveChannelEndpointThreadLocals())
             .conductorCycleThresholdNs(600_000_000)
             .nameResolver(DefaultNameResolver.INSTANCE)
-            .threadingMode(ThreadingMode.DEDICATED)
+            .threadingMode(threadingMode)
             .conductorDutyCycleTracker(conductorDutyCycleTracker)
             .nameResolverTimeTracker(nameResolverTimeTracker)
             .senderPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, true))
-            .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false));
+            .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false))
+            .asyncTaskExecutor(Runnable::run);
 
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
         driverConductor = new DriverConductor(ctx);
+        ctx.driverConductorProxy().driverConductor(driverConductor);
         driverConductor.onStart();
 
         doAnswer(closeChannelEndpointAnswer).when(receiverProxy).closeReceiveChannelEndpoint(any());
@@ -332,8 +338,9 @@ class DriverConductorTest
     void shouldBeAbleToAddAndRemoveSingleSubscription()
     {
         final long id = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
-        driverProxy.removeSubscription(id);
+        driverConductor.doWork();
 
+        driverProxy.removeSubscription(id);
         driverConductor.doWork();
 
         verify(receiverProxy).registerReceiveChannelEndpoint(any());
@@ -460,6 +467,8 @@ class DriverConductorTest
     void shouldErrorOnRemovePublicationOnUnknownRegistrationId()
     {
         final long id = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
+        driverConductor.doWork();
+
         driverProxy.removePublication(id + 1);
 
         driverConductor.doWork();
@@ -495,8 +504,9 @@ class DriverConductorTest
     void shouldErrorOnRemoveSubscriptionOnUnknownRegistrationId()
     {
         final long id1 = driverProxy.addSubscription(CHANNEL_4000, STREAM_ID_1);
-        driverProxy.removeSubscription(id1 + 100);
+        driverConductor.doWork();
 
+        driverProxy.removeSubscription(id1 + 100);
         driverConductor.doWork();
 
         final InOrder inOrder = inOrder(receiverProxy, mockClientProxy);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -1122,6 +1122,7 @@ class DriverConductorTest
     {
         driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long idSpy = driverProxy.addSubscription(spyForChannel(CHANNEL_4000), STREAM_ID_1);
+        driverConductor.doWork();
         driverProxy.removeSubscription(idSpy);
 
         while (true)
@@ -1217,6 +1218,7 @@ class DriverConductorTest
     {
         final long id1 = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_1);
         final long id2 = driverProxy.addPublication(CHANNEL_4000, STREAM_ID_2);
+        driverConductor.doWork();
         driverProxy.removePublication(id1);
         driverProxy.removePublication(id2);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -197,7 +197,7 @@ class DriverConductorTest
             .senderPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, true))
             .receiverPortManager(new WildcardPortManager(WildcardPortManager.EMPTY_PORT_RANGE, false))
             .asyncTaskExecutor(CALLER_RUNS_TASK_EXECUTOR)
-            .asyncTaskExecutorThreadCount(0);
+            .asyncTaskExecutorThreads(0);
 
         driverProxy = new DriverProxy(toDriverCommands, toDriverCommands.nextCorrelationId());
         driverConductor = new DriverConductor(ctx);

--- a/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DriverConductorTest.java
@@ -36,7 +36,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
@@ -161,8 +161,7 @@ class DriverConductorTest
             1_000_000_000);
 
         final ThreadingMode threadingMode = ThreadingMode.DEDICATED;
-        final ManyToOneConcurrentArrayQueue<Runnable> driverCommandQueue =
-            new ManyToOneConcurrentArrayQueue<>(CMD_QUEUE_CAPACITY);
+        final ManyToOneConcurrentLinkedQueue<Runnable> driverCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
         final DriverConductorProxy driverConductorProxy =
             new DriverConductorProxy(threadingMode, driverCommandQueue, mock(AtomicCounter.class));
         final MediaDriver.Context ctx = new MediaDriver.Context()

--- a/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/IpcPublicationTest.java
@@ -21,7 +21,11 @@ import io.aeron.driver.buffer.TestLogFactory;
 import io.aeron.driver.status.SystemCounters;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.test.Tests;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.SystemEpochClock;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.ringbuffer.ManyToOneRingBuffer;
 import org.agrona.concurrent.ringbuffer.RingBuffer;
 import org.agrona.concurrent.status.CountersManager;
@@ -71,7 +75,7 @@ class IpcPublicationTest
             .clientProxy(mock(ClientProxy.class))
             .senderProxy(senderProxy)
             .receiverProxy(receiverProxy)
-            .driverCommandQueue(new ManyToOneConcurrentArrayQueue<>(256))
+            .driverCommandQueue(new ManyToOneConcurrentLinkedQueue<>())
             .epochClock(SystemEpochClock.INSTANCE)
             .cachedEpochClock(new CachedEpochClock())
             .cachedNanoClock(new CachedNanoClock())

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
@@ -16,6 +16,7 @@
 package io.aeron.driver;
 
 import io.aeron.driver.MediaDriver.Context;
+import io.aeron.driver.media.DataTransportPoller;
 import io.aeron.exceptions.ConfigurationException;
 import io.aeron.test.Tests;
 import org.hamcrest.CoreMatchers;
@@ -42,7 +43,8 @@ import static org.mockito.Mockito.*;
 
 class MediaDriverContextTest
 {
-    private final Context context = new Context();
+    private final Context context = new Context()
+        .dataTransportPoller(mock(DataTransportPoller.class));
 
     @AfterEach
     void afterEach()
@@ -202,8 +204,8 @@ class MediaDriverContextTest
         final CopyOnWriteArraySet<Thread> threads = new CopyOnWriteArraySet<>();
         final Runnable task = () ->
         {
-            count.incrementAndGet();
             threads.add(Thread.currentThread());
+            count.incrementAndGet();
         };
         final int numTasks = asyncExecutorThreadCount * 3;
         for (int i = 0; i < numTasks; i++)

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverContextTest.java
@@ -158,17 +158,17 @@ class MediaDriverContextTest
     @ValueSource(ints = { -100, 42, Integer.MAX_VALUE })
     void asyncTaskExecutorThreadCount(final int threadCount)
     {
-        assertEquals(1, context.asyncTaskExecutorThreadCount());
+        assertEquals(1, context.asyncTaskExecutorThreads());
 
-        context.asyncTaskExecutorThreadCount(threadCount);
-        assertEquals(threadCount, context.asyncTaskExecutorThreadCount());
+        context.asyncTaskExecutorThreads(threadCount);
+        assertEquals(threadCount, context.asyncTaskExecutorThreads());
     }
 
     @ParameterizedTest
     @ValueSource(ints = { -5, 0 })
     void shouldDisableAsyncExecutionIfThreadsAreNotConfigured(final int asyncExecutorThreadCount)
     {
-        context.asyncTaskExecutorThreadCount(asyncExecutorThreadCount);
+        context.asyncTaskExecutorThreads(asyncExecutorThreadCount);
         assertNull(context.asyncTaskExecutor());
         assertFalse(context.ownsAsyncTaskExecutor());
 
@@ -186,7 +186,7 @@ class MediaDriverContextTest
     {
         assertNull(context.asyncTaskExecutor());
         assertFalse(context.ownsAsyncTaskExecutor());
-        context.asyncTaskExecutorThreadCount(asyncExecutorThreadCount);
+        context.asyncTaskExecutorThreads(asyncExecutorThreadCount);
 
         context.concludeNullProperties();
 

--- a/aeron-driver/src/test/java/io/aeron/driver/MediaDriverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/MediaDriverTest.java
@@ -168,7 +168,7 @@ class MediaDriverTest
         final MediaDriver.Context context = new MediaDriver.Context()
             .aeronDirectoryName(aeronDir.toString())
             .threadingMode(ThreadingMode.DEDICATED)
-            .asyncTaskExecutorThreadCount(2);
+            .asyncTaskExecutorThreads(2);
         try (TestMediaDriver mediaDriver = TestMediaDriver.launch(context, systemTestWatcher))
         {
             systemTestWatcher.dataCollector().add(mediaDriver.context().aeronDirectory());

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -206,6 +206,7 @@ class ReceiverTest
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
         receiver.doWork();
+        receiver.doWork();
 
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(
@@ -271,6 +272,7 @@ class ReceiverTest
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
+        receiver.doWork();
         receiver.doWork();
 
         fillSetupFrame(setupHeader);
@@ -339,6 +341,7 @@ class ReceiverTest
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
         receiver.doWork();
+        receiver.doWork();
 
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
@@ -406,8 +409,8 @@ class ReceiverTest
     void shouldOverwriteHeartbeatWithDataFrame()
     {
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
+        receiver.doWork();
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
-
         receiver.doWork();
 
         fillSetupFrame(setupHeader);
@@ -483,6 +486,7 @@ class ReceiverTest
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
         receiver.doWork();
+        receiver.doWork();
 
         fillSetupFrame(setupHeader, initialTermOffset);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
@@ -554,6 +558,7 @@ class ReceiverTest
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
         receiver.doWork();
+        receiver.doWork();
 
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
@@ -575,6 +580,7 @@ class ReceiverTest
         receiverProxy.registerReceiveChannelEndpoint(receiveChannelEndpoint);
         receiverProxy.addSubscription(receiveChannelEndpoint, STREAM_ID);
 
+        receiver.doWork();
         receiver.doWork();
 
         fillSetupFrame(setupHeader);

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -32,7 +32,10 @@ import io.aeron.test.InterruptAfter;
 import io.aeron.test.InterruptingTestCallback;
 import org.agrona.CloseHelper;
 import org.agrona.ErrorHandler;
-import org.agrona.concurrent.*;
+import org.agrona.concurrent.CachedEpochClock;
+import org.agrona.concurrent.CachedNanoClock;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
 import org.agrona.concurrent.status.Position;
@@ -148,7 +151,7 @@ class ReceiverTest
             .controlTransportPoller(mockControlTransportPoller)
             .logFactory(new TestLogFactory())
             .systemCounters(mockSystemCounters)
-            .receiverCommandQueue(new OneToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
+            .receiverCommandQueue(new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY))
             .nanoClock(nanoClock)
             .cachedNanoClock(nanoClock)
             .senderCachedNanoClock(nanoClock)

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -231,7 +231,7 @@ class ReceiverTest
             SOURCE_IDENTITY,
             congestionControl);
 
-        final int messagesRead = CommandProxy.drain(
+        final int messagesRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -276,7 +276,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -343,7 +343,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -413,7 +413,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->
@@ -487,7 +487,7 @@ class ReceiverTest
         fillSetupFrame(setupHeader, initialTermOffset);
         receiveChannelEndpoint.onSetupMessage(setupHeader, setupBuffer, SetupFlyweight.HEADER_LENGTH, senderAddress, 0);
 
-        final int commandsRead = CommandProxy.drain(
+        final int commandsRead = CommandProxy.drainQueue(
             toConductorQueue,
             Integer.MAX_VALUE,
             (e) ->

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -31,7 +31,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -88,8 +88,7 @@ class SenderTest
     private final DataHeaderFlyweight dataHeader = new DataHeaderFlyweight();
     private final SetupFlyweight setupHeader = new SetupFlyweight();
     private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
-    private final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
-        new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
 
     private final HeaderWriter headerWriter = HeaderWriter.newInstance(HEADER);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -31,7 +31,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
+import org.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -88,8 +88,8 @@ class SenderTest
     private final DataHeaderFlyweight dataHeader = new DataHeaderFlyweight();
     private final SetupFlyweight setupHeader = new SetupFlyweight();
     private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
-    private final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
-        new OneToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
+    private final ManyToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
+        new ManyToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
 
     private final HeaderWriter headerWriter = HeaderWriter.newInstance(HEADER);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/SenderTest.java
@@ -31,7 +31,7 @@ import org.agrona.DirectBuffer;
 import org.agrona.ErrorHandler;
 import org.agrona.concurrent.CachedEpochClock;
 import org.agrona.concurrent.CachedNanoClock;
-import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
+import org.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.AtomicLongPosition;
@@ -88,7 +88,8 @@ class SenderTest
     private final DataHeaderFlyweight dataHeader = new DataHeaderFlyweight();
     private final SetupFlyweight setupHeader = new SetupFlyweight();
     private final SystemCounters mockSystemCounters = mock(SystemCounters.class);
-    private final ManyToOneConcurrentLinkedQueue<Runnable> senderCommandQueue = new ManyToOneConcurrentLinkedQueue<>();
+    private final OneToOneConcurrentArrayQueue<Runnable> senderCommandQueue =
+        new OneToOneConcurrentArrayQueue<>(Configuration.CMD_QUEUE_CAPACITY);
 
     private final HeaderWriter headerWriter = HeaderWriter.newInstance(HEADER);
 

--- a/aeron-driver/src/test/java/io/aeron/driver/media/SocketAddressParserTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/media/SocketAddressParserTest.java
@@ -18,6 +18,9 @@ package io.aeron.driver.media;
 import io.aeron.driver.DefaultNameResolver;
 import io.aeron.driver.NameResolver;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -26,9 +29,9 @@ import java.net.UnknownHostException;
 
 import static io.aeron.CommonContext.ENDPOINT_PARAM_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SocketAddressParserTest
 {
@@ -148,6 +151,48 @@ class SocketAddressParserTest
             LOOKUP_RESOLVER_HOSTNAME + ":" + LOOKUP_RESOLVER_PORT, ENDPOINT_PARAM_NAME, false, LOOKUP_RESOLVER);
         assertEquals(InetAddress.getByName(LOOKUP_RESOLVER_HOSTNAME), socketAddress.getAddress());
         assertEquals(LOOKUP_RESOLVER_PORT, socketAddress.getPort());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "127.0.0.1:8080, false",
+        "224.0.0.0:24, true",
+        "224.0.0.255:44444, true",
+        "239.255.255.250:1010, true",
+        "239.1.1.1:1111, true",
+        "233.251.255.255:5555, true",
+        "999.255.255.250:7777, false",
+        "a.b.c.d:7777, false",
+        "192.b.c.d:7777, false",
+        "192.168.0.1:1234, false",
+        "test:1234, false",
+        "[ff02::1]:1234, true",
+        "[Ff05::1:3]:80, true",
+        "[fF9E::108]:5555, true",
+        "[FF01:0:0:0:0:0:0:18C]:5555, true",
+        "[fe80::ce81:b1c:bd2c:69e%utun3]:8080, false",
+        "[fe80::1%lo0]:5555, false",
+        "[ff02:0:0:0:0:2]:7777, true"
+    })
+    void shouldCheckForMulticastAddress(final String hostAndPort, final boolean expected)
+    {
+        assertEquals(expected, SocketAddressParser.isMulticastAddress(hostAndPort));
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionIfValueIsNull()
+    {
+        assertThrowsExactly(NullPointerException.class, () -> SocketAddressParser.isMulticastAddress(null));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "a", "1.2.3", "[x]", "[f0:xx]:5" })
+    void shouldThrowIllegalArgumentExceptionIfValueIsInvalid(final String hostAndPort)
+    {
+        final IllegalArgumentException exception = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> SocketAddressParser.isMulticastAddress(hostAndPort));
+        assertThat(exception.getMessage(), containsString(hostAndPort));
     }
 
     private void assertCorrectParse(final String host, final int port) throws UnknownHostException

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/MultiModuleSharedDriverTest.java
@@ -283,9 +283,8 @@ class MultiModuleSharedDriverTest
         ConsensusModule consensusModule(final int clusterId, final String aeronDirectoryName)
         {
             final int nodeOffset = (clusterId * 100) + (nodeId * 10);
-            // The `:X` suffix will be removed by the `RedirectingNameResolver:lookup`
             final String ingressChannelWithInvalidEndpointFormatToBeRemovedByNameResolver =
-                "aeron:udp?term-length=64k|endpoint=node" + nodeId + ":2" + clusterId + "11" + nodeId + ":X";
+                "aeron:udp?term-length=64k|endpoint=node" + nodeId + ":2" + clusterId + "11" + nodeId;
             final ConsensusModule.Context ctx = new ConsensusModule.Context()
                 .clusterMemberId(nodeId)
                 .clusterId(clusterId)
@@ -297,7 +296,6 @@ class MultiModuleSharedDriverTest
                 .serviceStreamId(104 + nodeOffset)
                 .consensusModuleStreamId(105 + nodeOffset)
                 .ingressChannel(ingressChannelWithInvalidEndpointFormatToBeRemovedByNameResolver)
-                .nameResolver(nameResolver)
                 .replicationChannel("aeron:udp?endpoint=localhost:0");
 
             return ConsensusModule.launch(ctx);

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -1085,7 +1085,6 @@ public final class TestNode implements AutoCloseable
         Context(final TestService[] services, final String nodeMappings)
         {
             mediaDriverContext.nameResolver(new RedirectingNameResolver(nodeMappings));
-            consensusModuleContext.nameResolver(new RedirectingNameResolver(nodeMappings));
 
             this.services = services;
             hasServiceTerminated = new AtomicBoolean[services.length];


### PR DESCRIPTION
This PR implements asynchronous DNS resolution in the Java MediaDriver including:
* Client commands: `ADD_RCV_DESTINATION` (spy and network), `REMOVE_RCV_DESTINATION`, `ADD_SUBSCRIPTION` (spy and network), `ADD_PUBLICATION`, `ADD_DESTINATION` and `REMOVE_DESTINATION`.
* Address re-resolution (`onReResolveControl` and `onReResolveEndpoint`) which are triggered by the receiver and sender threads respectively.
* `ConsensusModule#connectIngress` - check for multicast address is now done without calling `NameResolver`.

What is not included:
* Initial host name resolution, i.e. `DriverConductor#onStart`.
* `DriverNameResolver` - bootstrap neighbor resolution and duty cycle.