### PR TITLE
[java]fix resolution bug

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -356,7 +356,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
             {
                 timeOfLastResolutionNs = nowNs;
                 final String endpoint = udpChannel.channelUri().get(CommonContext.ENDPOINT_PARAM_NAME);
-                conductorProxy.reResolveEndpoint(endpoint, this, udpChannel.remoteData());
+                conductorProxy.reResolveEndpoint(endpoint, this, this.connectAddress);
             }
         }
     }


### PR DESCRIPTION
when the new address is back to the udpChannel.remoteData, this can not be triggered `resolution changes`