### PR TITLE
Support configuration flag for experimental features

### DIFF
--- a/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
+++ b/aeron-agent/src/main/java/io/aeron/agent/ChannelEndpointInterceptor.java
@@ -124,12 +124,20 @@ class ChannelEndpointInterceptor
                 final int length,
                 @Advice.This final Object thisObject)
             {
+                if (null == connections || null == thisObject)
+                {
+                    return;
+                }
+
                 final ReceiveChannelEndpoint endpoint = (ReceiveChannelEndpoint)thisObject;
                 final String channel = endpoint.originalUriString();
                 for (final ImageConnection connection : connections)
                 {
-                    LOGGER.logSendNakMessage(
-                        connection.controlAddress, sessionId, streamId, termId, termOffset, length, channel);
+                    if (null != connection)
+                    {
+                        LOGGER.logSendNakMessage(
+                            connection.controlAddress, sessionId, streamId, termId, termOffset, length, channel);
+                    }
                 }
             }
         }

--- a/aeron-client/src/main/java/io/aeron/Aeron.java
+++ b/aeron-client/src/main/java/io/aeron/Aeron.java
@@ -723,6 +723,11 @@ public class Aeron implements AutoCloseable
         public static final boolean PRE_TOUCH_MAPPED_MEMORY_DEFAULT = false;
 
         /**
+         * Should new/experimental features be enabled.
+         */
+        public static final String ENABLE_EXPERIMENTAL_FEATURES_PROP_NAME = "aeron.enable.experimental.features";
+
+        /**
          * The Default handler for Aeron runtime exceptions.
          * When a {@link DriverTimeoutException} is encountered, this handler will exit the program.
          * <p>
@@ -801,6 +806,16 @@ public class Aeron implements AutoCloseable
             }
 
             return PRE_TOUCH_MAPPED_MEMORY_DEFAULT;
+        }
+
+        /**
+         * Determine if new experimental features should be enabled.
+         *
+         * @return <code>true</code> if experimental features should be enabled, <code>false</code> otherwise.
+         */
+        public static boolean enableExperimentalFeatures()
+        {
+            return Boolean.getBoolean(ENABLE_EXPERIMENTAL_FEATURES_PROP_NAME);
         }
     }
 

--- a/aeron-client/src/test/cpp_shared/EmbeddedMediaDriver.h
+++ b/aeron-client/src/test/cpp_shared/EmbeddedMediaDriver.h
@@ -108,6 +108,7 @@ protected:
         aeron_driver_context_set_term_buffer_length(m_context, 64 * 1024);
         aeron_driver_context_set_timer_interval_ns(m_context, m_livenessTimeoutNs / 10);
         aeron_driver_context_set_client_liveness_timeout_ns(m_context, m_livenessTimeoutNs);
+        aeron_driver_context_set_enable_experimental_features(m_context, true);
 
         long long debugTimeoutMs;
         if (0 != (debugTimeoutMs = EmbeddedMediaDriver::getDebugTimeoutMs()))

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -339,6 +339,7 @@ static void aeron_driver_untethered_subscription_state_change_null(
 #define AERON_DRIVER_RESOURCE_FREE_LIMIT_DEFAULT UINT32_C(10)
 #define AERON_CPU_AFFINITY_DEFAULT (-1)
 #define AERON_DRIVER_CONNECT_DEFAULT true
+#define AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT false
 
 int aeron_driver_context_init(aeron_driver_context_t **context)
 {
@@ -563,6 +564,7 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->conductor_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->sender_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->receiver_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
+    _context->enable_experimental_features = AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT;
 
     char *value = NULL;
 
@@ -1056,6 +1058,9 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
         _context->resource_free_limit,
         1,
         INT32_MAX);
+
+    _context->enable_experimental_features = aeron_parse_bool(
+        getenv(AERON_ENABLE_EXPERIMENTAL_FEATURES_ENV_VAR), _context->enable_experimental_features);
 
     _context->to_driver_buffer = NULL;
     _context->to_clients_buffer = NULL;
@@ -2985,6 +2990,19 @@ int aeron_driver_context_set_receiver_port_manager(
 aeron_port_manager_t *aeron_driver_context_get_receiver_port_manager(aeron_driver_context_t *context)
 {
     return NULL != context ? context->receiver_port_manager : NULL;
+}
+
+int aeron_driver_context_set_enable_experimental_features(aeron_driver_context_t *context, bool value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->enable_experimental_features = value;
+    return 0;
+}
+
+int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->enable_experimental_features : false;
 }
 
 int aeron_driver_context_bindings_clientd_find_first_free_index(aeron_driver_context_t *context)

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -181,6 +181,7 @@ typedef struct aeron_driver_context_stct
     int32_t conductor_cpu_affinity_no;                      /* aeron.conductor.cpu.affinity = -1 */
     int32_t receiver_cpu_affinity_no;                       /* aeron.receiver.cpu.affinity = -1 */
     int32_t sender_cpu_affinity_no;                         /* aeron.sender.cpu.affinity = -1 */
+    bool enable_experimental_features;                      /* aeron.enable.experimental.features = false */
 
     struct                                                  /* aeron.receiver.receiver.tag = <unset> */
     {

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -896,6 +896,10 @@ uint32_t aeron_driver_context_get_resource_free_limit(aeron_driver_context_t *co
  */
 #define AERON_DRIVER_DYNAMIC_LIBRARIES_ENV_VAR "AERON_DRIVER_DYNAMIC_LIBRARIES"
 
+#define AERON_ENABLE_EXPERIMENTAL_FEATURES_ENV_VAR "AERON_ENABLE_EXPERIMENTAL_FEATURES"
+int aeron_driver_context_set_enable_experimental_features(aeron_driver_context_t *context, bool value);
+int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t *context);
+
 /**
  * Return full version and build string.
  *

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -2525,7 +2525,7 @@ public final class DriverConductor implements Agent
         }
 
         if (null != channel.channelUri().get(RESPONSE_CORRELATION_ID_PARAM_NAME) ||
-            ControlMode.RESPONSE.name().equalsIgnoreCase(channel.channelUri().get(MDC_CONTROL_MODE_PARAM_NAME)))
+            ControlMode.RESPONSE == channel.controlMode())
         {
             throw new IllegalArgumentException(
                 "Response Channels is an experimental feature, and " +

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -516,6 +516,7 @@ public final class DriverConductor implements Agent
                 final UdpChannel udpChannel = asyncResult.get();
                 final ChannelUri channelUri = udpChannel.channelUri();
                 final PublicationParams params = getPublicationParams(channelUri, ctx, this, false);
+                validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
                 validateEndpointForPublication(udpChannel);
                 validateControlForPublication(udpChannel);
                 validateMtuForMaxMessage(params, channel);
@@ -994,6 +995,7 @@ public final class DriverConductor implements Agent
                 final UdpChannel udpChannel = asyncResult.get();
                 final ControlMode controlMode = udpChannel.controlMode();
 
+                validateExperimentalFeatures(ctx.enableExperimentalFeatures(), udpChannel);
                 validateControlForSubscription(udpChannel);
                 validateTimestampConfiguration(udpChannel);
 
@@ -2512,6 +2514,22 @@ public final class DriverConductor implements Agent
         {
             throw new InvalidChannelException(ENDPOINT_PARAM_NAME + " has port=0 for send destination: channel=" +
                 destinationUri);
+        }
+    }
+
+    private static void validateExperimentalFeatures(final boolean enableExperimentalFeatures, final UdpChannel channel)
+    {
+        if (enableExperimentalFeatures)
+        {
+            return;
+        }
+
+        if (null != channel.channelUri().get(RESPONSE_CORRELATION_ID_PARAM_NAME) ||
+            ControlMode.RESPONSE.name().equalsIgnoreCase(channel.channelUri().get(MDC_CONTROL_MODE_PARAM_NAME)))
+        {
+            throw new IllegalArgumentException(
+                "Response Channels is an experimental feature, and " +
+                "MediaDriver.Context.enableExperimentalFeatures is false");
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -492,6 +492,7 @@ public final class MediaDriver implements AutoCloseable
         private String resolverBootstrapNeighbor = Configuration.resolverBootstrapNeighbor();
         private String senderWildcardPortRange = Configuration.senderWildcardPortRange();
         private String receiverWildcardPortRange = Configuration.receiverWildcardPortRange();
+        private boolean enableExperimentalFeatures = Aeron.Configuration.enableExperimentalFeatures();
 
         private EpochClock epochClock;
         private NanoClock nanoClock;
@@ -3528,6 +3529,32 @@ public final class MediaDriver implements AutoCloseable
         public EpochNanoClock channelSendTimestampClock()
         {
             return channelSendTimestampClock;
+        }
+
+        /**
+         * Should experimental features for the driver be enabled.
+         *
+         * @return <code>true</code> if enabled, <code>false</code> otherwise.
+         * @see #enableExperimentalFeatures(boolean)
+         */
+        public boolean enableExperimentalFeatures()
+        {
+            return enableExperimentalFeatures;
+        }
+
+        /**
+         * Should experimental features for the driver be enabled.
+         *
+         * @param enableExperimentalFeatures indicate whether experimental features for the driver should be enabled.
+         * @return this for a fluent API
+         * @see Aeron.Configuration#enableExperimentalFeatures()
+         * @see Aeron.Configuration#ENABLE_EXPERIMENTAL_FEATURES_PROP_NAME
+         * @see #enableExperimentalFeatures()
+         */
+        public Context enableExperimentalFeatures(final boolean enableExperimentalFeatures)
+        {
+            this.enableExperimentalFeatures = enableExperimentalFeatures;
+            return this;
         }
 
         OneToOneConcurrentArrayQueue<Runnable> receiverCommandQueue()

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -4245,6 +4245,7 @@ public final class MediaDriver implements AutoCloseable
                 "\n    resourceFreeLimit=" + resourceFreeLimit +
                 "\n    asyncTaskExecutorThreads=" + asyncTaskExecutorThreads +
                 "\n    asyncTaskExecutor=" + asyncTaskExecutor +
+                "\n    enabledExperimentalFeatures=" + enableExperimentalFeatures +
                 "\n}";
         }
     }

--- a/aeron-system-tests/src/test/java/io/aeron/ResponseChannelsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResponseChannelsTest.java
@@ -70,16 +70,17 @@ public class ResponseChannelsTest
     {
         driver = TestMediaDriver.launch(new MediaDriver.Context()
                 .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)
-                .threadingMode(ThreadingMode.SHARED),
+                .threadingMode(ThreadingMode.SHARED)
+                .enableExperimentalFeatures(true),
             watcher);
         watcher.dataCollector().add(driver.context().aeronDirectory());
     }
 
-        @AfterEach
-        void tearDown()
-        {
-            CloseHelper.quietClose(driver);
-        }
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.quietClose(driver);
+    }
 
     @Test
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/ResponseChannelsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/ResponseChannelsTest.java
@@ -75,11 +75,11 @@ public class ResponseChannelsTest
         watcher.dataCollector().add(driver.context().aeronDirectory());
     }
 
-    @AfterEach
-    void tearDown()
-    {
-        CloseHelper.quietClose(driver);
-    }
+        @AfterEach
+        void tearDown()
+        {
+            CloseHelper.quietClose(driver);
+        }
 
     @Test
     @InterruptAfter(10)

--- a/aeron-system-tests/src/test/java/io/aeron/driver/ExperimentalDriverFeaturesTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/driver/ExperimentalDriverFeaturesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.driver;
+
+import io.aeron.Aeron;
+import io.aeron.logbuffer.LogBufferDescriptor;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ExperimentalDriverFeaturesTest
+{
+    @RegisterExtension
+    final SystemTestWatcher watcher = new SystemTestWatcher();
+
+    private TestMediaDriver driver;
+
+    @BeforeEach
+    void setUp()
+    {
+        driver = TestMediaDriver.launch(new MediaDriver.Context()
+            .publicationTermBufferLength(LogBufferDescriptor.TERM_MIN_LENGTH)
+            .threadingMode(ThreadingMode.SHARED)
+            .enableExperimentalFeatures(false),
+            watcher);
+        watcher.dataCollector().add(driver.context().aeronDirectory());
+        watcher.ignoreErrorsMatching(s -> true);
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.quietClose(driver);
+    }
+
+    @Test
+    void shouldFailToCreateResponsePublicationIfExperimentalFeaturesAreDisabled()
+    {
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            final Exception ex1 = assertThrows(Exception.class, () -> aeron.addPublication(
+                "aeron:udp?endpoint=localhost:10000|response-correlation-id=10", 10001));
+            assertThat(ex1.getMessage(), containsString("experimental feature"));
+            final Exception ex2 = assertThrows(Exception.class, () -> aeron.addPublication(
+                "aeron:udp?endpoint=localhost:10000|control-mode=response", 10001));
+            assertThat(ex2.getMessage(), containsString("experimental feature"));
+        }
+    }
+
+    @Test
+    void shouldFailToCreateResponseSubscriptionIfExperimentalFeaturesAreDisabled()
+    {
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(driver.aeronDirectoryName())))
+        {
+            final Exception ex1 = assertThrows(Exception.class, () -> aeron.addSubscription(
+                "aeron:udp?endpoint=localhost:10000|response-correlation-id=10", 10001));
+            assertThat(ex1.getMessage(), containsString("experimental feature"));
+            final Exception ex2 = assertThrows(Exception.class, () -> aeron.addSubscription(
+                "aeron:udp?endpoint=localhost:10000|control-mode=response", 10001));
+            assertThat(ex2.getMessage(), containsString("experimental feature"));
+        }
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -289,6 +289,7 @@ public final class CTestMediaDriver implements TestMediaDriver
             environment.put("AERON_RECEIVER_WILDCARD_PORT_RANGE", receiverWildcardPortRange);
         }
 
+        environment.put("AERON_ENABLE_EXPERIMENTAL_FEATURES", String.valueOf(context.enableExperimentalFeatures()));
         setFlowControlStrategy(environment, context);
         setLogging(environment);
         setTransportSecurity(environment);


### PR DESCRIPTION
* Add checking for experimental support in the media driver
* Mark response channels as an experimental feature.