### PR TITLE
C++ wrapper improvements

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/FragmentAssembler.h
+++ b/aeron-client/src/main/cpp_wrapper/FragmentAssembler.h
@@ -61,6 +61,11 @@ public:
         aeron_fragment_assembler_delete(m_fragment_assembler);
     }
 
+    FragmentAssembler(FragmentAssembler& other) = delete;
+    FragmentAssembler(FragmentAssembler&& other) = delete;
+    FragmentAssembler& operator=(FragmentAssembler& other) = delete;
+    FragmentAssembler& operator=(FragmentAssembler&& other) = delete;
+
     /**
      * Compose a fragment_handler_t that calls the this FragmentAssembler instance for reassembly. Suitable for
      * passing to Subscription::poll(fragment_handler_t, int).

--- a/aeron-client/src/main/cpp_wrapper/Subscription.h
+++ b/aeron-client/src/main/cpp_wrapper/Subscription.h
@@ -487,6 +487,11 @@ public:
     inline std::shared_ptr<Image> imageBySessionId(std::int32_t sessionId) const
     {
         aeron_image_t *image = aeron_subscription_image_by_session_id(m_subscription, sessionId);
+        if (nullptr == image)
+        {
+            return nullptr;
+        }
+
         return std::make_shared<Image>(m_subscription, image);
     }
 
@@ -502,6 +507,11 @@ public:
     inline std::shared_ptr<Image> imageByIndex(std::size_t index) const
     {
         aeron_image_t *image = aeron_subscription_image_at_index(m_subscription, index);
+        if (nullptr == image)
+        {
+            throw std::logic_error("index out of range");
+        }
+
         return std::make_shared<Image>(m_subscription, image);
     }
 

--- a/aeron-client/src/test/cpp_wrapper/PubSubTest.cpp
+++ b/aeron-client/src/test/cpp_wrapper/PubSubTest.cpp
@@ -581,11 +581,10 @@ public:
         m_subscription(subscription),
         m_publication(publication),
         m_assembler(
-            FragmentAssembler(
-                [&](AtomicBuffer &buffer, index_t offset, index_t length, Header &header)
-                {
-                    m_innerHandler(buffer, offset, length, header);
-                })),
+             [&](AtomicBuffer &buffer, index_t offset, index_t length, Header &header)
+             {
+                 m_innerHandler(buffer, offset, length, header);
+             }),
         m_outerHandler(m_assembler.handler()),
         m_generator(generator_t(m_rd())),
         m_invoker(invoker)


### PR DESCRIPTION
Josh raised a couple of issues through premium support tickets. More notes in the commit messages. Based on the README, I think it is okay to assume `>= C++11`, but please correct me if I am wrong.