### PR TITLE
[C] Fix dangling pointer in replay merge.

### DIFF
--- a/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
+++ b/aeron-archive/src/main/c/client/aeron_archive_replay_merge.c
@@ -721,6 +721,7 @@ static int aeron_archive_replay_merge_handle_async_destination(aeron_archive_rep
         }
         else if (rc < 0)
         {
+            replay_merge->async_destination = NULL;
             AERON_APPEND_ERR("%s", "");
             return -1;
         }


### PR DESCRIPTION
If an error occurs during replay merge, in aeron_async_destination_poll(), async_destination gets freed but never gets set to null.

If aeron_archive_replay_merge_close() is then called to clean up, aeron_archive_replay_merge_handle_async_destination() gets invoked again, which dereferences a dangling replay_merge->async_destination.