### PR TITLE
[Java] Reduce archive listRecordingsForUri idling

### DIFF
--- a/aeron-archive/src/main/java/io/aeron/archive/AbstractListRecordingsSession.java
+++ b/aeron-archive/src/main/java/io/aeron/archive/AbstractListRecordingsSession.java
@@ -101,7 +101,7 @@ abstract class AbstractListRecordingsSession implements Session
             }
         }
 
-        final int alreadySent = sent;
+        final int batchStartPosition = position;
         for (int recordsScanned = 0; sent < count && recordsScanned < MAX_SCANS_PER_WORK_CYCLE; recordsScanned++)
         {
             final boolean noMoreRecordings = position < 0 || position > lastPosition;
@@ -140,7 +140,7 @@ abstract class AbstractListRecordingsSession implements Session
             isDone = true;
         }
 
-        return sent - alreadySent;
+        return (position - batchStartPosition) / 2;
     }
 
     /**

--- a/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
+++ b/aeron-archive/src/test/java/io/aeron/archive/ListRecordingsForUriSessionTest.java
@@ -91,7 +91,7 @@ class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        assertEquals(3, session.doWork());
+        assertEquals(5, session.doWork());
         verify(controlSession, times(3)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
     }
 
@@ -115,7 +115,7 @@ class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        assertEquals(2, session.doWork());
+        assertEquals(4, session.doWork());
         verify(controlSession, times(2)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
     }
 
@@ -136,7 +136,7 @@ class ListRecordingsForUriSessionTest
             recordingDescriptorDecoder);
 
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy))).thenReturn(0);
-        assertEquals(0, session.doWork());
+        assertEquals(1, session.doWork());
         verify(controlSession, times(1)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
 
         final MutableLong counter = new MutableLong(fromRecordingId);
@@ -166,7 +166,7 @@ class ListRecordingsForUriSessionTest
         when(controlSession.sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy)))
             .then(verifySendDescriptor(counter));
 
-        assertEquals(2, session.doWork());
+        assertEquals(4, session.doWork());
         verify(controlSession, times(2)).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
         verify(controlSession).sendRecordingUnknown(eq(correlationId), eq(5L), eq(controlResponseProxy));
     }
@@ -186,7 +186,7 @@ class ListRecordingsForUriSessionTest
             descriptorBuffer,
             recordingDescriptorDecoder);
 
-        assertEquals(0, session.doWork());
+        assertEquals(4, session.doWork());
 
         verify(controlSession, never()).sendDescriptor(eq(correlationId), any(), eq(controlResponseProxy));
         verify(controlSession).sendRecordingUnknown(eq(correlationId), eq(5L), eq(controlResponseProxy));


### PR DESCRIPTION
With the recent reduction to MAX_SCANS_PER_WORK_CYCLE in https://github.com/real-logic/aeron/commit/1c558899c4d8e62b351adac9addd177d9d108f51, we noted that some list operations took significantly longer time, but when profiling it looked like archive was just sleeping.

As it turns out, list recordings only return a positive work count if it actually found something, but this means that a listRecordingsForUri API call that matches only a small subset of recordings (or even none at all) will idle every 64 recordings, which for a large catalog caused the list operation to take multiple seconds of sleeping.

This instead changes work count to be based on the number of recordings processed, which for listRecordings should be exactly the same, but for listRecordingsForUri should only idle if there are no more recordings to check at the moment.