### PR TITLE
Tethering join position

### DIFF
--- a/aeron-driver/src/main/c/aeron_ipc_publication.c
+++ b/aeron-driver/src/main/c/aeron_ipc_publication.c
@@ -372,7 +372,8 @@ void aeron_ipc_publication_check_untethered_subscriptions(
                 case AERON_SUBSCRIPTION_TETHER_RESTING:
                     if (now_ns > (tetherable_position->time_of_last_update_ns + resting_timeout_ns))
                     {
-                        aeron_counter_set_ordered(tetherable_position->value_addr, consumer_position);
+                        int64_t join_position = aeron_ipc_publication_join_position(publication);
+                        aeron_counter_set_ordered(tetherable_position->value_addr, join_position);
                         aeron_driver_conductor_on_available_image(
                             conductor,
                             publication->conductor_fields.managed_resource.registration_id,

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -1048,7 +1048,7 @@ void aeron_publication_image_check_untethered_subscriptions(
                 case AERON_SUBSCRIPTION_TETHER_RESTING:
                     if (now_ns > (tetherable_position->time_of_last_update_ns + resting_timeout_ns))
                     {
-                        aeron_counter_set_ordered(tetherable_position->value_addr, *image->rcv_pos_position.value_addr);
+                        aeron_counter_set_ordered(tetherable_position->value_addr, max_sub_pos);
                         aeron_driver_conductor_on_available_image(
                             conductor,
                             image->conductor_fields.managed_resource.registration_id,

--- a/aeron-driver/src/main/c/aeron_publication_image.c
+++ b/aeron-driver/src/main/c/aeron_publication_image.c
@@ -1048,7 +1048,8 @@ void aeron_publication_image_check_untethered_subscriptions(
                 case AERON_SUBSCRIPTION_TETHER_RESTING:
                     if (now_ns > (tetherable_position->time_of_last_update_ns + resting_timeout_ns))
                     {
-                        aeron_counter_set_ordered(tetherable_position->value_addr, max_sub_pos);
+                        int64_t join_position = aeron_publication_image_join_position(image);
+                        aeron_counter_set_ordered(tetherable_position->value_addr, join_position);
                         aeron_driver_conductor_on_available_image(
                             conductor,
                             image->conductor_fields.managed_resource.registration_id,

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -461,7 +461,7 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
                         sessionId,
                         untethered.subscriptionLink,
                         untethered.position.id(),
-                        joinPosition(),
+                        consumerPosition,
                         rawLog.fileName(),
                         CommonContext.IPC_CHANNEL);
                     untethered.state(UntetheredSubscription.State.ACTIVE, nowNs, streamId, sessionId);

--- a/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/IpcPublication.java
@@ -455,13 +455,14 @@ public final class IpcPublication implements DriverManagedResource, Subscribable
             {
                 if ((untethered.timeOfLastUpdateNs + untetheredRestingTimeoutNs) - nowNs <= 0)
                 {
+                    final long joinPosition = joinPosition();
                     subscriberPositions = ArrayUtil.add(subscriberPositions, untethered.position);
                     conductor.notifyAvailableImageLink(
                         registrationId,
                         sessionId,
                         untethered.subscriptionLink,
                         untethered.position.id(),
-                        consumerPosition,
+                        joinPosition,
                         rawLog.fileName(),
                         CommonContext.IPC_CHANNEL);
                     untethered.state(UntetheredSubscription.State.ACTIVE, nowNs, streamId, sessionId);

--- a/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
+++ b/aeron-driver/src/test/java/io/aeron/driver/UntetheredSubscriptionTest.java
@@ -113,7 +113,7 @@ class UntetheredSubscriptionTest
             eq(SESSION_ID),
             eq(untetheredLink),
             anyInt(),
-            eq(ipcPublication.joinPosition()),
+            eq(tetheredPosition.get()),
             eq(rawLog.fileName()),
             eq(CommonContext.IPC_CHANNEL));
     }

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -218,6 +219,10 @@ class UntetheredSubscriptionTest
                         aeron.conductorAgentInvoker().invoke();
                     }
 
+                    if (!channel.startsWith("aeron-spy"))
+                    {
+                        assertEquals(tetheredSub.imageAtIndex(0).position(), untetheredSub.imageAtIndex(0).joinPosition());
+                    }
                     return;
                 }
             }

--- a/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/UntetheredSubscriptionTest.java
@@ -221,7 +221,9 @@ class UntetheredSubscriptionTest
 
                     if (!channel.startsWith("aeron-spy"))
                     {
-                        assertEquals(tetheredSub.imageAtIndex(0).position(), untetheredSub.imageAtIndex(0).joinPosition());
+                        final long tetheredPosition = tetheredSub.imageAtIndex(0).position();
+                        final long untetheredJoinPosition = untetheredSub.imageAtIndex(0).joinPosition();
+                        assertEquals(tetheredPosition, untetheredJoinPosition);
                     }
                     return;
                 }


### PR DESCRIPTION
For untethered subscriptions transitioning from resting to active, avoid using their own position in minimum join position