### PR TITLE
[Java] modify onStart callback for ConsensusModuleExtension.

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -368,6 +368,11 @@ final class ConsensusModuleAgent
             {
                 workCount += consensusWork(timestamp, nowNs);
             }
+
+            if (null != consensusModuleExtension)
+            {
+                workCount += consensusModuleExtension.doWork(election != null, nowNs);
+            }
         }
         catch (final AgentTerminationException ex)
         {
@@ -2415,10 +2420,6 @@ final class ConsensusModuleAgent
 
         workCount += consensusModuleAdapter.poll();
         workCount += pollStandbySnapshotReplication(nowNs);
-        if (null != consensusModuleExtension)
-        {
-            workCount += consensusModuleExtension.doWork(nowNs);
-        }
 
         return workCount;
     }

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleAgent.java
@@ -3612,9 +3612,10 @@ final class ConsensusModuleAgent
             {
                 loadSnapshot(recoveryPlan.snapshots.get(0), archive);
             }
-            else if (null != consensusModuleExtension)
+
+            if (null != consensusModuleExtension)
             {
-                consensusModuleExtension.onStart(this, null);
+                consensusModuleExtension.onStart(this);
             }
 
             while (!ServiceAck.hasReached(expectedAckPosition, serviceAckId, serviceAckQueues))

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
@@ -57,9 +57,10 @@ public interface ConsensusModuleExtension extends AutoCloseable
      * If the extension wished to terminate and close then a {@link AgentTerminationException} can be thrown.
      *
      * @param nowNs is cluster time in nanoseconds.
+     * @param duringElection indicates if the cluster is in an election.
      * @return 0 to indicate no work was currently available, a positive value otherwise.
      */
-    int doWork(long nowNs);
+    int doWork(boolean duringElection, long nowNs);
 
     /**
      * Cluster election is complete and new publication is added for the leadership term. If the node is a follower

--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusModuleExtension.java
@@ -36,17 +36,15 @@ public interface ConsensusModuleExtension extends AutoCloseable
     int supportedSchemaId();
 
     /**
-     * Start event where the extension can perform any initialisation required and load snapshot state.
-     * The snapshot image can be null if no previous snapshot exists.
+     * Start event where the extension can perform any initialisation required.
      * <p>
      * <b>Note:</b> As this is a potentially long-running operation the implementation should use
      * {@link Cluster#idleStrategy()} and then occasionally call {@link org.agrona.concurrent.IdleStrategy#idle()} or
      * {@link org.agrona.concurrent.IdleStrategy#idle(int)}, especially when polling the {@link Image} returns 0.
      *
      * @param consensusModuleControl with which the extension can interact.
-     * @param snapshotImage          from which the extension can load its state which can be null when no snapshot.
      */
-    void onStart(ConsensusModuleControl consensusModuleControl, Image snapshotImage);
+    void onStart(ConsensusModuleControl consensusModuleControl);
 
     /**
      * An extension should implement this method to do its work. Long-running operations should be decomposed.

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
@@ -72,7 +72,7 @@ class ClusterWithNoServicesTest
         final InOrder inOrder = inOrder(consensusModuleExtensionSpy);
         inOrder.verify(consensusModuleExtensionSpy).onStart(any(ConsensusModuleControl.class), isNull());
         inOrder.verify(consensusModuleExtensionSpy).onElectionComplete(any(ConsensusControlState.class));
-        inOrder.verify(consensusModuleExtensionSpy, atLeastOnce()).doWork(anyLong());
+        inOrder.verify(consensusModuleExtensionSpy, atLeastOnce()).doWork(anyBoolean(), anyLong());
 
         verify(consensusModuleExtensionSpy).onSessionOpened(anyLong());
 
@@ -124,7 +124,7 @@ class ClusterWithNoServicesTest
         {
         }
 
-        public int doWork(final long nowNs)
+        public int doWork(final boolean duringElection, final long nowNs)
         {
             return 0;
         }

--- a/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
+++ b/aeron-cluster/src/test/java/io/aeron/cluster/ClusterWithNoServicesTest.java
@@ -15,7 +15,6 @@
  */
 package io.aeron.cluster;
 
-import io.aeron.Image;
 import io.aeron.archive.ArchiveThreadingMode;
 import io.aeron.cluster.client.AeronCluster;
 import io.aeron.driver.MediaDriver;
@@ -70,7 +69,7 @@ class ClusterWithNoServicesTest
         assertTrue(aeronCluster.sendKeepAlive());
 
         final InOrder inOrder = inOrder(consensusModuleExtensionSpy);
-        inOrder.verify(consensusModuleExtensionSpy).onStart(any(ConsensusModuleControl.class), isNull());
+        inOrder.verify(consensusModuleExtensionSpy).onStart(any(ConsensusModuleControl.class));
         inOrder.verify(consensusModuleExtensionSpy).onElectionComplete(any(ConsensusControlState.class));
         inOrder.verify(consensusModuleExtensionSpy, atLeastOnce()).doWork(anyBoolean(), anyLong());
 
@@ -120,7 +119,7 @@ class ClusterWithNoServicesTest
             return 0;
         }
 
-        public void onStart(final ConsensusModuleControl consensusModuleControl, final Image snapshotImage)
+        public void onStart(final ConsensusModuleControl consensusModuleControl)
         {
         }
 


### PR DESCRIPTION
Ensure the onStart method is executed at program startup, regardless of whether a snapshot exists or not.