### PR TITLE
[Java] Introduce clustered service specific SnapshotDurationTracker

### DIFF
--- a/aeron-client/src/main/java/io/aeron/AeronCounters.java
+++ b/aeron-client/src/main/java/io/aeron/AeronCounters.java
@@ -394,6 +394,18 @@ public final class AeronCounters
      */
     public static final int CLUSTER_TOTAL_SNAPSHOT_DURATION_THRESHOLD_EXCEEDED_TYPE_ID = 235;
 
+    /**
+     * The type id of the {@link Counter} used for keeping track of the maximum snapshot duration
+     * for a given clustered service.
+     */
+    public static final int CLUSTERED_SERVICE_MAX_SNAPSHOT_DURATION_TYPE_ID = 236;
+
+    /**
+     * The type id of the {@link Counter} used for keeping track of the count snapshot duration
+     * has exceeded the threshold for a given clustered service.
+     */
+    public static final int CLUSTERED_SERVICE_SNAPSHOT_DURATION_THRESHOLD_EXCEEDED_TYPE_ID = 237;
+
     private AeronCounters()
     {
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/service/ClusteredServiceContainer.java
@@ -335,6 +335,16 @@ public final class ClusteredServiceContainer implements AutoCloseable
         public static final long CYCLE_THRESHOLD_DEFAULT_NS = TimeUnit.MILLISECONDS.toNanos(1000);
 
         /**
+         * Property name for threshold value, which is used for tracking snapshot duration breaches.
+         */
+        public static final String SNAPSHOT_DURATION_THRESHOLD_PROP_NAME = "aeron.cluster.service.snapshot.threshold";
+
+        /**
+         * Default threshold value, which is used for tracking snapshot duration breaches.
+         */
+        public static final long SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS = TimeUnit.MILLISECONDS.toNanos(1000);
+
+        /**
          * Counter type id for the cluster node role.
          */
         public static final int CLUSTER_NODE_ROLE_TYPE_ID = AeronCounters.CLUSTER_NODE_ROLE_TYPE_ID;
@@ -560,6 +570,17 @@ public final class ClusteredServiceContainer implements AutoCloseable
         }
 
         /**
+         * Get threshold value, which is used for monitoring snapshot duration breaches of its predefined
+         * threshold.
+         *
+         * @return threshold value in nanoseconds.
+         */
+        public static long snapshotDurationThresholdNs()
+        {
+            return getDurationInNanos(SNAPSHOT_DURATION_THRESHOLD_PROP_NAME, SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS);
+        }
+
+        /**
          * Get the configuration value to determine if this node should take standby snapshots be enabled.
          *
          * @return configuration value for standby snapshots being enabled.
@@ -656,6 +677,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
         private boolean isRespondingService = Configuration.isRespondingService();
         private int logFragmentLimit = Configuration.logFragmentLimit();
         private long cycleThresholdNs = Configuration.cycleThresholdNs();
+        private long snapshotDurationThresholdNs = Configuration.snapshotDurationThresholdNs();
         private boolean standbySnapshotEnabled = Configuration.standbySnapshotEnabled();
 
         private CountDownLatch abortLatch;
@@ -675,6 +697,7 @@ public final class ClusteredServiceContainer implements AutoCloseable
         private String aeronDirectoryName = CommonContext.getAeronDirectoryName();
         private Aeron aeron;
         private DutyCycleTracker dutyCycleTracker;
+        private SnapshotDurationTracker snapshotDurationTracker;
         private AppVersionValidator appVersionValidator;
         private boolean ownsAeronClient;
 
@@ -851,6 +874,29 @@ public final class ClusteredServiceContainer implements AutoCloseable
                         clusterId,
                         serviceId),
                     cycleThresholdNs);
+            }
+
+            if (null == snapshotDurationTracker)
+            {
+                snapshotDurationTracker = new SnapshotDurationTracker(
+                    ClusterCounters.allocateServiceCounter(
+                        aeron,
+                        tempBuffer,
+                        "Clustered service max snapshot duration in ns",
+                        AeronCounters.CLUSTERED_SERVICE_MAX_SNAPSHOT_DURATION_TYPE_ID,
+                        clusterId,
+                        serviceId
+                    ),
+                    ClusterCounters.allocateServiceCounter(
+                        aeron,
+                        tempBuffer,
+                        "Clustered service max snapshot duration exceeded count: threshold=" +
+                            snapshotDurationThresholdNs,
+                        AeronCounters.CLUSTERED_SERVICE_SNAPSHOT_DURATION_THRESHOLD_EXCEEDED_TYPE_ID,
+                        clusterId,
+                        serviceId
+                    ),
+                    snapshotDurationThresholdNs);
             }
 
             if (null == archiveContext)
@@ -1765,6 +1811,52 @@ public final class ClusteredServiceContainer implements AutoCloseable
         public DutyCycleTracker dutyCycleTracker()
         {
             return dutyCycleTracker;
+        }
+
+        /**
+         * Set a threshold for snapshot duration which when exceeded will result in a counter increment.
+         *
+         * @param thresholdNs value in nanoseconds
+         * @return this for fluent API.
+         * @see Configuration#SNAPSHOT_DURATION_THRESHOLD_PROP_NAME
+         * @see Configuration#SNAPSHOT_DURATION_THRESHOLD_DEFAULT_NS
+         */
+        public Context snapshotDurationThresholdNs(final long thresholdNs)
+        {
+            this.snapshotDurationThresholdNs = thresholdNs;
+            return this;
+        }
+
+        /**
+         * Threshold for snapshot duration which when exceeded will result in a counter increment.
+         *
+         * @return threshold value in nanoseconds.
+         */
+        public long snapshotDurationThresholdNs()
+        {
+            return snapshotDurationThresholdNs;
+        }
+
+        /**
+         * Set snapshot duration tracker used for monitoring snapshot duration.
+         *
+         * @param snapshotDurationTracker snapshot duration tracker.
+         * @return this for fluent API.
+         */
+        public Context snapshotDurationTracker(final SnapshotDurationTracker snapshotDurationTracker)
+        {
+            this.snapshotDurationTracker = snapshotDurationTracker;
+            return this;
+        }
+
+        /**
+         * Get snapshot duration tracker used for monitoring snapshot duration.
+         *
+         * @return snapshot duration tracker
+         */
+        public SnapshotDurationTracker snapshotDurationTracker()
+        {
+            return snapshotDurationTracker;
         }
 
         /**

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1988,10 +1988,10 @@ class ClusterTest
         assertTrue(totalSnapshotDurationTracker.maxSnapshotDuration().get() > 0);
 
         assertEquals(1L, service1SnapshotDurationTracker.snapshotDurationThresholdExceededCount().get());
-        assertTrue(service1SnapshotDurationTracker.snapshotDurationThresholdExceededCount().get() > 0);
+        assertTrue(service1SnapshotDurationTracker.maxSnapshotDuration().get() > 0);
 
         assertEquals(1L, service2SnapshotDurationTracker.snapshotDurationThresholdExceededCount().get());
-        assertTrue(service2SnapshotDurationTracker.snapshotDurationThresholdExceededCount().get() > 0);
+        assertTrue(service2SnapshotDurationTracker.maxSnapshotDuration().get() > 0);
     }
 
     @Test

--- a/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/cluster/TestNode.java
@@ -117,6 +117,7 @@ public final class TestNode implements AutoCloseable
                     .clusterDir(context.consensusModuleContext.clusterDir())
                     .markFileDir(context.consensusModuleContext.markFileDir())
                     .clusteredService(services[i])
+                    .snapshotDurationThresholdNs(TimeUnit.MILLISECONDS.toNanos(100))
                     .serviceId(i);
                 containers[i] = ClusteredServiceContainer.launch(ctx);
             }
@@ -171,7 +172,12 @@ public final class TestNode implements AutoCloseable
             throw new IllegalStateException("container count expected=1 actual=" + containers.length);
         }
 
-        return containers[0];
+        return container(0);
+    }
+
+    public ClusteredServiceContainer container(final int index)
+    {
+        return containers[index];
     }
 
     public TestService service()


### PR DESCRIPTION
Following #1532, this PR introduces snapshot duration tracking to clustered services.
Note that `aeron.cluster.service.snapshot.threshold` property usage sets the threshold value for **all** clustered services. If a per-service threshold setting is needed, `ClusteredServiceContainer.Context#snapshotDurationThresholdNs` API can be used.