### PR TITLE
Expose a "retransmitted bytes" counter

### DIFF
--- a/aeron-driver/src/main/c/aeron_network_publication.h
+++ b/aeron-driver/src/main/c/aeron_network_publication.h
@@ -127,6 +127,7 @@ typedef struct aeron_network_publication_stct
     volatile int64_t *heartbeats_sent_counter;
     volatile int64_t *sender_flow_control_limits_counter;
     volatile int64_t *retransmits_sent_counter;
+    volatile int64_t *retransmitted_bytes_counter;
     volatile int64_t *unblocked_publications_counter;
     volatile int64_t *mapped_bytes_counter;
 }

--- a/aeron-driver/src/main/c/aeron_system_counters.c
+++ b/aeron-driver/src/main/c/aeron_system_counters.c
@@ -59,6 +59,7 @@ static aeron_system_counter_t system_counters[] =
         { "NameResolver exceeded threshold count", AERON_SYSTEM_COUNTER_NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED },
         { "Aeron software: version=" AERON_VERSION_TXT " commit=" AERON_VERSION_GITSHA, AERON_SYSTEM_COUNTER_AERON_VERSION },
         { "Bytes currently mapped", AERON_SYSTEM_COUNTER_BYTES_CURRENTLY_MAPPED },
+        { "Retransmitted bytes", AERON_SYSTEM_COUNTER_RETRANSMITTED_BYTES },
     };
 
 static size_t num_system_counters = sizeof(system_counters) / sizeof(aeron_system_counter_t);

--- a/aeron-driver/src/main/c/aeron_system_counters.h
+++ b/aeron-driver/src/main/c/aeron_system_counters.h
@@ -57,6 +57,7 @@ typedef enum aeron_system_counter_enum_stct
     AERON_SYSTEM_COUNTER_NAME_RESOLVER_TIME_THRESHOLD_EXCEEDED = 33,
     AERON_SYSTEM_COUNTER_AERON_VERSION = 34,
     AERON_SYSTEM_COUNTER_BYTES_CURRENTLY_MAPPED = 35,
+    AERON_SYSTEM_COUNTER_RETRANSMITTED_BYTES = 36,
 
     // Add all new counters before this one (used for a static assertion).
     AERON_SYSTEM_COUNTER_DUMMY_LAST,

--- a/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/NetworkPublication.java
@@ -161,6 +161,7 @@ public final class NetworkPublication
     private final RawLog rawLog;
     private final AtomicCounter heartbeatsSent;
     private final AtomicCounter retransmitsSent;
+    private final AtomicCounter retransmittedBytes;
     private final AtomicCounter senderFlowControlLimits;
     private final AtomicCounter senderBpe;
     private final AtomicCounter shortSends;
@@ -226,6 +227,7 @@ public final class NetworkPublication
         heartbeatsSent = systemCounters.get(HEARTBEATS_SENT);
         shortSends = systemCounters.get(SHORT_SENDS);
         retransmitsSent = systemCounters.get(RETRANSMITS_SENT);
+        retransmittedBytes = systemCounters.get(RETRANSMITTED_BYTES);
         senderFlowControlLimits = systemCounters.get(SENDER_FLOW_CONTROL_LIMITS);
         unblockedPublications = systemCounters.get(UNBLOCKED_PUBLICATIONS);
         this.senderBpe = senderBpe;
@@ -527,6 +529,7 @@ public final class NetworkPublication
             final ByteBuffer sendBuffer = sendBuffers[activeIndex];
 
             int remainingBytes = length;
+            int totalBytesSent = 0;
             int bytesSent = 0;
             int offset = termOffset;
             do
@@ -550,10 +553,12 @@ public final class NetworkPublication
 
                 bytesSent = available + padding(scanOutcome);
                 remainingBytes -= bytesSent;
+                totalBytesSent += bytesSent;
             }
             while (remainingBytes > 0);
 
             retransmitsSent.incrementOrdered();
+            retransmittedBytes.getAndAddOrdered(totalBytesSent);
         }
     }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
@@ -207,7 +207,13 @@ public enum SystemCounterDescriptor
     BYTES_CURRENTLY_MAPPED(35, "Bytes currently mapped"),
 
     /**
-     * Number of bytes re-transmitted as a result of NAKs.
+     * A minimum bound on the number of bytes re-transmitted as a result of NAKs.
+     * <p>
+     * MDC retransmits are only counted once; therefore, this is a minimum bound rather than the actual number
+     * of retransmitted bytes. We may change this in the future.
+     * <p>
+     * Note that retransmitted bytes are not included in the {@link SystemCounterDescriptor#BYTES_SENT}
+     * counter value. We may change this in the future.
      */
     RETRANSMITTED_BYTES(36, "Retransmitted bytes");
 

--- a/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/status/SystemCounterDescriptor.java
@@ -204,7 +204,12 @@ public enum SystemCounterDescriptor
     /**
      * The total number of bytes currently mapped in log buffers, CnC file, and loss report.
      */
-    BYTES_CURRENTLY_MAPPED(35, "Bytes currently mapped");
+    BYTES_CURRENTLY_MAPPED(35, "Bytes currently mapped"),
+
+    /**
+     * Number of bytes re-transmitted as a result of NAKs.
+     */
+    RETRANSMITTED_BYTES(36, "Retransmitted bytes");
 
     /**
      * All system counters have the same type id, i.e. system counters are the same type. Other types can exist.

--- a/aeron-driver/src/test/java/io/aeron/driver/ext/FixedLossGeneratorTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ext/FixedLossGeneratorTest.java
@@ -66,17 +66,20 @@ class FixedLossGeneratorTest
     @Test
     void shouldOnlyDropInMatchingFrames()
     {
-        final FixedLossGenerator fixedLossGenerator = new FixedLossGenerator(1, 50, 1408);
+        final FixedLossGenerator fixedLossGenerator = new FixedLossGenerator(1, 2000, 1408);
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 0, 0, 1408));
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 0, 1408, 1408));
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 0, 2 * 1408, 1408));
+        assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 0, 3 * 1408, 1408));
 
-        assertTrue(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 0, 1408));
+        assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 0, 1408));
         assertTrue(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 1408, 1408));
-        assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 2 * 1408, 1408));
+        assertTrue(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 2 * 1408, 1408));
+        assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 1, 3 * 1408, 1408));
 
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 2, 0, 1408));
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 2, 1408, 1408));
         assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 2, 2 * 1408, 1408));
+        assertFalse(fixedLossGenerator.shouldDropFrame(null, null, 123, 456, 2, 3 * 1408, 1408));
     }
 }


### PR DESCRIPTION
Exposes a counter for the number of bytes retransmitted due to resending after receiving NAKs.

Caveats (shown in 44e89dfd7539ea2fa1f6a82655c119ef2681ab97):
- Only counts bytes sent to multiple MDC destinations once
- Retransmitted bytes are not included in total bytes

I looked into addressing those caveats, but I couldn't decide on the best approach.

Would it be best to revert the disabled tests? Whilst it is useful documentation, it will probably rot.