### PR TITLE
[C++] Fix the issue with .h file imports in apron-client cpp_wrapper.

### DIFF
--- a/aeron-client/src/main/cpp_wrapper/Image.h
+++ b/aeron-client/src/main/cpp_wrapper/Image.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <cassert>
 #include <functional>
+#include <memory>
 
 #include "concurrent/AtomicBuffer.h"
 #include "concurrent/logbuffer/Header.h"

--- a/aeron-client/src/main/cpp_wrapper/Publication.h
+++ b/aeron-client/src/main/cpp_wrapper/Publication.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "concurrent/AtomicBuffer.h"
 #include "concurrent/logbuffer/BufferClaim.h"


### PR DESCRIPTION
In the Linux build environment, compiling Publication.h and Image.h results in errors indicating that the required headers for shared_ptr and mutex are missing.