### PR TITLE
Correctly close a subscription and publication

### DIFF
--- a/aeron-client/src/main/cpp/Publication.cpp
+++ b/aeron-client/src/main/cpp/Publication.cpp
@@ -52,10 +52,20 @@ Publication::Publication(
 {
 }
 
-Publication::~Publication()
+Publication::~Publication() noexcept
 {
-    m_isClosed.store(true, std::memory_order_release);
-    m_conductor.releasePublication(m_registrationId);
+    try 
+    {
+        close();
+    }
+    catch(...) {}
+}
+
+void Publication::close() {
+    if (!isClosed()) {
+        m_isClosed.store(true, std::memory_order_release);
+        m_conductor.releasePublication(m_registrationId);
+    }
 }
 
 std::int64_t Publication::addDestination(const std::string &endpointChannel)

--- a/aeron-client/src/main/cpp/Publication.h
+++ b/aeron-client/src/main/cpp/Publication.h
@@ -91,7 +91,7 @@ public:
         std::shared_ptr<LogBuffers> logBuffers);
     /// @endcond
 
-    ~Publication();
+    ~Publication() noexcept;
 
     /**
      * Media address for delivery to the channel.
@@ -633,10 +633,7 @@ public:
     bool findDestinationResponse(std::int64_t correlationId);
 
     /// @cond HIDDEN_SYMBOLS
-    inline void close()
-    {
-        m_isClosed.store(true, std::memory_order_release);
-    }
+    void close();
     /// @endcond
 
 private:

--- a/aeron-client/src/main/cpp/Subscription.h
+++ b/aeron-client/src/main/cpp/Subscription.h
@@ -59,7 +59,7 @@ public:
         std::int32_t channelStatusId);
 
     /// @endcond
-    ~Subscription();
+    ~Subscription() noexcept;
 
     /**
      * Media address for delivery to the channel.
@@ -505,17 +505,7 @@ public:
         return result;
     }
 
-    std::pair<Image::array_t, std::size_t> closeAndRemoveImages()
-    {
-        if (!m_isClosed.exchange(true))
-        {
-            return m_imageArray.store(new std::shared_ptr<Image>[0], 0);
-        }
-        else
-        {
-            return { nullptr, 0 };
-        }
-    }
+    std::pair<Image::array_t, std::size_t> closeAndRemoveImages();
     /// @endcond
 
 private:


### PR DESCRIPTION
Previous to this commit, a `close()` on a publication would not release the publication through the underlying conductor. Analog for subscriptions.