### PR TITLE
Per Stream Session Limits

### DIFF
--- a/aeron-client/src/main/c/collections/aeron_int64_counter_map.c
+++ b/aeron-client/src/main/c/collections/aeron_int64_counter_map.c
@@ -51,3 +51,7 @@ extern int aeron_int64_counter_map_get_and_dec(aeron_int64_counter_map_t *map, c
 extern void aeron_int64_counter_map_for_each(
     aeron_int64_counter_map_t *map, aeron_int64_counter_map_for_each_func_t func, void *clientd);
 
+extern void aeron_int64_counter_map_remove_if(
+    aeron_int64_counter_map_t *map, aeron_int64_counter_map_predicate_func_t func, void *clientd);
+
+

--- a/aeron-client/src/main/c/collections/aeron_int64_to_ptr_hash_map.h
+++ b/aeron-client/src/main/c/collections/aeron_int64_to_ptr_hash_map.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef AERON_INT32_TO_PTR_HASH_MAP_H
-#define AERON_INT32_TO_PTR_HASH_MAP_H
+#ifndef AERON_INT64_TO_PTR_HASH_MAP_H
+#define AERON_INT64_TO_PTR_HASH_MAP_H
 
 #include <errno.h>
 

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -473,7 +473,7 @@ int aeron_data_packet_dispatcher_on_setup(
     {
         if ((size_t)dispatcher->stream_session_limit <= stream_interest->image_by_session_id_map.size)
         {
-            AERON_SET_ERR(EINVAL, "exceeded session limit, streamId=" PRId32, header->stream_id);
+            AERON_SET_ERR(EINVAL, "exceeded session limit, stream-id=%" PRId32, header->stream_id);
             return -1;
         }
 

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -471,14 +471,13 @@ int aeron_data_packet_dispatcher_on_setup(
 
     if (NULL != stream_interest)
     {
-        const int32_t session_id = header->session_id;
-
         if ((size_t)dispatcher->stream_session_limit <= stream_interest->image_by_session_id_map.size)
         {
             AERON_SET_ERR(EINVAL, "exceeded session limit, streamId=" PRId32, header->stream_id);
             return -1;
         }
 
+        const int32_t session_id = header->session_id;
         aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
             &stream_interest->image_by_session_id_map, session_id);
 

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -48,7 +48,7 @@ static int aeron_data_packet_dispatcher_stream_interest_init(
     bool is_all_sessions)
 {
     stream_interest->is_all_sessions = is_all_sessions;
-    if (aeron_int64_to_tagged_ptr_hash_map_init(
+    if (aeron_int64_to_ptr_hash_map_init(
         &stream_interest->image_by_session_id_map, 16, AERON_MAP_DEFAULT_LOAD_FACTOR) < 0)
     {
         AERON_APPEND_ERR("%s", "Unable to init image_by_session_id_map");
@@ -62,13 +62,21 @@ static int aeron_data_packet_dispatcher_stream_interest_init(
         return -1;
     }
 
+    if (aeron_int64_counter_map_init(
+        &stream_interest->state_by_session_id_map, -1, 16, AERON_MAP_DEFAULT_LOAD_FACTOR) < 0)
+    {
+        AERON_APPEND_ERR("%s", "Unable to init image_by_session_id_map");
+        return -1;
+    }
+
     return 0;
 }
 
 static int aeron_data_packet_dispatcher_stream_interest_close(
     aeron_data_packet_dispatcher_stream_interest_t *stream_interest)
 {
-    aeron_int64_to_tagged_ptr_hash_map_delete(&stream_interest->image_by_session_id_map);
+    aeron_int64_to_ptr_hash_map_delete(&stream_interest->image_by_session_id_map);
+    aeron_int64_counter_map_delete(&stream_interest->state_by_session_id_map);
     aeron_int64_to_ptr_hash_map_delete(&stream_interest->subscribed_sessions);
     return 0;
 }
@@ -109,20 +117,17 @@ int aeron_data_packet_dispatcher_mark_image_pending_setup(
     int32_t session_id,
     bool *should_elicit_setup)
 {
-    aeron_publication_image_t *image = NULL;
-    uint32_t tag = 0;
     *should_elicit_setup = false;
 
-    bool found = aeron_int64_to_tagged_ptr_hash_map_get(
-        &stream_interest->image_by_session_id_map, session_id, &tag, (void **)&image);
+    int64_t state = aeron_int64_counter_map_get(&stream_interest->state_by_session_id_map, session_id);
 
-    if (!found || AERON_DATA_PACKET_DISPATCHER_IMAGE_ACTIVE == tag)
+    if (AERON_DATA_PACKET_DISPATCHER_IMAGE_ACTIVE == state || stream_interest->state_by_session_id_map.initial_value == state)
     {
-        if (aeron_int64_to_tagged_ptr_hash_map_put(
-            &stream_interest->image_by_session_id_map,
+        if (aeron_int64_counter_map_put(
+            &stream_interest->state_by_session_id_map,
             session_id,
             AERON_DATA_PACKET_DISPATCHER_IMAGE_PENDING_SETUP_FRAME,
-            image) < 0)
+            NULL) < 0)
         {
             AERON_APPEND_ERR(
                 "Unable to set IMAGE_PENDING_SETUP_FRAME for session_id (%" PRId32 ") in image_by_session_id_map",
@@ -136,9 +141,23 @@ int aeron_data_packet_dispatcher_mark_image_pending_setup(
     return 0;
 }
 
-bool aeron_data_packet_dispatcher_match_tombstone(void *clientd, int64_t key, uint32_t tag, void *value)
+bool aeron_data_packet_dispatcher_match_tombstone(void *clientd, int64_t key, int64_t value)
 {
-    return AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST == tag;
+    return (int64_t)AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST == value;
+}
+
+bool aeron_data_packet_dispatcher_match_image_with_no_subscription(void *clientd, int64_t key, void *value)
+{
+    aeron_data_packet_dispatcher_stream_interest_t *stream_interest = clientd;
+
+    return NULL == aeron_int64_to_ptr_hash_map_get(&stream_interest->subscribed_sessions, key);
+}
+
+bool aeron_data_packet_dispatcher_match_state_with_no_subscription(void *clientd, int64_t key, int64_t value)
+{
+    aeron_data_packet_dispatcher_stream_interest_t *stream_interest = clientd;
+
+    return NULL == aeron_int64_to_ptr_hash_map_get(&stream_interest->subscribed_sessions, key);
 }
 
 bool aeron_data_packet_dispatcher_match_no_subscription(void *clientd, int64_t key, uint32_t tag, void *value)
@@ -166,8 +185,8 @@ int aeron_data_packet_dispatcher_add_subscription(aeron_data_packet_dispatcher_t
     {
         stream_interest->is_all_sessions = true;
 
-        aeron_int64_to_tagged_ptr_hash_map_remove_if(
-            &stream_interest->image_by_session_id_map, aeron_data_packet_dispatcher_match_tombstone, NULL);
+        aeron_int64_counter_map_remove_if(
+            &stream_interest->state_by_session_id_map, aeron_data_packet_dispatcher_match_tombstone, NULL);
     }
 
     return 0;
@@ -203,11 +222,10 @@ int aeron_data_packet_dispatcher_add_subscription_by_session(
         return -1;
     }
 
-    uint32_t tag = 0;
-    if (aeron_int64_to_tagged_ptr_hash_map_get(&stream_interest->image_by_session_id_map, session_id, &tag, NULL) &&
-        AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST == tag)
+    if ((int64_t)AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST == aeron_int64_counter_map_get(
+        &stream_interest->state_by_session_id_map, session_id))
     {
-        aeron_int64_to_tagged_ptr_hash_map_remove(&stream_interest->image_by_session_id_map, session_id, NULL, NULL);
+        aeron_int64_counter_map_remove(&stream_interest->state_by_session_id_map, session_id);
     }
 
     return 0;
@@ -223,12 +241,19 @@ int aeron_data_packet_dispatcher_remove_subscription(aeron_data_packet_dispatche
         return -1;
     }
 
-    aeron_int64_to_tagged_ptr_hash_map_remove_if(
-        &stream_interest->image_by_session_id_map, aeron_data_packet_dispatcher_match_no_subscription, stream_interest);
+    aeron_int64_to_ptr_hash_map_remove_if(
+        &stream_interest->image_by_session_id_map,
+        aeron_data_packet_dispatcher_match_image_with_no_subscription,
+        stream_interest);
+
+    aeron_int64_counter_map_remove_if(
+        &stream_interest->state_by_session_id_map,
+        aeron_data_packet_dispatcher_match_state_with_no_subscription,
+        stream_interest);
 
     stream_interest->is_all_sessions = false;
 
-    if (0 == stream_interest->image_by_session_id_map.size)
+    if (0 == stream_interest->image_by_session_id_map.size && 0 == stream_interest->state_by_session_id_map.size)
     {
         aeron_int64_to_ptr_hash_map_remove(&dispatcher->session_by_stream_id_map, stream_id);
         aeron_data_packet_dispatcher_stream_interest_delete(stream_interest);
@@ -250,7 +275,8 @@ int aeron_data_packet_dispatcher_remove_subscription_by_session(
 
     if (!stream_interest->is_all_sessions)
     {
-        aeron_int64_to_tagged_ptr_hash_map_remove(&stream_interest->image_by_session_id_map, session_id, NULL, NULL);
+        aeron_int64_to_ptr_hash_map_remove(&stream_interest->image_by_session_id_map, session_id);
+        aeron_int64_counter_map_remove(&stream_interest->state_by_session_id_map, session_id);
     }
 
     aeron_int64_to_ptr_hash_map_remove(&stream_interest->subscribed_sessions, session_id);
@@ -272,8 +298,8 @@ int aeron_data_packet_dispatcher_add_publication_image(
 
     if (NULL != stream_interest)
     {
-        if (aeron_int64_to_tagged_ptr_hash_map_put(
-            &stream_interest->image_by_session_id_map, image->session_id, AERON_DATA_PACKET_DISPATCHER_IMAGE_ACTIVE, image) < 0)
+        aeron_int64_counter_map_remove(&stream_interest->state_by_session_id_map, image->session_id);
+        if (aeron_int64_to_ptr_hash_map_put(&stream_interest->image_by_session_id_map, image->session_id, image) < 0)
         {
             AERON_APPEND_ERR("%s", "Failed to add image to image_by_session_id_map");
             return -1;
@@ -291,15 +317,17 @@ int aeron_data_packet_dispatcher_remove_publication_image(
 
     if (NULL != stream_interest)
     {
-        aeron_publication_image_t *mapped_image = NULL;
-        aeron_int64_to_tagged_ptr_hash_map_get(
-            &stream_interest->image_by_session_id_map, image->session_id, NULL, (void **)&mapped_image);
+        aeron_publication_image_t *mapped_image = aeron_int64_to_ptr_hash_map_get(
+            &stream_interest->image_by_session_id_map, image->session_id);
 
         if (NULL != mapped_image &&
             image->conductor_fields.managed_resource.registration_id == mapped_image->conductor_fields.managed_resource.registration_id)
         {
-            if (aeron_int64_to_tagged_ptr_hash_map_put(
-                &stream_interest->image_by_session_id_map, image->session_id, AERON_DATA_PACKET_DISPATCHER_IMAGE_COOL_DOWN, NULL) < 0)
+            aeron_int64_to_ptr_hash_map_remove(&stream_interest->image_by_session_id_map, image->session_id);
+
+            // TODO: Java driver checks end of stream at this point.
+            if (aeron_int64_counter_map_put(
+                &stream_interest->state_by_session_id_map, image->session_id, AERON_DATA_PACKET_DISPATCHER_IMAGE_COOL_DOWN, NULL) < 0)
             {
                 AERON_APPEND_ERR(
                     "Unable to set IMAGE_COOL_DOWN for session_id (%" PRId32 ") in image_by_session_id_map",
@@ -323,33 +351,19 @@ bool aeron_data_packet_dispatcher_has_interest_in(
         return false;
     }
 
-    aeron_publication_image_t *image = NULL;
-    const bool found = aeron_int64_to_tagged_ptr_hash_map_get(
-        &stream_interest->image_by_session_id_map, session_id, NULL, (void **)&image);
+    aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
+        &stream_interest->image_by_session_id_map, session_id);
 
-    if (NULL != image)
-    {
-        return true;
-    }
-    else if (!found)
-    {
-        if (aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, session_id))
-        {
-            return true;
-        }
-    }
-
-    return false;
+    return NULL != image ? true : aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, session_id);
 }
 
 static void aeron_data_packet_dispatcher_mark_as_no_interest_to_prevent_repeated_hash_lookups(
-    aeron_int64_to_tagged_ptr_hash_map_t *image_by_session_id_map, int32_t session_id)
+    aeron_int64_counter_map_t *mage, int32_t session_id)
 {
     // This is here as an optimisation so that streams that we don't care about don't trigger the slow
     // path and require checking for interest. As it is an optimisation, we are ignoring the possible
     // put failure from the hash map (occurs if a rehash fails to allocation memory).
-    aeron_int64_to_tagged_ptr_hash_map_put(
-        image_by_session_id_map, session_id, AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST, NULL);
+    aeron_int64_counter_map_put(mage, session_id, AERON_DATA_PACKET_DISPATCHER_IMAGE_NO_INTEREST, NULL);
 }
 
 int aeron_data_packet_dispatcher_on_data(
@@ -366,21 +380,22 @@ int aeron_data_packet_dispatcher_on_data(
 
     if (NULL != stream_interest)
     {
-        aeron_publication_image_t *image = NULL;
-        const bool found = aeron_int64_to_tagged_ptr_hash_map_get(
-            &stream_interest->image_by_session_id_map, header->session_id, NULL, (void **)&image);
+        const int32_t session_id = header->session_id;
+        aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
+            &stream_interest->image_by_session_id_map, session_id);
 
         if (NULL != image)
         {
             return aeron_publication_image_insert_packet(
                 image, destination, header->term_id, header->term_offset, buffer, length, addr);
         }
-        else if (!found && (header->frame_header.flags & AERON_DATA_HEADER_EOS_FLAG) == 0)
+        else if (0 == (header->frame_header.flags & AERON_DATA_HEADER_EOS_FLAG) &&
+            stream_interest->state_by_session_id_map.initial_value == aeron_int64_counter_map_get(&stream_interest->state_by_session_id_map, session_id))
         {
-            if (aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, header->session_id))
+            if (aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, session_id))
             {
                 if (aeron_data_packet_dispatcher_elicit_setup_from_source(
-                    dispatcher, stream_interest, endpoint, destination, addr, header->stream_id, header->session_id) < 0)
+                    dispatcher, stream_interest, endpoint, destination, addr, header->stream_id, session_id) < 0)
                 {
                     AERON_APPEND_ERR("%s", "");
                     return -1;
@@ -391,7 +406,7 @@ int aeron_data_packet_dispatcher_on_data(
             else
             {
                 aeron_data_packet_dispatcher_mark_as_no_interest_to_prevent_repeated_hash_lookups(
-                    &stream_interest->image_by_session_id_map, header->session_id);
+                    &stream_interest->state_by_session_id_map, session_id);
             }
         }
     }
@@ -407,8 +422,8 @@ int aeron_data_packet_dispatcher_create_publication(
     struct sockaddr_storage *addr,
     aeron_data_packet_dispatcher_stream_interest_t *stream_interest)
 {
-    if (aeron_int64_to_tagged_ptr_hash_map_put(
-        &stream_interest->image_by_session_id_map,
+    if (aeron_int64_counter_map_put(
+        &stream_interest->state_by_session_id_map,
         header->session_id,
         AERON_DATA_PACKET_DISPATCHER_IMAGE_INIT_IN_PROGRESS,
         NULL) < 0)
@@ -454,14 +469,18 @@ int aeron_data_packet_dispatcher_on_setup(
 
     if (NULL != stream_interest)
     {
-        uint32_t tag = 0;
-        aeron_publication_image_t *image = NULL;
-        bool found = aeron_int64_to_tagged_ptr_hash_map_get(
-            &stream_interest->image_by_session_id_map, header->session_id, &tag, (void **)&image);
+        const int32_t session_id = header->session_id;
+        aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
+            &stream_interest->image_by_session_id_map, session_id);
 
-        if (found)
+        if (NULL != image)
         {
-            if (NULL == image && AERON_DATA_PACKET_DISPATCHER_IMAGE_PENDING_SETUP_FRAME == tag)
+            aeron_publication_image_add_connection_if_unknown(image, destination, addr);
+        }
+        else
+        {
+            int64_t state = aeron_int64_counter_map_get(&stream_interest->state_by_session_id_map, session_id);
+            if (AERON_DATA_PACKET_DISPATCHER_IMAGE_PENDING_SETUP_FRAME == state)
             {
                 if (destination->conductor_fields.udp_channel->is_multicast &&
                     destination->conductor_fields.udp_channel->multicast_ttl < header->ttl)
@@ -475,25 +494,21 @@ int aeron_data_packet_dispatcher_on_setup(
                     return -1;
                 }
             }
-            else if (NULL != image)
+            else if(stream_interest->state_by_session_id_map.initial_value == state)
             {
-                aeron_publication_image_add_connection_if_unknown(image, destination, addr);
-            }
-        }
-        else
-        {
-            if (aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, header->session_id))
-            {
-                if (aeron_data_packet_dispatcher_create_publication(
-                    dispatcher, endpoint, destination, header, addr, stream_interest) < 0)
+                if (aeron_data_packet_dispatcher_stream_interest_for_session(stream_interest, session_id))
                 {
-                    return -1;
+                    if (aeron_data_packet_dispatcher_create_publication(
+                        dispatcher, endpoint, destination, header, addr, stream_interest) < 0)
+                    {
+                        return -1;
+                    }
                 }
-            }
-            else
-            {
-                aeron_data_packet_dispatcher_mark_as_no_interest_to_prevent_repeated_hash_lookups(
-                    &stream_interest->image_by_session_id_map, header->session_id);
+                else
+                {
+                    aeron_data_packet_dispatcher_mark_as_no_interest_to_prevent_repeated_hash_lookups(
+                        &stream_interest->state_by_session_id_map, session_id);
+                }
             }
         }
     }
@@ -515,8 +530,8 @@ int aeron_data_packet_dispatcher_on_rttm(
 
     if (NULL != stream_interest)
     {
-        aeron_publication_image_t *image = NULL;
-        aeron_int64_to_tagged_ptr_hash_map_get(&stream_interest->image_by_session_id_map, header->session_id, NULL, (void **)&image);
+        aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
+            &stream_interest->image_by_session_id_map, header->session_id);
 
         if (NULL != image)
         {
@@ -629,24 +644,11 @@ void aeron_data_packet_dispatcher_remove_pending_setup(
 
     if (NULL != stream_interest)
     {
-        uint32_t tag = 0;
-        aeron_publication_image_t *image = NULL;
-        aeron_int64_to_tagged_ptr_hash_map_get(
-            &stream_interest->image_by_session_id_map, session_id, &tag, (void **)&image);
+        int64_t state = aeron_int64_counter_map_get(&stream_interest->state_by_session_id_map, session_id);
 
-        if (AERON_DATA_PACKET_DISPATCHER_IMAGE_PENDING_SETUP_FRAME == tag)
+        if (AERON_DATA_PACKET_DISPATCHER_IMAGE_PENDING_SETUP_FRAME == state)
         {
-            if (NULL == image)
-            {
-                aeron_int64_to_tagged_ptr_hash_map_remove(
-                    &stream_interest->image_by_session_id_map, session_id, NULL, NULL);
-            }
-            else
-            {
-                aeron_int64_to_tagged_ptr_hash_map_put(
-                    &stream_interest->image_by_session_id_map, session_id,
-                    AERON_DATA_PACKET_DISPATCHER_IMAGE_ACTIVE, image);
-            }
+            aeron_int64_counter_map_remove(&stream_interest->state_by_session_id_map, session_id);
         }
     }
 }

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.c
@@ -40,6 +40,8 @@ int aeron_data_packet_dispatcher_init(
 
     dispatcher->conductor_proxy = conductor_proxy;
     dispatcher->receiver = receiver;
+    dispatcher->stream_session_limit = receiver->context->stream_session_limit;
+
     return 0;
 }
 
@@ -470,6 +472,13 @@ int aeron_data_packet_dispatcher_on_setup(
     if (NULL != stream_interest)
     {
         const int32_t session_id = header->session_id;
+
+        if ((size_t)dispatcher->stream_session_limit <= stream_interest->image_by_session_id_map.size)
+        {
+            AERON_SET_ERR(EINVAL, "exceeded session limit, streamId=" PRId32, header->stream_id);
+            return -1;
+        }
+
         aeron_publication_image_t *image = aeron_int64_to_ptr_hash_map_get(
             &stream_interest->image_by_session_id_map, session_id);
 

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.h
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.h
@@ -48,6 +48,7 @@ typedef struct aeron_data_packet_dispatcher_stct
 
     aeron_driver_conductor_proxy_t *conductor_proxy;
     aeron_driver_receiver_t *receiver;
+    int32_t stream_session_limit;
 }
 aeron_data_packet_dispatcher_t;
 

--- a/aeron-driver/src/main/c/aeron_data_packet_dispatcher.h
+++ b/aeron-driver/src/main/c/aeron_data_packet_dispatcher.h
@@ -60,8 +60,9 @@ int aeron_data_packet_dispatcher_close(aeron_data_packet_dispatcher_t *dispatche
 typedef struct aeron_data_packet_dispatcher_stream_interest_stct
 {
     bool is_all_sessions;
-    aeron_int64_to_tagged_ptr_hash_map_t image_by_session_id_map;
     aeron_int64_to_ptr_hash_map_t subscribed_sessions;
+    aeron_int64_to_ptr_hash_map_t image_by_session_id_map;
+    aeron_int64_counter_map_t state_by_session_id_map;
 }
 aeron_data_packet_dispatcher_stream_interest_t;
 
@@ -138,12 +139,19 @@ inline void aeron_data_packet_dispatcher_remove_matching_state(
 
     if (NULL != stream_interest)
     {
-        uint32_t tag = 0;
-        aeron_int64_to_tagged_ptr_hash_map_get(&stream_interest->image_by_session_id_map, session_id, &tag, NULL);
-        if (image_state == tag)
+        if (AERON_DATA_PACKET_DISPATCHER_IMAGE_ACTIVE == image_state)
         {
-            aeron_int64_to_tagged_ptr_hash_map_remove(
-                &stream_interest->image_by_session_id_map, session_id, NULL, NULL);
+            aeron_int64_to_ptr_hash_map_remove(&stream_interest->image_by_session_id_map, session_id);
+        }
+        else
+        {
+            int64_t state = aeron_int64_counter_map_get(&stream_interest->state_by_session_id_map, session_id);
+
+            // If not found state will be -1 so won't match.
+            if ((int64_t)image_state == state)
+            {
+                aeron_int64_counter_map_remove(&stream_interest->state_by_session_id_map, session_id);
+            }
         }
     }
 }

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -673,6 +673,8 @@ void aeron_driver_context_print_configuration(aeron_driver_context_t *context)
         context->sender_wildcard_port_manager.low_port, context->sender_wildcard_port_manager.high_port);
     fprintf(fpout, "\n    receiver_wildcard_port_range=\"%" PRIu16 " %" PRIu16 "\"",
         context->receiver_wildcard_port_manager.low_port, context->receiver_wildcard_port_manager.high_port);
+    fprintf(fpout, "\n    enable_experimental_features=%s", context->enable_experimental_features ? "true" : "false");
+    fprintf(fpout, "\n    stream_session_limit=%" PRId32, context->stream_session_limit);
 
     const aeron_udp_channel_transport_bindings_t *bindings = context->udp_channel_transport_bindings;
     if (NULL != bindings)

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -341,6 +341,8 @@ static void aeron_driver_untethered_subscription_state_change_null(
 #define AERON_CPU_AFFINITY_DEFAULT (-1)
 #define AERON_DRIVER_CONNECT_DEFAULT true
 #define AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT false
+#define AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT (INT32_MAX)
+
 
 int aeron_driver_context_init(aeron_driver_context_t **context)
 {
@@ -567,6 +569,7 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
     _context->sender_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->receiver_cpu_affinity_no = AERON_CPU_AFFINITY_DEFAULT;
     _context->enable_experimental_features = AERON_ENABLE_EXPERIMENTAL_FEATURES_DEFAULT;
+    _context->stream_session_limit = AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT;
 
     char *value = NULL;
 
@@ -1079,6 +1082,13 @@ int aeron_driver_context_init(aeron_driver_context_t **context)
 
     _context->enable_experimental_features = aeron_parse_bool(
         getenv(AERON_ENABLE_EXPERIMENTAL_FEATURES_ENV_VAR), _context->enable_experimental_features);
+
+    _context->stream_session_limit = aeron_config_parse_int32(
+        AERON_DRIVER_STREAM_SESSION_LIMIT_ENV_VAR,
+        getenv(AERON_DRIVER_STREAM_SESSION_LIMIT_ENV_VAR),
+        _context->stream_session_limit,
+        1,
+        INT32_MAX);
 
     _context->to_driver_buffer = NULL;
     _context->to_clients_buffer = NULL;
@@ -3023,7 +3033,7 @@ int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t
     return NULL != context ? context->enable_experimental_features : false;
 }
 
-int aeron_driver_set_stream_session_limit(aeron_driver_context_t *context, int32_t value)
+int aeron_driver_context_set_stream_session_limit(aeron_driver_context_t *context, int32_t value)
 {
     AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
 

--- a/aeron-driver/src/main/c/aeron_driver_context.c
+++ b/aeron-driver/src/main/c/aeron_driver_context.c
@@ -3023,6 +3023,20 @@ int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t
     return NULL != context ? context->enable_experimental_features : false;
 }
 
+int aeron_driver_set_stream_session_limit(aeron_driver_context_t *context, int32_t value)
+{
+    AERON_DRIVER_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
+
+    context->stream_session_limit = value;
+    return 0;
+}
+
+int32_t aeron_driver_context_get_stream_session_limit(aeron_driver_context_t *context)
+{
+    return NULL != context ? context->stream_session_limit : AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT;
+}
+
+
 int aeron_driver_context_bindings_clientd_find_first_free_index(aeron_driver_context_t *context)
 {
     for (size_t i = 0; i < context->num_bindings_clientd_entries; i++)

--- a/aeron-driver/src/main/c/aeron_driver_context.h
+++ b/aeron-driver/src/main/c/aeron_driver_context.h
@@ -182,6 +182,7 @@ typedef struct aeron_driver_context_stct
     int32_t conductor_cpu_affinity_no;                      /* aeron.conductor.cpu.affinity = -1 */
     int32_t receiver_cpu_affinity_no;                       /* aeron.receiver.cpu.affinity = -1 */
     int32_t sender_cpu_affinity_no;                         /* aeron.sender.cpu.affinity = -1 */
+    int32_t stream_session_limit;                           /* aeron.driver.stream.session.limit = INT32_MAX */
     bool enable_experimental_features;                      /* aeron.enable.experimental.features = false */
 
     struct                                                  /* aeron.receiver.receiver.tag = <unset> */

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -905,6 +905,17 @@ int aeron_driver_context_set_enable_experimental_features(aeron_driver_context_t
 int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t *context);
 
 /**
+ * Limit the number of sessions for a given stream that the driver will support
+ */
+#define AERON_DRIVER_STREAM_SESSION_LIMIT_ENV_VAR "AERON_DRIVER_STREAM_SESSION_LIMIT"
+
+#define AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT (INT32_MAX)
+
+int aeron_driver_set_stream_session_limit(aeron_driver_context_t *context, int32_t value);
+int32_t aeron_driver_context_get_stream_session_limit(aeron_driver_context_t *context);
+
+
+/**
  * Return full version and build string.
  *
  * @return full version and build string.

--- a/aeron-driver/src/main/c/aeronmd.h
+++ b/aeron-driver/src/main/c/aeronmd.h
@@ -909,9 +909,7 @@ int aeron_driver_context_get_enable_experimental_features(aeron_driver_context_t
  */
 #define AERON_DRIVER_STREAM_SESSION_LIMIT_ENV_VAR "AERON_DRIVER_STREAM_SESSION_LIMIT"
 
-#define AERON_DRIVER_STREAM_SESSION_LIMIT_DEFAULT (INT32_MAX)
-
-int aeron_driver_set_stream_session_limit(aeron_driver_context_t *context, int32_t value);
+int aeron_driver_context_set_stream_session_limit(aeron_driver_context_t *context, int32_t value);
 int32_t aeron_driver_context_get_stream_session_limit(aeron_driver_context_t *context);
 
 

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -25,6 +25,7 @@ import io.aeron.exceptions.ConfigurationException;
 import io.aeron.logbuffer.BufferClaim;
 import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
+import org.agrona.AsciiNumberFormatException;
 import org.agrona.BitUtil;
 import org.agrona.LangUtil;
 import org.agrona.Strings;
@@ -1868,13 +1869,23 @@ public final class Configuration
     /**
      * Get the configured limit for the number of streams per session.
      *
-     * @return configured session limit.
+     * @return configured session limit
+     * @throws AsciiNumberFormatException if the property referenced by {@link #STREAM_SESSION_LIMIT_PROP_NAME} is not
+     * a valid number
      */
     public static int streamSessionLimit()
     {
         final String streamSessionLimitString = getProperty(STREAM_SESSION_LIMIT_PROP_NAME);
-        return Strings.isEmpty(streamSessionLimitString) ?
-            STREAM_SESSION_LIMIT_DEFAULT : Integer.parseInt(streamSessionLimitString);
+        try
+        {
+            return Strings.isEmpty(streamSessionLimitString) ?
+                STREAM_SESSION_LIMIT_DEFAULT : Integer.parseInt(streamSessionLimitString);
+        }
+        catch (final NumberFormatException ex)
+        {
+            throw new AsciiNumberFormatException(
+                "Property " + STREAM_SESSION_LIMIT_PROP_NAME + "=" + streamSessionLimitString + " is not a number");
+        }
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -27,6 +27,7 @@ import io.aeron.logbuffer.FrameDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
 import org.agrona.BitUtil;
 import org.agrona.LangUtil;
+import org.agrona.Strings;
 import org.agrona.collections.ArrayUtil;
 import org.agrona.concurrent.*;
 import org.agrona.concurrent.broadcast.BroadcastBufferDescriptor;
@@ -786,6 +787,10 @@ public final class Configuration
      * @since 1.44.0
      */
     public static final String ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME = "aeron.driver.async.executor.threads";
+
+    public static final String STREAM_SESSION_LIMIT_PROP_NAME = "aeron.driver.session.stream.limit";
+
+    public static final int STREAM_SESSION_LIMIT_DEFAULT = Integer.MAX_VALUE;
 
     /**
      * {@link Executor} that run tasks on the caller thread.
@@ -1858,6 +1863,18 @@ public final class Configuration
         }
 
         return supplier;
+    }
+
+    /**
+     * Get the configured limit for the number of streams per session.
+     *
+     * @return configured session limit.
+     */
+    public static int streamSessionLimit()
+    {
+        final String streamSessionLimitString = getProperty(STREAM_SESSION_LIMIT_PROP_NAME);
+        return Strings.isEmpty(streamSessionLimitString) ?
+            STREAM_SESSION_LIMIT_DEFAULT : Integer.parseInt(streamSessionLimitString);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/Configuration.java
@@ -788,7 +788,7 @@ public final class Configuration
      */
     public static final String ASYNC_TASK_EXECUTOR_THREADS_PROP_NAME = "aeron.driver.async.executor.threads";
 
-    public static final String STREAM_SESSION_LIMIT_PROP_NAME = "aeron.driver.session.stream.limit";
+    public static final String STREAM_SESSION_LIMIT_PROP_NAME = "aeron.driver.stream.session.limit";
 
     public static final int STREAM_SESSION_LIMIT_DEFAULT = Integer.MAX_VALUE;
 

--- a/aeron-driver/src/main/java/io/aeron/driver/DataPacketDispatcher.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DataPacketDispatcher.java
@@ -44,26 +44,53 @@ public final class DataPacketDispatcher
         NO_INTEREST
     }
 
-    static class SessionInterest
-    {
-        SessionState state;
-        PublicationImage image;
-
-        SessionInterest(final SessionState state)
-        {
-            this.state = state;
-        }
-    }
-
     static class StreamInterest
     {
         boolean isAllSessions;
-        final Int2ObjectHashMap<SessionInterest> sessionInterestByIdMap = new Int2ObjectHashMap<>();
+        final Int2ObjectHashMap<SessionState> sessionInterestByIdMap = new Int2ObjectHashMap<>();
+        final Int2ObjectHashMap<PublicationImage> activeImageByIdMap = new Int2ObjectHashMap<>();
         final IntHashSet subscribedSessionIds = new IntHashSet();
 
         StreamInterest(final boolean isAllSessions)
         {
             this.isAllSessions = isAllSessions;
+        }
+
+        PublicationImage findActive(final int sessionId)
+        {
+            return activeImageByIdMap.get(sessionId);
+        }
+
+        void removeNonSessionSpecificInterest()
+        {
+            final Int2ObjectHashMap<PublicationImage>.EntryIterator activeIterator =
+                activeImageByIdMap.entrySet().iterator();
+
+            while (activeIterator.hasNext())
+            {
+                activeIterator.next();
+
+                final int sessionId = activeIterator.getIntKey();
+                if (!subscribedSessionIds.contains(sessionId))
+                {
+                    activeIterator.getValue().deactivate();
+                    activeIterator.remove();
+                }
+            }
+
+            final Int2ObjectHashMap<SessionState>.EntryIterator iterator =
+                sessionInterestByIdMap.entrySet().iterator();
+
+            while (iterator.hasNext())
+            {
+                iterator.next();
+
+                final int sessionId = iterator.getIntKey();
+                if (!subscribedSessionIds.contains(sessionId))
+                {
+                    iterator.remove();
+                }
+            }
         }
     }
 
@@ -94,13 +121,12 @@ public final class DataPacketDispatcher
         {
             streamInterest.isAllSessions = true;
 
-            final Int2ObjectHashMap<SessionInterest>.ValueIterator iterator =
+            final Int2ObjectHashMap<SessionState>.ValueIterator iterator =
                 streamInterest.sessionInterestByIdMap.values().iterator();
 
             while (iterator.hasNext())
             {
-                final SessionInterest sessionInterest = iterator.next();
-                if (NO_INTEREST == sessionInterest.state)
+                if (NO_INTEREST == iterator.next())
                 {
                     iterator.remove();
                 }
@@ -125,8 +151,8 @@ public final class DataPacketDispatcher
 
         streamInterest.subscribedSessionIds.add(sessionId);
 
-        final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
-        if (null != sessionInterest && NO_INTEREST == sessionInterest.state)
+        final SessionState sessionState = streamInterest.sessionInterestByIdMap.get(sessionId);
+        if (NO_INTEREST == sessionState)
         {
             streamInterest.sessionInterestByIdMap.remove(sessionId);
         }
@@ -145,25 +171,7 @@ public final class DataPacketDispatcher
             throw new UnknownSubscriptionException("no subscription for stream " + streamId);
         }
 
-        final Int2ObjectHashMap<SessionInterest>.EntryIterator iterator =
-            streamInterest.sessionInterestByIdMap.entrySet().iterator();
-
-        while (iterator.hasNext())
-        {
-            iterator.next();
-
-            final int sessionId = iterator.getIntKey();
-            if (!streamInterest.subscribedSessionIds.contains(sessionId))
-            {
-                final SessionInterest sessionInterest = iterator.getValue();
-                if (null != sessionInterest.image)
-                {
-                    sessionInterest.image.deactivate();
-                }
-
-                iterator.remove();
-            }
-        }
+        streamInterest.removeNonSessionSpecificInterest();
 
         streamInterest.isAllSessions = false;
 
@@ -189,11 +197,12 @@ public final class DataPacketDispatcher
 
         if (!streamInterest.isAllSessions)
         {
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.remove(sessionId);
-            if (null != sessionInterest && null != sessionInterest.image)
+            final PublicationImage publicationImage = streamInterest.activeImageByIdMap.remove(sessionId);
+            if (null != publicationImage)
             {
-                sessionInterest.image.deactivate();
+                publicationImage.deactivate();
             }
+            streamInterest.sessionInterestByIdMap.remove(sessionId);
         }
 
         streamInterest.subscribedSessionIds.remove(sessionId);
@@ -212,19 +221,8 @@ public final class DataPacketDispatcher
     public void addPublicationImage(final PublicationImage image)
     {
         final StreamInterest streamInterest = streamInterestByIdMap.get(image.streamId());
-        SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(image.sessionId());
-
-        if (null == sessionInterest)
-        {
-            sessionInterest = new SessionInterest(ACTIVE);
-            streamInterest.sessionInterestByIdMap.put(image.sessionId(), sessionInterest);
-        }
-        else
-        {
-            sessionInterest.state = ACTIVE;
-        }
-
-        sessionInterest.image = image;
+        streamInterest.sessionInterestByIdMap.remove(image.sessionId());
+        streamInterest.activeImageByIdMap.put(image.sessionId(), image);
         image.activate();
     }
 
@@ -238,20 +236,14 @@ public final class DataPacketDispatcher
         final StreamInterest streamInterest = streamInterestByIdMap.get(image.streamId());
         if (null != streamInterest)
         {
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(image.sessionId());
-            if (null != sessionInterest && null != sessionInterest.image)
+            final PublicationImage activeImage = streamInterest.activeImageByIdMap.get(image.sessionId());
+            if (null != activeImage && activeImage.correlationId() == image.correlationId())
             {
-                if (sessionInterest.image.correlationId() == image.correlationId())
+                streamInterest.activeImageByIdMap.remove(image.sessionId());
+
+                if (!image.isEndOfStream())
                 {
-                    if (image.isEndOfStream)
-                    {
-                        streamInterest.sessionInterestByIdMap.remove(image.sessionId());
-                    }
-                    else
-                    {
-                        sessionInterest.state = ON_COOL_DOWN;
-                        sessionInterest.image = null;
-                    }
+                    streamInterest.sessionInterestByIdMap.put(image.sessionId(), ON_COOL_DOWN);
                 }
             }
         }
@@ -306,26 +298,24 @@ public final class DataPacketDispatcher
         if (null != streamInterest)
         {
             final int sessionId = header.sessionId();
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
 
-            if (null != sessionInterest)
+            final PublicationImage image = streamInterest.findActive(sessionId);
+            if (null != image)
             {
-                if (null != sessionInterest.image)
-                {
-                    return sessionInterest.image.insertPacket(
-                        header.termId(), header.termOffset(), buffer, length, transportIndex, srcAddress);
-                }
+                return image.insertPacket(
+                    header.termId(), header.termOffset(), buffer, length, transportIndex, srcAddress);
             }
-            else if (!DataHeaderFlyweight.isEndOfStream(buffer))
+            else if (!DataHeaderFlyweight.isEndOfStream(buffer) &&
+                !streamInterest.sessionInterestByIdMap.containsKey(sessionId))
             {
                 if (streamInterest.isAllSessions || streamInterest.subscribedSessionIds.contains(sessionId))
                 {
-                    streamInterest.sessionInterestByIdMap.put(sessionId, new SessionInterest(PENDING_SETUP_FRAME));
+                    streamInterest.sessionInterestByIdMap.put(sessionId, PENDING_SETUP_FRAME);
                     elicitSetupMessageFromSource(channelEndpoint, transportIndex, srcAddress, streamId, sessionId);
                 }
                 else
                 {
-                    streamInterest.sessionInterestByIdMap.put(sessionId, new SessionInterest(NO_INTEREST));
+                    streamInterest.sessionInterestByIdMap.put(sessionId, NO_INTEREST);
                 }
             }
         }
@@ -353,13 +343,19 @@ public final class DataPacketDispatcher
         if (null != streamInterest)
         {
             final int sessionId = msg.sessionId();
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
 
-            if (null != sessionInterest)
+            final PublicationImage image = streamInterest.findActive(sessionId);
+            final SessionState sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
+
+            if (null != image)
             {
-                if (null == sessionInterest.image && PENDING_SETUP_FRAME == sessionInterest.state)
+                image.addDestinationConnectionIfUnknown(transportIndex, srcAddress);
+            }
+            else if (null != sessionInterest)
+            {
+                if (PENDING_SETUP_FRAME == sessionInterest)
                 {
-                    sessionInterest.state = INIT_IN_PROGRESS;
+                    streamInterest.sessionInterestByIdMap.put(sessionId, INIT_IN_PROGRESS);
 
                     createPublicationImage(
                         channelEndpoint,
@@ -375,31 +371,30 @@ public final class DataPacketDispatcher
                         msg.ttl(),
                         msg.flags());
                 }
-                else if (null != sessionInterest.image)
-                {
-                    sessionInterest.image.addDestinationConnectionIfUnknown(transportIndex, srcAddress);
-                }
-            }
-            else if (streamInterest.isAllSessions || streamInterest.subscribedSessionIds.contains(sessionId))
-            {
-                streamInterest.sessionInterestByIdMap.put(sessionId, new SessionInterest(INIT_IN_PROGRESS));
-                createPublicationImage(
-                    channelEndpoint,
-                    transportIndex,
-                    srcAddress,
-                    streamId,
-                    sessionId,
-                    msg.initialTermId(),
-                    msg.activeTermId(),
-                    msg.termOffset(),
-                    msg.termLength(),
-                    msg.mtuLength(),
-                    msg.ttl(),
-                    msg.flags());
             }
             else
             {
-                streamInterest.sessionInterestByIdMap.put(sessionId, new SessionInterest(NO_INTEREST));
+                if (streamInterest.isAllSessions || streamInterest.subscribedSessionIds.contains(sessionId))
+                {
+                    streamInterest.sessionInterestByIdMap.put(sessionId, INIT_IN_PROGRESS);
+                    createPublicationImage(
+                        channelEndpoint,
+                        transportIndex,
+                        srcAddress,
+                        streamId,
+                        sessionId,
+                        msg.initialTermId(),
+                        msg.activeTermId(),
+                        msg.termOffset(),
+                        msg.termLength(),
+                        msg.mtuLength(),
+                        msg.ttl(),
+                        msg.flags());
+                }
+                else
+                {
+                    streamInterest.sessionInterestByIdMap.put(sessionId, NO_INTEREST);
+                }
             }
         }
     }
@@ -424,9 +419,9 @@ public final class DataPacketDispatcher
         if (null != streamInterest)
         {
             final int sessionId = msg.sessionId();
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
 
-            if (null != sessionInterest && null != sessionInterest.image)
+            final PublicationImage image = streamInterest.findActive(sessionId);
+            if (null != image)
             {
                 if (RttMeasurementFlyweight.REPLY_FLAG == (msg.flags() & RttMeasurementFlyweight.REPLY_FLAG))
                 {
@@ -438,7 +433,7 @@ public final class DataPacketDispatcher
                 }
                 else
                 {
-                    sessionInterest.image.onRttMeasurement(msg, transportIndex, srcAddress);
+                    image.onRttMeasurement(msg, transportIndex, srcAddress);
                 }
             }
         }
@@ -459,8 +454,8 @@ public final class DataPacketDispatcher
         final StreamInterest streamInterest = streamInterestByIdMap.get(streamId);
         if (null != streamInterest)
         {
-            final SessionInterest sessionInterest = streamInterest.sessionInterestByIdMap.get(sessionId);
-            if (null != sessionInterest && state == sessionInterest.state)
+            final SessionState sessionState = streamInterest.sessionInterestByIdMap.get(sessionId);
+            if (null != sessionState && state == sessionState)
             {
                 streamInterest.sessionInterestByIdMap.remove(sessionId);
             }

--- a/aeron-driver/src/main/java/io/aeron/driver/DataPacketDispatcher.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DataPacketDispatcher.java
@@ -232,9 +232,12 @@ public final class DataPacketDispatcher
     public void addPublicationImage(final PublicationImage image)
     {
         final StreamInterest streamInterest = streamInterestByIdMap.get(image.streamId());
-        streamInterest.sessionInterestByIdMap.remove(image.sessionId());
-        streamInterest.activeImageByIdMap.put(image.sessionId(), image);
-        image.activate();
+        if (null != streamInterest)
+        {
+            streamInterest.sessionInterestByIdMap.remove(image.sessionId());
+            streamInterest.activeImageByIdMap.put(image.sessionId(), image);
+            image.activate();
+        }
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -1996,7 +1996,7 @@ public final class DriverConductor implements Agent
                 channelStatus = ReceiveChannelStatus.allocate(tempBuffer, countersManager, registrationId, channel);
 
                 final DataPacketDispatcher dispatcher = new DataPacketDispatcher(
-                    ctx.driverConductorProxy(), receiverProxy.receiver());
+                    ctx.driverConductorProxy(), receiverProxy.receiver(), ctx.streamSessionLimit());
                 channelEndpoint = ctx.receiveChannelEndpointSupplier().newInstance(
                     udpChannel, dispatcher, channelStatus, ctx);
 

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3525,11 +3525,9 @@ public final class MediaDriver implements AutoCloseable
         }
 
         /**
-         * Set a limit on the number of sessions allow per stream for subscriptions.
-         * <p>
-         * From a specific endpoint, host??
+         * Set the limit on the number of sessions allow per stream for subscriptions.
          *
-         * @param sessionLimit maximum number of sessions
+         * @param sessionLimit the limit of sessions per stream
          * @return this for a fluent API.
          */
         public Context streamSessionLimit(final int sessionLimit)
@@ -3538,6 +3536,11 @@ public final class MediaDriver implements AutoCloseable
             return this;
         }
 
+        /**
+         * Get the limit on the number of sessions allow per stream for subscriptions.
+         *
+         * @return the limit of sessions per stream
+         */
         public int streamSessionLimit()
         {
             return this.streamSessionLimit;

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -561,6 +561,7 @@ public final class MediaDriver implements AutoCloseable
         private DutyCycleTracker nameResolverTimeTracker;
         private PortManager senderPortManager;
         private PortManager receiverPortManager;
+        private int streamSessionLimit = Configuration.streamSessionLimit();
 
         /**
          * Perform a shallow copy of the object.
@@ -3521,6 +3522,25 @@ public final class MediaDriver implements AutoCloseable
         {
             this.receiverPortManager = portManager;
             return this;
+        }
+
+        /**
+         * Set a limit on the number of sessions allow per stream for subscriptions.
+         * <p>
+         * From a specific endpoint, host??
+         *
+         * @param sessionLimit maximum number of sessions
+         * @return this for a fluent API.
+         */
+        public Context streamSessionLimit(final int sessionLimit)
+        {
+            this.streamSessionLimit = sessionLimit;
+            return this;
+        }
+
+        public int streamSessionLimit()
+        {
+            return this.streamSessionLimit;
         }
 
         /**

--- a/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/MediaDriver.java
@@ -3529,6 +3529,9 @@ public final class MediaDriver implements AutoCloseable
          *
          * @param sessionLimit the limit of sessions per stream
          * @return this for a fluent API.
+         * @see Configuration#STREAM_SESSION_LIMIT_PROP_NAME
+         * @see Configuration#STREAM_SESSION_LIMIT_DEFAULT
+         * @see Configuration#streamSessionLimit()
          */
         public Context streamSessionLimit(final int sessionLimit)
         {
@@ -3540,6 +3543,7 @@ public final class MediaDriver implements AutoCloseable
          * Get the limit on the number of sessions allow per stream for subscriptions.
          *
          * @return the limit of sessions per stream
+         * @see Context#streamSessionLimit(int)
          */
         public int streamSessionLimit()
         {

--- a/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/PublicationImage.java
@@ -656,6 +656,11 @@ public final class PublicationImage
             (!isEndOfStream || !isReceiverReleaseTriggered);
     }
 
+    boolean isEndOfStream()
+    {
+        return isEndOfStream;
+    }
+
     /**
      * Check for EOS from publication and switch to {@link State#DRAINING} if at end of stream position.
      *

--- a/aeron-driver/src/test/java/io/aeron/driver/DataPacketDispatcherTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/DataPacketDispatcherTest.java
@@ -18,8 +18,6 @@ package io.aeron.driver;
 import io.aeron.driver.media.ReceiveChannelEndpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import io.aeron.logbuffer.LogBufferDescriptor;
 import io.aeron.protocol.DataHeaderFlyweight;
@@ -43,10 +41,12 @@ class DataPacketDispatcherTest
     private static final int MTU_LENGTH = 1024;
     private static final int TERM_LENGTH = LogBufferDescriptor.TERM_MIN_LENGTH;
     private static final InetSocketAddress SRC_ADDRESS = new InetSocketAddress("localhost", 4510);
+    private static final int STREAM_SESSION_LIMIT = 10;
 
     private final DriverConductorProxy mockConductorProxy = mock(DriverConductorProxy.class);
     private final Receiver mockReceiver = mock(Receiver.class);
-    private final DataPacketDispatcher dispatcher = new DataPacketDispatcher(mockConductorProxy, mockReceiver);
+    private final DataPacketDispatcher dispatcher = new DataPacketDispatcher(
+        mockConductorProxy, mockReceiver, STREAM_SESSION_LIMIT);
     private final DataHeaderFlyweight mockHeader = mock(DataHeaderFlyweight.class);
     private final SetupFlyweight mockSetupHeader = mock(SetupFlyweight.class);
     private final UnsafeBuffer mockBuffer = mock(UnsafeBuffer.class);
@@ -287,5 +287,40 @@ class DataPacketDispatcherTest
         dispatcher.onDataPacket(mockChannelEndpoint, mockHeader, mockBuffer, LENGTH, SRC_ADDRESS, 0);
 
         verify(mockImage).insertPacket(ACTIVE_TERM_ID, TERM_OFFSET, mockBuffer, LENGTH, 0, SRC_ADDRESS);
+    }
+
+    @Test
+    void shouldPreventNewSessionsOnceStreamSessionLimitIsExceeded()
+    {
+        final PublicationImage mockImage = mock(PublicationImage.class);
+
+        when(mockImage.streamId()).thenReturn(STREAM_ID);
+        when(mockImage.correlationId()).thenReturn(CORRELATION_ID_1);
+
+        dispatcher.addSubscription(STREAM_ID);
+
+        int sessionId = SESSION_ID;
+        for (int i = 0; i < STREAM_SESSION_LIMIT; i++)
+        {
+            when(mockImage.sessionId()).thenReturn(sessionId);
+            when(mockSetupHeader.sessionId()).thenReturn(sessionId);
+            sessionId++;
+
+            dispatcher.onSetupMessage(mockChannelEndpoint, mockSetupHeader, SRC_ADDRESS, 0);
+            dispatcher.addPublicationImage(mockImage);
+        }
+        verify(mockConductorProxy, times(10)).createPublicationImage(
+            anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(),
+            anyShort(), any(), any(), any());
+
+        when(mockSetupHeader.sessionId()).thenReturn(sessionId);
+        try
+        {
+            dispatcher.onSetupMessage(mockChannelEndpoint, mockSetupHeader, SRC_ADDRESS, 0);
+        }
+        catch (final Exception ignore)
+        {
+        }
+        verifyNoMoreInteractions(mockConductorProxy);
     }
 }

--- a/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/ReceiverTest.java
@@ -189,7 +189,7 @@ class ReceiverTest
 
         receiveChannelEndpoint = new ReceiveChannelEndpoint(
             UdpChannel.parse(URI),
-            new DataPacketDispatcher(driverConductorProxy, receiver),
+            new DataPacketDispatcher(driverConductorProxy, receiver, ctx.streamSessionLimit()),
             mock(AtomicCounter.class),
             receiverChannelContext);
     }

--- a/aeron-system-tests/src/test/java/io/aeron/StreamSessionLimitsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/StreamSessionLimitsTest.java
@@ -53,6 +53,7 @@ public class StreamSessionLimitsTest
 
         driver = TestMediaDriver.launch(context, watcher);
         watcher.dataCollector().add(driver.context().aeronDirectory());
+        watcher.ignoreErrorsMatching(s -> s.contains("session limit"));
     }
 
     @AfterEach

--- a/aeron-system-tests/src/test/java/io/aeron/StreamSessionLimitsTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/StreamSessionLimitsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron;
+
+import io.aeron.driver.MediaDriver;
+import io.aeron.driver.status.SystemCounterDescriptor;
+import io.aeron.test.InterruptAfter;
+import io.aeron.test.InterruptingTestCallback;
+import io.aeron.test.SlowTest;
+import io.aeron.test.SystemTestWatcher;
+import io.aeron.test.Tests;
+import io.aeron.test.driver.TestMediaDriver;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@ExtendWith(InterruptingTestCallback.class)
+public class StreamSessionLimitsTest
+{
+    private final MediaDriver.Context context = new MediaDriver.Context();
+    private TestMediaDriver driver;
+
+    @RegisterExtension
+    final SystemTestWatcher watcher = new SystemTestWatcher();
+
+    private void launch()
+    {
+        context
+            .dirDeleteOnStart(true)
+            .publicationConnectionTimeoutNs(TimeUnit.MILLISECONDS.toNanos(500))
+            .timerIntervalNs(TimeUnit.MILLISECONDS.toNanos(100));
+
+        driver = TestMediaDriver.launch(context, watcher);
+        watcher.dataCollector().add(driver.context().aeronDirectory());
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        CloseHelper.quietClose(driver);
+    }
+
+    @Test
+    @SlowTest
+    void shouldNotConnectPublicationWhenImageCountWouldExceedLimit()
+    {
+        context.streamSessionLimit(2);
+        launch();
+
+        final String channel = "aeron:udp?endpoint=localhost:10000";
+        final int streamId = 10000;
+
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+            Subscription sub = aeron.addSubscription(channel, streamId);
+            Publication pub1 = aeron.addExclusivePublication(channel, streamId);
+            Publication pub2 = aeron.addExclusivePublication(channel, streamId))
+        {
+            Tests.awaitConnected(sub);
+            Tests.awaitConnected(pub1);
+            Tests.awaitConnected(pub2);
+
+            final Publication shouldNotConnect = aeron.addExclusivePublication(channel, streamId);
+
+            final long initialErrorCount = errorCount(aeron);
+            final long deadlineNs = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (0 < deadlineNs - System.nanoTime())
+            {
+                assertFalse(shouldNotConnect.isConnected(), "should not have connected");
+            }
+            final long updatedErrorCount = errorCount(aeron);
+            assertThat(updatedErrorCount, greaterThan(initialErrorCount));
+        }
+    }
+
+    @Test
+    @SlowTest
+    @InterruptAfter(10)
+    void shouldAllowConnectPublicationAfterImageCountExceedsLimitButPreviousPublicationHasClosed()
+    {
+        context.streamSessionLimit(2);
+        launch();
+
+        final String channel = "aeron:udp?endpoint=localhost:10000";
+        final int streamId = 10000;
+
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+            Subscription sub = aeron.addSubscription(channel, streamId);
+            Publication pub1 = aeron.addExclusivePublication(channel, streamId))
+        {
+            Tests.awaitConnected(sub);
+            Tests.awaitConnected(pub1);
+
+            try (Publication pub2 = aeron.addExclusivePublication(channel, streamId))
+            {
+                Tests.awaitConnected(pub2);
+                final long initialErrorCount = errorCount(aeron);
+
+                final Publication shouldNotConnect = aeron.addExclusivePublication(channel, streamId);
+                while (initialErrorCount == errorCount(aeron))
+                {
+                    assertFalse(shouldNotConnect.isConnected());
+                    Tests.yield();
+                }
+            }
+
+            while (2 <= sub.imageCount())
+            {
+                Tests.yield();
+            }
+
+            final Publication shouldNowConnect = aeron.addExclusivePublication(channel, streamId);
+
+            while (!shouldNowConnect.isConnected())
+            {
+                Tests.yieldingIdle("Never connected");
+            }
+        }
+    }
+
+    @Test
+    @SlowTest
+    void shouldSessionLimitsShouldBeScopedToChannelAndStream()
+    {
+        context.streamSessionLimit(1);
+        launch();
+
+        final String channel1 = "aeron:udp?endpoint=localhost:10000";
+        final int streamId1 = 10000;
+        final String channel2 = "aeron:udp?endpoint=localhost:10001";
+        final int streamId2 = 10001;
+
+        try (Aeron aeron = Aeron.connect(new Aeron.Context().aeronDirectoryName(context.aeronDirectoryName()));
+            Subscription sub1 = aeron.addSubscription(channel1, streamId1);
+            Subscription sub2 = aeron.addSubscription(channel1, streamId2);
+            Subscription sub3 = aeron.addSubscription(channel2, streamId1);
+            Subscription sub4 = aeron.addSubscription(channel2, streamId2);
+            Publication pub1 = aeron.addExclusivePublication(channel1, streamId1);
+            Publication pub2 = aeron.addExclusivePublication(channel2, streamId1);
+            Publication pub3 = aeron.addExclusivePublication(channel1, streamId2);
+            Publication pub4 = aeron.addExclusivePublication(channel2, streamId2))
+        {
+            Tests.awaitConnected(sub1);
+            Tests.awaitConnected(sub2);
+            Tests.awaitConnected(sub3);
+            Tests.awaitConnected(sub4);
+            Tests.awaitConnected(pub1);
+            Tests.awaitConnected(pub2);
+            Tests.awaitConnected(pub3);
+            Tests.awaitConnected(pub4);
+        }
+    }
+
+    private static long errorCount(final Aeron aeron)
+    {
+        return aeron.countersReader().getCounterValue(SystemCounterDescriptor.ERRORS.id());
+    }
+}

--- a/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
+++ b/aeron-test-support/src/main/java/io/aeron/test/driver/CTestMediaDriver.java
@@ -291,6 +291,9 @@ public final class CTestMediaDriver implements TestMediaDriver
         }
 
         environment.put("AERON_ENABLE_EXPERIMENTAL_FEATURES", String.valueOf(context.enableExperimentalFeatures()));
+
+        environment.put("AERON_DRIVER_STREAM_SESSION_LIMIT", String.valueOf(context.streamSessionLimit()));
+
         setFlowControlStrategy(environment, context);
         setLogging(environment);
         setTransportSecurity(environment);
@@ -399,7 +402,7 @@ public final class CTestMediaDriver implements TestMediaDriver
     {
         environment.put("AERON_EVENT_LOG", System.getProperty(
             "aeron.event.log",
-            "all"));
+            "admin"));
         environment.put("AERON_EVENT_LOG_DISABLE", System.getProperty("aeron.event.log.disable", ""));
 
         final String driverAgentPath = System.getProperty(DRIVER_AGENT_PATH_PROP_NAME);


### PR DESCRIPTION
Limit the number of sessions that a single stream can have.  By default it is unlimited (specifically 2^31 - 1).  This can help prevent denial of service behaviour by creating too many publications on the same stream.