### PR TITLE
Fix: Set AgentRunner thread name.

### DIFF
--- a/aeron-client/src/main/cpp/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp/concurrent/AgentRunner.h
@@ -122,7 +122,9 @@ public:
 #elif defined(Darwin)
                 pthread_setname_np(m_name.c_str());
 #else
-                pthread_setname_np(pthread_self(), m_name.c_str());
+                char thread_name [16UL]{};
+                std::copy( m_name.begin(), m_name.begin() + std::min(m_name.size(), 15UL), thread_name );
+                pthread_setname_np(pthread_self(), thread_name);
 #endif
                 run();
             });


### PR DESCRIPTION
[see issue 1592](https://github.com/real-logic/aeron/issues/1592)