### PR TITLE
Unknown cppbuild arg, exit with exitcode=1

### DIFF
--- a/cppbuild/cppbuild
+++ b/cppbuild/cppbuild
@@ -172,7 +172,7 @@ do
     *)
       echo "Unknown option ${option}"
       echo "Use --help for help"
-      exit
+      exit 1
       ;;
   esac
 done


### PR DESCRIPTION
When an unknown argument is passed to cppbuild, the exitcode is 0. Making it difficult to determine if the build was a success or a failure (especially if the cppbuild is part of a another script).

This PR changes that by setting the exitcode to 1.