### PR TITLE
[C] Remove duplicate definition of aeron_semantic_version_compose.

### DIFF
--- a/aeron-archive/src/main/c/client/aeron_archive_configuration.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_configuration.c
@@ -15,11 +15,7 @@
  */
 
 #include "aeron_archive_configuration.h"
-
-int32_t aeron_semantic_version_compose(uint8_t major, uint8_t minor, uint8_t patch)
-{
-    return (major << 16) | (minor << 8) | patch;
-}
+#include "aeron_common.h"
 
 int32_t aeron_archive_semantic_version(void)
 {


### PR DESCRIPTION
This fixes a duplicate symbol error when linking.