### PR TITLE
[C] add and use aeron_mkdir_recursive

### DIFF
--- a/aeron-client/src/main/c/util/aeron_fileutil.c
+++ b/aeron-client/src/main/c/util/aeron_fileutil.c
@@ -488,7 +488,7 @@ int aeron_mkdir_recursive(const char *pathname, int permission)
             }
             else
             {
-                AERON_APPEND_ERR("%s", "");
+                AERON_APPEND_ERR("pathname=%s", pathname);
                 return rc;
             }
         }

--- a/aeron-client/src/main/c/util/aeron_fileutil.c
+++ b/aeron-client/src/main/c/util/aeron_fileutil.c
@@ -453,9 +453,9 @@ int aeron_open_file_rw(const char *path)
 }
 #endif
 
-int aeron_mkdir_recursive(const char *pathname, mode_t mode)
+int aeron_mkdir_recursive(const char *pathname, int permission)
 {
-    if (aeron_mkdir(pathname, mode) == 0)
+    if (aeron_mkdir(pathname, permission) == 0)
     {
         return 0;
     }
@@ -475,7 +475,7 @@ int aeron_mkdir_recursive(const char *pathname, mode_t mode)
         {
             *p = '\0';
             // _pathname is now the parent directory of the original pathname
-            rc = aeron_mkdir_recursive(_pathname, mode);
+            rc = aeron_mkdir_recursive(_pathname, permission);
             break;
         }
     }
@@ -492,7 +492,7 @@ int aeron_mkdir_recursive(const char *pathname, mode_t mode)
     {
         // if rc is 0, then we were able to create the parent directory
         // so retry the original pathname
-        return aeron_mkdir(pathname, mode);
+        return aeron_mkdir(pathname, permission);
     }
 
     return rc;

--- a/aeron-client/src/main/c/util/aeron_fileutil.h
+++ b/aeron-client/src/main/c/util/aeron_fileutil.h
@@ -39,7 +39,7 @@ aeron_mapped_buffer_t;
 
 int aeron_is_directory(const char *path);
 int aeron_delete_directory(const char *directory);
-int aeron_mkdir_recursive(const char *pathname, mode_t mode);
+int aeron_mkdir_recursive(const char *pathname, int permission);
 
 int aeron_map_new_file(aeron_mapped_file_t *mapped_file, const char *path, bool fill_with_zeroes);
 int aeron_map_existing_file(aeron_mapped_file_t *mapped_file, const char *path);

--- a/aeron-client/src/main/c/util/aeron_fileutil.h
+++ b/aeron-client/src/main/c/util/aeron_fileutil.h
@@ -39,6 +39,7 @@ aeron_mapped_buffer_t;
 
 int aeron_is_directory(const char *path);
 int aeron_delete_directory(const char *directory);
+int aeron_mkdir_recursive(const char *pathname, mode_t mode);
 
 int aeron_map_new_file(aeron_mapped_file_t *mapped_file, const char *path, bool fill_with_zeroes);
 int aeron_map_existing_file(aeron_mapped_file_t *mapped_file, const char *path);

--- a/aeron-client/src/test/c/util/aeron_fileutil_test.cpp
+++ b/aeron-client/src/test/c/util/aeron_fileutil_test.cpp
@@ -25,6 +25,18 @@ extern "C"
 #include "util/aeron_error.h"
 }
 
+#if defined(AERON_COMPILER_GCC)
+#define removeDir remove
+#elif defined(AERON_COMPILER_MSVC)
+#define removeDir RemoveDirectoryA
+#endif
+
+#ifdef _MSC_VER
+#define AERON_FILE_SEP_STR "\\"
+#else
+#define AERON_FILE_SEP_STR "/"
+#endif
+
 class FileUtilTest : public testing::Test {
 public:
     FileUtilTest() = default;
@@ -328,13 +340,13 @@ TEST_F(FileUtilTest, shouldNotErrorIfAddressIsNull)
 TEST_F(FileUtilTest, simpleMkdir)
 {
     const char *dirA = "dirA";
-    const char *dirB = "dirA/dirB";
-    const char *dirC = "dirA/dirNOPE/dirC";
+    const char *dirB = "dirA" AERON_FILE_SEP_STR "dirB";
+    const char *dirC = "dirA" AERON_FILE_SEP_STR "dirNOPE" AERON_FILE_SEP_STR "dirC";
 
-    remove("dirA/dirNOPE/dirC");
-    remove("dirA/dirNOPE");
-    remove("dirA/dirB");
-    remove("dirA");
+    removeDir("dirA" AERON_FILE_SEP_STR "dirNOPE" AERON_FILE_SEP_STR "dirC");
+    removeDir("dirA" AERON_FILE_SEP_STR "dirNOPE");
+    removeDir("dirA" AERON_FILE_SEP_STR "dirB");
+    removeDir("dirA");
 
     ASSERT_EQ(0, aeron_mkdir(dirA, S_IRWXU | S_IRWXG | S_IRWXO));
     ASSERT_EQ(0, aeron_mkdir(dirB, S_IRWXU | S_IRWXG | S_IRWXO));
@@ -344,15 +356,15 @@ TEST_F(FileUtilTest, simpleMkdir)
 TEST_F(FileUtilTest, recursiveMkdir)
 {
     const char *dirW = "dirW";
-    const char *dirY = "dirX/dirY";
-    const char *dirZ = "dirW/dirX/dirY/dirZ";
+    const char *dirY = "dirX" AERON_FILE_SEP_STR "dirY";
+    const char *dirZ = "dirW" AERON_FILE_SEP_STR "dirX" AERON_FILE_SEP_STR "dirY" AERON_FILE_SEP_STR "dirZ";
 
-    remove("dirW/dirX/dirY/dirZ");
-    remove("dirW/dirX/dirY");
-    remove("dirW/dirX");
-    remove("dirW");
-    remove("dirX/dirY");
-    remove("dirX");
+    removeDir("dirW" AERON_FILE_SEP_STR "dirX" AERON_FILE_SEP_STR "dirY" AERON_FILE_SEP_STR "dirZ");
+    removeDir("dirW" AERON_FILE_SEP_STR "dirX" AERON_FILE_SEP_STR "dirY");
+    removeDir("dirW" AERON_FILE_SEP_STR "dirX");
+    removeDir("dirW");
+    removeDir("dirX" AERON_FILE_SEP_STR "dirY");
+    removeDir("dirX");
 
     ASSERT_EQ(0, aeron_mkdir_recursive(dirW, S_IRWXU | S_IRWXG | S_IRWXO));
     ASSERT_EQ(0, aeron_mkdir_recursive(dirY, S_IRWXU | S_IRWXG | S_IRWXO));

--- a/aeron-client/src/test/c/util/aeron_fileutil_test.cpp
+++ b/aeron-client/src/test/c/util/aeron_fileutil_test.cpp
@@ -324,3 +324,37 @@ TEST_F(FileUtilTest, shouldNotErrorIfAddressIsNull)
 {
     ASSERT_EQ(0, aeron_msync(nullptr, 10));
 }
+
+TEST_F(FileUtilTest, simpleMkdir)
+{
+    const char *dirA = "dirA";
+    const char *dirB = "dirA/dirB";
+    const char *dirC = "dirA/dirNOPE/dirC";
+
+    remove("dirA/dirNOPE/dirC");
+    remove("dirA/dirNOPE");
+    remove("dirA/dirB");
+    remove("dirA");
+
+    ASSERT_EQ(0, aeron_mkdir(dirA, S_IRWXU | S_IRWXG | S_IRWXO));
+    ASSERT_EQ(0, aeron_mkdir(dirB, S_IRWXU | S_IRWXG | S_IRWXO));
+    ASSERT_EQ(-1, aeron_mkdir(dirC, S_IRWXU | S_IRWXG | S_IRWXO));
+}
+
+TEST_F(FileUtilTest, recursiveMkdir)
+{
+    const char *dirW = "dirW";
+    const char *dirY = "dirX/dirY";
+    const char *dirZ = "dirW/dirX/dirY/dirZ";
+
+    remove("dirW/dirX/dirY/dirZ");
+    remove("dirW/dirX/dirY");
+    remove("dirW/dirX");
+    remove("dirW");
+    remove("dirX/dirY");
+    remove("dirX");
+
+    ASSERT_EQ(0, aeron_mkdir_recursive(dirW, S_IRWXU | S_IRWXG | S_IRWXO));
+    ASSERT_EQ(0, aeron_mkdir_recursive(dirY, S_IRWXU | S_IRWXG | S_IRWXO));
+    ASSERT_EQ(0, aeron_mkdir_recursive(dirZ, S_IRWXU | S_IRWXG | S_IRWXO));
+}

--- a/aeron-driver/src/main/c/aeron_driver.c
+++ b/aeron-driver/src/main/c/aeron_driver.c
@@ -244,7 +244,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_context_t *context)
         }
     }
 
-    if (aeron_mkdir(context->aeron_dir, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
+    if (aeron_mkdir_recursive(context->aeron_dir, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
     {
         AERON_SET_ERR(errno, "Failed to mkdir aeron directory: %s", context->aeron_dir);
         return -1;
@@ -256,7 +256,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_context_t *context)
         return -1;
     }
 
-    if (aeron_mkdir(filename, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
+    if (aeron_mkdir_recursive(filename, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
     {
         AERON_SET_ERR(errno, "Failed to mkdir publications directory: %s", context->aeron_dir);
         return -1;
@@ -268,7 +268,7 @@ int aeron_driver_ensure_dir_is_recreated(aeron_driver_context_t *context)
         return -1;
     }
 
-    if (aeron_mkdir(filename, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
+    if (aeron_mkdir_recursive(filename, S_IRWXU | S_IRWXG | S_IRWXO) != 0)
     {
         AERON_SET_ERR(errno, "Failed to mkdir images directory: %s", context->aeron_dir);
         return -1;


### PR DESCRIPTION
aeron_mkdir_recursive() will recursively create parent directories until it finds one that's already created.

Also, it calls itself... recursively.

(Windows tests are failing... why is Windows different!?!?!)