### PR TITLE
[C++ wrapper] tidy up the namespace for exception_handler_t

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/concurrent/AgentInvoker.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/AgentInvoker.h
@@ -31,7 +31,7 @@ template<typename Agent>
 class AgentInvoker
 {
 public:
-    AgentInvoker(Agent &agent, logbuffer::exception_handler_t &exceptionHandler) :
+    AgentInvoker(Agent &agent, util::exception_handler_t &exceptionHandler) :
         m_agent(agent),
         m_exceptionHandler(exceptionHandler)
     {
@@ -140,7 +140,7 @@ public:
 
 private:
     Agent &m_agent;
-    logbuffer::exception_handler_t &m_exceptionHandler;
+    util::exception_handler_t &m_exceptionHandler;
     bool m_isStarted = false;
     bool m_isRunning = false;
     bool m_isClosed = false;

--- a/aeron-client/src/main/cpp_wrapper/concurrent/AgentRunner.h
+++ b/aeron-client/src/main/cpp_wrapper/concurrent/AgentRunner.h
@@ -37,7 +37,7 @@ template <typename Agent, typename IdleStrategy>
 class AgentRunner
 {
 public:
-    AgentRunner(Agent &agent, IdleStrategy &idleStrategy, logbuffer::exception_handler_t &exceptionHandler) :
+    AgentRunner(Agent &agent, IdleStrategy &idleStrategy, util::exception_handler_t &exceptionHandler) :
         m_agent(agent),
         m_idleStrategy(idleStrategy),
         m_exceptionHandler(exceptionHandler),
@@ -48,7 +48,7 @@ public:
     AgentRunner(
         Agent &agent,
         IdleStrategy &idleStrategy,
-        logbuffer::exception_handler_t &exceptionHandler,
+        util::exception_handler_t &exceptionHandler,
         const std::string &name) :
         m_agent(agent),
         m_idleStrategy(idleStrategy),
@@ -197,7 +197,7 @@ public:
 private:
     Agent &m_agent;
     IdleStrategy &m_idleStrategy;
-    logbuffer::exception_handler_t &m_exceptionHandler;
+    util::exception_handler_t &m_exceptionHandler;
     std::atomic<bool> m_isStarted = { false };
     std::atomic<bool> m_isRunning = { false };
     std::atomic<bool> m_isClosed = { false };


### PR DESCRIPTION

```
/aeron-client/src/main/cpp_wrapper/concurrent/AgentInvoker.h
/aeron-client/src/main/cpp_wrapper/concurrent/AgentRunner.h
```


It seems more appropriate to change the logbuffer::exception_handler_t declared in the constructors of AgentRunner and AgentInvoker to util::exception_handler_t.