### PR TITLE
Undef macros major() and minor() defined in sys/sysmacros.h to prevent name collisions

### DIFF
--- a/aeron-archive/src/main/cpp/client/AeronArchiveVersion.h
+++ b/aeron-archive/src/main/cpp/client/AeronArchiveVersion.h
@@ -18,6 +18,13 @@
 
 #include "string"
 
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
 namespace aeron { namespace archive { namespace client
 {
 

--- a/aeron-client/src/main/cpp/AeronVersion.h
+++ b/aeron-client/src/main/cpp/AeronVersion.h
@@ -19,6 +19,13 @@
 #include "string"
 #include "util/Export.h"
 
+#ifdef major
+#undef major
+#endif
+#ifdef minor
+#undef minor
+#endif
+
 namespace aeron
 {
 


### PR DESCRIPTION
Older libc versions include the file sys/sysmacros.h in sys/types.h which causes name collisions with the major() and minor() functions.