### PR TITLE
modify the generation method of replay token

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/ArchiveConductor.java
@@ -2416,7 +2416,7 @@ abstract class ArchiveConductor
 
     public long generateReplayToken(final ControlSession session, final long recordingId)
     {
-        long replayToken = aeron.nextCorrelationId();
+        final long replayToken = aeron.nextCorrelationId();
 
         final SessionForReplay sessionForReplay = new SessionForReplay(
             recordingId, session, nanoClock.nanoTime() + TimeUnit.MILLISECONDS.toNanos(connectTimeoutMs));


### PR DESCRIPTION
Using random numbers as replay tokens may lead to token conflicts, introducing instability. I think it could be replaced with the aeron.nextCorrelationId() method. Alternatively, changing to the following code would also be safer.


![image](https://github.com/real-logic/aeron/assets/13658946/6dbd8139-b568-4539-96a1-b8e749dbfa30)
