### PR TITLE
[Java] Use `archiveId` for looking up the RecordingPos counters.

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -408,6 +408,11 @@ abstract class ArchiveConductor
         return controlSession;
     }
 
+    void archiveId(final long correlationId, final ControlSession controlSession)
+    {
+        controlSession.sendOkResponse(correlationId, ctx.archiveId(), controlResponseProxy);
+    }
+
     void startRecording(
         final long correlationId,
         final int streamId,

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlRequestDecoders.java
@@ -62,4 +62,5 @@ class ControlRequestDecoders
     final ChallengeResponseDecoder challengeResponse = new ChallengeResponseDecoder();
     final KeepAliveRequestDecoder keepAliveRequest = new KeepAliveRequestDecoder();
     final TaggedReplicateRequestDecoder taggedReplicateRequest = new TaggedReplicateRequestDecoder();
+    final ArchiveIdRequestDecoder archiveIdRequestDecoder = new ArchiveIdRequestDecoder();
 }

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSession.java
@@ -470,6 +470,15 @@ final class ControlSession implements Session
         }
     }
 
+    void onArchiveId(final long correlationId)
+    {
+        attemptToActivate();
+        if (State.ACTIVE == state)
+        {
+            conductor.archiveId(correlationId, this);
+        }
+    }
+
     void onListRecordingSubscriptions(
         final long correlationId,
         final int pseudoIndex,

--- a/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ControlSessionDemuxer.java
@@ -998,6 +998,26 @@ class ControlSessionDemuxer implements Session, FragmentHandler
                 }
                 break;
             }
+
+            case ArchiveIdRequestDecoder.TEMPLATE_ID:
+            {
+                final ArchiveIdRequestDecoder decoder = decoders.archiveIdRequestDecoder;
+                decoder.wrap(
+                    buffer,
+                    offset + MessageHeaderDecoder.ENCODED_LENGTH,
+                    headerDecoder.blockLength(),
+                    headerDecoder.version());
+
+                final long controlSessionId = decoder.controlSessionId();
+                final long correlationId = decoder.correlationId();
+                final ControlSession controlSession = getControlSession(correlationId, controlSessionId, templateId);
+
+                if (null != controlSession)
+                {
+                    controlSession.onArchiveId(correlationId);
+                }
+                break;
+            }
         }
     }
 

--- a/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/client/ArchiveProxy.java
@@ -75,6 +75,7 @@ public final class ArchiveProxy
     private PurgeSegmentsRequestEncoder purgeSegmentsRequest;
     private AttachSegmentsRequestEncoder attachSegmentsRequest;
     private MigrateSegmentsRequestEncoder migrateSegmentsRequest;
+    private ArchiveIdRequestEncoder archiveIdRequestEncoder;
 
     /**
      * Create a proxy with a {@link Publication} for sending control message requests.
@@ -898,6 +899,28 @@ public final class ArchiveProxy
             .recordingId(recordingId);
 
         return offer(stopOrRecordingPositionRequest.encodedLength());
+    }
+
+    /**
+     * Get the id of the Archive.
+     *
+     * @param correlationId    for this request.
+     * @param controlSessionId for this request.
+     * @return true if successfully offered otherwise false.
+     */
+    public boolean archiveId(final long correlationId, final long controlSessionId)
+    {
+        if (null == archiveIdRequestEncoder)
+        {
+            archiveIdRequestEncoder = new ArchiveIdRequestEncoder();
+        }
+
+        archiveIdRequestEncoder
+            .wrapAndApplyHeader(buffer, 0, messageHeader)
+            .controlSessionId(controlSessionId)
+            .correlationId(correlationId);
+
+        return offer(archiveIdRequestEncoder.encodedLength());
     }
 
     /**

--- a/aeron-archive/src/main/java/io/aeron/archive/status/RecordingPos.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/status/RecordingPos.java
@@ -68,10 +68,10 @@ public final class RecordingPos
      */
     public static final String NAME = "rec-pos";
 
-    private static final int RECORDING_ID_OFFSET = 0;
-    private static final int SESSION_ID_OFFSET = RECORDING_ID_OFFSET + SIZE_OF_LONG;
-    private static final int SOURCE_IDENTITY_LENGTH_OFFSET = SESSION_ID_OFFSET + SIZE_OF_INT;
-    private static final int SOURCE_IDENTITY_OFFSET = SOURCE_IDENTITY_LENGTH_OFFSET + SIZE_OF_INT;
+    static final int RECORDING_ID_OFFSET = 0;
+    static final int SESSION_ID_OFFSET = RECORDING_ID_OFFSET + SIZE_OF_LONG;
+    static final int SOURCE_IDENTITY_LENGTH_OFFSET = SESSION_ID_OFFSET + SIZE_OF_INT;
+    static final int SOURCE_IDENTITY_OFFSET = SOURCE_IDENTITY_LENGTH_OFFSET + SIZE_OF_INT;
 
     /**
      * Allocated a recording position counter and populate the metadata.
@@ -133,7 +133,9 @@ public final class RecordingPos
      * @param countersReader to search within.
      * @param recordingId    for the active recording.
      * @return the counter id if found otherwise {@link CountersReader#NULL_COUNTER_ID}.
+     * @deprecated Use {@link #findCounterIdByRecording(CountersReader, long, long)} instead.
      */
+    @Deprecated
     public static int findCounterIdByRecording(final CountersReader countersReader, final long recordingId)
     {
         final DirectBuffer buffer = countersReader.metaDataBuffer();
@@ -144,9 +146,50 @@ public final class RecordingPos
             if (RECORD_ALLOCATED == counterState)
             {
                 if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID &&
-                    buffer.getLong(CountersReader.metaDataOffset(i) + KEY_OFFSET + RECORDING_ID_OFFSET) == recordingId)
+                    buffer.getLong(metaDataOffset(i) + KEY_OFFSET + RECORDING_ID_OFFSET) == recordingId)
                 {
                     return i;
+                }
+            }
+            else if (RECORD_UNUSED == counterState)
+            {
+                break;
+            }
+        }
+
+        return NULL_COUNTER_ID;
+    }
+
+    /**
+     * Find the active counter id for a stream based on the recording id and archive id.
+     *
+     * @param countersReader to search within.
+     * @param recordingId    for the active recording.
+     * @param archiveId      to target specific Archive.
+     * @return the counter id if found otherwise {@link CountersReader#NULL_COUNTER_ID}.
+     */
+    public static int findCounterIdByRecording(
+        final CountersReader countersReader, final long recordingId, final long archiveId)
+    {
+        final DirectBuffer buffer = countersReader.metaDataBuffer();
+
+        for (int i = 0, size = countersReader.maxCounterId(); i < size; i++)
+        {
+            final int counterState = countersReader.getCounterState(i);
+            if (RECORD_ALLOCATED == counterState)
+            {
+                if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID)
+                {
+                    final int keyOffset = metaDataOffset(i) + KEY_OFFSET;
+                    if (buffer.getLong(keyOffset + RECORDING_ID_OFFSET) == recordingId)
+                    {
+                        final int sourceIdentityLength = buffer.getInt(keyOffset + SOURCE_IDENTITY_LENGTH_OFFSET);
+                        final int archiveIdOffset = keyOffset + SOURCE_IDENTITY_OFFSET + sourceIdentityLength;
+                        if (buffer.getLong(archiveIdOffset) == archiveId)
+                        {
+                            return i;
+                        }
+                    }
                 }
             }
             else if (RECORD_UNUSED == counterState)
@@ -164,7 +207,9 @@ public final class RecordingPos
      * @param countersReader to search within.
      * @param sessionId      for the active recording.
      * @return the counter id if found otherwise {@link CountersReader#NULL_COUNTER_ID}.
+     * @deprecated Use {@link #findCounterIdBySession(CountersReader, int, long)} instead.
      */
+    @Deprecated
     public static int findCounterIdBySession(final CountersReader countersReader, final int sessionId)
     {
         final DirectBuffer buffer = countersReader.metaDataBuffer();
@@ -175,9 +220,50 @@ public final class RecordingPos
             if (RECORD_ALLOCATED == counterState)
             {
                 if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID &&
-                    buffer.getInt(CountersReader.metaDataOffset(i) + KEY_OFFSET + SESSION_ID_OFFSET) == sessionId)
+                    buffer.getInt(metaDataOffset(i) + KEY_OFFSET + SESSION_ID_OFFSET) == sessionId)
                 {
                     return i;
+                }
+            }
+            else if (RECORD_UNUSED == counterState)
+            {
+                break;
+            }
+        }
+
+        return NULL_COUNTER_ID;
+    }
+
+    /**
+     * Find the active counter id for a stream based on the session id and archive id.
+     *
+     * @param countersReader to search within.
+     * @param sessionId      for the active recording.
+     * @param archiveId      to target specific Archive.
+     * @return the counter id if found otherwise {@link CountersReader#NULL_COUNTER_ID}.
+     */
+    public static int findCounterIdBySession(
+        final CountersReader countersReader, final int sessionId, final long archiveId)
+    {
+        final DirectBuffer buffer = countersReader.metaDataBuffer();
+
+        for (int i = 0, size = countersReader.maxCounterId(); i < size; i++)
+        {
+            final int counterState = countersReader.getCounterState(i);
+            if (RECORD_ALLOCATED == counterState)
+            {
+                if (countersReader.getCounterTypeId(i) == RECORDING_POSITION_TYPE_ID)
+                {
+                    final int keyOffset = metaDataOffset(i) + KEY_OFFSET;
+                    if (buffer.getInt(keyOffset + SESSION_ID_OFFSET) == sessionId)
+                    {
+                        final int sourceIdentityLength = buffer.getInt(keyOffset + SOURCE_IDENTITY_LENGTH_OFFSET);
+                        final int archiveIdOffset = keyOffset + SOURCE_IDENTITY_OFFSET + sourceIdentityLength;
+                        if (buffer.getLong(archiveIdOffset) == archiveId)
+                        {
+                            return i;
+                        }
+                    }
                 }
             }
             else if (RECORD_UNUSED == counterState)
@@ -202,7 +288,7 @@ public final class RecordingPos
             countersReader.getCounterTypeId(counterId) == RECORDING_POSITION_TYPE_ID)
         {
             return countersReader.metaDataBuffer()
-                .getLong(CountersReader.metaDataOffset(counterId) + KEY_OFFSET + RECORDING_ID_OFFSET);
+                .getLong(metaDataOffset(counterId) + KEY_OFFSET + RECORDING_ID_OFFSET);
         }
 
         return NULL_RECORDING_ID;
@@ -220,7 +306,7 @@ public final class RecordingPos
         if (counters.getCounterState(counterId) == RECORD_ALLOCATED &&
             counters.getCounterTypeId(counterId) == RECORDING_POSITION_TYPE_ID)
         {
-            final int recordOffset = CountersReader.metaDataOffset(counterId);
+            final int recordOffset = metaDataOffset(counterId);
             return counters.metaDataBuffer().getStringAscii(recordOffset + KEY_OFFSET + SOURCE_IDENTITY_LENGTH_OFFSET);
         }
 

--- a/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
+++ b/aeron-archive/src/main/resources/archive/aeron-archive-codecs.xml
@@ -70,7 +70,7 @@
              extend-recording | truncate-recording | replicate-recording | stop-replication | stop-all-replication |
              start-position | recording-position | stop-position | stop-or-recording-position |
              detach-segments | delete-detached-segments | purge-segments | attach-segments | migrate-segments |
-             purge-recording],
+             purge-recording | archive-id],
            close
                 \
         <-       +[control-response | challenge],
@@ -570,6 +570,14 @@
         <field name="controlSessionId"     id="1" type="int64"/>
         <field name="correlationId"        id="2" type="int64"/>
         <field name="recordingId"          id="3" type="int64"/>
+    </sbe:message>
+
+    <sbe:message name="ArchiveIdRequest"
+                 id="68"
+                 description="Resolve id of the Archive."
+                 sinceVersion="9">
+        <field name="controlSessionId"     id="1" type="int64"/>
+        <field name="correlationId"        id="2" type="int64"/>
     </sbe:message>
 
     <!-- Archive Recording Progress Events -->

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -229,7 +229,8 @@ class ArchiveTest
             int counterId;
             final int sessionId = publication.sessionId();
             final CountersReader countersReader = aeron.countersReader();
-            while (Aeron.NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(countersReader, sessionId)))
+            while (Aeron.NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(
+                countersReader, sessionId, archive.archiveId())))
             {
                 Tests.yield();
             }
@@ -637,7 +638,7 @@ class ArchiveTest
                 final int sessionId = publication.sessionId();
 
                 final CountersReader counters = aeron.countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+                final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, archive.archiveId());
 
                 final BufferClaim bufferClaim = new BufferClaim();
                 for (int i = 0; i < 111; i++)
@@ -695,7 +696,8 @@ class ArchiveTest
                 final int sessionId = publication.sessionId();
                 final CountersReader countersReader = aeron.countersReader();
 
-                while (Aeron.NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(countersReader, sessionId)))
+                while (Aeron.NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(
+                    countersReader, sessionId, archive.archiveId())))
                 {
                     Tests.yield();
                 }

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -429,10 +429,6 @@ class ArchiveTest
             .threadingMode(ThreadingMode.SHARED)
             .aeronDirectoryName(aeronDir.toString());
 
-        final Archive.Context archive1Ctx = TestContexts.localhostArchive()
-            .deleteArchiveOnStart(true)
-            .threadingMode(SHARED);
-
         try (MediaDriver ignore = MediaDriver.launch(driverCtx);
             Archive archive1 = Archive.launch(
                 new Archive.Context()

--- a/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ArchiveTest.java
@@ -51,6 +51,7 @@ import org.agrona.concurrent.status.AtomicCounter;
 import org.agrona.concurrent.status.CountersReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -61,6 +62,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileStore;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -75,6 +77,7 @@ import static io.aeron.archive.client.AeronArchive.segmentFileBasePosition;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
 import static io.aeron.logbuffer.FrameDescriptor.FRAME_ALIGNMENT;
 import static io.aeron.protocol.DataHeaderFlyweight.HEADER_LENGTH;
+import static io.aeron.test.TestContexts.*;
 import static org.agrona.BitUtil.align;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
@@ -410,6 +413,54 @@ class ArchiveTest
         {
             archiveCtx.deleteDirectory();
             driverCtx.deleteDirectory();
+        }
+    }
+
+    @Test
+    @InterruptAfter(10)
+    void shouldResolveArchiveId(@TempDir final Path dir)
+    {
+        final Path aeronDir = dir.resolve("driver");
+        final Path archive1Dir = dir.resolve("archive1");
+        final Path archive2Dir = dir.resolve("archive2");
+        final MediaDriver.Context driverCtx = new MediaDriver.Context()
+            .dirDeleteOnStart(true)
+            .threadingMode(ThreadingMode.SHARED)
+            .aeronDirectoryName(aeronDir.toString());
+
+        final Archive.Context archive1Ctx = TestContexts.localhostArchive()
+            .deleteArchiveOnStart(true)
+            .threadingMode(SHARED);
+
+        try (MediaDriver ignore = MediaDriver.launch(driverCtx);
+            Archive archive1 = Archive.launch(
+                new Archive.Context()
+                .controlChannel(LOCALHOST_CONTROL_REQUEST_CHANNEL)
+                .replicationChannel(LOCALHOST_REPLICATION_CHANNEL)
+                .deleteArchiveOnStart(true)
+                .threadingMode(SHARED)
+                .aeronDirectoryName(aeronDir.toString())
+                .archiveDir(archive1Dir.toFile())
+                .archiveId(42));
+            Archive archive2 = Archive.launch(
+                new Archive.Context()
+                .controlChannel("aeron:udp?endpoint=localhost:8011")
+                .replicationChannel(LOCALHOST_REPLICATION_CHANNEL)
+                .deleteArchiveOnStart(true)
+                .threadingMode(SHARED)
+                .aeronDirectoryName(aeronDir.toString())
+                .archiveDir(archive2Dir.toFile()));
+            AeronArchive client1 = AeronArchive.connect(new AeronArchive.Context()
+                .aeronDirectoryName(aeronDir.toString())
+                .controlRequestChannel(archive1.context().controlChannel())
+                .controlResponseChannel(LOCALHOST_CONTROL_RESPONSE_CHANNEL));
+            AeronArchive client2 = AeronArchive.connect(new AeronArchive.Context()
+                .aeronDirectoryName(aeronDir.toString())
+                .controlRequestChannel(archive2.context().controlChannel())
+                .controlResponseChannel(LOCALHOST_CONTROL_RESPONSE_CHANNEL)))
+        {
+            assertEquals(42, client1.archiveId());
+            assertEquals(archive2.context().archiveId(), client2.archiveId());
         }
     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterBackupAgent.java
@@ -836,7 +836,8 @@ public final class ClusterBackupAgent implements Agent
             {
                 final CountersReader countersReader = aeron.countersReader();
 
-                liveLogRecCounterId = RecordingPos.findCounterIdBySession(countersReader, (int)liveLogReplaySessionId);
+                liveLogRecCounterId = RecordingPos.findCounterIdBySession(
+                    countersReader, (int)liveLogReplaySessionId, clusterArchive.archiveId());
                 if (NULL_COUNTER_ID != liveLogRecCounterId)
                 {
                     liveLogPositionCounter.setOrdered(countersReader.getCounterValue(liveLogRecCounterId));

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ClusterTool.java
@@ -1266,9 +1266,9 @@ public class ClusterTool
     {
         File[] clusterMarkFileNames =
             clusterDir.listFiles((dir, name) ->
-                name.startsWith(ClusterMarkFile.SERVICE_FILENAME_PREFIX) &&
-                    (name.endsWith(ClusterMarkFile.FILE_EXTENSION) ||
-                        name.endsWith(ClusterMarkFile.LINK_FILE_EXTENSION)));
+            name.startsWith(ClusterMarkFile.SERVICE_FILENAME_PREFIX) &&
+            (name.endsWith(ClusterMarkFile.FILE_EXTENSION) ||
+            name.endsWith(ClusterMarkFile.LINK_FILE_EXTENSION)));
 
         if (null == clusterMarkFileNames)
         {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/RecordingReplication.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/RecordingReplication.java
@@ -183,7 +183,8 @@ final class RecordingReplication implements AutoCloseable
             if (RecordingSignal.EXTEND == signal)
             {
                 final CountersReader counters = archive.context().aeron().countersReader();
-                recordingPositionCounterId = RecordingPos.findCounterIdByRecording(counters, recordingId);
+                recordingPositionCounterId =
+                    RecordingPos.findCounterIdByRecording(counters, recordingId, archive.archiveId());
             }
             else if (RecordingSignal.SYNC == signal)
             {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceAgent.java
@@ -1010,12 +1010,13 @@ final class ClusteredServiceAgent extends ClusteredServiceAgentRhsPadding implem
     private int awaitRecordingCounter(final int sessionId, final CountersReader counters, final AeronArchive archive)
     {
         idleStrategy.reset();
-        int counterId = RecordingPos.findCounterIdBySession(counters, sessionId);
+        final long archiveId = archive.archiveId();
+        int counterId = RecordingPos.findCounterIdBySession(counters, sessionId, archiveId);
         while (NULL_COUNTER_ID == counterId)
         {
             idle();
             archive.checkForErrorResponse();
-            counterId = RecordingPos.findCounterIdBySession(counters, sessionId);
+            counterId = RecordingPos.findCounterIdBySession(counters, sessionId, archiveId);
         }
 
         return counterId;

--- a/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
+++ b/aeron-samples/src/main/java/io/aeron/cluster/ConsensusModuleSnapshotPendingServiceMessagesPatch.java
@@ -209,7 +209,7 @@ public class ConsensusModuleSnapshotPendingServiceMessagesPatch
             {
                 final int publicationSessionId = publication.sessionId();
                 final CountersReader countersReader = aeron.countersReader();
-                final int counterId = awaitRecordingCounter(publicationSessionId, countersReader);
+                final int counterId = awaitRecordingCounter(publicationSessionId, archive.archiveId(), countersReader);
                 final long newRecordingId = RecordingPos.getRecordingId(countersReader, counterId);
 
                 replayLocalSnapshotRecording(
@@ -229,10 +229,12 @@ public class ConsensusModuleSnapshotPendingServiceMessagesPatch
         }
     }
 
-    private static int awaitRecordingCounter(final int publicationSessionId, final CountersReader countersReader)
+    private static int awaitRecordingCounter(
+        final int publicationSessionId, final long archiveId, final CountersReader countersReader)
     {
         int counterId;
-        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(countersReader, publicationSessionId)))
+        while (NULL_VALUE ==
+            (counterId = RecordingPos.findCounterIdBySession(countersReader, publicationSessionId, archiveId)))
         {
             Thread.yield();
         }

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/ArchiveCreator.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/ArchiveCreator.java
@@ -122,7 +122,7 @@ public class ArchiveCreator
         try (Publication publication = aeronArchive.addRecordedExclusivePublication(uriBuilder.build(), STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId = awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             System.out.println(
@@ -145,10 +145,10 @@ public class ArchiveCreator
         }
     }
 
-    private static int awaitRecordingCounterId(final CountersReader counters, final int sessionId)
+    private static int awaitRecordingCounterId(final CountersReader counters, final int sessionId, final long archiveId)
     {
         int counterId;
-        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(counters, sessionId)))
+        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(counters, sessionId, archiveId)))
         {
             Thread.yield();
             checkInterruptStatus();

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedRecordingThroughput.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/EmbeddedRecordingThroughput.java
@@ -148,7 +148,8 @@ public class EmbeddedRecordingThroughput implements AutoCloseable
 
             final long stopPosition = publication.position();
             final CountersReader counters = aeron.countersReader();
-            final int counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId());
+            final int counterId =
+                RecordingPos.findCounterIdBySession(counters, publication.sessionId(), aeronArchive.archiveId());
 
             idleStrategy.reset();
             while (counters.getCounterValue(counterId) < stopPosition)

--- a/aeron-samples/src/main/java/io/aeron/samples/archive/RecordedBasicPublisher.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/archive/RecordedBasicPublisher.java
@@ -70,7 +70,8 @@ public class RecordedBasicPublisher
                 final IdleStrategy idleStrategy = YieldingIdleStrategy.INSTANCE;
                 // Wait for recording to have started before publishing.
                 final CountersReader counters = archive.context().aeron().countersReader();
-                int counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId());
+                final long archiveId = archive.archiveId();
+                int counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId(), archiveId);
                 while (CountersReader.NULL_COUNTER_ID == counterId)
                 {
                     if (!running.get())
@@ -79,7 +80,7 @@ public class RecordedBasicPublisher
                     }
 
                     idleStrategy.idle();
-                    counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId());
+                    counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId(), archiveId);
                 }
 
                 final long recordingId = RecordingPos.getRecordingId(counters, counterId);

--- a/aeron-samples/src/test/java/io/aeron/samples/archive/RecordingReplicatorTest.java
+++ b/aeron-samples/src/test/java/io/aeron/samples/archive/RecordingReplicatorTest.java
@@ -209,7 +209,8 @@ class RecordingReplicatorTest
         try (ExclusivePublication publication = aeronArchive.addRecordedExclusivePublication(channel, streamId))
         {
             final CountersReader counters = aeronArchive.context().aeron().countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
             final BufferClaim bufferClaim = new BufferClaim();
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveAuthenticationTest.java
@@ -387,7 +387,8 @@ class ArchiveAuthenticationTest
             Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId = Tests.awaitRecordingCounterId(
+                counters, publication.sessionId(), aeronArchive.archiveId());
 
             offer(publication, messageCount, messagePrefix);
             consume(subscription, messageCount, messagePrefix);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTruncateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ArchiveTruncateRecordingTest.java
@@ -155,7 +155,8 @@ class ArchiveTruncateRecordingTest
                 ChannelUri.addSessionId(channel, publication.sessionId()), streamId, SourceLocation.LOCAL);
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
             assertEquals(startPosition, aeronArchive.getStartPosition(recordingId));
             assertEquals(NULL_VALUE, aeronArchive.getStopPosition(recordingId));
@@ -232,7 +233,8 @@ class ArchiveTruncateRecordingTest
             Subscription subscription = aeron.addSubscription(channel, streamId))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
             assertEquals(0, aeronArchive.getStartPosition(recordingId));
 
@@ -335,7 +337,8 @@ class ArchiveTruncateRecordingTest
                 ChannelUri.addSessionId(channel, publication.sessionId()), streamId, SourceLocation.LOCAL);
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
             assertEquals(startPosition, aeronArchive.getStartPosition(recordingId));
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/BasicArchiveTest.java
@@ -137,7 +137,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -224,7 +224,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -284,7 +284,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -367,7 +367,7 @@ class BasicArchiveTest
                 sessionId = publication.sessionId();
 
                 final CountersReader counters = aeron.countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+                final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
                 recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
                 assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -426,7 +426,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -485,7 +485,8 @@ class BasicArchiveTest
             Publication publication = aeronArchive.addRecordedPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -526,7 +527,8 @@ class BasicArchiveTest
             Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -563,7 +565,8 @@ class BasicArchiveTest
             Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -594,7 +597,8 @@ class BasicArchiveTest
             Publication publication = aeron.addPublication(RECORDED_CHANNEL, RECORDED_STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
             assertNotEquals(RecordingPos.NULL_RECORDING_ID, recordingId);
 
@@ -634,7 +638,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));
@@ -750,7 +754,7 @@ class BasicArchiveTest
             sessionId = publication.sessionId();
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId);
+            final int counterId = Tests.awaitRecordingCounterId(counters, sessionId, aeronArchive.archiveId());
             recordingIdFromCounter = RecordingPos.getRecordingId(counters, counterId);
 
             assertEquals(CommonContext.IPC_CHANNEL, RecordingPos.getSourceIdentity(counters, counterId));

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ExtendRecordingTest.java
@@ -166,7 +166,8 @@ class ExtendRecordingTest
                 offer(publication, 0, messageCount);
 
                 final CountersReader counters = aeron.countersReader();
-                final int counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId());
+                final int counterId =
+                    RecordingPos.findCounterIdBySession(counters, publication.sessionId(), aeronArchive.archiveId());
                 recordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 consume(subscription, 0, messageCount);
@@ -206,7 +207,8 @@ class ExtendRecordingTest
                 offer(publication, messageCount, messageCount);
 
                 final CountersReader counters = aeron.countersReader();
-                final int counterId = RecordingPos.findCounterIdBySession(counters, publication.sessionId());
+                final int counterId =
+                    RecordingPos.findCounterIdBySession(counters, publication.sessionId(), aeronArchive.archiveId());
 
                 consume(subscription, messageCount, messageCount);
 

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ManageRecordingHistoryTest.java
@@ -127,7 +127,8 @@ class ManageRecordingHistoryTest
         try (Publication publication = aeronArchive.addRecordedPublication(uriBuilder.build(), STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -165,7 +166,8 @@ class ManageRecordingHistoryTest
             assertEquals(startPosition, publication.position());
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -228,7 +230,8 @@ class ManageRecordingHistoryTest
         try (Publication publication = aeronArchive.addRecordedPublication(uriBuilder.build(), STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -267,7 +270,8 @@ class ManageRecordingHistoryTest
             assertEquals(startPosition, publication.position());
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -300,7 +304,8 @@ class ManageRecordingHistoryTest
         try (Publication publication = aeronArchive.addRecordedPublication(uriBuilder.build(), STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -352,7 +357,8 @@ class ManageRecordingHistoryTest
             assertEquals(startPosition, publication.position());
 
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);
@@ -396,7 +402,8 @@ class ManageRecordingHistoryTest
         try (Publication publication = aeronArchive.addRecordedPublication(uriBuilder.build(), STREAM_ID))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long newRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offerToPosition(publication, messagePrefix, targetPosition);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/MigrateSegmentsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/MigrateSegmentsTest.java
@@ -260,7 +260,8 @@ class MigrateSegmentsTest
         try (Publication publication = aeron.addExclusivePublication(channelUri, streamParams.streamId()))
         {
             final CountersReader counters = aeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
 
             offerToPosition(publication, "ext-message-", extendPosition + SEGMENT_LENGTH + 1L);
             Tests.awaitPosition(counters, counterId, publication.position());
@@ -324,7 +325,8 @@ class MigrateSegmentsTest
         final long subscriptionId = aeronArchive.startRecording(
             channelUri, streamParams.streamId(), SourceLocation.LOCAL, false);
         final CountersReader counters = aeron.countersReader();
-        final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+        final int counterId =
+            Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
         final long recordingId = RecordingPos.getRecordingId(counters, counterId);
 
         offerToPosition(publication, "src-message-", recordingParams.recordedPosition());

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplayMergeTest.java
@@ -181,7 +181,8 @@ class ReplayMergeTest
 
             aeronArchive.startRecording(recordingChannel, STREAM_ID, REMOTE, true);
             final CountersReader counters = aeron.countersReader();
-            final int recordingCounterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int recordingCounterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
             final long recordingId = RecordingPos.getRecordingId(counters, recordingCounterId);
 
             publishMessages(publication);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -15,9 +15,15 @@
  */
 package io.aeron.archive;
 
-import io.aeron.*;
-import io.aeron.archive.client.*;
-import io.aeron.archive.codecs.RecordingSignal;
+import io.aeron.Aeron;
+import io.aeron.ChannelUriStringBuilder;
+import io.aeron.ExclusivePublication;
+import io.aeron.Image;
+import io.aeron.Publication;
+import io.aeron.Subscription;
+import io.aeron.archive.client.AeronArchive;
+import io.aeron.archive.client.ArchiveException;
+import io.aeron.archive.client.ReplicationParams;
 import io.aeron.archive.status.RecordingPos;
 import io.aeron.driver.MediaDriver;
 import io.aeron.driver.ThreadingMode;
@@ -25,7 +31,12 @@ import io.aeron.logbuffer.FragmentHandler;
 import io.aeron.samples.archive.RecordingDescriptor;
 import io.aeron.samples.archive.RecordingDescriptorCollector;
 import io.aeron.samples.archive.SampleAuthenticatorSupplier;
-import io.aeron.test.*;
+import io.aeron.test.EventLogExtension;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
 import io.aeron.test.cluster.TestCluster;
 import io.aeron.test.driver.TestMediaDriver;
 import org.agrona.CloseHelper;
@@ -53,10 +64,7 @@ import static io.aeron.CommonContext.IPC_CHANNEL;
 import static io.aeron.CommonContext.generateRandomDirName;
 import static io.aeron.archive.ArchiveSystemTests.*;
 import static io.aeron.archive.client.AeronArchive.NULL_POSITION;
-import static io.aeron.archive.codecs.RecordingSignal.EXTEND;
-import static io.aeron.archive.codecs.RecordingSignal.REPLICATE;
-import static io.aeron.archive.codecs.RecordingSignal.REPLICATE_END;
-import static io.aeron.archive.codecs.RecordingSignal.STOP;
+import static io.aeron.archive.codecs.RecordingSignal.*;
 import static io.aeron.archive.codecs.SourceLocation.LOCAL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -255,7 +263,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader counters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -281,7 +290,7 @@ class ReplicateRecordingTest
         awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
         final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
     }
@@ -301,7 +310,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader counters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -322,7 +332,7 @@ class ReplicateRecordingTest
         awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
         final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
 
@@ -349,7 +359,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader counters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -375,7 +386,7 @@ class ReplicateRecordingTest
         awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
         final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
     }
@@ -397,7 +408,8 @@ class ReplicateRecordingTest
             try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
             {
                 final CountersReader counters = srcAeron.countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+                final int counterId =
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
                 srcRecordingIds[i] = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, messagePrefix);
@@ -448,7 +460,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -476,7 +489,8 @@ class ReplicateRecordingTest
                 EXTEND);
 
             final CountersReader dstCounters = dstAeronArchive.context().aeron().countersReader();
-            final int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            final int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
 
             offer(publication, messageCount, messagePrefix);
@@ -507,7 +521,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -544,7 +559,8 @@ class ReplicateRecordingTest
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
 
             offer(publication, messageCount, messagePrefix);
-            final int srcCounterId = RecordingPos.findCounterIdByRecording(srcCounters, srcRecordingId);
+            final int srcCounterId =
+                RecordingPos.findCounterIdByRecording(srcCounters, srcRecordingId, srcAeronArchive.archiveId());
             Tests.awaitPosition(srcCounters, srcCounterId, publication.position());
 
             assertTrue(firstPosition < publication.position());
@@ -576,7 +592,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -595,7 +612,8 @@ class ReplicateRecordingTest
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
 
             final CountersReader dstCounters = dstArchive.context().aeron().countersReader();
-            int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
 
             dstRecordingSignalConsumer.reset();
@@ -616,7 +634,8 @@ class ReplicateRecordingTest
 
             awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
 
-            dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
 
             offer(publication, messageCount, messagePrefix);
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
@@ -646,7 +665,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -672,7 +692,7 @@ class ReplicateRecordingTest
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
 
 
-            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
             resetAndAwaitSignal(
                 dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
@@ -691,7 +711,7 @@ class ReplicateRecordingTest
                 dstAeronArchive.replicate(
                     srcRecordingId, dstRecordingId, SRC_CONTROL_STREAM_ID, SRC_CONTROL_REQUEST_CHANNEL, null);
             }
-            awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+            awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
             resetAndAwaitSignal(
                 dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         }
@@ -712,10 +732,11 @@ class ReplicateRecordingTest
         srcRecordingSignalConsumer.reset();
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
-            awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, RecordingSignal.START);
+            awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, START);
             final long signaledRecordingId = srcRecordingSignalConsumer.recordingId;
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
             assertEquals(srcRecordingId, signaledRecordingId);
 
@@ -742,10 +763,11 @@ class ReplicateRecordingTest
             awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
             final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, MERGE);
 
             final CountersReader dstCounters = dstArchive.context().aeron().countersReader();
-            final int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            final int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
 
             offer(publication, messageCount, messagePrefix);
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
@@ -772,7 +794,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             dstRecordingSignalConsumer.reset();
@@ -793,10 +816,12 @@ class ReplicateRecordingTest
             awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
             dstRecordingId = dstRecordingSignalConsumer.recordingId;
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
 
             final CountersReader dstCounters = dstArchive.context().aeron().countersReader();
-            final int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            final int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
 
             offer(publication, messageCount, messagePrefix);
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
@@ -806,8 +831,8 @@ class ReplicateRecordingTest
         srcRecordingSignalConsumer.reset();
         srcAeronArchive.stopRecording(subscriptionId);
         awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, srcRecordingId, STOP);
-
-        awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
+        assertEquals(0, dstAeronArchive.pollForRecordingSignals());
+        assertEquals(NULL_VALUE, dstRecordingSignalConsumer.recordingId);
     }
 
     @ParameterizedTest
@@ -832,7 +857,8 @@ class ReplicateRecordingTest
             Subscription taggedSubscription = dstAeron.addSubscription(taggedChannel, LIVE_STREAM_ID))
         {
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
 
             offer(publication, messageCount, messagePrefix);
@@ -869,10 +895,12 @@ class ReplicateRecordingTest
             awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
             dstRecordingId = dstRecordingSignalConsumer.recordingId;
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
 
             final CountersReader dstCounters = dstAeron.countersReader();
-            final int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            final int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstAeronArchive.archiveId());
 
             offer(publication, messageCount, messagePrefix);
             consume(taggedSubscription, messageCount, messagePrefix);
@@ -886,7 +914,8 @@ class ReplicateRecordingTest
         srcRecordingSignalConsumer.reset();
         srcAeronArchive.stopRecording(subscriptionId);
         awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, srcRecordingId, STOP);
-        awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
+        assertEquals(0, dstAeronArchive.pollForRecordingSignals());
+        assertEquals(NULL_VALUE, dstRecordingSignalConsumer.recordingId);
     }
 
     @Test
@@ -914,7 +943,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader counters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, longMessagePrefix.toString());
@@ -935,7 +965,7 @@ class ReplicateRecordingTest
         awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
         final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
 
@@ -969,7 +999,8 @@ class ReplicateRecordingTest
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
             final CountersReader counters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
             offer(publication, messageCount, longMessagePrefix.toString());
@@ -1036,7 +1067,7 @@ class ReplicateRecordingTest
         {
             dstRecordingSignalConsumer.reset();
             dstAeronArchive.truncateRecording(dstRecordingId, 0);
-            awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.DELETE);
+            awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, DELETE);
             dstStreamId++;
         }
 
@@ -1060,14 +1091,14 @@ class ReplicateRecordingTest
 
         dstRecordingSignalConsumer.reset();
         dstAeronArchive.truncateRecording(dstRecordingId, dstRecording.startPosition());
-        awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.DELETE);
+        awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, DELETE);
 
         dstRecordingSignalConsumer.reset();
         dstAeronArchive.replicate(
             srcRecordingId, dstRecordingId, SRC_CONTROL_STREAM_ID, SRC_CONTROL_REQUEST_CHANNEL, null);
 
         awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.SYNC);
+        resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, SYNC);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, REPLICATE_END);
         resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, STOP);
 
@@ -1145,10 +1176,11 @@ class ReplicateRecordingTest
         srcRecordingSignalConsumer.reset();
         try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
         {
-            awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, RecordingSignal.START);
+            awaitSignal(srcAeronArchive, srcRecordingSignalConsumer, START);
             final long signaledRecordingId = srcRecordingSignalConsumer.recordingId;
             final CountersReader srcCounters = srcAeron.countersReader();
-            final int counterId = Tests.awaitRecordingCounterId(srcCounters, publication.sessionId());
+            final int counterId =
+                Tests.awaitRecordingCounterId(srcCounters, publication.sessionId(), srcAeronArchive.archiveId());
             srcRecordingId = RecordingPos.getRecordingId(srcCounters, counterId);
             assertEquals(srcRecordingId, signaledRecordingId);
 
@@ -1175,10 +1207,11 @@ class ReplicateRecordingTest
             awaitSignal(dstAeronArchive, dstRecordingSignalConsumer, REPLICATE);
             final long dstRecordingId = dstRecordingSignalConsumer.recordingId;
             resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, EXTEND);
-            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, RecordingSignal.MERGE);
+            resetAndAwaitSignal(dstAeronArchive, dstRecordingSignalConsumer, dstRecordingId, MERGE);
 
             final CountersReader dstCounters = dstArchive.context().aeron().countersReader();
-            final int dstCounterId = RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId);
+            final int dstCounterId =
+                RecordingPos.findCounterIdByRecording(dstCounters, dstRecordingId, dstArchive.context().archiveId());
 
             offer(publication, messageCount, messagePrefix);
             Tests.awaitPosition(dstCounters, dstCounterId, publication.position());
@@ -1245,7 +1278,8 @@ class ReplicateRecordingTest
             try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
             {
                 final CountersReader counters = srcAeron.countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+                final int counterId =
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
                 srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, messagePrefix);
@@ -1303,7 +1337,8 @@ class ReplicateRecordingTest
             try (Publication publication = srcAeron.addPublication(LIVE_CHANNEL, LIVE_STREAM_ID))
             {
                 final CountersReader counters = srcAeron.countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+                final int counterId =
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
                 srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, messagePrefix);
@@ -1376,7 +1411,8 @@ class ReplicateRecordingTest
             try
             {
                 final CountersReader counters = aeronArchive.context().aeron().countersReader();
-                final int counterId = Tests.awaitRecordingCounterId(counters, publication.sessionId());
+                final int counterId =
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
                 recordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, payload);

--- a/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/archive/ReplicateRecordingTest.java
@@ -1279,7 +1279,7 @@ class ReplicateRecordingTest
             {
                 final CountersReader counters = srcAeron.countersReader();
                 final int counterId =
-                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
                 srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, messagePrefix);
@@ -1338,7 +1338,7 @@ class ReplicateRecordingTest
             {
                 final CountersReader counters = srcAeron.countersReader();
                 final int counterId =
-                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
                 srcRecordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, messagePrefix);
@@ -1412,7 +1412,7 @@ class ReplicateRecordingTest
             {
                 final CountersReader counters = aeronArchive.context().aeron().countersReader();
                 final int counterId =
-                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), srcAeronArchive.archiveId());
+                    Tests.awaitRecordingCounterId(counters, publication.sessionId(), aeronArchive.archiveId());
                 recordingId = RecordingPos.getRecordingId(counters, counterId);
 
                 offer(publication, messageCount, payload);

--- a/aeron-test-support/src/main/java/io/aeron/test/Tests.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/Tests.java
@@ -700,10 +700,10 @@ public class Tests
         };
     }
 
-    public static int awaitRecordingCounterId(final CountersReader counters, final int sessionId)
+    public static int awaitRecordingCounterId(final CountersReader counters, final int sessionId, final long archiveId)
     {
         int counterId;
-        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(counters, sessionId)))
+        while (NULL_VALUE == (counterId = RecordingPos.findCounterIdBySession(counters, sessionId, archiveId)))
         {
             Tests.yield();
         }

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -256,7 +256,8 @@ public final class TestNode implements AutoCloseable
         }
 
         final CountersReader countersReader = countersReader();
-        final int counterId = RecordingPos.findCounterIdByRecording(countersReader, recordingId);
+        final int counterId =
+            RecordingPos.findCounterIdByRecording(countersReader, recordingId, archive.context().archiveId());
         if (NULL_VALUE == counterId)
         {
             fail("recording not active " + recordingId);

--- a/aeron-test-support/src/main/java/io/aeron/test/launcher/FileResolveUtil.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/launcher/FileResolveUtil.java
@@ -62,10 +62,10 @@ public class FileResolveUtil
 
         final File[] aeronAllJarFiles = allBuildLibs.listFiles(
             (dir, name) ->
-                name.startsWith(moduleName + "-") &&
-                name.endsWith(".jar") &&
-                !name.endsWith("-sources.jar") &&
-                !name.endsWith("-javadoc.jar"));
+            name.startsWith(moduleName + "-") &&
+            name.endsWith(".jar") &&
+            !name.endsWith("-sources.jar") &&
+            !name.endsWith("-javadoc.jar"));
 
         if (null == aeronAllJarFiles || 0 == aeronAllJarFiles.length)
         {


### PR DESCRIPTION
* Add a command to expose `archiveId` to the Archive control protocol.
* Add `AeronArchive.archiveId()`.
* Use `archiveId` when searching for `RecordingPos` by `recordingId` and `sessionId`.