### PR TITLE
Bug/fix error with tagged channels reresolution

### DIFF
--- a/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/DriverConductor.java
@@ -2127,8 +2127,7 @@ public final class DriverConductor implements Agent
         {
             for (final SendChannelEndpoint endpoint : sendChannelEndpointByChannelMap.values())
             {
-                final UdpChannel endpointUdpChannel = endpoint.udpChannel();
-                if (endpointUdpChannel.matchesTag(udpChannel))
+                if (endpoint.matchesTag(udpChannel))
                 {
                     return endpoint;
                 }

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -619,18 +619,7 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
      */
     public boolean matchesTag(final UdpChannel udpChannel)
     {
-        final boolean udpChannelMatches = super.udpChannel.matchesTag(udpChannel);
-
-        final InetSocketAddress thisRemoteData = super.udpChannel.remoteData();
-        final InetSocketAddress thatRemoteData = udpChannel.remoteData();
-        final InetSocketAddress thatLocalData = udpChannel.localData();
-
-        final boolean addressMatches = thatRemoteData.getAddress().equals(thisRemoteData.getAddress()) &&
-            thatRemoteData.getPort() == thisRemoteData.getPort() &&
-            thatLocalData.getAddress().equals(currentControlAddress.getAddress()) &&
-            thatLocalData.getPort() == currentControlAddress.getPort();
-
-        return udpChannelMatches && (udpChannel.isWildcard() || addressMatches);
+        return udpChannel.matchesTag(super.udpChannel, currentControlAddress, null);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/ReceiveChannelEndpoint.java
@@ -619,7 +619,18 @@ public class ReceiveChannelEndpoint extends ReceiveChannelEndpointRhsPadding
      */
     public boolean matchesTag(final UdpChannel udpChannel)
     {
-        return super.udpChannel.matchesTag(udpChannel);
+        final boolean udpChannelMatches = super.udpChannel.matchesTag(udpChannel);
+
+        final InetSocketAddress thisRemoteData = super.udpChannel.remoteData();
+        final InetSocketAddress thatRemoteData = udpChannel.remoteData();
+        final InetSocketAddress thatLocalData = udpChannel.localData();
+
+        final boolean addressMatches = thatRemoteData.getAddress().equals(thisRemoteData.getAddress()) &&
+            thatRemoteData.getPort() == thisRemoteData.getPort() &&
+            thatLocalData.getAddress().equals(currentControlAddress.getAddress()) &&
+            thatLocalData.getPort() == currentControlAddress.getPort();
+
+        return udpChannelMatches && (udpChannel.isWildcard() || addressMatches);
     }
 
     /**

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -643,7 +643,23 @@ public class SendChannelEndpoint extends UdpChannelTransport
      */
     public boolean matchesTag(final UdpChannel udpChannel)
     {
-        return super.udpChannel.matchesTag(udpChannel);
+        final boolean udpChannelMatches = super.udpChannel.matchesTag(udpChannel);
+
+        final InetSocketAddress thatRemoteData = udpChannel.remoteData();
+        final InetSocketAddress thisLocalData = super.udpChannel.localData();
+        final InetSocketAddress thatLocalData = udpChannel.localData();
+
+        final boolean wildcardMatches = thatRemoteData.getAddress().isAnyLocalAddress() &&
+            thatRemoteData.getPort() == 0 &&
+            thatLocalData.getAddress().isAnyLocalAddress() &&
+            thatLocalData.getPort() == 0;
+
+        final boolean addressMatches = thatRemoteData.getAddress().equals(connectAddress.getAddress()) &&
+            thatRemoteData.getPort() == connectAddress.getPort() &&
+            thatLocalData.getAddress().equals(thisLocalData.getAddress()) &&
+            thatLocalData.getPort() == thisLocalData.getPort();
+
+        return udpChannelMatches && (wildcardMatches || addressMatches);
     }
 }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -643,23 +643,7 @@ public class SendChannelEndpoint extends UdpChannelTransport
      */
     public boolean matchesTag(final UdpChannel udpChannel)
     {
-        final boolean udpChannelMatches = super.udpChannel.matchesTag(udpChannel);
-
-        final InetSocketAddress thatRemoteData = udpChannel.remoteData();
-        final InetSocketAddress thisLocalData = super.udpChannel.localData();
-        final InetSocketAddress thatLocalData = udpChannel.localData();
-
-        final boolean wildcardMatches = thatRemoteData.getAddress().isAnyLocalAddress() &&
-            thatRemoteData.getPort() == 0 &&
-            thatLocalData.getAddress().isAnyLocalAddress() &&
-            thatLocalData.getPort() == 0;
-
-        final boolean addressMatches = thatRemoteData.getAddress().equals(connectAddress.getAddress()) &&
-            thatRemoteData.getPort() == connectAddress.getPort() &&
-            thatLocalData.getAddress().equals(thisLocalData.getAddress()) &&
-            thatLocalData.getPort() == thisLocalData.getPort();
-
-        return udpChannelMatches && (wildcardMatches || addressMatches);
+        return udpChannel.matchesTag(super.udpChannel, null, connectAddress);
     }
 }
 

--- a/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/SendChannelEndpoint.java
@@ -634,6 +634,17 @@ public class SendChannelEndpoint extends UdpChannelTransport
             }
         }
     }
+
+    /**
+     * Does the channel have a matching tag?
+     *
+     * @param udpChannel with tag to match against.
+     * @return true if the channel matches on tag identity.
+     */
+    public boolean matchesTag(final UdpChannel udpChannel)
+    {
+        return super.udpChannel.matchesTag(udpChannel);
+    }
 }
 
 abstract class MultiSndDestinationLhsPadding

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -790,28 +790,21 @@ public final class UdpChannel
                 "matching tag=" + tag + " has mismatched control-mode: " + uriStr + " <> " + udpChannel.uriStr);
         }
 
-        if (!hasMatchingAddress(udpChannel))
-        {
-            throw new IllegalArgumentException(
-                "matching tag=" + tag + " has mismatched endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
-        }
-
         return true;
     }
 
-    private boolean hasMatchingAddress(final UdpChannel udpChannel)
+    /**
+     * Is this channel a fill wildcard, i.e. no addresses specified.
+     *
+     * @return <code>true</code> if all the address/port pairs of this channel are set to wildcard values,
+     * <code>false</code> otherwise.
+     */
+    public boolean isWildcard()
     {
-        final boolean otherChannelIsWildcard = udpChannel.remoteData().getAddress().isAnyLocalAddress() &&
-            udpChannel.remoteData().getPort() == 0 &&
-            udpChannel.localData().getAddress().isAnyLocalAddress() &&
-            udpChannel.localData().getPort() == 0;
-
-        final boolean otherChannelMatches = udpChannel.remoteData().getAddress().equals(remoteData.getAddress()) &&
-            udpChannel.remoteData().getPort() == remoteData.getPort() &&
-            udpChannel.localData().getAddress().equals(localData.getAddress()) &&
-            udpChannel.localData().getPort() == localData.getPort();
-
-        return otherChannelIsWildcard || otherChannelMatches;
+        return remoteData.getAddress().isAnyLocalAddress() &&
+            remoteData.getPort() == 0 &&
+            localData.getAddress().isAnyLocalAddress() &&
+            localData.getPort() == 0;
     }
 
     private boolean matchesControlMode(final UdpChannel udpChannel)

--- a/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
+++ b/aeron-driver/src/main/java/io/aeron/driver/media/UdpChannel.java
@@ -775,31 +775,36 @@ public final class UdpChannel
      * Does this channel have a tag match to another channel having INADDR_ANY endpoints.
      *
      * @param udpChannel to match against.
+     * @param localAddress local address override to use for this channel.
+     * @param remoteAddress remote address override to use for this channel.
      * @return true if there is a match otherwise false.
      */
-    public boolean matchesTag(final UdpChannel udpChannel)
+    public boolean matchesTag(
+        final UdpChannel udpChannel,
+        final InetSocketAddress localAddress,
+        final InetSocketAddress remoteAddress)
     {
         if (!hasTag || !udpChannel.hasTag() || tag != udpChannel.tag())
         {
             return false;
         }
 
-        if (!matchesControlMode(udpChannel))
+        if (!hasMatchingControlMode(udpChannel))
         {
             throw new IllegalArgumentException(
                 "matching tag=" + tag + " has mismatched control-mode: " + uriStr + " <> " + udpChannel.uriStr);
         }
 
+        if (!hasMatchingAddress(udpChannel, localAddress, remoteAddress))
+        {
+            throw new IllegalArgumentException(
+                "matching tag=" + tag + " has mismatched endpoint or control: " + uriStr + " <> " + udpChannel.uriStr);
+        }
+
         return true;
     }
 
-    /**
-     * Is this channel a fill wildcard, i.e. no addresses specified.
-     *
-     * @return <code>true</code> if all the address/port pairs of this channel are set to wildcard values,
-     * <code>false</code> otherwise.
-     */
-    public boolean isWildcard()
+    private boolean isWildcard()
     {
         return remoteData.getAddress().isAnyLocalAddress() &&
             remoteData.getPort() == 0 &&
@@ -807,9 +812,23 @@ public final class UdpChannel
             localData.getPort() == 0;
     }
 
-    private boolean matchesControlMode(final UdpChannel udpChannel)
+    private boolean hasMatchingControlMode(final UdpChannel udpChannel)
     {
-        return udpChannel.controlMode() == ControlMode.NONE || controlMode() == udpChannel.controlMode();
+        return controlMode() == ControlMode.NONE || controlMode() == udpChannel.controlMode();
+    }
+
+    private boolean hasMatchingAddress(
+        final UdpChannel udpChannel,
+        final InetSocketAddress localAddress,
+        final InetSocketAddress remoteAddress)
+    {
+        final InetSocketAddress otherLocalData = localAddress != null ? localAddress : udpChannel.localData();
+        final InetSocketAddress otherRemoteData = remoteAddress != null ? remoteAddress : udpChannel.remoteData();
+
+        return isWildcard() || remoteData().getAddress().equals(otherRemoteData.getAddress()) &&
+            remoteData().getPort() == otherRemoteData.getPort() &&
+            localData().getAddress().equals(otherLocalData.getAddress()) &&
+            localData().getPort() == otherLocalData.getPort();
     }
 
     /**

--- a/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
+++ b/aeron-system-tests/src/test/java/io/aeron/NameReResolutionTest.java
@@ -579,6 +579,54 @@ class NameReResolutionTest
         }
     }
 
+    @Test
+    @SlowTest
+    @InterruptAfter(10)
+    void shouldHandleTaggedSubscriptionsAddressWithReResolutionToMdcPublications()
+    {
+        final String taggedUri = SUBSCRIPTION_DYNAMIC_MDC_URI + "|tags=22701";
+
+        subscription = client.addSubscription(taggedUri, STREAM_ID);
+        assertFalse(subscription.isConnected());
+
+        assertTrue(updateNameResolutionStatus(countersReader, CONTROL_NAME, USE_RE_RESOLUTION_HOST));
+
+        publication = client.addPublication(SECOND_PUBLICATION_DYNAMIC_MDC_URI, STREAM_ID);
+
+        Tests.awaitConnected(subscription);
+
+        try (Subscription taggedSub1 = client.addSubscription("aeron:udp?tags=22701", STREAM_ID);
+            Subscription taggedSub2 = client.addSubscription(taggedUri, STREAM_ID))
+        {
+            Tests.awaitConnected(taggedSub1);
+            Tests.awaitConnected(taggedSub2);
+        }
+    }
+
+    @Test
+    @SlowTest
+    @InterruptAfter(10)
+    void shouldHandleTaggedPublication()
+    {
+        final String taggedUri = PUBLICATION_URI + "|tags=22701";
+
+        publication = client.addPublication(taggedUri, STREAM_ID);
+        assertFalse(publication.isConnected());
+
+        assertTrue(updateNameResolutionStatus(countersReader, ENDPOINT_NAME, USE_RE_RESOLUTION_HOST));
+
+        subscription = client.addSubscription(SECOND_SUBSCRIPTION_URI, STREAM_ID);
+
+        Tests.awaitConnected(publication);
+
+        try (Publication taggedPub1 = client.addPublication("aeron:udp?tags=22701", STREAM_ID);
+            Publication taggedPub2 = client.addPublication(taggedUri, STREAM_ID))
+        {
+            Tests.awaitConnected(taggedPub1);
+            Tests.awaitConnected(taggedPub2);
+        }
+    }
+
     private static void assumeBindAddressAvailable(final String address)
     {
         final String message = NetworkTestingUtil.isBindAddressAvailable(address);


### PR DESCRIPTION
Look to address #1714.  Use endpoint addresses when ensuring that tags match when resolving endpoints.  This will handle the case of names being used and the IP address being re-resolved.