### PR TITLE
appoint leader during runTime

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -734,7 +734,7 @@ final class ConsensusModuleAgent
         }
         else if (AdminRequestType.APPOINT_LEADER == requestType)
         {
-            int appointedLeaderId = payload.getInt(payloadOffset);
+            final int appointedLeaderId = payload.getInt(payloadOffset);
             if (ConsensusModule.State.ACTIVE == state && appendAction(ClusterAction.APPOINT_LEADER, appointedLeaderId))
             {
                 egressPublisher.sendAdminResponse(session, correlationId, requestType, AdminResponseCode.OK, "");

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -165,6 +165,7 @@ final class ConsensusModuleAgent
     private String catchupLogDestination;
     private String ingressEndpoints;
     private StandbySnapshotReplicator standbySnapshotReplicator = null;
+    private int currentAppointedLeaderId;
 
     ConsensusModuleAgent(final ConsensusModule.Context ctx)
     {
@@ -196,6 +197,7 @@ final class ConsensusModuleAgent
         this.serviceAckQueues = ServiceAck.newArrayOfQueues(serviceCount);
         this.dutyCycleTracker = ctx.dutyCycleTracker();
         this.totalSnapshotDurationTracker = ctx.totalSnapshotDurationTracker();
+        this.currentAppointedLeaderId = NULL_VALUE;
 
         aeronClientInvoker = aeron.conductorAgentInvoker();
         aeronClientInvoker.invoke();
@@ -727,6 +729,20 @@ final class ConsensusModuleAgent
             else
             {
                 final String msg = "Failed to switch ClusterControl to the ToggleState.SNAPSHOT state";
+                egressPublisher.sendAdminResponse(session, correlationId, requestType, AdminResponseCode.ERROR, msg);
+            }
+        }
+        else if (AdminRequestType.APPOINT_LEADER == requestType)
+        {
+            int appointedLeaderId = payload.getInt(payloadOffset);
+            if (ConsensusModule.State.ACTIVE == state && appendAction(ClusterAction.APPOINT_LEADER, appointedLeaderId))
+            {
+                egressPublisher.sendAdminResponse(session, correlationId, requestType, AdminResponseCode.OK, "");
+                this.onAppointLeader(appointedLeaderId);
+            }
+            else
+            {
+                final String msg = "Failed to append appoint leader command to cluster";
                 egressPublisher.sendAdminResponse(session, correlationId, requestType, AdminResponseCode.ERROR, msg);
             }
         }
@@ -1545,6 +1561,10 @@ final class ConsensusModuleAgent
             else if (ClusterAction.SNAPSHOT == action && CLUSTER_ACTION_FLAGS_DEFAULT == flags)
             {
                 state(ConsensusModule.State.SNAPSHOT);
+            }
+            else if (ClusterAction.APPOINT_LEADER == action && ConsensusModule.State.ACTIVE == state && election == null)
+            {
+                this.onAppointLeader(flags);
             }
         }
     }
@@ -3112,6 +3132,13 @@ final class ConsensusModuleAgent
         }
     }
 
+    void onAppointLeader(final int appointedLeaderId)
+    {
+        this.currentAppointedLeaderId = appointedLeaderId;
+        this.enterElection(false, "appoint leader member id : " + appointedLeaderId);
+        this.currentAppointedLeaderId = NULL_VALUE;
+    }
+
     private void clearSessionsAfter(final long logPosition)
     {
         for (int i = sessions.size() - 1; i >= 0; i--)
@@ -3232,7 +3259,8 @@ final class ConsensusModuleAgent
             thisMember,
             consensusPublisher,
             ctx,
-            this);
+            this,
+            currentAppointedLeaderId);
 
         election.doWork(clusterClock.timeNanos());
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1569,8 +1569,7 @@ final class ConsensusModuleAgent
         }
     }
 
-    void onReplayNewLeadershipTermEvent(
-        final long leadershipTermId,
+    void onReplayNewLeadershipTermEvent(final long leadershipTermId,
         final long logPosition,
         final long timestamp,
         final long termBaseLogPosition,

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -1562,7 +1562,9 @@ final class ConsensusModuleAgent
             {
                 state(ConsensusModule.State.SNAPSHOT);
             }
-            else if (ClusterAction.APPOINT_LEADER == action && ConsensusModule.State.ACTIVE == state && election == null)
+            else if (ClusterAction.APPOINT_LEADER == action &&
+                ConsensusModule.State.ACTIVE == state &&
+                election == null)
             {
                 this.onAppointLeader(flags);
             }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -695,9 +695,9 @@ class Election
             workCount++;
         }
 
-        if (isPassiveMember()
-            || (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id())
-            || (this.currentAppointedLeaderId != NULL_VALUE && this.currentAppointedLeaderId != thisMember.id()))
+        if (isPassiveMember() ||
+            (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id()) ||
+            (this.currentAppointedLeaderId != NULL_VALUE && this.currentAppointedLeaderId != thisMember.id()))
         {
             return workCount;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/Election.java
@@ -87,6 +87,7 @@ class Election
     private long replicationTermBaseLogPosition;
     private long lastPublishedCommitPosition;
     private int gracefulClosedLeaderId;
+    private int currentAppointedLeaderId;
 
     Election(
         final boolean isNodeStartup,
@@ -101,6 +102,26 @@ class Election
         final ConsensusPublisher consensusPublisher,
         final ConsensusModule.Context ctx,
         final ConsensusModuleAgent consensusModuleAgent)
+    {
+        this(isNodeStartup, gracefulClosedLeaderId, leadershipTermId, termBaseLogPosition,
+            logPosition, appendPosition, clusterMembers, clusterMemberByIdMap, thisMember,
+            consensusPublisher, ctx, consensusModuleAgent, NULL_VALUE);
+    }
+
+    Election(
+        final boolean isNodeStartup,
+        final int gracefulClosedLeaderId,
+        final long leadershipTermId,
+        final long termBaseLogPosition,
+        final long logPosition,
+        final long appendPosition,
+        final ClusterMember[] clusterMembers,
+        final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap,
+        final ClusterMember thisMember,
+        final ConsensusPublisher consensusPublisher,
+        final ConsensusModule.Context ctx,
+        final ConsensusModuleAgent consensusModuleAgent,
+        final int currentAppointedLeaderId)
     {
         this.isNodeStartup = isNodeStartup;
         this.isExtendedCanvass = isNodeStartup;
@@ -118,6 +139,7 @@ class Election
         this.consensusPublisher = consensusPublisher;
         this.ctx = ctx;
         this.consensusModuleAgent = consensusModuleAgent;
+        this.currentAppointedLeaderId = currentAppointedLeaderId;
 
         final long nowNs = ctx.clusterClock().timeNanos();
         this.initialTimeOfLastUpdateNs = nowNs - TimeUnit.DAYS.toNanos(1);
@@ -673,7 +695,9 @@ class Election
             workCount++;
         }
 
-        if (isPassiveMember() || (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id()))
+        if (isPassiveMember()
+            || (ctx.appointedLeaderId() != NULL_VALUE && ctx.appointedLeaderId() != thisMember.id())
+            || (this.currentAppointedLeaderId != NULL_VALUE && this.currentAppointedLeaderId != thisMember.id()))
         {
             return workCount;
         }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -257,6 +257,7 @@ public final class AeronCluster implements AutoCloseable
     /**
      * Close session and release associated resources.
      */
+    @Override
     public void close()
     {
         if (null != publication && publication.isConnected() && !isClosed)
@@ -489,8 +490,8 @@ public final class AeronCluster implements AutoCloseable
 
         final int length =
             MessageHeaderEncoder.ENCODED_LENGTH +
-                AdminRequestEncoder.BLOCK_LENGTH +
-                AdminRequestEncoder.payloadHeaderLength();
+            AdminRequestEncoder.BLOCK_LENGTH +
+            AdminRequestEncoder.payloadHeaderLength();
 
         while (true)
         {
@@ -645,11 +646,10 @@ public final class AeronCluster implements AutoCloseable
         final UnsafeBuffer payload = new UnsafeBuffer(new byte[SIZE_OF_INT]);
         payload.putInt(0, memberId);
 
-        final int length =
-            MessageHeaderEncoder.ENCODED_LENGTH +
-                AdminRequestEncoder.BLOCK_LENGTH +
-                AdminRequestEncoder.payloadHeaderLength() +
-                SIZE_OF_INT;
+        final int length = MessageHeaderEncoder.ENCODED_LENGTH +
+            AdminRequestEncoder.BLOCK_LENGTH +
+            AdminRequestEncoder.payloadHeaderLength() +
+            SIZE_OF_INT;
 
         while (true)
         {
@@ -1313,6 +1313,7 @@ public final class AeronCluster implements AutoCloseable
          *
          * @return a shallow copy of the object.
          */
+        @Override
         public Context clone()
         {
             try
@@ -1848,6 +1849,7 @@ public final class AeronCluster implements AutoCloseable
         /**
          * {@inheritDoc}
          */
+        @Override
         public String toString()
         {
             return "AeronCluster.Context" +
@@ -1945,6 +1947,7 @@ public final class AeronCluster implements AutoCloseable
         /**
          * Close allocated resources. Must be called on error. On success this is a no op.
          */
+        @Override
         public void close()
         {
             if (State.DONE != state)
@@ -2063,12 +2066,12 @@ public final class AeronCluster implements AutoCloseable
                     egressSubscription.tryResolveChannelEndpointPort() : "<unknown>";
                 final TimeoutException ex = new TimeoutException(
                     "cluster connect timeout: state=" + state +
-                        " messageTimeout=" + ctx.messageTimeoutNs() + "ns" +
-                        " ingressChannel=" + ctx.ingressChannel() +
-                        " ingressEndpoints=" + ctx.ingressEndpoints() +
-                        " ingressPublication=" + ingressPublication +
-                        " egress.isConnected=" + isConnected +
-                        " responseChannel=" + endpointPort);
+                    " messageTimeout=" + ctx.messageTimeoutNs() + "ns" +
+                    " ingressChannel=" + ctx.ingressChannel() +
+                    " ingressEndpoints=" + ctx.ingressEndpoints() +
+                    " ingressPublication=" + ingressPublication +
+                    " egress.isConnected=" + isConnected +
+                    " responseChannel=" + endpointPort);
 
                 for (final MemberIngress member : memberByIdMap.values())
                 {
@@ -2356,6 +2359,7 @@ public final class AeronCluster implements AutoCloseable
             this.endpoint = endpoint;
         }
 
+        @Override
         public void close()
         {
             if (null != publication)
@@ -2370,6 +2374,7 @@ public final class AeronCluster implements AutoCloseable
             publication = null;
         }
 
+        @Override
         public String toString()
         {
             return "MemberIngress{" +

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -489,8 +489,8 @@ public final class AeronCluster implements AutoCloseable
 
         final int length =
             MessageHeaderEncoder.ENCODED_LENGTH +
-            AdminRequestEncoder.BLOCK_LENGTH +
-            AdminRequestEncoder.payloadHeaderLength();
+                AdminRequestEncoder.BLOCK_LENGTH +
+                AdminRequestEncoder.payloadHeaderLength();
 
         while (true)
         {
@@ -642,7 +642,7 @@ public final class AeronCluster implements AutoCloseable
     {
         idleStrategy.reset();
         int attempts = SEND_ATTEMPTS;
-        UnsafeBuffer payload = new UnsafeBuffer(new byte[SIZE_OF_INT]);
+        final UnsafeBuffer payload = new UnsafeBuffer(new byte[SIZE_OF_INT]);
         payload.putInt(0, memberId);
 
         final int length =
@@ -691,7 +691,8 @@ public final class AeronCluster implements AutoCloseable
         return false;
     }
 
-    static Int2ObjectHashMap<MemberIngress> parseIngressEndpoints(final Context ctx, final String endpoints) {
+    static Int2ObjectHashMap<MemberIngress> parseIngressEndpoints(final Context ctx, final String endpoints)
+    {
         final Int2ObjectHashMap<MemberIngress> endpointByIdMap = new Int2ObjectHashMap<>();
 
         if (null != endpoints)
@@ -2062,12 +2063,12 @@ public final class AeronCluster implements AutoCloseable
                     egressSubscription.tryResolveChannelEndpointPort() : "<unknown>";
                 final TimeoutException ex = new TimeoutException(
                     "cluster connect timeout: state=" + state +
-                    " messageTimeout=" + ctx.messageTimeoutNs() + "ns" +
-                    " ingressChannel=" + ctx.ingressChannel() +
-                    " ingressEndpoints=" + ctx.ingressEndpoints() +
-                    " ingressPublication=" + ingressPublication +
-                    " egress.isConnected=" + isConnected +
-                    " responseChannel=" + endpointPort);
+                        " messageTimeout=" + ctx.messageTimeoutNs() + "ns" +
+                        " ingressChannel=" + ctx.ingressChannel() +
+                        " ingressEndpoints=" + ctx.ingressEndpoints() +
+                        " ingressPublication=" + ingressPublication +
+                        " egress.isConnected=" + isConnected +
+                        " responseChannel=" + endpointPort);
 
                 for (final MemberIngress member : memberByIdMap.values())
                 {

--- a/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/client/AeronCluster.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.aeron.Aeron.NULL_VALUE;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
+import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.SystemUtil.getDurationInNanos;
 
 /**
@@ -628,8 +629,69 @@ public final class AeronCluster implements AutoCloseable
         controlledEgressListener.onNewLeader(clusterSessionId, leadershipTermId, leaderMemberId, ingressEndpoints);
     }
 
-    static Int2ObjectHashMap<MemberIngress> parseIngressEndpoints(final Context ctx, final String endpoints)
+    /**
+     * Sends an admin request to appoint leader in the cluster. This request requires elevated privileges.
+     *
+     * @param correlationId for the request.
+     * @param memberId      of appointed leader.
+     * @return {@code true} if the request was sent or {@code false} otherwise.
+     * @see EgressListener#onAdminResponse(long, long, AdminRequestType, AdminResponseCode, String, DirectBuffer, int, int)
+     * @see ControlledEgressListener#onAdminResponse(long, long, AdminRequestType, AdminResponseCode, String, DirectBuffer, int, int)
+     */
+    public boolean sendAdminRequestToAppointLeader(final long correlationId, final int memberId)
     {
+        idleStrategy.reset();
+        int attempts = SEND_ATTEMPTS;
+        UnsafeBuffer payload = new UnsafeBuffer(new byte[SIZE_OF_INT]);
+        payload.putInt(0, memberId);
+
+        final int length =
+            MessageHeaderEncoder.ENCODED_LENGTH +
+                AdminRequestEncoder.BLOCK_LENGTH +
+                AdminRequestEncoder.payloadHeaderLength() +
+                SIZE_OF_INT;
+
+        while (true)
+        {
+            final long position = publication.tryClaim(length, bufferClaim);
+            if (position > 0)
+            {
+                adminRequestEncoder
+                    .wrapAndApplyHeader(bufferClaim.buffer(), bufferClaim.offset(), messageHeaderEncoder)
+                    .leadershipTermId(leadershipTermId)
+                    .clusterSessionId(clusterSessionId)
+                    .correlationId(correlationId)
+                    .requestType(AdminRequestType.APPOINT_LEADER)
+                    .putPayload(payload, 0, SIZE_OF_INT);
+
+                bufferClaim.commit();
+
+                return true;
+            }
+
+            if (position == Publication.CLOSED)
+            {
+                throw new ClusterException("ingress publication is closed");
+            }
+
+            if (position == Publication.MAX_POSITION_EXCEEDED)
+            {
+                throw new ClusterException("max position exceeded: term-length=" + publication.termBufferLength());
+            }
+
+            if (--attempts <= 0)
+            {
+                break;
+            }
+
+            idleStrategy.idle();
+            invokeInvokers();
+        }
+
+        return false;
+    }
+
+    static Int2ObjectHashMap<MemberIngress> parseIngressEndpoints(final Context ctx, final String endpoints) {
         final Int2ObjectHashMap<MemberIngress> endpointByIdMap = new Int2ObjectHashMap<>();
 
         if (null != endpoints)

--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -45,6 +45,7 @@
             <validValue name="SUSPEND" description="Suspend ingress to the cluster.">0</validValue>
             <validValue name="RESUME" description="Resume ingress to the cluster.">1</validValue>
             <validValue name="SNAPSHOT" description="Snapshot state in the cluster.">2</validValue>
+            <validValue name="APPOINT_LEADER" description="Appoint leader in the cluster.">3</validValue>
         </enum>
         <enum name="SnapshotMark" encodingType="int32" description="Mark within a snapshot.">
             <validValue name="BEGIN" description="Begin marker for a snapshot.">0</validValue>
@@ -62,6 +63,7 @@
         </enum>
         <enum name="AdminRequestType" encodingType="int32" description="Admin command to execute in the cluster.">
             <validValue name="SNAPSHOT" description="Command to snapshot state in the cluster.">0</validValue>
+            <validValue name="APPOINT_LEADER" description="Command to appoint leader in the cluster.">1</validValue>
         </enum>
         <enum name="AdminResponseCode" encodingType="int32" description="Response code for an admin command request.">
             <validValue name="OK" description="Command was submitted or executed successfully.">0</validValue>

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -1476,6 +1476,130 @@ class ElectionTest
         verifyNoInteractions(recordingLog);
     }
 
+    @Test
+    @SuppressWarnings("MethodLength")
+    void shouldElectCurrentAppointedLeader()
+    {
+        final long leadershipTermId = NULL_VALUE;
+        final long logPosition = 0;
+        final ClusterMember[] clusterMembers = prepareClusterMembers();
+        final ClusterMember candidateMember = clusterMembers[0];
+        when(consensusModuleAgent.logRecordingId()).thenReturn(RECORDING_ID);
+
+        final Election election = newElection(leadershipTermId, logPosition, clusterMembers, candidateMember, candidateMember.id());
+
+        final long candidateTermId = leadershipTermId + 1;
+        clock.update(1, clock.timeUnit());
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.CANVASS.code());
+
+        election.onCanvassPosition(leadershipTermId, logPosition, leadershipTermId, 1, VERSION);
+        election.onCanvassPosition(leadershipTermId, logPosition, leadershipTermId, 2, VERSION);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.NOMINATE.code());
+
+        clock.increment(ctx.electionTimeoutNs() >> 1);
+        election.doWork(clock.nanoTime());
+        election.doWork(clock.nanoTime());
+        verify(consensusPublisher).requestVote(
+            clusterMembers[1].publication(),
+            leadershipTermId,
+            logPosition,
+            candidateTermId,
+            candidateMember.id());
+        verify(consensusPublisher).requestVote(
+            clusterMembers[2].publication(),
+            leadershipTermId,
+            logPosition,
+            candidateTermId,
+            candidateMember.id());
+        verify(electionStateCounter).setOrdered(ElectionState.CANDIDATE_BALLOT.code());
+        verify(consensusModuleAgent).role(Cluster.Role.CANDIDATE);
+
+        when(consensusModuleAgent.role()).thenReturn(Cluster.Role.CANDIDATE);
+        election.onVote(
+            candidateTermId, leadershipTermId, logPosition, candidateMember.id(), clusterMembers[1].id(), true);
+        election.onVote(
+            candidateTermId, leadershipTermId, logPosition, candidateMember.id(), clusterMembers[2].id(), true);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_LOG_REPLICATION.code());
+
+        election.doWork(clock.nanoTime());
+
+        verify(consensusPublisher).newLeadershipTerm(
+            clusterMembers[1].publication(),
+            leadershipTermId,
+            0,
+            0,
+            NULL_POSITION,
+            candidateTermId,
+            logPosition,
+            logPosition,
+            RECORDING_ID,
+            clock.nanoTime(),
+            candidateMember.id(),
+            LOG_SESSION_ID,
+            election.isLeaderStartup());
+
+        verify(consensusPublisher).newLeadershipTerm(
+            clusterMembers[2].publication(),
+            leadershipTermId,
+            0,
+            0,
+            NULL_POSITION,
+            candidateTermId,
+            logPosition,
+            logPosition,
+            RECORDING_ID,
+            clock.nanoTime(),
+            candidateMember.id(),
+            LOG_SESSION_ID,
+            election.isLeaderStartup());
+
+        when(recordingLog.isUnknown(candidateTermId)).thenReturn(Boolean.TRUE);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_REPLAY.code());
+
+        election.doWork(clock.nanoTime());
+
+        verify(consensusModuleAgent).joinLogAsLeader(eq(candidateTermId), eq(logPosition), anyInt(), eq(true));
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_READY.code());
+        verify(recordingLog).ensureCoherent(
+            RECORDING_ID,
+            NULL_VALUE,
+            logPosition,
+            candidateTermId,
+            logPosition,
+            NULL_VALUE,
+            clock.nanoTime(),
+            clock.nanoTime(),
+            ctx.fileSyncLevel());
+
+        assertEquals(NULL_POSITION, clusterMembers[1].logPosition());
+        assertEquals(NULL_POSITION, clusterMembers[2].logPosition());
+        assertEquals(candidateTermId, election.leadershipTermId());
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_READY.code());
+
+        when(consensusModuleAgent.appendNewLeadershipTermEvent(anyLong())).thenReturn(true);
+
+        clock.increment(1);
+        election.onAppendPosition(candidateTermId, logPosition, clusterMembers[1].id(), APPEND_POSITION_FLAG_NONE);
+        election.onAppendPosition(candidateTermId, logPosition, clusterMembers[2].id(), APPEND_POSITION_FLAG_NONE);
+        election.doWork(clock.nanoTime());
+        final InOrder inOrder = inOrder(consensusModuleAgent, electionStateCounter);
+        inOrder.verify(consensusModuleAgent).electionComplete(anyLong());
+        inOrder.verify(electionStateCounter).setOrdered(ElectionState.CLOSED.code());
+    }
+
     private Election newElection(
         final boolean isStartup,
         final long logLeadershipTermId,
@@ -1525,6 +1649,33 @@ class ElectionTest
             consensusPublisher,
             ctx,
             consensusModuleAgent);
+    }
+
+    private Election newElection(
+        final long logLeadershipTermId,
+        final long logPosition,
+        final ClusterMember[] clusterMembers,
+        final ClusterMember thisMember,
+        final int currentAppointedLeaderId)
+    {
+        final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap = new Int2ObjectHashMap<>();
+
+        ClusterMember.addClusterMemberIds(clusterMembers, clusterMemberByIdMap);
+
+        return new Election(
+            true,
+            NULL_VALUE,
+            logLeadershipTermId,
+            logPosition,
+            logPosition,
+            logPosition,
+            clusterMembers,
+            clusterMemberByIdMap,
+            thisMember,
+            consensusPublisher,
+            ctx,
+            consensusModuleAgent,
+            currentAppointedLeaderId);
     }
 
     private static ClusterMember[] prepareClusterMembers()

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -1486,7 +1486,8 @@ class ElectionTest
         final ClusterMember candidateMember = clusterMembers[0];
         when(consensusModuleAgent.logRecordingId()).thenReturn(RECORDING_ID);
 
-        final Election election = newElection(leadershipTermId, logPosition, clusterMembers, candidateMember, candidateMember.id());
+        final Election election =
+            newElection(leadershipTermId, logPosition, clusterMembers, candidateMember, candidateMember.id());
 
         final long candidateTermId = leadershipTermId + 1;
         clock.update(1, clock.timeUnit());


### PR DESCRIPTION
Appoint a node as the leader during runTime, use ClusterAction to push all members enter election mode at the same position, and dynamically set the appointedLeaderId which only takes effect once.