### PR TITLE
[C] Allocate a buffer for client name.

### DIFF
--- a/aeron-client/src/main/c/aeron_context.c
+++ b/aeron-client/src/main/c/aeron_context.c
@@ -110,7 +110,13 @@ int aeron_context_init(aeron_context_t **context)
 
     if ((value = getenv(AERON_CLIENT_NAME_ENV_VAR)))
     {
-        _context->client_name = value;
+        size_t name_length = strlen(value);
+        if (aeron_alloc((void **)&_context->client_name, name_length + 1) < 0)
+        {
+            AERON_APPEND_ERR("%s", "Unable to allocate client_name");
+            return -1;
+        }
+        snprintf(_context->client_name, name_length + 1, "%s", value);
     }
 
     if ((value = getenv(AERON_DRIVER_TIMEOUT_ENV_VAR)))
@@ -216,7 +222,13 @@ int aeron_context_set_client_name(aeron_context_t *context, const char *value)
     AERON_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, context);
     AERON_CONTEXT_SET_CHECK_ARG_AND_RETURN(-1, value);
 
-    context->client_name = value;
+    size_t name_length = strlen(value);
+    if (aeron_reallocf((void **)&context->client_name, name_length + 1) < 0)
+    {
+        AERON_APPEND_ERR("%s", "Unable to reallocate context->client_name");
+        return -1;
+    }
+    snprintf(context->client_name, name_length + 1, "%s", value);
     return 0;
 }
 

--- a/aeron-client/src/main/c/aeron_context.h
+++ b/aeron-client/src/main/c/aeron_context.h
@@ -29,7 +29,7 @@
 typedef struct aeron_context_stct
 {
     char *aeron_dir;
-    const char *client_name;
+    char *client_name;
 
     aeron_error_handler_t error_handler;
     void *error_handler_clientd;


### PR DESCRIPTION
Setting the client name with the C library causes a crash when closing the context because it tries to free a pointer that hasn't been heap-allocated. I fixed it by copying the name to a new buffer.

The issue can be reproduced with sample binaries:
```
$ AERON_CLIENT_NAME=oops ./binaries/cpong 
Subscribing Ping at channel aeron:udp?endpoint=localhost:20123 on Stream ID 1002
Publishing Pong at channel aeron:udp?endpoint=localhost:20124 on Stream ID 1003
Subscription channel status 1
Publication channel status 1
^Cmunmap_chunk(): invalid pointer
Aborted (core dumped)
```

Another option would be to just not free, but I think holding it in a new buffer is more robust and consistent with `aeron_context_set_dir()`.