### PR TITLE
Replacement of ThreadHints.onSpinWait by Thread.

### DIFF
--- a/aeron-samples/src/main/java/io/aeron/samples/raw/BurstSendReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/BurstSendReceiveUdpPing.java
@@ -21,7 +21,6 @@ import org.agrona.BitUtil;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -139,7 +138,7 @@ public class BurstSendReceiveUdpPing
                     {
                         break;
                     }
-                    ThreadHints.onSpinWait();
+                    Thread.onSpinWait();
                 }
 
                 final long receivedSequenceNumber = buffer.getLong(0);

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/ReceiveSendUdpPong.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/ReceiveSendUdpPong.java
@@ -19,7 +19,6 @@ import io.aeron.driver.Configuration;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -88,7 +87,7 @@ public class ReceiveSendUdpPong
             boolean available = false;
             while (!available)
             {
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
                 if (!running.get())
                 {
                     return;

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/ReceiveWriteUdpPong.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/ReceiveWriteUdpPong.java
@@ -18,7 +18,6 @@ package io.aeron.samples.raw;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -79,7 +78,7 @@ public class ReceiveWriteUdpPong
             boolean available = false;
             while (!available)
             {
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
                 if (!running.get())
                 {
                     return;

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/SelectReceiveSendUdpPong.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/SelectReceiveSendUdpPong.java
@@ -19,7 +19,6 @@ import io.aeron.driver.Configuration;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -107,7 +106,7 @@ public class SelectReceiveSendUdpPong
                     return;
                 }
 
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
             }
 
             final Set<SelectionKey> selectedKeys = selector.selectedKeys();

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/SendReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/SendReceiveUdpPing.java
@@ -21,7 +21,6 @@ import org.agrona.BitUtil;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -119,7 +118,7 @@ public class SendReceiveUdpPing
             boolean available = false;
             while (!available)
             {
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
                 if (!running.get())
                 {
                     return;

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/SendSelectReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/SendSelectReceiveUdpPing.java
@@ -21,7 +21,6 @@ import org.agrona.SystemUtil;
 import org.agrona.collections.MutableLong;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -145,7 +144,7 @@ public class SendSelectReceiveUdpPing
                     return;
                 }
 
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
             }
 
             final Set<SelectionKey> selectedKeys = selector.selectedKeys();

--- a/aeron-samples/src/main/java/io/aeron/samples/raw/WriteReceiveUdpPing.java
+++ b/aeron-samples/src/main/java/io/aeron/samples/raw/WriteReceiveUdpPing.java
@@ -18,7 +18,6 @@ import org.HdrHistogram.Histogram;
 import org.agrona.SystemUtil;
 import org.agrona.concurrent.HighResolutionTimer;
 import org.agrona.concurrent.SigInt;
-import org.agrona.hints.ThreadHints;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -111,7 +110,7 @@ public class WriteReceiveUdpPing
             boolean available = false;
             while (!available)
             {
-                ThreadHints.onSpinWait();
+                Thread.onSpinWait();
                 if (!running.get())
                 {
                     return;


### PR DESCRIPTION
The ThreadHints class in Agrona has been deprecated and all call to ThreadHints.onSpinWait have been replaced by Thread.onSpinWait.

For more info see:

https://github.com/real-logic/agrona/pull/312