### PR TITLE
[Java] Version interface to allow testing usage of it

### DIFF
--- a/aeron-annotations/src/main/java/io/aeron/version/Version.java
+++ b/aeron-annotations/src/main/java/io/aeron/version/Version.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2024 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.aeron.version;
+
+/**
+ * version information for a specific component
+ */
+public interface Version
+{
+
+     /**
+      * @return     version string
+      */
+    String version();
+
+     /**
+      * @return     major version portion
+      */
+    int majorVersion();
+
+     /**
+      * @return     minor version portion
+      */
+    int minorVersion();
+
+     /**
+      * @return     patched version portion
+      */
+    int patchVersion();
+
+     /**
+      * @return     git SHA
+      */
+    String gitSha();
+}

--- a/aeron-annotations/src/main/java/io/aeron/version/VersionProcessor.java
+++ b/aeron-annotations/src/main/java/io/aeron/version/VersionProcessor.java
@@ -37,6 +37,34 @@ import java.util.regex.Pattern;
 @SupportedOptions({"io.aeron.version", "io.aeron.gitsha"})
 public class VersionProcessor extends AbstractProcessor
 {
+    private static final String VERSION_IMPL =
+        "\n" +
+        "    public String version()\n" +
+        "    {\n" +
+        "        return VERSION;\n" +
+        "    }\n" +
+        "\n" +
+        "    public int majorVersion()\n" +
+        "    {\n" +
+        "        return MAJOR_VERSION;\n" +
+        "    }\n" +
+        "\n" +
+        "    public int minorVersion()\n" +
+        "    {\n" +
+        "        return MINOR_VERSION;\n" +
+        "    }\n" +
+        "\n" +
+        "    public int patchVersion()\n" +
+        "    {\n" +
+        "        return PATCH_VERSION;\n" +
+        "    }\n" +
+        "\n" +
+        "    @Override\n" +
+        "    public String gitSha()\n" +
+        "    {\n" +
+        "        return GIT_SHA;\n" +
+        "    }";
+
     /**
      * {@inheritDoc}
      */
@@ -71,13 +99,14 @@ public class VersionProcessor extends AbstractProcessor
 
                         out.printf("package %s;%n", packageName);
                         out.println();
-                        out.printf("public class %s%n", className);
+                        out.printf("public class %s%n implements io.aeron.version.Version%n", className);
                         out.printf("{%n");
                         out.printf("    public static final String VERSION = \"%s\";%n", versionString);
                         out.printf("    public static final int MAJOR_VERSION = %s;%n", info.major);
                         out.printf("    public static final int MINOR_VERSION = %s;%n", info.minor);
                         out.printf("    public static final int PATCH_VERSION = %s;%n", info.patch);
                         out.printf("    public static final String GIT_SHA = \"%s\";%n", gitSha);
+                        out.println(VERSION_IMPL);
                         out.printf("}%n");
                     }
                 }


### PR DESCRIPTION
This should allow to verify logic of validating versions in a test. 
constants are still there for the cases where access to version info is on the hot path (+ regardless JIT might optimize it anyway?) 