### PR TITLE
appoint leader during runTime

### DIFF
--- a/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
+++ b/aeron-cluster/src/main/resources/cluster/aeron-cluster-codecs.xml
@@ -45,6 +45,7 @@
             <validValue name="SUSPEND" description="Suspend ingress to the cluster.">0</validValue>
             <validValue name="RESUME" description="Resume ingress to the cluster.">1</validValue>
             <validValue name="SNAPSHOT" description="Snapshot state in the cluster.">2</validValue>
+            <validValue name="APPOINT_LEADER" description="Appoint leader in the cluster.">3</validValue>
         </enum>
         <enum name="SnapshotMark" encodingType="int32" description="Mark within a snapshot.">
             <validValue name="BEGIN" description="Begin marker for a snapshot.">0</validValue>
@@ -62,6 +63,7 @@
         </enum>
         <enum name="AdminRequestType" encodingType="int32" description="Admin command to execute in the cluster.">
             <validValue name="SNAPSHOT" description="Command to snapshot state in the cluster.">0</validValue>
+            <validValue name="APPOINT_LEADER" description="Command to appoint leader in the cluster.">1</validValue>
         </enum>
         <enum name="AdminResponseCode" encodingType="int32" description="Response code for an admin command request.">
             <validValue name="OK" description="Command was submitted or executed successfully.">0</validValue>

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ElectionTest.java
@@ -1476,6 +1476,131 @@ class ElectionTest
         verifyNoInteractions(recordingLog);
     }
 
+    @Test
+    @SuppressWarnings("MethodLength")
+    void shouldElectCurrentAppointedLeader()
+    {
+        final long leadershipTermId = NULL_VALUE;
+        final long logPosition = 0;
+        final ClusterMember[] clusterMembers = prepareClusterMembers();
+        final ClusterMember candidateMember = clusterMembers[0];
+        when(consensusModuleAgent.logRecordingId()).thenReturn(RECORDING_ID);
+
+        final Election election =
+            newElection(leadershipTermId, logPosition, clusterMembers, candidateMember, candidateMember.id());
+
+        final long candidateTermId = leadershipTermId + 1;
+        clock.update(1, clock.timeUnit());
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.CANVASS.code());
+
+        election.onCanvassPosition(leadershipTermId, logPosition, leadershipTermId, 1, VERSION);
+        election.onCanvassPosition(leadershipTermId, logPosition, leadershipTermId, 2, VERSION);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.NOMINATE.code());
+
+        clock.increment(ctx.electionTimeoutNs() >> 1);
+        election.doWork(clock.nanoTime());
+        election.doWork(clock.nanoTime());
+        verify(consensusPublisher).requestVote(
+            clusterMembers[1].publication(),
+            leadershipTermId,
+            logPosition,
+            candidateTermId,
+            candidateMember.id());
+        verify(consensusPublisher).requestVote(
+            clusterMembers[2].publication(),
+            leadershipTermId,
+            logPosition,
+            candidateTermId,
+            candidateMember.id());
+        verify(electionStateCounter).setOrdered(ElectionState.CANDIDATE_BALLOT.code());
+        verify(consensusModuleAgent).role(Cluster.Role.CANDIDATE);
+
+        when(consensusModuleAgent.role()).thenReturn(Cluster.Role.CANDIDATE);
+        election.onVote(
+            candidateTermId, leadershipTermId, logPosition, candidateMember.id(), clusterMembers[1].id(), true);
+        election.onVote(
+            candidateTermId, leadershipTermId, logPosition, candidateMember.id(), clusterMembers[2].id(), true);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_LOG_REPLICATION.code());
+
+        election.doWork(clock.nanoTime());
+
+        verify(consensusPublisher).newLeadershipTerm(
+            clusterMembers[1].publication(),
+            leadershipTermId,
+            0,
+            0,
+            NULL_POSITION,
+            candidateTermId,
+            logPosition,
+            logPosition,
+            RECORDING_ID,
+            clock.nanoTime(),
+            candidateMember.id(),
+            LOG_SESSION_ID,
+            election.isLeaderStartup());
+
+        verify(consensusPublisher).newLeadershipTerm(
+            clusterMembers[2].publication(),
+            leadershipTermId,
+            0,
+            0,
+            NULL_POSITION,
+            candidateTermId,
+            logPosition,
+            logPosition,
+            RECORDING_ID,
+            clock.nanoTime(),
+            candidateMember.id(),
+            LOG_SESSION_ID,
+            election.isLeaderStartup());
+
+        when(recordingLog.isUnknown(candidateTermId)).thenReturn(Boolean.TRUE);
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_REPLAY.code());
+
+        election.doWork(clock.nanoTime());
+
+        verify(consensusModuleAgent).joinLogAsLeader(eq(candidateTermId), eq(logPosition), anyInt(), eq(true));
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_READY.code());
+        verify(recordingLog).ensureCoherent(
+            RECORDING_ID,
+            NULL_VALUE,
+            logPosition,
+            candidateTermId,
+            logPosition,
+            NULL_VALUE,
+            clock.nanoTime(),
+            clock.nanoTime(),
+            ctx.fileSyncLevel());
+
+        assertEquals(NULL_POSITION, clusterMembers[1].logPosition());
+        assertEquals(NULL_POSITION, clusterMembers[2].logPosition());
+        assertEquals(candidateTermId, election.leadershipTermId());
+
+        clock.increment(1);
+        election.doWork(clock.nanoTime());
+        verify(electionStateCounter).setOrdered(ElectionState.LEADER_READY.code());
+
+        when(consensusModuleAgent.appendNewLeadershipTermEvent(anyLong())).thenReturn(true);
+
+        clock.increment(1);
+        election.onAppendPosition(candidateTermId, logPosition, clusterMembers[1].id(), APPEND_POSITION_FLAG_NONE);
+        election.onAppendPosition(candidateTermId, logPosition, clusterMembers[2].id(), APPEND_POSITION_FLAG_NONE);
+        election.doWork(clock.nanoTime());
+        final InOrder inOrder = inOrder(consensusModuleAgent, electionStateCounter);
+        inOrder.verify(consensusModuleAgent).electionComplete(anyLong());
+        inOrder.verify(electionStateCounter).setOrdered(ElectionState.CLOSED.code());
+    }
+
     private Election newElection(
         final boolean isStartup,
         final long logLeadershipTermId,
@@ -1525,6 +1650,33 @@ class ElectionTest
             consensusPublisher,
             ctx,
             consensusModuleAgent);
+    }
+
+    private Election newElection(
+        final long logLeadershipTermId,
+        final long logPosition,
+        final ClusterMember[] clusterMembers,
+        final ClusterMember thisMember,
+        final int currentAppointedLeaderId)
+    {
+        final Int2ObjectHashMap<ClusterMember> clusterMemberByIdMap = new Int2ObjectHashMap<>();
+
+        ClusterMember.addClusterMemberIds(clusterMembers, clusterMemberByIdMap);
+
+        return new Election(
+            true,
+            NULL_VALUE,
+            logLeadershipTermId,
+            logPosition,
+            logPosition,
+            logPosition,
+            clusterMembers,
+            clusterMemberByIdMap,
+            thisMember,
+            consensusPublisher,
+            ctx,
+            consensusModuleAgent,
+            currentAppointedLeaderId);
     }
 
     private static ClusterMember[] prepareClusterMembers()

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -1986,14 +1986,13 @@ class ClusterTest
         final long service2SnapshotDelayMs = 222;
 
         cluster = aCluster()
-            .withServiceSupplier(
-                (i) -> new TestNode.TestService[]
-                    {
-                        new TestNode.SleepOnSnapshotTestService()
-                            .snapshotDelayMs(service1SnapshotDelayMs).index(i),
-                        new TestNode.SleepOnSnapshotTestService()
-                            .snapshotDelayMs(service2SnapshotDelayMs).index(i)
-                    })
+            .withServiceSupplier((i) -> new TestNode.TestService[]
+            {
+                new TestNode.SleepOnSnapshotTestService()
+                    .snapshotDelayMs(service1SnapshotDelayMs).index(i),
+                new TestNode.SleepOnSnapshotTestService()
+                    .snapshotDelayMs(service2SnapshotDelayMs).index(i)
+            })
             .withStaticNodes(3)
             .withAuthorisationServiceSupplier(() -> AuthorisationService.ALLOW_ALL)
             .start();
@@ -2211,23 +2210,23 @@ class ClusterTest
             .withLogChannel("aeron:udp?term-length=1m|alias=raft")
             .withStaticNodes(3)
             .withServiceSupplier((i) -> new TestNode.TestService[]
+            {
+                new TestNode.TestService().index(i),
+                new TestNode.TestService()
                 {
-                    new TestNode.TestService().index(i),
-                    new TestNode.TestService()
+                    public void onSessionMessage(
+                        final ClientSession session,
+                        final long timestamp,
+                        final DirectBuffer buffer,
+                        final int offset,
+                        final int length,
+                        final Header header)
                     {
-                        public void onSessionMessage(
-                            final ClientSession session,
-                            final long timestamp,
-                            final DirectBuffer buffer,
-                            final int offset,
-                            final int length,
-                            final Header header)
-                        {
-                            Tests.sleep(sleepTimeMs);
-                            messageCount.incrementAndGet();
-                        }
-                    }.index(i)
-                })
+                        Tests.sleep(sleepTimeMs);
+                        messageCount.incrementAndGet();
+                    }
+                }.index(i)
+            })
             .start();
         systemTestWatcher.cluster(cluster);
 

--- a/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/cluster/ClusterTest.java
@@ -46,11 +46,7 @@ import org.agrona.BitUtil;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
-import org.agrona.collections.Hashing;
-import org.agrona.collections.IntHashSet;
-import org.agrona.collections.MutableBoolean;
-import org.agrona.collections.MutableInteger;
-import org.agrona.collections.MutableLong;
+import org.agrona.collections.*;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.status.CountersReader;
 import org.hamcrest.CoreMatchers;
@@ -87,9 +83,10 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.concurrent.TimeUnit.*;
 import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.concurrent.status.CountersReader.NULL_COUNTER_ID;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.number.OrderingComparison.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SlowTest
@@ -1992,10 +1989,10 @@ class ClusterTest
             .withServiceSupplier(
                 (i) -> new TestNode.TestService[]
                     {
-                    new TestNode.SleepOnSnapshotTestService()
-                        .snapshotDelayMs(service1SnapshotDelayMs).index(i),
-                    new TestNode.SleepOnSnapshotTestService()
-                        .snapshotDelayMs(service2SnapshotDelayMs).index(i)
+                        new TestNode.SleepOnSnapshotTestService()
+                            .snapshotDelayMs(service1SnapshotDelayMs).index(i),
+                        new TestNode.SleepOnSnapshotTestService()
+                            .snapshotDelayMs(service2SnapshotDelayMs).index(i)
                     })
             .withStaticNodes(3)
             .withAuthorisationServiceSupplier(() -> AuthorisationService.ALLOW_ALL)
@@ -2214,23 +2211,23 @@ class ClusterTest
             .withLogChannel("aeron:udp?term-length=1m|alias=raft")
             .withStaticNodes(3)
             .withServiceSupplier((i) -> new TestNode.TestService[]
-            {
-                new TestNode.TestService().index(i),
-                new TestNode.TestService()
                 {
-                    public void onSessionMessage(
-                        final ClientSession session,
-                        final long timestamp,
-                        final DirectBuffer buffer,
-                        final int offset,
-                        final int length,
-                        final Header header)
+                    new TestNode.TestService().index(i),
+                    new TestNode.TestService()
                     {
-                        Tests.sleep(sleepTimeMs);
-                        messageCount.incrementAndGet();
-                    }
-                }.index(i)
-            })
+                        public void onSessionMessage(
+                            final ClientSession session,
+                            final long timestamp,
+                            final DirectBuffer buffer,
+                            final int offset,
+                            final int length,
+                            final Header header)
+                        {
+                            Tests.sleep(sleepTimeMs);
+                            messageCount.incrementAndGet();
+                        }
+                    }.index(i)
+                })
             .start();
         systemTestWatcher.cluster(cluster);
 
@@ -2273,6 +2270,7 @@ class ClusterTest
             {
                 private int messageOffset;
 
+                @Override
                 public void onSessionMessage(
                     final ClientSession session,
                     final long timestamp,
@@ -2690,6 +2688,54 @@ class ClusterTest
         }
     }
 
+    @Test
+    @InterruptAfter(20)
+    void shouldChangeAppointedLeaderAfterReceivingAdminRequestOfAppointLeader()
+    {
+        cluster = aCluster()
+            .withStaticNodes(3)
+            .withAuthorisationServiceSupplier(() ->
+                (protocolId, actionId, type, encodedPrincipal) ->
+                {
+                    assertEquals(MessageHeaderDecoder.SCHEMA_ID, protocolId);
+                    assertEquals(AdminRequestEncoder.TEMPLATE_ID, actionId);
+                    assertEquals(AdminRequestType.APPOINT_LEADER, type);
+                    return true;
+                })
+            .start();
+        systemTestWatcher.cluster(cluster);
+
+        final TestNode leader = cluster.awaitLeader();
+
+        final long requestCorrelationId = System.nanoTime();
+        final MutableBoolean hasResponse =
+            injectAppointedLeadeerAdminRequestControlledEgressListener(requestCorrelationId);
+
+        final AeronCluster client = cluster.connectClient();
+        int appointedLeaderId = 0;
+        for (final ClusterMember activeMember : leader.clusterMembership().activeMembers)
+        {
+            if (activeMember.id() != leader.clusterMembership().memberId)
+            {
+                appointedLeaderId = activeMember.id();
+                break;
+            }
+        }
+        while (!client.sendAdminRequestToAppointLeader(requestCorrelationId, appointedLeaderId))
+        {
+            Tests.yield();
+        }
+
+        while (!hasResponse.get())
+        {
+            client.controlledPollEgress();
+            Tests.yield();
+        }
+
+        final TestNode newLeader = cluster.awaitLeaderAndClosedElection(leader.clusterMembership().memberId);
+        assertEquals(appointedLeaderId, newLeader.clusterMembership().memberId);
+    }
+
     private static void verifyClientName(final Aeron aeron, final long targetClientId, final String expectedClientName)
     {
         assertNotEquals(aeron.clientId(), targetClientId);
@@ -2824,6 +2870,55 @@ class ClusterTest
                     assertNotNull(payload);
                     final int minPayloadOffset =
                         MessageHeaderEncoder.ENCODED_LENGTH +
+                        AdminResponseEncoder.BLOCK_LENGTH +
+                        AdminResponseEncoder.messageHeaderLength() +
+                        message.length() +
+                        AdminResponseEncoder.payloadHeaderLength();
+                    assertTrue(payloadOffset > minPayloadOffset);
+                    assertEquals(0, payloadLength);
+                }
+            });
+
+        return hasResponse;
+    }
+
+    private MutableBoolean injectAppointedLeadeerAdminRequestControlledEgressListener(final long expectedCorrelationId)
+    {
+        final MutableBoolean hasResponse = new MutableBoolean();
+
+        cluster.controlledEgressListener(
+            new ControlledEgressListener()
+            {
+                @Override
+                public ControlledFragmentHandler.Action onMessage(
+                    final long clusterSessionId,
+                    final long timestamp,
+                    final DirectBuffer buffer,
+                    final int offset,
+                    final int length,
+                    final Header header)
+                {
+                    return ControlledFragmentHandler.Action.ABORT;
+                }
+
+                @Override
+                public void onAdminResponse(
+                    final long clusterSessionId,
+                    final long correlationId,
+                    final AdminRequestType requestType,
+                    final AdminResponseCode responseCode,
+                    final String message,
+                    final DirectBuffer payload,
+                    final int payloadOffset,
+                    final int payloadLength)
+                {
+                    hasResponse.set(true);
+                    assertEquals(expectedCorrelationId, correlationId);
+                    assertEquals(AdminRequestType.APPOINT_LEADER, requestType);
+                    assertEquals(AdminResponseCode.OK, responseCode);
+                    assertEquals(EMPTY_MSG, message);
+                    assertNotNull(payload);
+                    final int minPayloadOffset = MessageHeaderEncoder.ENCODED_LENGTH +
                         AdminResponseEncoder.BLOCK_LENGTH +
                         AdminResponseEncoder.messageHeaderLength() +
                         message.length() +


### PR DESCRIPTION
Appoint a node as the leader during runTime, use ClusterAction to push all members enter election mode at the same position, and dynamically set the appointedLeaderId which only takes effect once.