### PR TITLE
[java] optimize the logic of LogAdapter to determine whether the stream is closed.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2227,10 +2227,13 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                 {
                     final long limit = null != appendPosition ? appendPosition.get() : logRecordingStopPosition;
                     final int count = logAdapter.poll(Math.min(notifiedCommitPosition, limit));
-                    if (0 == count && logAdapter.isImageClosed())
+                    if (0 == count)
                     {
                         final boolean isEos = logAdapter.isLogEndOfStream();
-                        enterElection(isEos, "log disconnected from leader: eos=" + isEos);
+                        if(isEos || logAdapter.isImageClosed())
+                        {
+                            enterElection(isEos, "log disconnected from leader: eos=" + isEos);
+                        }
                         return 1;
                     }
 

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2230,7 +2230,7 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                     if (0 == count)
                     {
                         final boolean isEos = logAdapter.isLogEndOfStream();
-                        if(isEos || logAdapter.isImageClosed())
+                        if (isEos || logAdapter.isImageClosed())
                         {
                             enterElection(isEos, "log disconnected from leader: eos=" + isEos);
                         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -2233,8 +2233,8 @@ final class ConsensusModuleAgent implements Agent, TimerService.TimerHandler, Co
                         if (isEos || logAdapter.isImageClosed())
                         {
                             enterElection(isEos, "log disconnected from leader: eos=" + isEos);
+                            return 1;
                         }
-                        return 1;
                     }
 
                     commitPosition.proposeMaxOrdered(logAdapter.position());


### PR DESCRIPTION
The purpose of this optimization is to quickly detect when the stream is closed, and then enter the election phase. In the scenario of leader.gracefulClose(), it shortens the time for cluster election.