### PR TITLE
appoint leader during runTime

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -87,21 +87,40 @@ class Election
     private long replicationTermBaseLogPosition;
     private long lastPublishedCommitPosition;
     private int gracefulClosedLeaderId;
+    private int currentAppointedLeaderId;
 
     Election(
-        final boolean isNodeStartup,
-        final int gracefulClosedLeaderId,
-        final long leadershipTermId,
-        final long termBaseLogPosition,
-        final long logPosition,
-        final long appendPosition,
-        final ClusterMember[] clusterMembers,
-        final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap,
-        final ClusterMember thisMember,
-        final ConsensusPublisher consensusPublisher,
-        final ConsensusModule.Context ctx,
-        final ConsensusModuleAgent consensusModuleAgent)
-    {
+            final boolean isNodeStartup,
+            final int gracefulClosedLeaderId,
+            final long leadershipTermId,
+            final long termBaseLogPosition,
+            final long logPosition,
+            final long appendPosition,
+            final ClusterMember[] clusterMembers,
+            final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap,
+            final ClusterMember thisMember,
+            final ConsensusPublisher consensusPublisher,
+            final ConsensusModule.Context ctx,
+            final ConsensusModuleAgent consensusModuleAgent) {
+        this(isNodeStartup, gracefulClosedLeaderId, leadershipTermId, termBaseLogPosition,
+                logPosition, appendPosition, clusterMembers, clusterMemberByIdMap, thisMember,
+                consensusPublisher, ctx, consensusModuleAgent, NULL_VALUE);
+    }
+
+    Election(
+            final boolean isNodeStartup,
+            final int gracefulClosedLeaderId,
+            final long leadershipTermId,
+            final long termBaseLogPosition,
+            final long logPosition,
+            final long appendPosition,
+            final ClusterMember[] clusterMembers,
+            final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap,
+            final ClusterMember thisMember,
+            final ConsensusPublisher consensusPublisher,
+            final ConsensusModule.Context ctx,
+            final ConsensusModuleAgent consensusModuleAgent,
+            final int currentAppointedLeaderId) {
         this.isNodeStartup = isNodeStartup;
         this.isExtendedCanvass = isNodeStartup;
         this.gracefulClosedLeaderId = gracefulClosedLeaderId;
@@ -118,6 +137,7 @@ class Election
         this.consensusPublisher = consensusPublisher;
         this.ctx = ctx;
         this.consensusModuleAgent = consensusModuleAgent;
+        this.currentAppointedLeaderId = currentAppointedLeaderId;
 
         final long nowNs = ctx.clusterClock().timeNanos();
         this.initialTimeOfLastUpdateNs = nowNs - TimeUnit.DAYS.toNanos(1);
@@ -673,8 +693,9 @@ class Election
             workCount++;
         }
 
-        if (isPassiveMember() || (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id()))
-        {
+        if (isPassiveMember()
+                || (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id())
+                || (this.currentAppointedLeaderId != NULL_VALUE && this.currentAppointedLeaderId != thisMember.id())) {
             return workCount;
         }
 

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -45,6 +45,7 @@
             <validValue name="SUSPEND" description="Suspend ingress to the cluster.">0</validValue>
             <validValue name="RESUME" description="Resume ingress to the cluster.">1</validValue>
             <validValue name="SNAPSHOT" description="Snapshot state in the cluster.">2</validValue>
+            <validValue name="APPOINT_LEADER" description="Appoint leader in the cluster.">3</validValue>
         </enum>
         <enum name="SnapshotMark" encodingType="int32" description="Mark within a snapshot.">
             <validValue name="BEGIN" description="Begin marker for a snapshot.">0</validValue>
@@ -62,6 +63,7 @@
         </enum>
         <enum name="AdminRequestType" encodingType="int32" description="Admin command to execute in the cluster.">
             <validValue name="SNAPSHOT" description="Command to snapshot state in the cluster.">0</validValue>
+            <validValue name="APPOINT_LEADER" description="Command to appoint leader in the cluster.">1</validValue>
         </enum>
         <enum name="AdminResponseCode" encodingType="int32" description="Response code for an admin command request.">
             <validValue name="OK" description="Command was submitted or executed successfully.">0</validValue>

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -2690,6 +2690,51 @@ class ClusterTest
         }
     }
 
+    @Test
+    @InterruptAfter(20)
+    void shouldChangeAppointedLeaderAfterReceivingAdminRequestOfAppointLeader()
+    {
+        cluster = aCluster()
+                .withStaticNodes(3)
+                .withAuthorisationServiceSupplier(() ->
+                        (protocolId, actionId, type, encodedPrincipal) ->
+                        {
+                            assertEquals(MessageHeaderDecoder.SCHEMA_ID, protocolId);
+                            assertEquals(AdminRequestEncoder.TEMPLATE_ID, actionId);
+                            assertEquals(AdminRequestType.APPOINT_LEADER, type);
+                            return true;
+                        })
+                .start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+
+        final long requestCorrelationId = System.nanoTime();
+        final MutableBoolean hasResponse = injectAppointedLeadeerAdminRequestControlledEgressListener(requestCorrelationId);
+
+        final AeronCluster client = cluster.connectClient();
+        int appointedLeaderId = 0;
+        for (ClusterMember activeMember : leader.clusterMembership().activeMembers) {
+            if(activeMember.id() != leader.clusterMembership().memberId) {
+                appointedLeaderId = activeMember.id();
+                break;
+            }
+        }
+        while (!client.sendAdminRequestToAppointLeader(requestCorrelationId, appointedLeaderId))
+        {
+            Tests.yield();
+        }
+
+        while (!hasResponse.get())
+        {
+            client.controlledPollEgress();
+            Tests.yield();
+        }
+
+        TestNode newLeader = cluster.awaitLeaderAndClosedElection(leader.clusterMembership().memberId);
+        assertEquals(appointedLeaderId, newLeader.clusterMembership().memberId);
+    }
+
     private static void verifyClientName(final Aeron aeron, final long targetClientId, final String expectedClientName)
     {
         assertNotEquals(aeron.clientId(), targetClientId);
@@ -2832,6 +2877,54 @@ class ClusterTest
                     assertEquals(0, payloadLength);
                 }
             });
+
+        return hasResponse;
+    }
+
+    private MutableBoolean injectAppointedLeadeerAdminRequestControlledEgressListener(final long expectedCorrelationId)
+    {
+        final MutableBoolean hasResponse = new MutableBoolean();
+
+        cluster.controlledEgressListener(
+                new ControlledEgressListener()
+                {
+                    public ControlledFragmentHandler.Action onMessage(
+                            final long clusterSessionId,
+                            final long timestamp,
+                            final DirectBuffer buffer,
+                            final int offset,
+                            final int length,
+                            final Header header)
+                    {
+                        return ControlledFragmentHandler.Action.ABORT;
+                    }
+
+                    public void onAdminResponse(
+                            final long clusterSessionId,
+                            final long correlationId,
+                            final AdminRequestType requestType,
+                            final AdminResponseCode responseCode,
+                            final String message,
+                            final DirectBuffer payload,
+                            final int payloadOffset,
+                            final int payloadLength)
+                    {
+                        hasResponse.set(true);
+                        assertEquals(expectedCorrelationId, correlationId);
+                        assertEquals(AdminRequestType.APPOINT_LEADER, requestType);
+                        assertEquals(AdminResponseCode.OK, responseCode);
+                        assertEquals(EMPTY_MSG, message);
+                        assertNotNull(payload);
+                        final int minPayloadOffset =
+                                MessageHeaderEncoder.ENCODED_LENGTH +
+                                        AdminResponseEncoder.BLOCK_LENGTH +
+                                        AdminResponseEncoder.messageHeaderLength() +
+                                        message.length() +
+                                        AdminResponseEncoder.payloadHeaderLength();
+                        assertTrue(payloadOffset > minPayloadOffset);
+                        assertEquals(0, payloadLength);
+                    }
+                });
 
         return hasResponse;
     }


### PR DESCRIPTION
Appoint a node as the leader during runTime, use ClusterAction to push all members enter election mode at the same position, and dynamically set the appointedLeaderId which only takes effect once.