### PR TITLE
Use provided credentials on standby snapshot

### DIFF
--- a/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
+++ b/aeron-cluster/src/main/java/io/aeron/cluster/ConsensusAdapter.java
@@ -351,6 +351,7 @@ class ConsensusAdapter implements FragmentHandler, AutoCloseable
                 else
                 {
                     encodedCredentials = new byte[standbySnapshotDecoder.encodedCredentialsLength()];
+                    standbySnapshotDecoder.getEncodedCredentials(encodedCredentials, 0, encodedCredentials.length);
                 }
 
                 consensusModuleAgent.onStandbySnapshot(


### PR DESCRIPTION
Currently the cluster is not able to receive standby snapshot notifications when using an authenticator that checks the credentials.
This is because the provided credentials on standby snapshot notifications are not read.